### PR TITLE
#294: Better Frontend Testing

### DIFF
--- a/src/frontend/src/tests/components/ActionButton.test.tsx
+++ b/src/frontend/src/tests/components/ActionButton.test.tsx
@@ -20,10 +20,6 @@ const renderComponent = () => {
 };
 
 describe('action button', () => {
-  it('renders without error', () => {
-    renderComponent();
-  });
-
   it('renders text', () => {
     renderComponent();
     expect(screen.getByText('test')).toBeInTheDocument();

--- a/src/frontend/src/tests/components/BulletList.test.tsx
+++ b/src/frontend/src/tests/components/BulletList.test.tsx
@@ -4,20 +4,12 @@
  */
 
 import { render, screen } from '@testing-library/react';
-import { useTheme } from '../../hooks/Theme.hooks';
+import * as themeHooks from '../../hooks/Theme.hooks';
 import themes from '../../utils/Themes';
-import { Theme } from '../../utils/Types';
 import BulletList from '../../components/BulletList';
 
-jest.mock('../../hooks/Theme.hooks');
-const mockTheme = useTheme as jest.Mock<Theme>;
-
-const mockHook = () => {
-  mockTheme.mockReturnValue(themes[0]);
-};
-
 describe('Bullet List Component', () => {
-  beforeEach(() => mockHook());
+  beforeEach(() => jest.spyOn(themeHooks, 'useTheme').mockReturnValue(themes[0]));
 
   it('renders the component title', () => {
     render(<BulletList title={'test'} list={[<></>]} />);

--- a/src/frontend/src/tests/layouts/NavTopBar/NavNotificationsMenu.test.tsx
+++ b/src/frontend/src/tests/layouts/NavTopBar/NavNotificationsMenu.test.tsx
@@ -25,12 +25,7 @@ const renderComponent = () => {
 };
 
 describe('navigation notifications menu tests', () => {
-  it('renders the bell button', () => {
-    renderComponent();
-    expect(screen.getByRole('button')).toBeInTheDocument();
-  });
-
-  it('renders the notification menu items', async () => {
+  it('renders the bell button and notification menu items', async () => {
     renderComponent();
     const bell: HTMLElement = screen.getByRole('button');
     expect(bell).toBeInTheDocument();

--- a/src/frontend/src/tests/layouts/NavTopBar/NavUserMenu.test.tsx
+++ b/src/frontend/src/tests/layouts/NavTopBar/NavUserMenu.test.tsx
@@ -25,12 +25,7 @@ const renderComponent = () => {
 };
 
 describe('navigation user menu tests', () => {
-  it('renders user icon dropdown menu button', () => {
-    renderComponent();
-    expect(screen.getByRole('button')).toBeInTheDocument();
-  });
-
-  it('renders the user menu items', async () => {
+  it('renders the button and user menu items', async () => {
     renderComponent();
     const user: HTMLElement = screen.getByRole('button');
     expect(user).toBeInTheDocument();

--- a/src/frontend/src/tests/layouts/PageBlock.test.tsx
+++ b/src/frontend/src/tests/layouts/PageBlock.test.tsx
@@ -4,17 +4,9 @@
  */
 
 import { render, screen } from '../test-support/test-utils';
-import { useTheme } from '../../hooks/Theme.hooks';
-import { Theme } from '../../utils/Types';
+import * as themeHooks from '../../hooks/Theme.hooks';
 import themes from '../../utils/Themes';
 import PageBlock from '../../layouts/PageBlock';
-
-jest.mock('../../hooks/Theme.hooks');
-const mockTheme = useTheme as jest.Mock<Theme>;
-
-const mockHook = () => {
-  mockTheme.mockReturnValue(themes[0]);
-};
 
 const renderComponent = (headerRight = false) => {
   return render(
@@ -25,27 +17,19 @@ const renderComponent = (headerRight = false) => {
 };
 
 describe('card component', () => {
-  beforeEach(() => mockHook());
-
-  it('renders without error', () => {
-    renderComponent();
-  });
+  beforeEach(() => jest.spyOn(themeHooks, 'useTheme').mockReturnValue(themes[0]));
 
   it('renders title', () => {
-    renderComponent();
-
-    expect(screen.getByText('test')).toBeInTheDocument();
-  });
-
-  it('renders header right', () => {
     renderComponent(true);
 
+    expect(screen.getByText('test')).toBeInTheDocument();
     expect(screen.getByText('hi')).toBeInTheDocument();
+    expect(screen.getByText('hello')).toBeInTheDocument();
   });
 
-  it('renders children', () => {
-    renderComponent();
+  it('doesnt render headerRight if none is given', () => {
+    renderComponent(false);
 
-    expect(screen.getByText('hello')).toBeInTheDocument();
+    expect(screen.queryByText('hi')).not.toBeInTheDocument();
   });
 });

--- a/src/frontend/src/tests/layouts/PageTitle/PageBreadcrumbs.test.tsx
+++ b/src/frontend/src/tests/layouts/PageTitle/PageBreadcrumbs.test.tsx
@@ -19,10 +19,6 @@ const renderComponent = (title = 'test', pages: LinkItem[] = []) => {
 };
 
 describe('page-breadcrumbs component', () => {
-  it('renders without error', () => {
-    renderComponent();
-  });
-
   it('renders current page', () => {
     renderComponent();
 

--- a/src/frontend/src/tests/layouts/PageTitle/PageTitle.test.tsx
+++ b/src/frontend/src/tests/layouts/PageTitle/PageTitle.test.tsx
@@ -16,19 +16,10 @@ jest.mock('../../../layouts/PageTitle/PageBreadcrumbs', () => {
 });
 
 describe('error page', () => {
-  it('renders without error', () => {
-    render(<PageTitle title={'test'} previousPages={[]} />);
-  });
-
-  it('renders title', () => {
+  it('renders title and breadcrumbs', () => {
     render(<PageTitle title={'test'} previousPages={[]} />);
 
     expect(screen.getByText('test')).toBeInTheDocument();
-  });
-
-  it('renders breadcrumbs', () => {
-    render(<PageTitle title={'test'} previousPages={[]} />);
-
     expect(screen.getByText('page-breadcrumbs')).toBeInTheDocument();
   });
 });

--- a/src/frontend/src/tests/layouts/Sidebar/NavPageLinks.test.tsx
+++ b/src/frontend/src/tests/layouts/Sidebar/NavPageLinks.test.tsx
@@ -20,18 +20,10 @@ const renderComponent = () => {
 };
 
 describe('Navigation Page Links Tests', () => {
-  it('Renders Home Page Link', () => {
+  it('renders all the test link items', () => {
     renderComponent();
     expect(screen.getByText(/Home/i)).toBeInTheDocument();
-  });
-
-  it('Renders Projects Page Link', () => {
-    renderComponent();
     expect(screen.getByText(/Projects/i)).toBeInTheDocument();
-  });
-
-  it('Renders Change Requests Page Link', () => {
-    renderComponent();
     expect(screen.getByText(/Change Requests/i)).toBeInTheDocument();
   });
 });

--- a/src/frontend/src/tests/pages/HomePage/Home.test.tsx
+++ b/src/frontend/src/tests/pages/HomePage/Home.test.tsx
@@ -6,8 +6,7 @@
 import { render, screen, routerWrapperBuilder } from '../../test-support/test-utils';
 import { routes } from '../../../utils/Routes';
 import Home from '../../../pages/HomePage/Home';
-import { useAuth } from '../../../hooks/Auth.hooks';
-import { Auth } from '../../../utils/Types';
+import * as authHooks from '../../../hooks/Auth.hooks';
 import { exampleAdminUser } from '../../test-support/test-data/users.stub';
 import { mockAuth } from '../../test-support/test-data/test-utils.stub';
 
@@ -38,14 +37,6 @@ jest.mock('../../../pages/HomePage/WorkPackagesByTimelineStatus', () => {
   };
 });
 
-jest.mock('../../../hooks/Auth.hooks');
-
-const mockedUseAuth = useAuth as jest.Mock<Auth>;
-
-const mockAuthHook = (user = exampleAdminUser) => {
-  mockedUseAuth.mockReturnValue(mockAuth(false, user));
-};
-
 /**
  * Sets up the component under test with the desired values and renders it.
  */
@@ -60,8 +51,10 @@ const renderComponent = () => {
 
 describe('home component', () => {
   beforeEach(() => {
-    mockAuthHook();
+    jest.spyOn(authHooks, 'useAuth').mockReturnValue(mockAuth(false, exampleAdminUser));
   });
+
+  afterAll(() => jest.clearAllMocks());
 
   it('renders welcome', () => {
     renderComponent();

--- a/src/frontend/src/tests/pages/ProjectDetailPage/ProjectEditContainer/ProjectEditContainer.test.tsx
+++ b/src/frontend/src/tests/pages/ProjectDetailPage/ProjectEditContainer/ProjectEditContainer.test.tsx
@@ -3,50 +3,22 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { UseMutationResult, UseQueryResult } from 'react-query';
-import { User } from 'shared';
 import { render, screen, routerWrapperBuilder } from '../../../test-support/test-utils';
 import { wbsPipe } from '../../../../utils/Pipes';
-import { useEditSingleProject } from '../../../../hooks/Projects.hooks';
+import * as projectHooks from '../../../../hooks/Projects.hooks';
 import { exampleProject1 as exPrj1 } from '../../../test-support/test-data/projects.stub';
-import { useAllUsers, useLogUserIn } from '../../../../hooks/Users.hooks';
-import {
-  mockUseMutationResult,
-  mockUseQueryResult
-} from '../../../test-support/test-data/test-utils.stub';
+import * as userHooks from '../../../../hooks/Users.hooks';
 import {
   exampleAdminUser,
   exampleAppAdminUser,
   exampleLeadershipUser
 } from '../../../test-support/test-data/users.stub';
 import ProjectEditContainer from '../../../../pages/ProjectDetailPage/ProjectEditContainer/ProjectEditContainer';
-
-jest.mock('../../../../hooks/Projects.hooks');
-
-// random shit to make test happy by mocking out this hook
-const mockedUseEditSingleProject = useEditSingleProject as jest.Mock<UseMutationResult>;
-
-const mockEditSingleProjectHook = (isLoading: boolean, isError: boolean, error?: Error) => {
-  mockedUseEditSingleProject.mockReturnValue(
-    mockUseMutationResult<{ in: string }>(isLoading, isError, { in: 'hi' }, error)
-  );
-};
-
-jest.mock('../../../../hooks/Users.hooks');
-
-const mockedUseAllUsers = useAllUsers as jest.Mock<UseQueryResult<User[]>>;
-
-const mockUsersHook = (isLoading: boolean, isError: boolean, data?: User[], error?: Error) => {
-  mockedUseAllUsers.mockReturnValue(mockUseQueryResult<User[]>(isLoading, isError, data, error));
-};
-
-const mockedUseLogUserIn = useLogUserIn as jest.Mock<UseMutationResult>;
-
-const mockUseLogUserInHook = (isLoading: boolean, isError: boolean, error?: Error) => {
-  mockedUseLogUserIn.mockReturnValue(
-    mockUseMutationResult<{ in: string }>(isLoading, isError, { in: 'hi' }, error)
-  );
-};
+import {
+  mockLogUserInReturnValue,
+  mockUseAllUsersReturnValue,
+  mockEditProjectReturnValue
+} from '../../../test-support/mock-hooks';
 
 const users = [exampleAdminUser, exampleAppAdminUser, exampleLeadershipUser];
 
@@ -62,45 +34,36 @@ const renderComponent = () => {
 
 describe('test suite for ProjectEditContainer', () => {
   beforeEach(() => {
-    mockUseLogUserInHook(false, false);
+    jest.spyOn(projectHooks, 'useEditSingleProject').mockReturnValue(mockEditProjectReturnValue);
+    jest.spyOn(userHooks, 'useAllUsers').mockReturnValue(mockUseAllUsersReturnValue(users));
+    jest.spyOn(userHooks, 'useLogUserIn').mockReturnValue(mockLogUserInReturnValue);
   });
+
+  afterAll(() => jest.clearAllMocks());
 
   describe('rendering subcomponents of ProjectEditContainer', () => {
     it('renders title', () => {
-      mockUsersHook(false, false, users);
-      mockEditSingleProjectHook(false, false);
       renderComponent();
-
       expect(screen.getAllByText(`${wbsPipe(exPrj1.wbsNum)} - ${exPrj1.name}`).length).toEqual(2);
     });
 
     it('renders change request input', () => {
-      mockUsersHook(false, false, users);
-      mockEditSingleProjectHook(false, false);
       renderComponent();
-
       expect(screen.getByPlaceholderText('Change Request ID #')).toBeInTheDocument();
     });
 
     it('render title of ProjectEditDetails', () => {
-      mockUsersHook(false, false, users);
-      mockEditSingleProjectHook(false, false);
       renderComponent();
-
       expect(screen.getByText('Project Details (EDIT)')).toBeInTheDocument();
     });
 
     it('render title of ProjectEditSummary', () => {
-      mockUsersHook(false, false, users);
-      mockEditSingleProjectHook(false, false);
       renderComponent();
 
       expect(screen.getByText('Project Summary')).toBeInTheDocument();
     });
 
     it('render goals list', async () => {
-      mockUsersHook(false, false, users);
-      mockEditSingleProjectHook(false, false);
       renderComponent();
 
       expect(screen.getByText('Goals')).toBeInTheDocument();
@@ -111,8 +74,6 @@ describe('test suite for ProjectEditContainer', () => {
     });
 
     it('render features list', async () => {
-      mockUsersHook(false, false, users);
-      mockEditSingleProjectHook(false, false);
       renderComponent();
 
       expect(screen.getByText('Features')).toBeInTheDocument();
@@ -123,8 +84,6 @@ describe('test suite for ProjectEditContainer', () => {
     });
 
     it('render other constraints list', async () => {
-      mockUsersHook(false, false, users);
-      mockEditSingleProjectHook(false, false);
       renderComponent();
 
       expect(screen.getByText('Other Constraints')).toBeInTheDocument();
@@ -135,8 +94,6 @@ describe('test suite for ProjectEditContainer', () => {
     });
 
     it('render rules list', async () => {
-      mockUsersHook(false, false, users);
-      mockEditSingleProjectHook(false, false);
       renderComponent();
 
       expect(screen.getByText('Goals')).toBeInTheDocument();
@@ -145,24 +102,18 @@ describe('test suite for ProjectEditContainer', () => {
     });
 
     it('render title of ChangesList', () => {
-      mockUsersHook(false, false, users);
-      mockEditSingleProjectHook(false, false);
       renderComponent();
 
       expect(screen.getByText('Changes')).toBeInTheDocument();
     });
 
     it('render title of ProjectEditWorkPackagesList', () => {
-      mockUsersHook(false, false, users);
-      mockEditSingleProjectHook(false, false);
       renderComponent();
 
       expect(screen.getByText('Work Packages')).toBeInTheDocument();
     });
 
     it('renders save and cancel buttons', () => {
-      mockUsersHook(false, false, users);
-      mockEditSingleProjectHook(false, false);
       renderComponent();
 
       expect(screen.getByText('Cancel')).toBeInTheDocument();
@@ -171,33 +122,11 @@ describe('test suite for ProjectEditContainer', () => {
   });
 
   it('renders the loaded project', () => {
-    mockUsersHook(false, false, users);
-    mockEditSingleProjectHook(false, false);
     renderComponent();
 
     expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
     expect(screen.getAllByText(`${wbsPipe(exPrj1.wbsNum)} - ${exPrj1.name}`).length).toEqual(2);
     expect(screen.getByText('Project Details (EDIT)')).toBeInTheDocument();
     expect(screen.getByText('Project Name:')).toBeInTheDocument();
-  });
-
-  it('handles the error with message', () => {
-    mockUsersHook(false, true, undefined, new Error('error'));
-    mockEditSingleProjectHook(false, false);
-    renderComponent();
-
-    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
-    expect(screen.getByText('Oops, sorry!')).toBeInTheDocument();
-    expect(screen.getByText('error')).toBeInTheDocument();
-  });
-
-  it('handles the error with no message', () => {
-    mockUsersHook(false, true, undefined);
-    mockEditSingleProjectHook(false, false);
-    renderComponent();
-
-    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
-    expect(screen.queryByText('project')).not.toBeInTheDocument();
-    expect(screen.getByText('Oops, sorry!')).toBeInTheDocument();
   });
 });

--- a/src/frontend/src/tests/pages/ProjectDetailPage/ProjectViewContainer/RulesList.test.tsx
+++ b/src/frontend/src/tests/pages/ProjectDetailPage/ProjectViewContainer/RulesList.test.tsx
@@ -4,21 +4,15 @@
  */
 
 import { render, screen } from '@testing-library/react';
-import { useTheme } from '../../../../hooks/Theme.hooks';
+import * as themeHooks from '../../../../hooks/Theme.hooks';
 import themes from '../../../../utils/Themes';
-import { Theme } from '../../../../utils/Types';
 import { exampleProject1 } from '../../../test-support/test-data/projects.stub';
 import RulesList from '../../../../pages/ProjectDetailPage/ProjectViewContainer/RulesList';
 
-jest.mock('../../../../hooks/Theme.hooks');
-const mockTheme = useTheme as jest.Mock<Theme>;
-
-const mockHook = () => {
-  mockTheme.mockReturnValue(themes[0]);
-};
-
 describe('Rendering Work Package Rules Component', () => {
-  beforeEach(() => mockHook());
+  beforeEach(() => {
+    jest.spyOn(themeHooks, 'useTheme').mockReturnValue(themes[0]);
+  });
 
   it('renders the component title', () => {
     render(<RulesList rules={exampleProject1.rules} />);

--- a/src/frontend/src/tests/test-support/mock-hooks.ts
+++ b/src/frontend/src/tests/test-support/mock-hooks.ts
@@ -1,0 +1,21 @@
+import { AuthenticatedUser, User } from 'shared';
+import { mockUseMutationResult, mockUseQueryResult } from './test-data/test-utils.stub';
+import { exampleAdminUser } from './test-data/users.stub';
+import { UseMutationResult } from 'react-query';
+
+export const mockLogUserInReturnValue = mockUseMutationResult<AuthenticatedUser>(
+  false,
+  false,
+  exampleAdminUser as AuthenticatedUser,
+  new Error()
+) as UseMutationResult<AuthenticatedUser, Error, string, unknown>;
+
+export const mockUseAllUsersReturnValue = (users: User[]) =>
+  mockUseQueryResult<User[]>(false, false, users, new Error());
+
+export const mockEditProjectReturnValue = mockUseMutationResult<{ message: string }>(
+  false,
+  false,
+  { message: 'hi' },
+  new Error()
+);


### PR DESCRIPTION
## Changes

Look at how many lines I'm able to delete!!!!

basically we can use jest.spyOn which is only one line each and we can save the mock values in another file which makes this super compact and we only ever have to write the mock for each hook once.

## Notes

If we like this we can turn this into a lot of tickets

closes #294
