### PR TITLE
#52 stop self reference in dependency wp

### DIFF
--- a/src/backend/src/controllers/work-packages.controllers.ts
+++ b/src/backend/src/controllers/work-packages.controllers.ts
@@ -105,8 +105,7 @@ export const createWorkPackage = async (req: Request, res: Response) => {
 
   if(dependencies.find((dep: { carNumber: any; projectNumber: any; workPackageNumber: any; }) =>
     dep.carNumber === carNumber
-    && dep.projectNumber === projectNumber
-    && dep.workPackageNumber === workPackageNumber) !== undefined) {
+    && dep.projectNumber === projectNumber && dep.workPackageNumber === workPackageNumber) !== undefined) {
     return res.status(400).json({ message: `A Work Package cannot have its own project as a dependency` });
   }
 

--- a/src/backend/src/controllers/work-packages.controllers.ts
+++ b/src/backend/src/controllers/work-packages.controllers.ts
@@ -103,8 +103,10 @@ export const createWorkPackage = async (req: Request, res: Response) => {
 
   if (workPackageNumber !== 0) throw new TypeError('Given WBS Number is not for a project.');
 
-  if(dependencies.find((dep: { carNumber: any; projectNumber: any; workPackageNumber: any; }) => dep.carNumber === carNumber
-    && dep.projectNumber === projectNumber && dep.workPackageNumber === workPackageNumber) !== undefined) {
+  if(dependencies.find((dep: { carNumber: any; projectNumber: any; workPackageNumber: any; }) =>
+    dep.carNumber === carNumber
+    && dep.projectNumber === projectNumber
+    && dep.workPackageNumber === workPackageNumber) !== undefined) {
     return res.status(400).json({ message: `A Work Package cannot have its own project as a dependency` });
   }
 

--- a/src/backend/src/controllers/work-packages.controllers.ts
+++ b/src/backend/src/controllers/work-packages.controllers.ts
@@ -105,7 +105,8 @@ export const createWorkPackage = async (req: Request, res: Response) => {
 
   if(dependencies.find((dep: { carNumber: any; projectNumber: any; workPackageNumber: any; }) =>
     dep.carNumber === carNumber
-    && dep.projectNumber === projectNumber && dep.workPackageNumber === workPackageNumber) !== undefined) {
+    && dep.projectNumber === projectNumber
+    && dep.workPackageNumber === workPackageNumber) !== undefined) {
     return res.status(400).json({ message: `A Work Package cannot have its own project as a dependency` });
   }
 

--- a/src/backend/src/controllers/work-packages.controllers.ts
+++ b/src/backend/src/controllers/work-packages.controllers.ts
@@ -157,6 +157,7 @@ export const createWorkPackage = async (req: Request, res: Response) => {
     return elem.wbsElementId;
   });
 
+
   // add to the database
   await prisma.work_Package.create({
     data: {
@@ -244,6 +245,10 @@ export const editWorkPackage = async (req: Request, res: Response) => {
   );
   if (depsIds.includes(undefined)) {
     return res.status(404).json({ message: `Dependency with wbs number ${depsIds} not found` });
+  }
+
+  if(depsIds.includes(originalWorkPackage.wbsElementId)) {
+      return res.status(400).json({message: `A Work Package cannot have itself as a dependency` });
   }
 
   const { wbsElementId } = originalWorkPackage;

--- a/src/backend/src/controllers/work-packages.controllers.ts
+++ b/src/backend/src/controllers/work-packages.controllers.ts
@@ -157,6 +157,10 @@ export const createWorkPackage = async (req: Request, res: Response) => {
     return elem.wbsElementId;
   });
 
+  if(dependenciesIds.find(id => id === projectId) !== undefined) {
+    return res.status(400).json({ message: `A Work Package cannot have its own project as a dependency` });
+  }
+
 
   // add to the database
   await prisma.work_Package.create({


### PR DESCRIPTION
## Changes

Added checks in work package create and edit endpoints to stop requests where the dependencies include the package's own project or itself.

## Notes

Could possibly instead use an OR instead of two passes through the dependencies in the edit endpoint. Let me know if this is preferred.

## Screenshots (if applicable)

<img width="466" alt="Screen Shot 2022-08-12 at 4 07 22 PM" src="https://user-images.githubusercontent.com/59621104/184434899-08bb0201-360d-433d-a8b6-5dd9e6a05844.png">

Closes #52
