### PR TITLE
#204: Fixing Dates

### DIFF
--- a/src/backend/src/controllers/work-packages.controllers.ts
+++ b/src/backend/src/controllers/work-packages.controllers.ts
@@ -131,11 +131,9 @@ export const createWorkPackage = async (req: Request, res: Response) => {
   });
 
   if (wbsElem === null) {
-    return res
-      .status(404)
-      .json({
-        message: `Could not find element with wbs number: ${carNumber}.${projectNumber}.${workPackageNumber}`
-      });
+    return res.status(404).json({
+      message: `Could not find element with wbs number: ${carNumber}.${projectNumber}.${workPackageNumber}`
+    });
   }
 
   const { project } = wbsElem;
@@ -419,11 +417,15 @@ export const editWorkPackage = async (req: Request, res: Response) => {
     .concat(expectedActivitiesChangeJson.changes)
     .concat(deliverablesChangeJson.changes);
 
+  // make the date object but add 12 hours so that the time isn't 00:00 to avoid timezone problems
+  const date = new Date(startDate);
+  date.setTime(date.getTime() + 12 * 60 * 60 * 1000);
+
   // update the work package with the input fields
   const updatedWorkPackage = await prisma.work_Package.update({
     where: { wbsElementId },
     data: {
-      startDate: new Date(startDate),
+      startDate: date,
       duration,
       progress,
       wbsElement: {

--- a/src/backend/src/controllers/work-packages.controllers.ts
+++ b/src/backend/src/controllers/work-packages.controllers.ts
@@ -179,6 +179,10 @@ export const createWorkPackage = async (req: Request, res: Response) => {
     return res.status(400).json({ message: 'One of the dependencies was not found.' });
   }
 
+  // make the date object but add 12 hours so that the time isn't 00:00 to avoid timezone problems
+  const date = new Date(startDate);
+  date.setTime(date.getTime() + 12 * 60 * 60 * 1000);
+
   // add to the database
   await prisma.work_Package.create({
     data: {
@@ -198,7 +202,7 @@ export const createWorkPackage = async (req: Request, res: Response) => {
         }
       },
       project: { connect: { projectId } },
-      startDate: new Date(startDate),
+      startDate: date,
       duration,
       orderInProject: project.workPackages.length + 1,
       dependencies: { connect: dependenciesIds.map((ele) => ({ wbsElementId: ele })) },

--- a/src/frontend/src/utils/Pipes.ts
+++ b/src/frontend/src/utils/Pipes.ts
@@ -63,19 +63,19 @@ export const emDashPipe = (str: string) => {
 /**
  * Return a given date as a string in the local en-US format,
  * with single digit numbers starting with a zero.
+ *
+ * Prisma sends date in UTC but TypeScript assumes it's in your local time,
+ * so to get around that we do the toDateString() of the time and pass it into the Date constructor
+ * where the constructor assumes it's in UTC and makes the correct Date object finally
  */
 export const datePipe = (date: Date) => {
+  date = new Date(date.toDateString());
   return date.toLocaleDateString('en-US', {
     day: '2-digit',
     month: '2-digit',
     year: 'numeric',
     timeZone: 'UTC'
   });
-};
-
-/** returns a given number as a string with a percent sign */
-export const percentPipe = (percent: number) => {
-  return `${percent}%`;
 };
 
 export const numberParamPipe = (param: string | null) => {

--- a/src/frontend/src/utils/Pipes.ts
+++ b/src/frontend/src/utils/Pipes.ts
@@ -78,6 +78,11 @@ export const datePipe = (date: Date) => {
   });
 };
 
+/** returns a given number as a string with a percent sign */
+export const percentPipe = (percent: number) => {
+  return `${percent}%`;
+};
+
 export const numberParamPipe = (param: string | null) => {
   if (!param) return null;
   try {


### PR DESCRIPTION
## Changes

1. makes the date pipe do the right conversions (very weird just trust me or read my documentation)
2. makes the work package setting the date not have weird not have weird UTC to EDT issues by making it be midday instead of 00:00. basically when you edit a wp to start on 10/08/2022 that gets set as 10/08/2022 at 00:00 am UTC in the db. Then, when this gets sent back to the frontend, it converts to EDT which is -4 hours so it bcomes 10/07/2022 at 8:00 pm which is weird so adding 12 hours gets rid of this problem with most or all time zones. idk it works for all the main ones

overall pretty happy with this because i think it covers the main issues. Probably still some more to it but whatever, should get rid of the biggest weird stuff

## Notes

## Todo
- if you edit a work package but it goes from the same day to the same day it shouldn't log that as a change but it will because it will change the date from an actual time to 00:00 sometimes. might make this its own ticket because i think that is just a problem with seed data?

Closes #204