### PR TITLE
#25: end date calculation of logic moved to back-end

### DIFF
--- a/src/backend/src/utils/projects.utils.ts
+++ b/src/backend/src/utils/projects.utils.ts
@@ -5,6 +5,7 @@ import {
   WbsElementStatus,
   DescriptionBullet,
   calculateEndDate,
+  calculateProjectEndDate,
   calculatePercentExpectedProgress,
   calculateTimelineStatus,
   calculateDuration
@@ -117,10 +118,7 @@ export const projectTransformer = (
     bomLink: project.bomLink ?? undefined,
     rules: project.rules,
     duration: calculateDuration(project.workPackages),
-    endDate: calculateEndDate(
-      project.workPackages[0].startDate,
-      calculateDuration(project.workPackages)
-    ),
+    endDate: calculateProjectEndDate(project.workPackages),
     goals: project.goals.map(descBulletConverter),
     features: project.features.map(descBulletConverter),
     otherConstraints: project.otherConstraints.map(descBulletConverter),

--- a/src/backend/src/utils/projects.utils.ts
+++ b/src/backend/src/utils/projects.utils.ts
@@ -117,6 +117,10 @@ export const projectTransformer = (
     bomLink: project.bomLink ?? undefined,
     rules: project.rules,
     duration: calculateDuration(project.workPackages),
+    endDate: calculateEndDate(
+      project.workPackages[0].startDate,
+      calculateDuration(project.workPackages)
+    ),
     goals: project.goals.map(descBulletConverter),
     features: project.features.map(descBulletConverter),
     otherConstraints: project.otherConstraints.map(descBulletConverter),

--- a/src/frontend/src/apis/Transformers/Projects.transformers.ts
+++ b/src/frontend/src/apis/Transformers/Projects.transformers.ts
@@ -31,7 +31,7 @@ export const projectTransformer = (project: Project) => {
   return {
     ...project,
     dateCreated: new Date(project.dateCreated),
-    endDate: new Date(project.endDate),
+    endDate: project.endDate ? new Date(project.endDate) : project.endDate,
     workPackages: project.workPackages.map(workPackageTransformer),
     goals: project.goals.map(descriptionBulletTransformer),
     features: project.features.map(descriptionBulletTransformer),

--- a/src/frontend/src/apis/Transformers/Projects.transformers.ts
+++ b/src/frontend/src/apis/Transformers/Projects.transformers.ts
@@ -31,6 +31,7 @@ export const projectTransformer = (project: Project) => {
   return {
     ...project,
     dateCreated: new Date(project.dateCreated),
+    endDate: new Date(project.endDate),
     workPackages: project.workPackages.map(workPackageTransformer),
     goals: project.goals.map(descriptionBulletTransformer),
     features: project.features.map(descriptionBulletTransformer),

--- a/src/frontend/src/apis/Transformers/Projects.transformers.ts
+++ b/src/frontend/src/apis/Transformers/Projects.transformers.ts
@@ -31,7 +31,7 @@ export const projectTransformer = (project: Project) => {
   return {
     ...project,
     dateCreated: new Date(project.dateCreated),
-    endDate: project.endDate ? new Date(project.endDate) : project.endDate,
+    endDate: project.endDate ? new Date(project.endDate) : undefined,
     workPackages: project.workPackages.map(workPackageTransformer),
     goals: project.goals.map(descriptionBulletTransformer),
     features: project.features.map(descriptionBulletTransformer),

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectDetails.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectDetails.tsx
@@ -30,15 +30,6 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ project }) => {
           )
         )
       : 'n/a';
-  const end = project.endDate
-    ? datePipe(
-        project.workPackages.reduce(
-          (min, cur) => (cur.endDate < min ? cur.endDate : min),
-          project.workPackages[0].endDate
-        )
-      )
-    : 'n/a';
-
   const allColsStyle = 'mb-2';
   return (
     <PageBlock title={'Project Details'} headerRight={<WbsStatus status={project.status} />}>
@@ -57,7 +48,7 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ project }) => {
             <b>Start Date:</b> {start}
           </Col>
           <Col className={allColsStyle} sm={4} md={4} lg={3} xl={2}>
-            <b>End Date:</b> {end}
+            <b>End Date:</b> {project.endDate}
           </Col>
         </Row>
         <Row>

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectDetails.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectDetails.tsx
@@ -48,7 +48,7 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ project }) => {
             <b>Start Date:</b> {start}
           </Col>
           <Col className={allColsStyle} sm={4} md={4} lg={3} xl={2}>
-            <b>End Date:</b> {project.endDate}
+            <b>End Date:</b> {datePipe(project.endDate)}
           </Col>
         </Row>
         <Row>

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectDetails.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectDetails.tsx
@@ -11,7 +11,7 @@ import {
   faListOl
 } from '@fortawesome/free-solid-svg-icons';
 import { Project } from 'shared';
-import { datePipe, dollarsPipe, endDatePipe, fullNamePipe, weeksPipe } from '../../../utils/Pipes';
+import { datePipe, dollarsPipe, fullNamePipe, weeksPipe } from '../../../utils/Pipes';
 import ExternalLink from '../../../components/ExternalLink';
 import WbsStatus from '../../../components/WbsStatus';
 import PageBlock from '../../../layouts/PageBlock';
@@ -32,12 +32,11 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ project }) => {
       : 'n/a';
   const end =
     project.workPackages.length > 0
-      ? endDatePipe(
+      ? datePipe(
           project.workPackages.reduce(
-            (min, cur) => (cur.startDate < min ? cur.startDate : min),
-            project.workPackages[0].startDate
-          ),
-          project.workPackages.reduce((tot, cur) => tot + cur.duration, 0)
+            (min, cur) => (cur.endDate < min ? cur.endDate : min),
+            project.workPackages[0].endDate
+          )
         )
       : 'n/a';
 

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectDetails.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectDetails.tsx
@@ -48,7 +48,7 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ project }) => {
             <b>Start Date:</b> {start}
           </Col>
           <Col className={allColsStyle} sm={4} md={4} lg={3} xl={2}>
-            <b>End Date:</b> {datePipe(project.endDate)}
+            <b>End Date:</b> {datePipe(project.endDate) || 'n/a'}
           </Col>
         </Row>
         <Row>

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectDetails.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectDetails.tsx
@@ -30,15 +30,14 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ project }) => {
           )
         )
       : 'n/a';
-  const end =
-    project.workPackages.length > 0
-      ? datePipe(
-          project.workPackages.reduce(
-            (min, cur) => (cur.endDate < min ? cur.endDate : min),
-            project.workPackages[0].endDate
-          )
+  const end = project.endDate
+    ? datePipe(
+        project.workPackages.reduce(
+          (min, cur) => (cur.endDate < min ? cur.endDate : min),
+          project.workPackages[0].endDate
         )
-      : 'n/a';
+      )
+    : 'n/a';
 
   const allColsStyle = 'mb-2';
   return (

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/WorkPackageSummary.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/WorkPackageSummary.tsx
@@ -7,7 +7,7 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Card, Collapse, Col, Container, Row } from 'react-bootstrap';
 import { WorkPackage } from 'shared';
-import { weeksPipe, wbsPipe, endDatePipe, listPipe, datePipe } from '../../../utils/Pipes';
+import { weeksPipe, wbsPipe, listPipe, datePipe } from '../../../utils/Pipes';
 import { useTheme } from '../../../hooks/theme.hooks';
 import { routes } from '../../../utils/Routes';
 import WbsStatus from '../../../components/WbsStatus';
@@ -63,7 +63,7 @@ const WorkPackageSummary: React.FC<WorkPackageSummaryProps> = ({ workPackage }) 
                 </Col>
                 <Col xs={6} md={4}>
                   <b>Start date:</b> {datePipe(workPackage.startDate)} <br />
-                  <b>End Date:</b> {endDatePipe(workPackage.startDate, workPackage.duration)}
+                  <b>End Date:</b> {datePipe(workPackage.endDate)}
                 </Col>
               </Row>
               <Row>

--- a/src/frontend/src/tests/pages/ProjectDetailPage/ProjectViewContainer/WorkPackageSummary.test.tsx
+++ b/src/frontend/src/tests/pages/ProjectDetailPage/ProjectViewContainer/WorkPackageSummary.test.tsx
@@ -5,7 +5,7 @@
 
 import { WorkPackage } from 'shared';
 import { render, screen, routerWrapperBuilder } from '../../../test-support/test-utils';
-import { wbsPipe, listPipe, endDatePipe, datePipe } from '../../../../utils/Pipes';
+import { wbsPipe, listPipe, datePipe } from '../../../../utils/Pipes';
 import {
   exampleWorkPackage1,
   exampleWorkPackage2,
@@ -31,9 +31,7 @@ describe('Rendering Work Package Summary Test', () => {
     expect(screen.getByText(`${wbsPipe(wp.wbsNum)}`)).toBeInTheDocument();
     expect(screen.getByText(`${wp.duration} weeks`)).toBeInTheDocument();
     expect(screen.getByText(`${datePipe(wp.startDate)}`, { exact: false })).toBeInTheDocument();
-    expect(
-      screen.getByText(`${endDatePipe(wp.startDate, wp.duration)}`, { exact: false })
-    ).toBeInTheDocument();
+    expect(screen.getByText(`${datePipe(wp.endDate)}`, { exact: false })).toBeInTheDocument();
     wp.expectedActivities.slice(0, 3).forEach((expectedActivity) => {
       expect(screen.getByText(`${expectedActivity.detail}`)).toBeInTheDocument();
     });
@@ -56,9 +54,7 @@ describe('Rendering Work Package Summary Test', () => {
     expect(screen.getByText(`${wp.duration} weeks`)).toBeInTheDocument();
     expect(screen.getByText(`${listPipe(wp.dependencies, wbsPipe)}`)).toBeInTheDocument();
     expect(screen.getByText(`${datePipe(wp.startDate)}`, { exact: false })).toBeInTheDocument();
-    expect(
-      screen.getByText(`${endDatePipe(wp.startDate, wp.duration)}`, { exact: false })
-    ).toBeInTheDocument();
+    expect(screen.getByText(`${datePipe(wp.endDate)}`, { exact: false })).toBeInTheDocument();
     wp.expectedActivities.slice(0, 3).forEach((expectedActivity) => {
       expect(screen.getByText(`${expectedActivity.detail}`)).toBeInTheDocument();
     });
@@ -81,9 +77,7 @@ describe('Rendering Work Package Summary Test', () => {
     expect(screen.getByText(`${wp.duration} weeks`)).toBeInTheDocument();
     expect(screen.getByText(`${listPipe(wp.dependencies, wbsPipe)}`)).toBeInTheDocument();
     expect(screen.getByText(`${datePipe(wp.startDate)}`, { exact: false })).toBeInTheDocument();
-    expect(
-      screen.getByText(`${endDatePipe(wp.startDate, wp.duration)}`, { exact: false })
-    ).toBeInTheDocument();
+    expect(screen.getByText(`${datePipe(wp.endDate)}`, { exact: false })).toBeInTheDocument();
     wp.expectedActivities.slice(0, 3).forEach((expectedActivity) => {
       expect(screen.getByText(`${expectedActivity.detail}`)).toBeInTheDocument();
     });

--- a/src/frontend/src/tests/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageDetails.test.tsx
+++ b/src/frontend/src/tests/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageDetails.test.tsx
@@ -5,7 +5,7 @@
 
 import { render, screen } from '../../../test-support/test-utils';
 import { WorkPackage } from 'shared';
-import { endDatePipe, fullNamePipe, weeksPipe, percentPipe } from '../../../../utils/Pipes';
+import { datePipe, fullNamePipe, weeksPipe, percentPipe } from '../../../../utils/Pipes';
 import {
   exampleWorkPackage1,
   exampleWorkPackage2,
@@ -51,9 +51,7 @@ describe.skip('Rendering Work Package Details Component', () => {
     expect(
       screen.getByText(`${wp.startDate.toLocaleDateString()}`, { exact: false })
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(`${endDatePipe(wp.startDate, wp.duration)}`, { exact: false })
-    ).toBeInTheDocument();
+    expect(screen.getByText(`${datePipe(wp.endDate)}`, { exact: false })).toBeInTheDocument();
     expect(screen.getByText(`${wp.progress}%`, { exact: false })).toBeInTheDocument();
     expect(screen.getByText(`${wp.timelineStatus}`, { exact: false })).toBeInTheDocument();
     expect(
@@ -79,9 +77,7 @@ describe.skip('Rendering Work Package Details Component', () => {
     expect(
       screen.getByText(`${wp.startDate.toLocaleDateString()}`, { exact: false })
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(`${endDatePipe(wp.startDate, wp.duration)}`, { exact: false })
-    ).toBeInTheDocument();
+    expect(screen.getByText(`${datePipe(wp.endDate)}`, { exact: false })).toBeInTheDocument();
     const progresses = screen.getAllByText(`${percentPipe(wp.progress)}`); // progress and expectedProgress should be equal and return 2 results
     expect(progresses.length).toBe(2);
     expect(screen.getByText(`${wp.timelineStatus}`, { exact: false })).toBeInTheDocument();
@@ -104,9 +100,7 @@ describe.skip('Rendering Work Package Details Component', () => {
     expect(
       screen.getByText(`${wp.startDate.toLocaleDateString()}`, { exact: false })
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(`${endDatePipe(wp.startDate, wp.duration)}`, { exact: false })
-    ).toBeInTheDocument();
+    expect(screen.getByText(`${datePipe(wp.endDate)}`, { exact: false })).toBeInTheDocument();
     const progresses = screen.getAllByText(`${percentPipe(wp.progress)}`); // progress and expectedProgress should be equal and return 2 results
     expect(progresses.length).toBe(2);
     expect(screen.getByText(`${wp.timelineStatus}`, { exact: false })).toBeInTheDocument();

--- a/src/frontend/src/tests/test-support/test-data/projects.stub.ts
+++ b/src/frontend/src/tests/test-support/test-data/projects.stub.ts
@@ -64,7 +64,7 @@ export const exampleProject1: Project = {
     }
   ],
   duration: 8,
-  endDate: new Date('07/21/21'),
+  endDate: new Date('02/26/21'),
   workPackages: [exampleWorkPackage1, exampleWorkPackage2],
   risks: []
 };
@@ -103,7 +103,7 @@ export const exampleProject2: Project = {
   ],
   changes: [],
   duration: 0,
-  endDate: new Date('06/10/21'),
+  endDate: undefined,
   workPackages: [],
   risks: []
 };
@@ -146,7 +146,7 @@ export const exampleProject3: Project = {
   ],
   changes: [],
   duration: 3,
-  endDate: new Date('08/23/21'),
+  endDate: new Date('01/22/21'),
   workPackages: [exampleWorkPackage1],
   risks: []
 };
@@ -185,7 +185,7 @@ export const exampleProject4: Project = {
   ],
   changes: [],
   duration: 5,
-  endDate: new Date('06/15/21'),
+  endDate: new Date('02/26/21'),
   workPackages: [exampleWorkPackage2],
   risks: []
 };
@@ -224,7 +224,7 @@ export const exampleProject5: Project = {
   ],
   changes: [],
   duration: 2,
-  endDate: new Date('02/19/21'),
+  endDate: new Date('01/15/21'),
   workPackages: [exampleWorkPackage3],
   risks: []
 };

--- a/src/frontend/src/tests/test-support/test-data/projects.stub.ts
+++ b/src/frontend/src/tests/test-support/test-data/projects.stub.ts
@@ -11,7 +11,11 @@ import {
   exampleProjectManagerUser
 } from './users.stub';
 import { exampleWbsProject1, exampleWbsProject2 } from './wbs-numbers.stub';
-import { exampleWorkPackage1, exampleWorkPackage2, exampleWorkPackage3 } from './work-packages.stub';
+import {
+  exampleWorkPackage1,
+  exampleWorkPackage2,
+  exampleWorkPackage3
+} from './work-packages.stub';
 
 export const exampleProject1: Project = {
   id: 4,
@@ -60,6 +64,7 @@ export const exampleProject1: Project = {
     }
   ],
   duration: 8,
+  endDate: new Date('07/21/21'),
   workPackages: [exampleWorkPackage1, exampleWorkPackage2],
   risks: []
 };
@@ -98,6 +103,7 @@ export const exampleProject2: Project = {
   ],
   changes: [],
   duration: 0,
+  endDate: new Date('06/10/21'),
   workPackages: [],
   risks: []
 };
@@ -140,6 +146,7 @@ export const exampleProject3: Project = {
   ],
   changes: [],
   duration: 3,
+  endDate: new Date('08/23/21'),
   workPackages: [exampleWorkPackage1],
   risks: []
 };
@@ -178,6 +185,7 @@ export const exampleProject4: Project = {
   ],
   changes: [],
   duration: 5,
+  endDate: new Date('06/15/21'),
   workPackages: [exampleWorkPackage2],
   risks: []
 };
@@ -216,6 +224,7 @@ export const exampleProject5: Project = {
   ],
   changes: [],
   duration: 2,
+  endDate: new Date('02/19/21'),
   workPackages: [exampleWorkPackage3],
   risks: []
 };

--- a/src/frontend/src/utils/Pipes.ts
+++ b/src/frontend/src/utils/Pipes.ts
@@ -48,13 +48,6 @@ export const listPipe = <T>(array: T[], transform: (ele: T) => string) => {
   return array.map(transform).join(', ');
 };
 
-/** Formats the end date as a string. */
-export const endDatePipe = (startDate: Date, durWeeks: number) => {
-  const endDate = new Date(startDate);
-  endDate.setDate(endDate.getDate() + durWeeks * 7);
-  return datePipe(endDate);
-};
-
 /** Replaces an empty string with an EM dash. */
 export const emDashPipe = (str: string) => {
   return str.trim() === '' ? '—' : str;

--- a/src/frontend/src/utils/Pipes.ts
+++ b/src/frontend/src/utils/Pipes.ts
@@ -61,7 +61,8 @@ export const emDashPipe = (str: string) => {
  * so to get around that we do the toDateString() of the time and pass it into the Date constructor
  * where the constructor assumes it's in UTC and makes the correct Date object finally
  */
-export const datePipe = (date: Date) => {
+export const datePipe = (date?: Date) => {
+  if (!date) return '';
   date = new Date(date.toDateString());
   return date.toLocaleDateString('en-US', {
     day: '2-digit',

--- a/src/shared/src/backend-supports/project-supports.ts
+++ b/src/shared/src/backend-supports/project-supports.ts
@@ -24,6 +24,7 @@ const calculateEndDate = (start: Date, weeks: number) => {
  * @returns the latest end date of the workpackages
  */
 const calculateProjectEndDate = (wps: { duration: number; startDate: Date }[]) => {
+  if (wps.length === 0) return undefined;
   const maxDate = wps.reduce(
     (max, cur) =>
       calculateEndDate(cur.startDate, cur.duration) > max

--- a/src/shared/src/backend-supports/project-supports.ts
+++ b/src/shared/src/backend-supports/project-supports.ts
@@ -7,7 +7,7 @@ import { WbsElementStatus } from '../types/project-types';
 import { TimelineStatus } from '../types/work-package-types';
 
 /**
- * This function calculates the end date.
+ * This function calculates the end date for a work package.
  * @param start the start date
  * @param weeks number of weeks
  * @returns the start date after the weeks have passed
@@ -16,6 +16,16 @@ const calculateEndDate = (start: Date, weeks: number) => {
   const end = new Date(start);
   end.setDate(start.getDate() + weeks * 7);
   return end;
+};
+
+/**
+ * This function calculates the end date for a project.
+ * @param wps an array of work packages
+ * @returns the latest end date of the workpackages
+ */
+const calculateProjectEndDate = (wps: { endDate: Date }[]) => {
+  const maxDate = wps.reduce((max, cur) => (cur.endDate > max ? cur.endDate : max), wps[0].endDate);
+  return maxDate;
 };
 
 /**
@@ -69,6 +79,7 @@ const calculateTimelineStatus = (progress: number, expectedProgress: number): Ti
 export {
   calculateDuration,
   calculateEndDate,
+  calculateProjectEndDate,
   calculatePercentExpectedProgress,
   calculateTimelineStatus
 };

--- a/src/shared/src/backend-supports/project-supports.ts
+++ b/src/shared/src/backend-supports/project-supports.ts
@@ -23,8 +23,14 @@ const calculateEndDate = (start: Date, weeks: number) => {
  * @param wps an array of work packages
  * @returns the latest end date of the workpackages
  */
-const calculateProjectEndDate = (wps: { endDate: Date }[]) => {
-  const maxDate = wps.reduce((max, cur) => (cur.endDate > max ? cur.endDate : max), wps[0].endDate);
+const calculateProjectEndDate = (wps: { duration: number; startDate: Date }[]) => {
+  const maxDate = wps.reduce(
+    (max, cur) =>
+      calculateEndDate(cur.startDate, cur.duration) > max
+        ? calculateEndDate(cur.startDate, cur.duration)
+        : max,
+    calculateEndDate(wps[0].startDate, wps[0].duration)
+  );
   return maxDate;
 };
 

--- a/src/shared/src/types/project-types.ts
+++ b/src/shared/src/types/project-types.ts
@@ -40,6 +40,7 @@ export interface Project extends WbsElement {
   slideDeckLink?: string;
   bomLink?: string;
   rules: string[];
+  endDate: Date;
   duration: number;
   goals: DescriptionBullet[];
   features: DescriptionBullet[];

--- a/src/shared/src/types/project-types.ts
+++ b/src/shared/src/types/project-types.ts
@@ -40,7 +40,7 @@ export interface Project extends WbsElement {
   slideDeckLink?: string;
   bomLink?: string;
   rules: string[];
-  endDate: Date;
+  endDate?: Date;
   duration: number;
   goals: DescriptionBullet[];
   features: DescriptionBullet[];


### PR DESCRIPTION
## Changes

Migrate the calculation of the project end date to the back-end where it belongs. Ensure the following happens:

- [x] frontend stops using the endDatePipe (see `pipes.ts`)
- [x] `endDatePipe` is deleted
- [x] frontend stops calculating the `endDate` field (search the project for endDate and see if you find any places where it's being calculated on the frontend)
- [x] the project type is updated to include the endDate field (`project-types.ts` in shared)
- [x] project transformer calculates the `endDate` field just like it does for the `duration` field
- [x] frontend uses the `datePipe` from `pipes.ts` whenever the endDate is shown

## Notes

Was a bit unsure how to edit the project-stubs.ts. All I did was manually put in an end date.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #25  (issue #25 )
