### PR TITLE
#190 - Unchecking fires a Confirmation Modal

### DIFF
--- a/src/frontend/src/components/CheckList.tsx
+++ b/src/frontend/src/components/CheckList.tsx
@@ -4,9 +4,9 @@
  */
 
 import PageBlock from '../layouts/PageBlock';
-import { Form } from 'react-bootstrap';
+import { Button, Form, Modal } from 'react-bootstrap';
 import styles from '../stylesheets/components/check-list.module.css';
-import { ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
 import { useCheckDescriptionBullet } from '../hooks/description-bullets.hooks';
 import { useAuth } from '../hooks/auth.hooks';
 
@@ -25,6 +25,13 @@ interface CheckListProps {
 const CheckList: React.FC<CheckListProps> = ({ title, headerRight, items }) => {
   const auth = useAuth();
   const { mutateAsync } = useCheckDescriptionBullet();
+  const [showConfirm, setShowConfirm] = useState<boolean>(false);
+  const [currIdx, setCurrIdx] = useState<number>(-1);
+
+  const handleUncheck = async (idx: number) => {
+    await handleCheck(idx);
+    setShowConfirm(false);
+  };
 
   const handleCheck = async (idx: number) => {
     await mutateAsync({ userId: auth.user!.userId, descriptionId: items[idx].id });
@@ -42,11 +49,33 @@ const CheckList: React.FC<CheckListProps> = ({ title, headerRight, items }) => {
                 </p>
               }
               checked={check.resolved}
-              onChange={() => handleCheck(idx)}
+              onChange={() => {
+                if (check.resolved) {
+                  setCurrIdx(idx);
+                  setShowConfirm(true);
+                } else {
+                  handleCheck(idx);
+                }
+              }}
             />
           </div>
         ))}
       </Form>
+      {showConfirm ? (
+        <Modal size="lg" centered show={showConfirm} onHide={() => setShowConfirm(false)}>
+          <Modal.Header closeButton>
+            <Modal.Title> Are you sure you want to mark this completed task as NOT completed?</Modal.Title>
+          </Modal.Header>
+          <Modal.Footer className="justify-content-around">
+            <Button onClick={() => handleUncheck(currIdx)} variant="success" type="submit" className="mb-3">
+              Yes
+            </Button>
+            <Button onClick={() => setShowConfirm(false)} variant="danger" className="mb-3">
+              No
+            </Button>
+          </Modal.Footer>
+        </Modal>
+      ) : null}
     </PageBlock>
   );
 };


### PR DESCRIPTION
## Changes

Unchecking a bullet now fires a Confirmation Modal.

## Screenshots

![Screenshot 2022-10-19 141310](https://user-images.githubusercontent.com/80832201/196771573-be2a8b42-7372-4757-8799-68aaba7ccc31.png)

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #190 
