### PR TITLE
#133 - moving the risk log below summary above gantt chart

### DIFF
--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
@@ -65,6 +65,7 @@ const ProjectViewContainer: React.FC<ProjectViewContainerProps> = ({ proj, enter
       />
       <ProjectDetails project={proj} />
       <PageBlock title={'Summary'}>{proj.summary}</PageBlock>
+      <RiskLog risks={testRisks} />
       <ProjectGantt workPackages={proj.workPackages} />
       <DescriptionList title={'Goals'} items={proj.goals.filter((goal) => !goal.dateDeleted)} />
       <DescriptionList
@@ -77,7 +78,6 @@ const ProjectViewContainer: React.FC<ProjectViewContainerProps> = ({ proj, enter
       />
       <RulesList rules={proj.rules} />
       <ChangesList changes={proj.changes} />
-      <RiskLog risks={testRisks} />
       <PageBlock title={'Work Packages'}>
         {proj.workPackages.map((ele: WorkPackage) => (
           <div key={wbsPipe(ele.wbsNum)} className="mt-3">


### PR DESCRIPTION
## Changes

Moved up risk log visibly on the page

## Notes

Very small change, physically just reordering things on the page

## Test Case
<img width="1344" alt="Screen Shot 2022-08-17 at 7 11 32 PM" src="https://user-images.githubusercontent.com/9142777/185259442-43b62b53-8fd8-4574-a02a-2b83e86168f6.png">
s



- Case A
- Edge case
- ...

## Screenshots (if applicable)

_Any relevant screenshots go here_

## To Do

_Any remaining things that need to get done_

- [ ] item 1
- [ ] ...

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://github.com/Northeastern-Electric-Racing/FinishLine/blob/develop/docs/ContributorGuide.md) and reach out to your squad if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors
- [ ] No newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (if applicable)
- [ ] Remove any not-applicable sections
- [ ] Assign the PR to yourself
- [ ] PR is linked to the ticket
- [ ] No `package-lock.json` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack

Closes # (issue #)
