### PR TITLE
#24-now-uses-proper-duration-util-function

### DIFF
--- a/src/backend/src/utils/projects.utils.ts
+++ b/src/backend/src/utils/projects.utils.ts
@@ -6,7 +6,7 @@ import {
   DescriptionBullet,
   calculateEndDate,
   calculatePercentExpectedProgress,
-  calculateTimelineStatus
+  calculateTimelineStatus, calculateDuration
 } from 'shared';
 import { descBulletConverter, wbsNumOf } from './utils';
 import { userTransformer } from './users.utils';
@@ -113,7 +113,7 @@ export const projectTransformer = (
     slideDeckLink: project.slideDeckLink ?? undefined,
     bomLink: project.bomLink ?? undefined,
     rules: project.rules,
-    duration: project.workPackages.reduce((prev, curr) => prev + curr.duration, 0),
+    duration: calculateDuration(project.workPackages),
     goals: project.goals.map(descBulletConverter),
     features: project.features.map(descBulletConverter),
     otherConstraints: project.otherConstraints.map(descBulletConverter),


### PR DESCRIPTION
## Changes

Now uses proper duration calculation function for project transformer return

## Notes

why was this function just sitting there in utils
Another grueling ticket.

## Screenshots (if applic
<img width="1611" alt="Screen Shot 2022-08-26 at 6 33 35 PM" src="https://user-images.githubusercontent.com/59621104/187000466-9f629ec3-46da-4d6f-aabb-a2867c1275c8.png">
able)

Closes #24 
