### PR TITLE
#379-calculated-WP-progress-if-no-bullets

### DIFF
--- a/src/backend/src/utils/work-packages.utils.ts
+++ b/src/backend/src/utils/work-packages.utils.ts
@@ -31,6 +31,9 @@ export const calculateWorkPackageProgress = (
   expectedActivities: Description_Bullet[]
 ) => {
   const bullets = deliverables.concat(expectedActivities);
+  if (bullets.length === 0) {
+    return 0;
+  }
   return Math.floor((bullets.filter((b) => b.dateTimeChecked).length / bullets.length) * 100);
 };
 

--- a/src/backend/src/utils/work-packages.utils.ts
+++ b/src/backend/src/utils/work-packages.utils.ts
@@ -31,10 +31,7 @@ export const calculateWorkPackageProgress = (
   expectedActivities: Description_Bullet[]
 ) => {
   const bullets = deliverables.concat(expectedActivities);
-  if (bullets.length === 0) {
-    return 0;
-  }
-  return Math.floor((bullets.filter((b) => b.dateTimeChecked).length / bullets.length) * 100);
+  return bullets.length === 0 ? 0 : Math.floor((bullets.filter((b) => b.dateTimeChecked).length / bullets.length) * 100);
 };
 
 export const workPackageTransformer = (wpInput: Prisma.Work_PackageGetPayload<typeof wpQueryArgs>) => {

--- a/src/backend/tests/work-packages.test.ts
+++ b/src/backend/tests/work-packages.test.ts
@@ -8,6 +8,7 @@ import { wonderwoman } from './test-data/users.test-data';
 import { createWorkPackagePayload } from './test-data/work-packages.test-data';
 import { changeBatmobile, unreviewedCr } from './test-data/change-requests.test-data';
 import { getChangeRequestReviewState } from '../src/utils/projects.utils';
+import { calculateWorkPackageProgress } from '../src/utils/work-packages.utils';
 
 const app = express();
 app.use(express.json());
@@ -95,5 +96,15 @@ describe('Work Packages', () => {
     expect(prisma.user.findUnique).toHaveBeenCalledTimes(1);
     expect(res.statusCode).toBe(400);
     expect(res.body.message).toBe(`Cannot implement an unreviewed change request`);
+  });
+
+  test('calculateWorkPackageProgress', async () => {
+    const proj = {
+      ...createWorkPackagePayload,
+      expectedActivities: [],
+      deliverables: []
+    };
+
+    expect(calculateWorkPackageProgress(proj.expectedActivities, proj.deliverables)).toBe(0);
   });
 });


### PR DESCRIPTION
## Changes

If there is no bullets, returned 0 for progress.
Created test to make sure it worked.

## Test Cases

- if it returns zero when there is no bullets

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #379
