### PR TITLE
#149 Make WPs block appear above the changes block in projects page

### DIFF
--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
@@ -77,7 +77,6 @@ const ProjectViewContainer: React.FC<ProjectViewContainerProps> = ({ proj, enter
         items={proj.otherConstraints.filter((constraint) => !constraint.dateDeleted)}
       />
       <RulesList rules={proj.rules} />
-      <ChangesList changes={proj.changes} />
       <PageBlock title={'Work Packages'}>
         {proj.workPackages.map((ele: WorkPackage) => (
           <div key={wbsPipe(ele.wbsNum)} className="mt-3">
@@ -85,6 +84,7 @@ const ProjectViewContainer: React.FC<ProjectViewContainerProps> = ({ proj, enter
           </div>
         ))}
       </PageBlock>
+      <ChangesList changes={proj.changes} />
     </Container>
   );
 };


### PR DESCRIPTION


## Changes

Updated the projects page so the WPs block appears above the changes block 

## Notes

N/A

## Test Cases

Have confirmed that WPs block is located above the changes block (screenshots are attached for reference)

## Screenshots (if applicable)

<img width="943" alt="#149_Manual_Test2" src="https://user-images.githubusercontent.com/91857946/187048857-ddc657ec-907f-4851-8498-221edf4314cf.png">
<img width="944" alt="#149_Manual_Test1" src="https://user-images.githubusercontent.com/91857946/187048858-6d8741a3-b069-4747-b885-a78d5bb68bf7.png">

## To Do

N/A

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://github.com/Northeastern-Electric-Racing/FinishLine/blob/develop/docs/ContributorGuide.md) and reach out to your squad if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors
- [x] No newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (if applicable)
- [x] Remove any not-applicable sections
- [x] Assign the PR to yourself
- [x] PR is linked to the ticket
- [x] No `package-lock.json` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack

Closes # (issue #)
