### PR TITLE
#276 - Converted Project Actions Button from Boostrap to MUI

### DIFF
--- a/src/frontend/src/layouts/PageTitle/PageTitle.tsx
+++ b/src/frontend/src/layouts/PageTitle/PageTitle.tsx
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import { ReactNode } from 'react';
 import { LinkItem } from '../../utils/Types';
 import PageBreadcrumbs from './PageBreadcrumbs';
@@ -25,11 +25,13 @@ const PageTitle: React.FC<PageTitleProps> = ({ title, previousPages, actionButto
     <div>
       <div>
         <PageBreadcrumbs currentPageTitle={title} previousPages={previousPages} />
-        <Typography variant="h4" fontSize={30} sx={{ py: 1 }}>
-          {title}
-        </Typography>
+        <Box sx={{ display: 'flex', flexDirection: 'row' }}>
+          <Typography variant="h4" fontSize={30} sx={{ flexGrow: 1 }}>
+            {title}
+          </Typography>
+          {actionButton}
+        </Box>
       </div>
-      <div>{actionButton}</div>
     </div>
   );
 };

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
@@ -3,7 +3,6 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { Dropdown, DropdownButton } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 import { WorkPackage, Project } from 'shared';
 import { wbsPipe } from '../../../utils/Pipes';
@@ -18,6 +17,10 @@ import RulesList from './RulesList';
 import RiskLog from './RiskLog';
 import { routes } from '../../../utils/Routes';
 import ProjectGantt from './ProjectGantt';
+import { NERButton } from '../../../components/NERButton';
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import { Menu, MenuItem } from '@mui/material';
+import { useState } from 'react';
 
 interface ProjectViewContainerProps {
   proj: Project;
@@ -28,22 +31,53 @@ const ProjectViewContainer: React.FC<ProjectViewContainerProps> = ({ proj, enter
   const auth = useAuth();
   proj.workPackages.sort((a, b) => a.startDate.getTime() - b.startDate.getTime());
 
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const dropdownOpen = Boolean(anchorEl);
+
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleDropdownClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleClickEdit = () => {
+    enterEditMode();
+    handleDropdownClose();
+  };
+
   const isGuest = auth.user?.role === 'GUEST';
   const editBtn = (
-    <Dropdown.Item onClick={enterEditMode} disabled={isGuest}>
+    <MenuItem onClick={handleClickEdit} disabled={isGuest}>
       Edit
-    </Dropdown.Item>
+    </MenuItem>
   );
   const createCRBtn = (
-    <Dropdown.Item as={Link} to={routes.CHANGE_REQUESTS_NEW_WITH_WBS + wbsPipe(proj.wbsNum)} disabled={isGuest}>
+    <MenuItem
+      component={Link}
+      to={routes.CHANGE_REQUESTS_NEW_WITH_WBS + wbsPipe(proj.wbsNum)}
+      disabled={isGuest}
+      onClick={handleDropdownClose}
+    >
       Request Change
-    </Dropdown.Item>
+    </MenuItem>
   );
   const projectActionsDropdown = (
-    <DropdownButton id="project-actions-dropdown" title="Actions">
-      {editBtn}
-      {createCRBtn}
-    </DropdownButton>
+    <div>
+      <NERButton
+        endIcon={<ArrowDropDownIcon style={{ fontSize: 28 }} />}
+        variant="contained"
+        id="project-actions-dropdown"
+        onClick={handleClick}
+      >
+        Actions
+      </NERButton>
+      <Menu open={dropdownOpen} anchorEl={anchorEl} onClose={handleDropdownClose}>
+        {editBtn}
+        {createCRBtn}
+      </Menu>
+    </div>
   );
 
   return (


### PR DESCRIPTION
## Changes

Converted Project Details Actions Button from Boostrap to MUI

## Screenshots

![image](https://user-images.githubusercontent.com/80832201/198157289-453b7186-90d9-4e3f-a847-92d3b8270b26.png)

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #276 
