### PR TITLE
#87: modifed endpoint for approving change requests

### DIFF
--- a/src/backend/src/controllers/change-requests.controllers.ts
+++ b/src/backend/src/controllers/change-requests.controllers.ts
@@ -51,15 +51,17 @@ export const reviewChangeRequest = async (req: Request, res: Response) => {
   if (reviewerId === foundCR.submitterId) return res.status(401).json({ message: 'Access Denied' });
 
   // make sure that a proposed solution is selected before approving
-  const foundPS = await prisma.proposed_Solution.findMany({ where: {changeRequestId: foundCR.crId }});
+  const foundPS = await prisma.proposed_Solution.findMany({
+    where: { changeRequestId: foundCR.crId }
+  });
   let selected = false;
   foundPS.forEach((proposedSolution) => {
-    if(proposedSolution.approved) {
+    if (proposedSolution.approved) {
       selected = true;
     }
   });
-  if (!selected) return res.status(401).json({message: 'No proposed solution selected'});
-  
+  if (!selected) return res.status(400).json({ message: 'No proposed solution selected' });
+
   // update change request
   const update = await prisma.change_Request.update({
     where: { crId },

--- a/src/backend/src/controllers/change-requests.controllers.ts
+++ b/src/backend/src/controllers/change-requests.controllers.ts
@@ -34,7 +34,7 @@ export const reviewChangeRequest = async (req: Request, res: Response) => {
   }
 
   const { body } = req;
-  const { reviewerId, crId, reviewNotes, accepted, selectedPs } = body;
+  const { reviewerId, crId, reviewNotes, accepted, psId } = body;
 
   // verify that the user is allowed review change requests
   const reviewer = await prisma.user.findUnique({ where: { userId: reviewerId } });
@@ -50,15 +50,15 @@ export const reviewChangeRequest = async (req: Request, res: Response) => {
   // verify that the user is not reviewing their own change request
   if (reviewerId === foundCR.submitterId) return res.status(401).json({ message: 'Access Denied' });
 
-  // make sure that a proposed solution is selected before approving
+  // if Scope CR, make sure that a proposed solution is selected before approving
   if (
     foundCR.type === 'ISSUE' ||
     foundCR.type === 'DEFINITION_CHANGE' ||
     foundCR.type === 'OTHER'
   ) {
-    if (!selectedPs) return res.status(400).json({ message: 'No proposed solution selected' });
+    if (!psId) return res.status(400).json({ message: 'No proposed solution selected' });
     await prisma.proposed_Solution.update({
-      where: { proposedSolutionId: selectedPs },
+      where: { proposedSolutionId: psId },
       data: {
         approved: true
       }

--- a/src/backend/src/controllers/change-requests.controllers.ts
+++ b/src/backend/src/controllers/change-requests.controllers.ts
@@ -51,12 +51,17 @@ export const reviewChangeRequest = async (req: Request, res: Response) => {
   if (reviewerId === foundCR.submitterId) return res.status(401).json({ message: 'Access Denied' });
 
   // if Scope CR, make sure that a proposed solution is selected before approving
-  if (
-    foundCR.type === 'ISSUE' ||
-    foundCR.type === 'DEFINITION_CHANGE' ||
-    foundCR.type === 'OTHER'
-  ) {
-    if (!psId) return res.status(400).json({ message: 'No proposed solution selected' });
+  const foundScopeCR = await prisma.scope_CR.findUnique({ where: { changeRequestId: crId } });
+  if (foundScopeCR) {
+    if (!psId)
+      return res
+        .status(400)
+        .json({ message: 'No proposed solution selected for scope change request' });
+    const foundPs = await prisma.proposed_Solution.findUnique({
+      where: { proposedSolutionId: psId }
+    });
+    if (!foundPs)
+      return res.status(400).json({ message: `Proposed solution with id #${psId} not found` });
     await prisma.proposed_Solution.update({
       where: { proposedSolutionId: psId },
       data: {

--- a/src/backend/src/controllers/change-requests.controllers.ts
+++ b/src/backend/src/controllers/change-requests.controllers.ts
@@ -51,9 +51,13 @@ export const reviewChangeRequest = async (req: Request, res: Response) => {
   if (reviewerId === foundCR.submitterId) return res.status(401).json({ message: 'Access Denied' });
 
   // make sure that a proposed solution is selected before approving
-  if(foundCR.type === 'ISSUE' || foundCR.type === 'DEFINITION_CHANGE' || foundCR.type === 'OTHER') {
-    if(!selectedPs) return res.status(400).json({ message: 'No proposed solution selected' });
-    await prisma.proposed_Solution.update({ 
+  if (
+    foundCR.type === 'ISSUE' ||
+    foundCR.type === 'DEFINITION_CHANGE' ||
+    foundCR.type === 'OTHER'
+  ) {
+    if (!selectedPs) return res.status(400).json({ message: 'No proposed solution selected' });
+    await prisma.proposed_Solution.update({
       where: { proposedSolutionId: selectedPs },
       data: {
         approved: true

--- a/src/backend/src/controllers/change-requests.controllers.ts
+++ b/src/backend/src/controllers/change-requests.controllers.ts
@@ -50,6 +50,16 @@ export const reviewChangeRequest = async (req: Request, res: Response) => {
   // verify that the user is not reviewing their own change request
   if (reviewerId === foundCR.submitterId) return res.status(401).json({ message: 'Access Denied' });
 
+  // make sure that a proposed solution is selected before approving
+  const foundPS = await prisma.proposed_Solution.findMany({ where: {changeRequestId: foundCR.crId }});
+  let selected = false;
+  foundPS.forEach((proposedSolution) => {
+    if(proposedSolution.approved) {
+      selected = true;
+    }
+  });
+  if (!selected) return res.status(401).json({message: 'No proposed solution selected'});
+  
   // update change request
   const update = await prisma.change_Request.update({
     where: { crId },

--- a/src/backend/src/controllers/change-requests.controllers.ts
+++ b/src/backend/src/controllers/change-requests.controllers.ts
@@ -60,8 +60,8 @@ export const reviewChangeRequest = async (req: Request, res: Response) => {
     const foundPs = await prisma.proposed_Solution.findUnique({
       where: { proposedSolutionId: psId }
     });
-    if (!foundPs)
-      return res.status(400).json({ message: `Proposed solution with id #${psId} not found` });
+    if (!foundPs || foundPs.changeRequestId !== crId)
+      return res.status(400).json({ message: `Proposed solution with id #${psId} not found for change request #${crId}` });
     // update proposed solution
     await prisma.proposed_Solution.update({
       where: { proposedSolutionId: psId },

--- a/src/backend/src/controllers/change-requests.controllers.ts
+++ b/src/backend/src/controllers/change-requests.controllers.ts
@@ -62,6 +62,7 @@ export const reviewChangeRequest = async (req: Request, res: Response) => {
     });
     if (!foundPs)
       return res.status(400).json({ message: `Proposed solution with id #${psId} not found` });
+    // update proposed solution
     await prisma.proposed_Solution.update({
       where: { proposedSolutionId: psId },
       data: {

--- a/src/backend/src/routes/change-requests.routes.ts
+++ b/src/backend/src/routes/change-requests.routes.ts
@@ -20,6 +20,7 @@ changeRequestsRouter.post(
   body('crId').isInt({ min: 0 }).not().isString(),
   body('reviewNotes').isString(),
   body('accepted').isBoolean(),
+  body('psId').isString(),
   reviewChangeRequest
 );
 changeRequestsRouter.post(

--- a/src/backend/src/routes/change-requests.routes.ts
+++ b/src/backend/src/routes/change-requests.routes.ts
@@ -20,7 +20,7 @@ changeRequestsRouter.post(
   body('crId').isInt({ min: 0 }).not().isString(),
   body('reviewNotes').isString(),
   body('accepted').isBoolean(),
-  body('psId').isString(),
+  body('psId').optional().isString().not().isEmpty(),
   reviewChangeRequest
 );
 changeRequestsRouter.post(


### PR DESCRIPTION
## Context

The existing endpoint for approving change request needs to be modified to reflect the N-Proposed Solutions model. 

## Changes

Added another check for approving to require that at least one proposed solution has been selected (`proposedSolution.approved`). Throws a 401 error if there is no solutions proposed, or none of the solutions are selected.
Approving process for other change requests are untouched.

## Notes

Change Request has been modified to ...

## Test Case

### Case 1: Success
Sending a POST request to the `/review` endpoint with:
```JSON
{
	"reviewerId": 3,
	"crId": 1,
	"reviewNotes": "test",
	"accepted": true
        "psId": "1"
}
```
The result should be:
`Status 200: OK`
```JSON
{
	"message": "Change request #1 successfully reviewed."
}
``` 
And update the `approved` field of the given proposed solution (psId: 1) to `true`.


### Case 2A: Fail: no psID provided
Sending a POST request without the psId field:
```JSON
{
	"reviewerId": 3,
	"crId": 1,
	"reviewNotes": "test",
	"accepted": true
}
```
The result should be:
`Status 400: Bad Request`
```JSON
{
	"message": "No proposed solution selected for scope change request"
}
``` 

### Case 2B: Fail: psID does not exist (or crId of the proposed solution does not match the crId being approved)
Sending a POST request without the psId field:
```JSON
{
	"reviewerId": 3,
	"crId": 1,
	"reviewNotes": "test",
	"accepted": true,
	"psId": "8"
}
```
The result should be:
`Status 400: Bad Request`
```JSON
{
	"message": "Proposed solution with id #8 not found for change request #1"
}
``` 

## Screenshots
With: 
![image](https://user-images.githubusercontent.com/17571655/189464254-1c660723-a15f-495f-a68e-d712d6cb5f20.png)

### Case 1: Success
![image](https://user-images.githubusercontent.com/17571655/188557426-e3fab1ad-1222-4d92-b0a0-581cf5ccde4f.png)

![image](https://user-images.githubusercontent.com/17571655/189464339-03eb9875-972d-458d-bc0e-e6b1c8f57a62.png)

### Case 2A: Fail
![image](https://user-images.githubusercontent.com/17571655/189022272-04077079-9f79-4ffb-b3bc-0046f8019355.png)

![image](https://user-images.githubusercontent.com/17571655/189464316-91ce6320-37da-4972-a23c-792ac2b68d9c.png)

### Case 2B: Fail
![image](https://user-images.githubusercontent.com/17571655/189464298-65e1c4ea-c079-41c6-8378-13aebbc58368.png)

![image](https://user-images.githubusercontent.com/17571655/189464293-4cac791e-d956-4803-95ca-3092e8fed46e.png)

![image](https://user-images.githubusercontent.com/17571655/189464314-04d417ca-a20b-4265-bf8c-ea5f061d583a.png)

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors
- [x] No newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (if applicable)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] PR is linked to the ticket
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack

Closes #87
