### PR TITLE
#213 - Update Description_Bullet with checked info

### DIFF
--- a/src/backend/src/prisma/migrations/20220929015048_make_description_bullets_checkable/migration.sql
+++ b/src/backend/src/prisma/migrations/20220929015048_make_description_bullets_checkable/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "Description_Bullet" ADD COLUMN     "dateTimeChecked" TIMESTAMP(3),
+ADD COLUMN     "userCheckedId" INTEGER;
+
+-- AddForeignKey
+ALTER TABLE "Description_Bullet" ADD CONSTRAINT "Description_Bullet_userCheckedId_fkey" FOREIGN KEY ("userCheckedId") REFERENCES "User"("userId") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/src/backend/src/prisma/schema.prisma
+++ b/src/backend/src/prisma/schema.prisma
@@ -247,6 +247,8 @@ model Work_Package {
 model Description_Bullet {
   descriptionId                   Int           @id @default(autoincrement())
   dateAdded                       DateTime      @default(now())
+  userChecked                     String?
+  dateTimeChecked                 DateTime?
   dateDeleted                     DateTime?
   detail                          String
   // Relation references

--- a/src/backend/src/prisma/schema.prisma
+++ b/src/backend/src/prisma/schema.prisma
@@ -61,20 +61,21 @@ model User {
   userSettings User_Settings?
 
   // Relation references
-  submittedChangeRequests  Change_Request[]    @relation(name: "submittedChangeRequests")
-  reviewedChangeRequests   Change_Request[]    @relation(name: "reviewedChangeRequests")
-  markedAsProjectLead      Activation_CR[]     @relation(name: "markAsProjectLead")
-  markedAsProjectManager   Activation_CR[]     @relation(name: "markAsProjectManager")
-  changes                  Change[]
-  projectLead              WBS_Element[]       @relation(name: "projectLead")
-  projectManager           WBS_Element[]       @relation(name: "projectManager")
-  Session                  Session[]
-  teams                    Team[]              @relation(name: "teamsAsMember")
-  teamAsLead               Team?               @relation(name: "teamAsLead")
-  createdRisks             Risk[]              @relation(name: "createdBy")
-  resolvedRisks            Risk[]              @relation(name: "resolvedBy")
-  deletedRisks             Risk[]              @relation(name: "deletedBy")
-  createdProposedSolutions Proposed_Solution[]
+  submittedChangeRequests   Change_Request[]     @relation(name: "submittedChangeRequests")
+  reviewedChangeRequests    Change_Request[]     @relation(name: "reviewedChangeRequests")
+  markedAsProjectLead       Activation_CR[]      @relation(name: "markAsProjectLead")
+  markedAsProjectManager    Activation_CR[]      @relation(name: "markAsProjectManager")
+  changes                   Change[]
+  projectLead               WBS_Element[]        @relation(name: "projectLead")
+  projectManager            WBS_Element[]        @relation(name: "projectManager")
+  Session                   Session[]
+  teams                     Team[]               @relation(name: "teamsAsMember")
+  teamAsLead                Team?                @relation(name: "teamAsLead")
+  checkedDescriptionBullets Description_Bullet[] @relation(name: "checkDescriptionBullets")
+  createdRisks              Risk[]               @relation(name: "createdBy")
+  resolvedRisks             Risk[]               @relation(name: "resolvedBy")
+  deletedRisks              Risk[]               @relation(name: "deletedBy")
+  createdProposedSolutions  Proposed_Solution[]
 }
 
 model Team {
@@ -247,7 +248,8 @@ model Work_Package {
 model Description_Bullet {
   descriptionId                   Int           @id @default(autoincrement())
   dateAdded                       DateTime      @default(now())
-  userChecked                     String?
+  userCheckedId                   Int?
+  userChecked                     User?         @relation(name: "checkDescriptionBullets", fields: [userCheckedId], references: [userId])
   dateTimeChecked                 DateTime?
   dateDeleted                     DateTime?
   detail                          String


### PR DESCRIPTION
## Changes

Add `userChecked` (User relation) and `dateTimeChecked` (DateTime) to schema for Description_Bullet and made new migration

## Notes

User relation isn't in the section labelled "Relation references" in `Description_Bullet` schema because it fits better with the checked DateTime than with the other relations

## To Do

None

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #213 
