### PR TITLE
#98 backend errors 4xx

### DIFF
--- a/src/backend/src/controllers/work-packages.controllers.ts
+++ b/src/backend/src/controllers/work-packages.controllers.ts
@@ -102,9 +102,9 @@ export const createWorkPackage = async (req: Request, res: Response) => {
   const { carNumber, projectNumber, workPackageNumber } = projectWbsNum;
 
   if (workPackageNumber !== 0) {
-    return res
-      .status(400)
-      .json({ message: `Given WBS Number ${projectWbsNum.toString()} is not for a project.` });
+    return res.status(400).json({
+      message: `Given WBS Number ${carNumber}.${projectNumber}.${workPackageNumber} is not for a project.`
+    });
   }
 
   if (dependencies.find((dep: any) => equalsWbsNumber(dep, projectWbsNum))) {
@@ -133,7 +133,9 @@ export const createWorkPackage = async (req: Request, res: Response) => {
   if (wbsElem === null) {
     return res
       .status(404)
-      .json({ message: `Could not find element with wbs number: ${projectWbsNum.toString()}` });
+      .json({
+        message: `Could not find element with wbs number: ${carNumber}.${projectNumber}.${workPackageNumber}`
+      });
   }
 
   const { project } = wbsElem;
@@ -165,12 +167,19 @@ export const createWorkPackage = async (req: Request, res: Response) => {
   const dependenciesIds: number[] = [];
   // populate dependenciesIds with the element ID's
   // and return error 400 if any elems are null
+
+  let dependenciesHasNulls = false;
   dependenciesWBSElems.forEach((elem) => {
     if (elem === null) {
-      return res.status(400).json({ message: 'One of the dependencies was not found.' });
+      dependenciesHasNulls = true;
+      return;
     }
     dependenciesIds.push(elem.wbsElementId);
   });
+
+  if (dependenciesHasNulls) {
+    return res.status(400).json({ message: 'One of the dependencies was not found.' });
+  }
 
   // add to the database
   await prisma.work_Package.create({

--- a/src/backend/src/controllers/work-packages.controllers.ts
+++ b/src/backend/src/controllers/work-packages.controllers.ts
@@ -162,11 +162,14 @@ export const createWorkPackage = async (req: Request, res: Response) => {
     })
   );
 
-  const dependenciesIds = dependenciesWBSElems.map((elem) => {
+  const dependenciesIds: number[] = [];
+  // populate dependenciesIds with the element ID's
+  // and return error 400 if any elems are null
+  dependenciesWBSElems.forEach((elem) => {
     if (elem === null) {
       return res.status(400).json({ message: 'One of the dependencies was not found.' });
     }
-    return elem.wbsElementId;
+    dependenciesIds.push(elem.wbsElementId);
   });
 
   // add to the database

--- a/src/backend/src/utils/projects.utils.ts
+++ b/src/backend/src/utils/projects.utils.ts
@@ -76,7 +76,6 @@ export const projectTransformer = (
     | Prisma.ProjectGetPayload<typeof manyRelationArgs>
     | Prisma.WBS_ElementGetPayload<typeof uniqueRelationArgs>
 ): Project => {
-  if (payload === null) throw new TypeError('WBS_Element not found');
   const wbsElement = 'wbsElement' in payload ? payload.wbsElement : payload;
   const project = 'project' in payload ? payload.project! : payload;
   const wbsNum = wbsNumOf(wbsElement);

--- a/src/backend/src/utils/teams.utils.ts
+++ b/src/backend/src/utils/teams.utils.ts
@@ -16,8 +16,6 @@ export const teamRelationArgs = Prisma.validator<Prisma.TeamArgs>()({
 });
 
 export const teamTransformer = (team: Prisma.TeamGetPayload<typeof teamRelationArgs>): Team => {
-  if (team === null) throw new TypeError('Team not found');
-
   return {
     teamId: team.teamId,
     teamName: team.teamName,

--- a/src/backend/src/utils/users.utils.ts
+++ b/src/backend/src/utils/users.utils.ts
@@ -22,8 +22,6 @@ export const authenticatedUserTransformer = (
 };
 
 export const userTransformer = (user: Prisma.UserGetPayload<null>): User => {
-  if (user === null) throw new TypeError('User not found');
-
   return {
     userId: user.userId ?? undefined,
     firstName: user.firstName ?? undefined,

--- a/src/backend/tests/work-packages.test.ts
+++ b/src/backend/tests/work-packages.test.ts
@@ -44,4 +44,11 @@ describe('Work Packages', () => {
 
     expect(res.statusCode).toBe(400);
   });
+
+  test('createWorkPackage fails if any elements in the dependencies are null', async () => {
+    const proj = { ...createWorkPackagePayload, dependencies: [null] };
+    const res = await request(app).post('/create').send(proj);
+
+    expect(res.statusCode).toBe(400);
+  });
 });

--- a/src/backend/tests/work-packages.test.ts
+++ b/src/backend/tests/work-packages.test.ts
@@ -1,0 +1,47 @@
+import request from 'supertest';
+import express from 'express';
+import workPackageRouter from '../src/routes/work-packages.routes';
+import { WBS_Element_Status } from '@prisma/client';
+import prisma from '../src/prisma/prisma';
+
+const app = express();
+app.use(express.json());
+app.use('/', workPackageRouter);
+
+// jest.mock('../src/utils/work-packages.utils');
+
+const createWorkPackagePayload = {
+  projectWbsNum: '1.2.0',
+  name: 'Pack your bags',
+  crId: 2,
+  userId: 1,
+  startDate: new Date('01/01/21'),
+  duration: 5,
+  dependencies: [
+    {
+      wbsElementId: 65,
+      dateCreated: new Date('12/25/20'),
+      carNumber: 1,
+      projectNumber: 1,
+      workPackageNumber: 1,
+      name: 'prereq',
+      status: WBS_Element_Status.COMPLETE
+    }
+  ],
+  expectedActivities: [{ descriptionId: 5, dateAdded: '01/05/21', detail: 'be active' }],
+  deliverables: [{ descriptionId: 3, dateAdded: '01/01/22', detail: 'did it work' }]
+};
+
+describe('Work Packages', () => {
+  beforeEach(() => {
+    prisma.work_Package.findMany = jest.fn();
+    prisma.work_Package.findUnique = jest.fn();
+  });
+
+  test('createWorkPackage fails if WBS number does not represent a project', async () => {
+    const proj = { ...createWorkPackagePayload, projectWbsNum: '1.2.1' };
+    const res = await request(app).post('/create').send(proj);
+
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/src/backend/tests/work-packages.test.ts
+++ b/src/backend/tests/work-packages.test.ts
@@ -1,26 +1,81 @@
 import request from 'supertest';
 import express from 'express';
 import workPackageRouter from '../src/routes/work-packages.routes';
-import { WBS_Element_Status } from '@prisma/client';
+import { CR_Type, Prisma, Role, WBS_Element_Status } from '@prisma/client';
 import prisma from '../src/prisma/prisma';
+import { WbsElement, WbsElementStatus } from 'shared';
+import userRouter from '../src/routes/users.routes';
 
 const app = express();
 app.use(express.json());
 app.use('/', workPackageRouter);
 
-// jest.mock('../src/utils/work-packages.utils');
+jest.mock('../src/utils/work-packages.utils');
+
+const batman = {
+  userId: 1,
+  firstName: 'Bruce',
+  lastName: 'Wayne',
+  email: 'notbatman@gmail.com',
+  emailId: 'notbatman',
+  role: Role.APP_ADMIN
+};
+
+const nullReturn = () => {
+  return null;
+};
+
+const mockDependency = nullReturn as unknown as jest.Mock<WbsElement>;
+
+const someWBElement = {
+  wbsElementId: 1,
+  status: WBS_Element_Status.ACTIVE,
+  carNumber: 1,
+  projectNumber: 2,
+  workPackageNumber: 0,
+  dateCreated: new Date(),
+  name: 'car',
+  projectLeadId: 4,
+  projectManagerId: 5,
+  project: {
+    projectId: 2,
+    wbsElementId: 3,
+    budget: 3,
+    summary: 'ajsjdfk',
+    rules: ['a'],
+    workPackages: [
+      {
+        workPackageId: 2,
+        wbsElementId: 7,
+        projectId: 6,
+        orderInProject: 0,
+        startDate: new Date('2020-07-14'),
+        progress: 5,
+        duration: 4,
+        wbsElement: {
+          workPackageNumber: 9
+        },
+        dependencies: []
+      }
+    ]
+  }
+};
 
 const createWorkPackagePayload = {
-  projectWbsNum: '1.2.0',
+  projectWbsNum: {
+    carNumber: 1,
+    projectNumber: 2,
+    workPackageNumber: 0
+  },
   name: 'Pack your bags',
-  crId: 2,
-  userId: 1,
-  startDate: new Date('01/01/21'),
+  crId: 1,
+  userId: batman.userId,
+  startDate: '2022-09-18',
   duration: 5,
   dependencies: [
     {
       wbsElementId: 65,
-      dateCreated: new Date('12/25/20'),
+      dateCreated: new Date('11/24/2021'),
       carNumber: 1,
       projectNumber: 1,
       workPackageNumber: 1,
@@ -28,27 +83,77 @@ const createWorkPackagePayload = {
       status: WBS_Element_Status.COMPLETE
     }
   ],
-  expectedActivities: [{ descriptionId: 5, dateAdded: '01/05/21', detail: 'be active' }],
-  deliverables: [{ descriptionId: 3, dateAdded: '01/01/22', detail: 'did it work' }]
+  expectedActivities: ['ayo'],
+  deliverables: ['ajdhjakfjafja']
 };
+
+const changeBatmobile = {
+  crId: 1,
+  submitterId: 1,
+  wbsElementId: 65,
+  type: CR_Type.DEFINITION_CHANGE,
+  changes: [
+    {
+      changeRequestId: 1,
+      implementerId: 1,
+      wbsElementId: 65,
+      detail: 'changed batmobile from white (yuck) to black'
+    }
+  ],
+  dateSubmitted: new Date('11/24/2020'),
+  dateReviewed: new Date('11/25/2020'),
+  accepted: true,
+  reviewerId: 1,
+  reviewNotes: 'white sucks'
+};
+
+const nulledWBS = null as unknown as jest.Mock<WbsElement>;
 
 describe('Work Packages', () => {
   beforeEach(() => {
+    prisma.user.findUnique = jest.fn();
+    prisma.change_Request.findUnique = jest.fn();
     prisma.work_Package.findMany = jest.fn();
     prisma.work_Package.findUnique = jest.fn();
   });
 
   test('createWorkPackage fails if WBS number does not represent a project', async () => {
-    const proj = { ...createWorkPackagePayload, projectWbsNum: '1.2.1' };
+    jest.spyOn(prisma.user, 'findUnique').mockResolvedValue({ ...batman, googleAuthId: 'b' });
+    jest.spyOn(prisma.change_Request, 'findUnique').mockResolvedValue(changeBatmobile);
+    const proj = {
+      ...createWorkPackagePayload,
+      projectWbsNum: {
+        carNumber: 1,
+        projectNumber: 2,
+        workPackageNumber: 2
+      }
+    };
     const res = await request(app).post('/create').send(proj);
 
     expect(res.statusCode).toBe(400);
+    expect(res.body.message).toBe('Given WBS Number 1.2.2 is not for a project.');
   });
 
   test('createWorkPackage fails if any elements in the dependencies are null', async () => {
-    const proj = { ...createWorkPackagePayload, dependencies: [null] };
-    const res = await request(app).post('/create').send(proj);
+    jest.spyOn(prisma.user, 'findUnique').mockResolvedValue({ ...batman, googleAuthId: 'b' });
+    jest.spyOn(prisma.change_Request, 'findUnique').mockResolvedValue(changeBatmobile);
+    jest.spyOn(prisma.wBS_Element, 'findUnique').mockResolvedValueOnce(someWBElement);
+    jest.spyOn(prisma.wBS_Element, 'findUnique').mockResolvedValueOnce(null);
+
+    const res = await request(app).post('/create').send(createWorkPackagePayload);
 
     expect(res.statusCode).toBe(400);
+    expect(res.body.message).toBe('One of the dependencies was not found.');
+  });
+
+  test('findUniqueUser', async () => {
+    app.use('/', workPackageRouter);
+    jest.spyOn(prisma.user, 'findUnique').mockResolvedValue({ ...batman, googleAuthId: 'b' });
+    jest.spyOn(prisma.change_Request, 'findUnique').mockResolvedValue(changeBatmobile);
+
+    const res = await request(app).post('/create').send(createWorkPackagePayload);
+
+    expect(prisma.user.findUnique).toHaveBeenCalledTimes(1);
+    expect(prisma.change_Request.findUnique).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/backend/tests/work-packages.test.ts
+++ b/src/backend/tests/work-packages.test.ts
@@ -3,13 +3,10 @@ import express from 'express';
 import workPackageRouter from '../src/routes/work-packages.routes';
 import { CR_Type, Role, WBS_Element_Status } from '@prisma/client';
 import prisma from '../src/prisma/prisma';
-import { WbsElement } from 'shared';
 
 const app = express();
 app.use(express.json());
 app.use('/', workPackageRouter);
-
-jest.mock('../src/utils/work-packages.utils');
 
 const batman = {
   userId: 1,
@@ -17,11 +14,8 @@ const batman = {
   lastName: 'Wayne',
   email: 'notbatman@gmail.com',
   emailId: 'notbatman',
-  role: Role.APP_ADMIN
-};
-
-const nullReturn = () => {
-  return null;
+  role: Role.APP_ADMIN,
+  googleAuthId: 'b'
 };
 
 const someWBElement = {
@@ -113,7 +107,7 @@ describe('Work Packages', () => {
   });
 
   test('createWorkPackage fails if WBS number does not represent a project', async () => {
-    jest.spyOn(prisma.user, 'findUnique').mockResolvedValue({ ...batman, googleAuthId: 'b' });
+    jest.spyOn(prisma.user, 'findUnique').mockResolvedValue(batman);
     jest.spyOn(prisma.change_Request, 'findUnique').mockResolvedValue(changeBatmobile);
     const proj = {
       ...createWorkPackagePayload,
@@ -130,7 +124,7 @@ describe('Work Packages', () => {
   });
 
   test('createWorkPackage fails if any elements in the dependencies are null', async () => {
-    jest.spyOn(prisma.user, 'findUnique').mockResolvedValue({ ...batman, googleAuthId: 'b' });
+    jest.spyOn(prisma.user, 'findUnique').mockResolvedValue(batman);
     jest.spyOn(prisma.change_Request, 'findUnique').mockResolvedValue(changeBatmobile);
     jest.spyOn(prisma.wBS_Element, 'findUnique').mockResolvedValueOnce(someWBElement);
     jest.spyOn(prisma.wBS_Element, 'findUnique').mockResolvedValueOnce(null);
@@ -139,16 +133,5 @@ describe('Work Packages', () => {
 
     expect(res.statusCode).toBe(400);
     expect(res.body.message).toBe('One of the dependencies was not found.');
-  });
-
-  test('findUniqueUser', async () => {
-    app.use('/', workPackageRouter);
-    jest.spyOn(prisma.user, 'findUnique').mockResolvedValue({ ...batman, googleAuthId: 'b' });
-    jest.spyOn(prisma.change_Request, 'findUnique').mockResolvedValue(changeBatmobile);
-
-    await request(app).post('/create').send(createWorkPackagePayload);
-
-    expect(prisma.user.findUnique).toHaveBeenCalledTimes(1);
-    expect(prisma.change_Request.findUnique).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/backend/tests/work-packages.test.ts
+++ b/src/backend/tests/work-packages.test.ts
@@ -1,10 +1,9 @@
 import request from 'supertest';
 import express from 'express';
 import workPackageRouter from '../src/routes/work-packages.routes';
-import { CR_Type, Prisma, Role, WBS_Element_Status } from '@prisma/client';
+import { CR_Type, Role, WBS_Element_Status } from '@prisma/client';
 import prisma from '../src/prisma/prisma';
-import { WbsElement, WbsElementStatus } from 'shared';
-import userRouter from '../src/routes/users.routes';
+import { WbsElement } from 'shared';
 
 const app = express();
 app.use(express.json());
@@ -24,8 +23,6 @@ const batman = {
 const nullReturn = () => {
   return null;
 };
-
-const mockDependency = nullReturn as unknown as jest.Mock<WbsElement>;
 
 const someWBElement = {
   wbsElementId: 1,
@@ -107,8 +104,6 @@ const changeBatmobile = {
   reviewNotes: 'white sucks'
 };
 
-const nulledWBS = null as unknown as jest.Mock<WbsElement>;
-
 describe('Work Packages', () => {
   beforeEach(() => {
     prisma.user.findUnique = jest.fn();
@@ -151,7 +146,7 @@ describe('Work Packages', () => {
     jest.spyOn(prisma.user, 'findUnique').mockResolvedValue({ ...batman, googleAuthId: 'b' });
     jest.spyOn(prisma.change_Request, 'findUnique').mockResolvedValue(changeBatmobile);
 
-    const res = await request(app).post('/create').send(createWorkPackagePayload);
+    await request(app).post('/create').send(createWorkPackagePayload);
 
     expect(prisma.user.findUnique).toHaveBeenCalledTimes(1);
     expect(prisma.change_Request.findUnique).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Changes

We added some tests to the work-packages.test.ts file, mainly tests with checking for a valid WBS Element ID and tests checking for null dependencies.

Other changes included: 

in wp controller : `throw TypeError` replaced with `return res.status(400)`
in `userTransformer`, `projectTransformer`, `teamTransformer`:  `TypeError` check for null input removed because TypeScript enforces that the input cannot be null

## To Do

Not sure if there's much else to do, but we'd like to double check before finalizing everything.

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors
- [x] No newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (if applicable)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] PR is linked to the ticket
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack

Closes #98 
