### PR TITLE
#114 removed expected progress and timeline status from project-details

### DIFF
--- a/src/frontend/src/pages/ProjectDetailPage/project-view-container/project-details.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/project-view-container/project-details.tsx
@@ -11,14 +11,7 @@ import {
   faListOl
 } from '@fortawesome/free-solid-svg-icons';
 import { Project } from 'shared';
-import {
-  datePipe,
-  dollarsPipe,
-  emDashPipe,
-  endDatePipe,
-  fullNamePipe,
-  weeksPipe
-} from '../../../utils/pipes';
+import { datePipe, dollarsPipe, endDatePipe, fullNamePipe, weeksPipe } from '../../../utils/pipes';
 import ExternalLink from '../../../components/external-link';
 import WbsStatus from '../../../components/wbs-status';
 import PageBlock from '../../../layouts/page-block';
@@ -72,12 +65,6 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ project }) => {
         <Row>
           <Col className={allColsStyle} sm={4} md={4} lg={4} xl={3}>
             <b>Budget:</b> {dollarsPipe(project.budget)}
-          </Col>
-          <Col className={allColsStyle} sm={4} md={4} lg={4} xl={3}>
-            <b>Expected Progress:</b> {emDashPipe('')}
-          </Col>
-          <Col className={allColsStyle} sm={4} md={4} lg={4} xl={2}>
-            <b>Timeline Status:</b> {emDashPipe('')}
           </Col>
         </Row>
         <Row className={`${allColsStyle} pl-3`}>


### PR DESCRIPTION
## Changes

Since fields "Expected Progress" and "Timeline Status" are unused in the project details page, they have been completely removed.

## Notes

Related import into project-details.ts has also been removed.

## Screenshots (if applicable)

![image](https://user-images.githubusercontent.com/17571655/184449526-9b516e68-054a-422f-b7eb-40e2fd6cf0b3.png)

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md) and reach out to your squad if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors
- [x] No newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (if applicable)
- [x] Remove any not-applicable sections
- [x] Assign the PR to yourself
- [x] PR is linked to the ticket
- [x] No `package-lock.json` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack

Closes #114 
