### PR TITLE
#289 hid add proposed solution button for guests

### DIFF
--- a/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionsList.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionsList.tsx
@@ -51,7 +51,7 @@ const ProposedSolutionsList: React.FC<ProposedSolutionsListProps> = ({
 
   return (
     <>
-      {crReviewed === undefined || auth.user?.role !== 'GUEST' ? (
+      {crReviewed === undefined && auth.user?.role !== 'GUEST' ? (
         <Button onClick={() => setShowEditableForm(true)} variant="success" className="mb-3">
           + Add Proposed Solution
         </Button>

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionsList.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionsList.tsx
@@ -51,7 +51,7 @@ const ProposedSolutionsList: React.FC<ProposedSolutionsListProps> = ({
 
   return (
     <>
-      {crReviewed === undefined ? (
+      {crReviewed === undefined || auth.user?.role !== 'GUEST' ? (
         <Button onClick={() => setShowEditableForm(true)} variant="success" className="mb-3">
           + Add Proposed Solution
         </Button>

--- a/src/frontend/src/pages/CreateChangeRequestPage/CreateProposedSolutionsList.tsx
+++ b/src/frontend/src/pages/CreateChangeRequestPage/CreateProposedSolutionsList.tsx
@@ -9,6 +9,7 @@ import { useState } from 'react';
 import { Button, Modal } from 'react-bootstrap';
 import ProposedSolutionView from '../ChangeRequestDetailPage/ProposedSolutionView';
 import styles from '../../stylesheets/pages/ChangeRequestDetailPage/ProposedSolutionsList.module.css';
+import { useAuth } from '../../hooks/Auth.hooks';
 
 interface CreateProposedSolutionsListProps {
   proposedSolutions: ProposedSolution[];
@@ -32,9 +33,13 @@ const CreateProposedSolutionsList: React.FC<CreateProposedSolutionsListProps> = 
 
   return (
     <>
-      <Button onClick={() => setShowEditableForm(true)} variant="success" className="mb-3">
-        + Add Proposed Solution
-      </Button>
+      {useAuth().user?.role !== 'GUEST' ? (
+        <Button onClick={() => setShowEditableForm(true)} variant="success" className="mb-3">
+          + Add Proposed Solution
+        </Button>
+      ) : (
+        ''
+      )}
       <div className={styles.proposedSolutionsList}>
         {proposedSolutions.map((proposedSolution, i) => (
           <ProposedSolutionView


### PR DESCRIPTION
## Changes

Added an if-else statement so that if the user is a 'GUEST', the add proposed solution button would not be visible.

## Notes

Had to refer to the string 'GUEST' instead of the role enum because enum would not function correctly

## Test Cases

Tested logging in with each type of user to ensure the button was visible appropriately.

## Screenshots

<img width="1676" alt="Screen Shot 2022-10-05 at 9 18 17 PM" src="https://user-images.githubusercontent.com/113950200/194192672-8e0c492f-7471-40db-8b7d-581053042da7.png">
<img width="1531" alt="Screen Shot 2022-10-05 at 9 18 25 PM" src="https://user-images.githubusercontent.com/113950200/194192697-389959db-b3bd-4816-a24f-31287255cdd3.png">

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #289
