### PR TITLE
#253: Write tests for createRulesChangesJson

### DIFF
--- a/src/backend/src/utils/projects.utils.ts
+++ b/src/backend/src/utils/projects.utils.ts
@@ -269,7 +269,6 @@ export const createRulesChangesJson = (
       changes.push({ element, type: 'Added new' });
     }
   });
-
   return changes.map((element) => {
     return {
       changeRequestId: crId,

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -2,11 +2,7 @@ import request from 'supertest';
 import express from 'express';
 import projectRouter from '../src/routes/projects.routes';
 import prisma from '../src/prisma/prisma';
-import {
-  createRulesChangesJson,
-  getChangeRequestReviewState,
-  getHighestProjectNumber
-} from '../src/utils/projects.utils';
+import { getChangeRequestReviewState, getHighestProjectNumber } from '../src/utils/projects.utils';
 import { batman } from './test-data/users.test-data';
 
 const app = express();
@@ -122,53 +118,5 @@ describe('Projects', () => {
     const res = await request(app).post('/edit').send(proj);
 
     expect(res.statusCode).toBe(400);
-  });
-
-  test('createRulesChangesJson with empty old + new lists', () => {
-    const rulesChanges = createRulesChangesJson('test', [], [], 1, 1, 1);
-    expect(rulesChanges.length).toEqual(0);
-  });
-
-  test('createRulesChangesJson with empty new list and non-empty old list', () => {
-    const rules = ['rule1', 'rule2', 'rule3'];
-    const rulesChanges = createRulesChangesJson('test', rules, [], 1, 1, 1);
-    expect(rulesChanges.length).toEqual(3);
-    rulesChanges.forEach((r, i) => {
-      expect(r.changeRequestId).toEqual(1);
-      expect(r.implementerId).toEqual(1);
-      expect(r.wbsElementId).toEqual(1);
-      expect(r.detail).toEqual(`Removed test "${rules[i]}"`);
-    });
-  });
-
-  test('createRulesChangesJson with empty old list and non-empty new list', () => {
-    const rules = ['rule1', 'rule2', 'rule3'];
-    const rulesChanges = createRulesChangesJson('test', [], rules, 1, 1, 1);
-    expect(rulesChanges.length).toEqual(3);
-    rulesChanges.forEach((r, i) => {
-      expect(r.changeRequestId).toEqual(1);
-      expect(r.implementerId).toEqual(1);
-      expect(r.wbsElementId).toEqual(1);
-      expect(r.detail).toEqual(`Added new test "${rules[i]}"`);
-    });
-  });
-
-  test('createRulesChangesJson with non-empty old list and non-empty new list', () => {
-    const oldRules = ['rule1', 'rule2', 'rule3'];
-    const newRules = ['rule4', 'rule5', 'rule6'];
-    const rulesChanges = createRulesChangesJson('test', oldRules, newRules, 1, 1, 1);
-    expect(rulesChanges.length).toEqual(6);
-    rulesChanges.slice(0, 3).forEach((r, i) => {
-      expect(r.changeRequestId).toEqual(1);
-      expect(r.implementerId).toEqual(1);
-      expect(r.wbsElementId).toEqual(1);
-      expect(r.detail).toEqual(`Removed test "${oldRules[i]}"`);
-    });
-    rulesChanges.slice(3).forEach((r, i) => {
-      expect(r.changeRequestId).toEqual(1);
-      expect(r.implementerId).toEqual(1);
-      expect(r.wbsElementId).toEqual(1);
-      expect(r.detail).toEqual(`Added new test "${newRules[i]}"`);
-    });
   });
 });

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -2,7 +2,11 @@ import request from 'supertest';
 import express from 'express';
 import projectRouter from '../src/routes/projects.routes';
 import prisma from '../src/prisma/prisma';
-import { getChangeRequestReviewState, getHighestProjectNumber } from '../src/utils/projects.utils';
+import {
+  createRulesChangesJson,
+  getChangeRequestReviewState,
+  getHighestProjectNumber
+} from '../src/utils/projects.utils';
 import { batman } from './test-data/users.test-data';
 
 const app = express();
@@ -118,5 +122,53 @@ describe('Projects', () => {
     const res = await request(app).post('/edit').send(proj);
 
     expect(res.statusCode).toBe(400);
+  });
+
+  test('createRulesChangesJson with empty old + new lists', async () => {
+    const rulesChanges = createRulesChangesJson('test', [], [], 1, 1, 1);
+    expect(rulesChanges.length).toEqual(0);
+  });
+
+  test('createRulesChangesJson with empty new list and non-empty old list', async () => {
+    const rules = ['rule1', 'rule2', 'rule3'];
+    const rulesChanges = createRulesChangesJson('test', rules, [], 1, 1, 1);
+    expect(rulesChanges.length).toEqual(3);
+    rulesChanges.forEach((r, i) => {
+      expect(r.changeRequestId).toEqual(1);
+      expect(r.implementerId).toEqual(1);
+      expect(r.wbsElementId).toEqual(1);
+      expect(r.detail).toEqual(`Removed test "${rules[i]}"`);
+    });
+  });
+
+  test('createRulesChangesJson with empty old list and non-empty new list', async () => {
+    const rules = ['rule1', 'rule2', 'rule3'];
+    const rulesChanges = createRulesChangesJson('test', [], rules, 1, 1, 1);
+    expect(rulesChanges.length).toEqual(3);
+    rulesChanges.forEach((r, i) => {
+      expect(r.changeRequestId).toEqual(1);
+      expect(r.implementerId).toEqual(1);
+      expect(r.wbsElementId).toEqual(1);
+      expect(r.detail).toEqual(`Added new test "${rules[i]}"`);
+    });
+  });
+
+  test('createRulesChangesJson with non-empty old list and non-empty new list', async () => {
+    const oldRules = ['rule1', 'rule2', 'rule3'];
+    const newRules = ['rule4', 'rule5', 'rule6'];
+    const rulesChanges = createRulesChangesJson('test', oldRules, newRules, 1, 1, 1);
+    expect(rulesChanges.length).toEqual(6);
+    rulesChanges.slice(0, 3).forEach((r, i) => {
+      expect(r.changeRequestId).toEqual(1);
+      expect(r.implementerId).toEqual(1);
+      expect(r.wbsElementId).toEqual(1);
+      expect(r.detail).toEqual(`Removed test "${oldRules[i]}"`);
+    });
+    rulesChanges.slice(3).forEach((r, i) => {
+      expect(r.changeRequestId).toEqual(1);
+      expect(r.implementerId).toEqual(1);
+      expect(r.wbsElementId).toEqual(1);
+      expect(r.detail).toEqual(`Added new test "${newRules[i]}"`);
+    });
   });
 });

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -124,12 +124,12 @@ describe('Projects', () => {
     expect(res.statusCode).toBe(400);
   });
 
-  test('createRulesChangesJson with empty old + new lists', async () => {
+  test('createRulesChangesJson with empty old + new lists', () => {
     const rulesChanges = createRulesChangesJson('test', [], [], 1, 1, 1);
     expect(rulesChanges.length).toEqual(0);
   });
 
-  test('createRulesChangesJson with empty new list and non-empty old list', async () => {
+  test('createRulesChangesJson with empty new list and non-empty old list', () => {
     const rules = ['rule1', 'rule2', 'rule3'];
     const rulesChanges = createRulesChangesJson('test', rules, [], 1, 1, 1);
     expect(rulesChanges.length).toEqual(3);
@@ -141,7 +141,7 @@ describe('Projects', () => {
     });
   });
 
-  test('createRulesChangesJson with empty old list and non-empty new list', async () => {
+  test('createRulesChangesJson with empty old list and non-empty new list', () => {
     const rules = ['rule1', 'rule2', 'rule3'];
     const rulesChanges = createRulesChangesJson('test', [], rules, 1, 1, 1);
     expect(rulesChanges.length).toEqual(3);
@@ -153,7 +153,7 @@ describe('Projects', () => {
     });
   });
 
-  test('createRulesChangesJson with non-empty old list and non-empty new list', async () => {
+  test('createRulesChangesJson with non-empty old list and non-empty new list', () => {
     const oldRules = ['rule1', 'rule2', 'rule3'];
     const newRules = ['rule4', 'rule5', 'rule6'];
     const rulesChanges = createRulesChangesJson('test', oldRules, newRules, 1, 1, 1);

--- a/src/backend/tests/projects.utils.test.ts
+++ b/src/backend/tests/projects.utils.test.ts
@@ -2,30 +2,30 @@ import { createRulesChangesJson } from '../src/utils/projects.utils';
 
 describe('CreateRulesChangesJson', () => {
   test('createRulesChangesJson with empty old + new lists', () => {
-    const rulesChanges = createRulesChangesJson('test', [], [], 1, 1, 1);
+    const rulesChanges = createRulesChangesJson('test', [], [], 1, 2, 3);
     expect(rulesChanges.length).toEqual(0);
   });
 
   test('createRulesChangesJson with empty new list and non-empty old list', () => {
     const rules = ['rule1', 'rule2', 'rule3'];
-    const rulesChanges = createRulesChangesJson('test', rules, [], 1, 1, 1);
+    const rulesChanges = createRulesChangesJson('test', rules, [], 1, 2, 3);
     expect(rulesChanges.length).toEqual(3);
     rulesChanges.forEach((r, i) => {
       expect(r.changeRequestId).toEqual(1);
-      expect(r.implementerId).toEqual(1);
-      expect(r.wbsElementId).toEqual(1);
+      expect(r.implementerId).toEqual(2);
+      expect(r.wbsElementId).toEqual(3);
       expect(r.detail).toEqual(`Removed test "${rules[i]}"`);
     });
   });
 
   test('createRulesChangesJson with empty old list and non-empty new list', () => {
     const rules = ['rule1', 'rule2', 'rule3'];
-    const rulesChanges = createRulesChangesJson('test', [], rules, 1, 1, 1);
+    const rulesChanges = createRulesChangesJson('test', [], rules, 1, 2, 3);
     expect(rulesChanges.length).toEqual(3);
     rulesChanges.forEach((r, i) => {
       expect(r.changeRequestId).toEqual(1);
-      expect(r.implementerId).toEqual(1);
-      expect(r.wbsElementId).toEqual(1);
+      expect(r.implementerId).toEqual(2);
+      expect(r.wbsElementId).toEqual(3);
       expect(r.detail).toEqual(`Added new test "${rules[i]}"`);
     });
   });
@@ -33,18 +33,18 @@ describe('CreateRulesChangesJson', () => {
   test('createRulesChangesJson with non-empty old list and non-empty new list', () => {
     const oldRules = ['rule1', 'rule2', 'rule3'];
     const newRules = ['rule4', 'rule5', 'rule6'];
-    const rulesChanges = createRulesChangesJson('test', oldRules, newRules, 1, 1, 1);
+    const rulesChanges = createRulesChangesJson('test', oldRules, newRules, 1, 2, 3);
     expect(rulesChanges.length).toEqual(6);
     rulesChanges.slice(0, 3).forEach((r, i) => {
       expect(r.changeRequestId).toEqual(1);
-      expect(r.implementerId).toEqual(1);
-      expect(r.wbsElementId).toEqual(1);
+      expect(r.implementerId).toEqual(2);
+      expect(r.wbsElementId).toEqual(3);
       expect(r.detail).toEqual(`Removed test "${oldRules[i]}"`);
     });
     rulesChanges.slice(3).forEach((r, i) => {
       expect(r.changeRequestId).toEqual(1);
-      expect(r.implementerId).toEqual(1);
-      expect(r.wbsElementId).toEqual(1);
+      expect(r.implementerId).toEqual(2);
+      expect(r.wbsElementId).toEqual(3);
       expect(r.detail).toEqual(`Added new test "${newRules[i]}"`);
     });
   });

--- a/src/backend/tests/projects.utils.test.ts
+++ b/src/backend/tests/projects.utils.test.ts
@@ -1,0 +1,51 @@
+import { createRulesChangesJson } from '../src/utils/projects.utils';
+
+describe('CreateRulesChangesJson', () => {
+  test('createRulesChangesJson with empty old + new lists', () => {
+    const rulesChanges = createRulesChangesJson('test', [], [], 1, 1, 1);
+    expect(rulesChanges.length).toEqual(0);
+  });
+
+  test('createRulesChangesJson with empty new list and non-empty old list', () => {
+    const rules = ['rule1', 'rule2', 'rule3'];
+    const rulesChanges = createRulesChangesJson('test', rules, [], 1, 1, 1);
+    expect(rulesChanges.length).toEqual(3);
+    rulesChanges.forEach((r, i) => {
+      expect(r.changeRequestId).toEqual(1);
+      expect(r.implementerId).toEqual(1);
+      expect(r.wbsElementId).toEqual(1);
+      expect(r.detail).toEqual(`Removed test "${rules[i]}"`);
+    });
+  });
+
+  test('createRulesChangesJson with empty old list and non-empty new list', () => {
+    const rules = ['rule1', 'rule2', 'rule3'];
+    const rulesChanges = createRulesChangesJson('test', [], rules, 1, 1, 1);
+    expect(rulesChanges.length).toEqual(3);
+    rulesChanges.forEach((r, i) => {
+      expect(r.changeRequestId).toEqual(1);
+      expect(r.implementerId).toEqual(1);
+      expect(r.wbsElementId).toEqual(1);
+      expect(r.detail).toEqual(`Added new test "${rules[i]}"`);
+    });
+  });
+
+  test('createRulesChangesJson with non-empty old list and non-empty new list', () => {
+    const oldRules = ['rule1', 'rule2', 'rule3'];
+    const newRules = ['rule4', 'rule5', 'rule6'];
+    const rulesChanges = createRulesChangesJson('test', oldRules, newRules, 1, 1, 1);
+    expect(rulesChanges.length).toEqual(6);
+    rulesChanges.slice(0, 3).forEach((r, i) => {
+      expect(r.changeRequestId).toEqual(1);
+      expect(r.implementerId).toEqual(1);
+      expect(r.wbsElementId).toEqual(1);
+      expect(r.detail).toEqual(`Removed test "${oldRules[i]}"`);
+    });
+    rulesChanges.slice(3).forEach((r, i) => {
+      expect(r.changeRequestId).toEqual(1);
+      expect(r.implementerId).toEqual(1);
+      expect(r.wbsElementId).toEqual(1);
+      expect(r.detail).toEqual(`Added new test "${newRules[i]}"`);
+    });
+  });
+});


### PR DESCRIPTION
## Changes

Write test cases for `createRulesChangesJson`

## Notes

I'm mainly looking for feedback as I'm not sure this is ready to be merged yet. `createRulesChangesJson` is returning undefined in the tests, and the breakpoints I am setting in the function seem to never be getting hit. I'm not sure whether it's an issue with the tests or something with the setup on my computer, but looking at the tests, I'm not quite sure what the issue with them would be. Just want to make sure I'm not missing something or am otherwise misunderstanding something.

## Test Cases

- Old rules and new rules are both empty
- Old rules is empty and new rules is not
- New rules is empty and old rules is not
- Both old rules and new rules are not empty

## To Do

- [x] Make sure the tests are written correctly

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #253 
