### PR TITLE
#232: Make Risks Less Restrictive

### DIFF
--- a/src/backend/src/controllers/risks.controllers.ts
+++ b/src/backend/src/controllers/risks.controllers.ts
@@ -31,6 +31,8 @@ export const createRisk = async (req: Request, res: Response) => {
     if (createdByUser.role === Role.GUEST) {
       return res.status(401).json({ message: 'Access Denied' });
     }
+  } else {
+    return res.status(404).json({ message: 'User Not Found' });
   }
 
   const createdRisk = await prisma.risk.create({


### PR DESCRIPTION
## Changes

Currently, risks are too restrictive. Let's change that.

Creating risks previously required the user to be one of:

- APP_ADMIN, ADMIN, or LEADERSHIP
- The project lead or project manager of the project for the risk to be added to

This will be changed to be open to anyone who is not a GUEST.

Deleting risks had the same requirement as creating risks - this will be changed so that you can delete your own risk, no matter your role.

## Test Cases
Conditions:

- Project 1 has 2 risks, both created by user `1`. The project lead is user `4`, and manager is user `5`. 
- User `6` is a MEMBER, User `7` is a GUEST.

### Create Risk

#### Success 
Sending a POST request to `/risks/create` endpoint with:
```JSON
{
	"projectId": 1,
	"createdById": 6,
	"detail": "this is a test."
}
```

The result should be:
`Status 200: OK`
```JSON
{
	"message": "Successfully created risk #9b4ca6c2-1e0a-463e-a95c-c1f6f3eb5876."
}
```
And should have a new risk with the provided ID.

#### Failure
Sending a POST request to `/risks/create` endpoint with:
```JSON
{
	"projectId": 1,
	"createdById": 7,
	"detail": "this is a test that should fail."
}
```

The result should be:
`Status 401: Unauthorized`
```JSON
{
	"message": "Access Denied"
}
```
### Delete Risk

#### Success
Sending a POST request to `/risks/delete` endpoint with:
```JSON
{
	"riskId": "e288b8f2-849c-46e9-aedf-cff4cc4dc132",
	"deletedByUserId": 6
}
```

The result should be:
`Status 200: OK`
```JSON
{
	"id": "e288b8f2-849c-46e9-aedf-cff4cc4dc132",
	"project": {
		"id": 1,
		"name": "Impact Attenuator",
		"wbsNum": {
			"carNumber": 1,
			"projectNumber": 1,
			"workPackageNumber": 0
		}
	},
	"detail": "this should be deleted by user 6.",
	"isResolved": false,
	"dateDeleted": "2022-10-11T07:58:46.611Z",
	"dateCreated": "2022-10-11T07:54:03.946Z",
	"createdBy": {
		"userId": 6,
		"firstName": "Emily",
		"lastName": "Bendara",
		"email": "bendara.e@husky.neu.edu",
		"emailId": "bendara.e",
		"role": "MEMBER"
	},
	"deletedBy": {
		"userId": 6,
		"firstName": "Emily",
		"lastName": "Bendara",
		"email": "bendara.e@husky.neu.edu",
		"emailId": "bendara.e",
		"role": "MEMBER"
	}
}
```
And the risk should be marked as `deleted` (`dateDeleted`, `deletedByUserId`, and `deletedBy` should be populated). 

#### Failure
Sending a POST request to `/risks/delete` endpoint with:
```JSON
{
	"riskId": "e288b8f2-849c-46e9-aedf-cff4cc4dc132",
	"deletedByUserId": 7
}
```
The result should be:
`Status 401: Unauthorized`
```JSON
{
	"message": "Access Denied"
}
```
## Screenshots

### Create

#### Starting Data 
![image](https://user-images.githubusercontent.com/17571655/195026079-7e6a7f12-48bd-438f-b035-64c9a74a9a47.png)

#### Success
![image](https://user-images.githubusercontent.com/17571655/195028613-05ca8de1-111f-4d30-a37b-736821926dcf.png)
![image](https://user-images.githubusercontent.com/17571655/195028529-73931088-0352-4245-aa8c-301a8bd1999e.png)

#### Failure
![image](https://user-images.githubusercontent.com/17571655/195030116-7916dda9-6725-44e1-b600-6f60fea1905d.png)
![image](https://user-images.githubusercontent.com/17571655/195030742-68fafc38-48bd-4a03-a778-716db39e8a94.png)

### Delete

#### Starting Data
![image](https://user-images.githubusercontent.com/17571655/195031380-e2f0e41d-15c1-47fe-a0a0-9b798588f450.png)

#### Success
![image](https://user-images.githubusercontent.com/17571655/195032705-41fa2d77-e295-43f3-9404-3085ce2b9dba.png)
![image](https://user-images.githubusercontent.com/17571655/195032758-f77b2ae0-a278-46d6-a7b4-d92756bde8a7.png)

#### Failure
![image](https://user-images.githubusercontent.com/17571655/195031712-fe8cb62d-4cfa-4c26-a51a-dc99a924d749.png)
![image](https://user-images.githubusercontent.com/17571655/195031764-8e40e5e6-d2f6-43fd-854f-a99fab0d263d.png)

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #232 
