### PR TITLE
#69: Edit Risk Endpoint

### DIFF
--- a/src/backend/src/controllers/risks.controllers.ts
+++ b/src/backend/src/controllers/risks.controllers.ts
@@ -25,16 +25,8 @@ export const createRisk = async (req: Request, res: Response) => {
   const { body } = req;
   const { projectId, detail, createdById } = body;
 
-  const targetProj = await prisma.project.findUnique({ where: { projectId } });
-
-  const targetUser = await prisma.user.findUnique({ where: { userId: createdById } });
-
-  if (!targetProj) {
-    return res.status(404).json({ message: `project with id #${projectId} not found!` });
-  }
-
-  if (!targetUser) {
-    return res.status(404).json({ message: `user with id #${projectId} not found!` });
+  if (!hasRiskPermissions(createdById, projectId)) {
+    return res.status(401).json({ message: 'Access Denied' });
   }
 
   const createdRisk = await prisma.risk.create({

--- a/src/backend/src/controllers/risks.controllers.ts
+++ b/src/backend/src/controllers/risks.controllers.ts
@@ -1,6 +1,6 @@
 import prisma from '../prisma/prisma';
 import { Request, Response } from 'express';
-import { riskQueryArgs, riskTransformer } from '../utils/risks.utils';
+import { hasRiskPermissions, riskQueryArgs, riskTransformer } from '../utils/risks.utils';
 import { validationResult } from 'express-validator';
 
 export const getRisksForProject = async (req: Request, res: Response) => {
@@ -46,4 +46,65 @@ export const createRisk = async (req: Request, res: Response) => {
   });
 
   return res.status(200).json({ message: `Successfully created risk #${createdRisk.id}.` });
+};
+
+export const editRisk = async (req: Request, res: Response) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() });
+  }
+
+  const { body } = req;
+  const { userId, id, detail, resolved } = body;
+
+  // get the original risk and check if it exists
+  const originalRisk = await prisma.risk.findUnique({ where: { id } });
+  if (!originalRisk) return res.status(404).json({ message: `Risk with id ${id} not found` });
+  if (originalRisk.dateDeleted) {
+    return res.status(400).json({ message: 'Cant edit a deleted risk' });
+  }
+
+  if (!hasRiskPermissions(userId, originalRisk.projectId)) {
+    return res.status(401).json({ message: 'Access Denied' });
+  }
+
+  let updatedRisk;
+
+  if (originalRisk.isResolved && !resolved) {
+    // if the risk is already resolved and we are unresolving it, we need to take away the resolved data in the db
+    updatedRisk = await prisma.risk.update({
+      where: { id },
+      data: {
+        detail,
+        isResolved: resolved,
+        resolvedByUserId: null,
+        resolvedAt: null
+      },
+      ...riskQueryArgs
+    });
+  } else if (!originalRisk.isResolved && resolved) {
+    // if it's not resolved and we're resolving it, we need to set the resolved data in the db
+    updatedRisk = await prisma.risk.update({
+      where: { id },
+      data: {
+        detail,
+        isResolved: resolved,
+        resolvedByUserId: userId,
+        resolvedAt: new Date()
+      },
+      ...riskQueryArgs
+    });
+  } else {
+    // any other case we are only changing the detail
+    updatedRisk = await prisma.risk.update({
+      where: { id },
+      data: {
+        detail
+      },
+      ...riskQueryArgs
+    });
+  }
+
+  // return the updated risk
+  return res.status(200).json(riskTransformer(updatedRisk));
 };

--- a/src/backend/src/routes/risks.routes.ts
+++ b/src/backend/src/routes/risks.routes.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import { body } from 'express-validator';
-import { createRisk, getRisksForProject } from '../controllers/risks.controllers';
+import { createRisk, editRisk, getRisksForProject } from '../controllers/risks.controllers';
 
 const risksRouter = express.Router();
 
@@ -11,6 +11,14 @@ risksRouter.post(
   body('createdById').isInt().not().isString(),
   body('detail').isString().not().isEmpty(),
   createRisk
+);
+risksRouter.post(
+  '/edit',
+  body('userId').isInt().not().isString(),
+  body('id').isString().not().isEmpty(),
+  body('detail').isString().not().isEmpty(),
+  body('resolved').isBoolean(),
+  editRisk
 );
 
 export default risksRouter;

--- a/src/backend/src/utils/risks.utils.ts
+++ b/src/backend/src/utils/risks.utils.ts
@@ -1,4 +1,5 @@
-import { Prisma } from '@prisma/client';
+import { Prisma, Role } from '@prisma/client';
+import prisma from '../prisma/prisma';
 import { Risk } from 'shared';
 import { userTransformer } from './users.utils';
 import { wbsNumOf } from './utils';
@@ -29,4 +30,30 @@ export const riskTransformer = (risk: Prisma.RiskGetPayload<typeof riskQueryArgs
     resolvedAt: risk.resolvedAt ?? undefined,
     deletedBy: risk.deletedBy ? userTransformer(risk.deletedBy) : undefined
   };
+};
+
+export const hasRiskPermissions = async (userId: number, projectId: number) => {
+  const user = await prisma.user.findUnique({ where: { userId } });
+
+  if (!user) return false;
+
+  if (user.role === Role.APP_ADMIN || user.role === Role.ADMIN || user.role === Role.LEADERSHIP) {
+    return true;
+  }
+
+  const project = await prisma.project.findUnique({
+    where: { projectId },
+    include: { wbsElement: true }
+  });
+
+  if (!project) return false;
+
+  if (
+    project.wbsElement.projectLeadId === user.userId ||
+    project.wbsElement.projectManagerId === user.userId
+  ) {
+    return true;
+  }
+
+  return false;
 };


### PR DESCRIPTION
## Changes

adding the endpoint

## Test Cases
This image shows me first editing just the detail, then resolving it (note that resolved by and time are now populated), then editing it but keeping it resolved (note that the resolved time doesn't change), then unresolving it (note that resolved by and time are now null)

![image](https://user-images.githubusercontent.com/63663597/185761434-a78c0b26-f262-45d6-86b7-d1dab5219e8e.png)

Closes #69 nice
