### PR TITLE
#264 backend test CreateWorkPackage endpoint part 2

### DIFF
--- a/src/backend/tests/test-data/change-requests.test-data.ts
+++ b/src/backend/tests/test-data/change-requests.test-data.ts
@@ -19,3 +19,23 @@ export const changeBatmobile = {
   reviewerId: 1,
   reviewNotes: 'white sucks'
 };
+
+export const unreviewedCr = {
+  crId: 69,
+  submitterId: 1,
+  wbsElementId: 65,
+  type: CR_Type.DEFINITION_CHANGE,
+  changes: [
+    {
+      changeRequestId: 1,
+      implementerId: 1,
+      wbsElementId: 65,
+      detail: "this won't get reviewed"
+    }
+  ],
+  dateSubmitted: new Date('11/24/2020'),
+  dateReviewed: null,
+  accepted: null,
+  reviewerId: null,
+  reviewNotes: null
+};

--- a/src/backend/tests/work-packages.test.ts
+++ b/src/backend/tests/work-packages.test.ts
@@ -8,6 +8,7 @@ import { wonderwoman } from './test-data/users.test-data';
 import { createWorkPackagePayload } from './test-data/work-packages.test-data';
 import { changeBatmobile, unreviewedCr } from './test-data/change-requests.test-data';
 import { getChangeRequestReviewState } from '../src/utils/projects.utils';
+
 const app = express();
 app.use(express.json());
 app.use('/', workPackageRouter);
@@ -25,6 +26,7 @@ describe('Work Packages', () => {
   test('createWorkPackage fails if WBS number does not represent a project', async () => {
     jest.spyOn(prisma.user, 'findUnique').mockResolvedValue(batman);
     jest.spyOn(prisma.change_Request, 'findUnique').mockResolvedValue(changeBatmobile);
+    mockGetChangeRequestReviewState.mockResolvedValue(true);
     const proj = {
       ...createWorkPackagePayload,
       projectWbsNum: {
@@ -45,6 +47,7 @@ describe('Work Packages', () => {
     jest.spyOn(prisma.change_Request, 'findUnique').mockResolvedValue(changeBatmobile);
     jest.spyOn(prisma.wBS_Element, 'findUnique').mockResolvedValueOnce(someProject);
     jest.spyOn(prisma.wBS_Element, 'findUnique').mockResolvedValueOnce(null);
+    mockGetChangeRequestReviewState.mockResolvedValue(true);
 
     const res = await request(app).post('/create').send(createWorkPackagePayload);
 

--- a/src/backend/tests/work-packages.test.ts
+++ b/src/backend/tests/work-packages.test.ts
@@ -6,7 +6,8 @@ import { batman } from './test-data/users.test-data';
 import { someProject } from './test-data/projects.test-data';
 import { wonderwoman } from './test-data/users.test-data';
 import { createWorkPackagePayload } from './test-data/work-packages.test-data';
-import { changeBatmobile } from './test-data/change-requests.test-data';
+import { changeBatmobile, unreviewedCr } from './test-data/change-requests.test-data';
+import { getChangeRequestReviewState } from '../src/utils/projects.utils';
 const app = express();
 app.use(express.json());
 app.use('/', workPackageRouter);
@@ -65,5 +66,17 @@ describe('Work Packages', () => {
     expect(prisma.user.findUnique).toHaveBeenCalledTimes(1);
     expect(res.statusCode).toBe(404);
     expect(res.body.message).toBe(`User with id #${createWorkPackagePayload.userId} not found!`);
+  });
+
+  test('getChangeRequestReviewState returns null when changeRequest is not found', async () => {
+    jest.spyOn(prisma.change_Request, 'findUnique').mockResolvedValue(null);
+    const result = await getChangeRequestReviewState(1);
+    expect(result).toEqual(null);
+  });
+
+  test('getChangeRequestReviewState returns false when changeRequest has not been reviewed', async () => {
+    jest.spyOn(prisma.change_Request, 'findUnique').mockResolvedValue(unreviewedCr);
+    const result = await getChangeRequestReviewState(1);
+    expect(result).toEqual(false);
   });
 });


### PR DESCRIPTION
## Changes

Added tests for edge cases of getChangeRequestReviewState function
## Test Cases

- getChangeRequestReviewState returns null when changeRequest is not found
- getChangeRequestReviewState returns false when changeRequest has not been reviewed

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #264 (issue #264)
