### PR TITLE
#325 - If a Work Package is not active then as per the UI checkboxes …

### DIFF
--- a/src/frontend/src/components/CheckList.tsx
+++ b/src/frontend/src/components/CheckList.tsx
@@ -20,9 +20,10 @@ interface CheckListProps {
   title: string;
   headerRight?: ReactNode;
   items: CheckListItem[];
+  isDisabled: boolean;
 }
 
-const CheckList: React.FC<CheckListProps> = ({ title, headerRight, items }) => {
+const CheckList: React.FC<CheckListProps> = ({ title, headerRight, items, isDisabled }) => {
   const auth = useAuth();
   const { mutateAsync } = useCheckDescriptionBullet();
 
@@ -42,6 +43,7 @@ const CheckList: React.FC<CheckListProps> = ({ title, headerRight, items }) => {
                 </p>
               }
               checked={check.resolved}
+              disabled={isDisabled}
               onChange={() => handleCheck(idx)}
             />
           </div>

--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.tsx
@@ -48,11 +48,7 @@ const WorkPackageViewContainer: React.FC<WorkPackageViewContainerProps> = ({
     </Dropdown.Item>
   );
   const stageGateBtn = (
-    <Dropdown.Item
-      as={Button}
-      onClick={() => setShowStageGateModal(true)}
-      disabled={!allowStageGate}
-    >
+    <Dropdown.Item as={Button} onClick={() => setShowStageGateModal(true)} disabled={!allowStageGate}>
       Stage Gate
     </Dropdown.Item>
   );
@@ -100,6 +96,7 @@ const WorkPackageViewContainer: React.FC<WorkPackageViewContainerProps> = ({
           .map((ea) => {
             return { ...ea, resolved: !!ea.userChecked };
           })}
+        isDisabled={workPackage.status !== WbsElementStatus.Active}
       />
       <CheckList
         title={'Deliverables'}
@@ -108,6 +105,7 @@ const WorkPackageViewContainer: React.FC<WorkPackageViewContainerProps> = ({
           .map((del) => {
             return { ...del, resolved: !!del.userChecked };
           })}
+        isDisabled={workPackage.status !== WbsElementStatus.Active}
       />
       <ChangesList changes={workPackage.changes} />
       {showActivateModal && (

--- a/src/frontend/src/tests/components/CheckList.test.tsx
+++ b/src/frontend/src/tests/components/CheckList.test.tsx
@@ -54,7 +54,7 @@ describe('Rendering CheckList Component', () => {
   it('Renders the CheckList items as enabled when isDisabled is false', () => {
     renderComponent(testItems, 'testTitle', false);
     const checkboxes = screen.getAllByRole('checkbox');
-    for (const c of checkboxes as Array<HTMLElement>) {
+    for (const c of checkboxes) {
       expect(c).toBeEnabled();
     }
   });
@@ -62,7 +62,7 @@ describe('Rendering CheckList Component', () => {
   it('Renders the CheckList items as disabled when isDisabled is true', () => {
     renderComponent(testItems, 'testTitle', true);
     const checkboxes = screen.getAllByRole('checkbox');
-    for (const c of checkboxes as Array<HTMLElement>) {
+    for (const c of checkboxes) {
       expect(c).toBeDisabled();
     }
   });

--- a/src/frontend/src/tests/components/CheckList.test.tsx
+++ b/src/frontend/src/tests/components/CheckList.test.tsx
@@ -13,6 +13,8 @@ import * as descBulletHooks from '../../hooks/description-bullets.hooks';
 import { mockAuth } from '../test-support/test-data/test-utils.stub';
 import { exampleAdminUser } from '../test-support/test-data/users.stub';
 import { mockCheckDescBulletReturnValue } from '../test-support/mock-hooks';
+import FormCheckInput from 'react-bootstrap/esm/FormCheckInput';
+import { check } from 'prettier';
 
 const testItems: CheckListItem[] = [
   { id: 1, detail: 'testItem1', resolved: false },
@@ -53,15 +55,17 @@ describe('Rendering CheckList Component', () => {
 
   it('Renders the CheckList items as enabled when isDisabled is false', () => {
     renderComponent(testItems, 'testTitle', false);
-    expect(screen.getByText('testItem1')).toBeEnabled();
-    expect(screen.getByText('testItem2')).toBeEnabled();
+    const checkboxes = screen.getAllByRole('checkbox');
+    for (var c of checkboxes as Array<HTMLElement>) {
+      expect(c).toBeEnabled();
+    }
   });
 
   it('Renders the CheckList items as disabled when isDisabled is true', () => {
     renderComponent(testItems, 'testTitle', true);
-    expect(screen.getByText('testItem1')).toBeDisabled();
-    expect(screen.getByText('testItem2')).toBeDisabled();
-    // expect(screen.getByText('testItem1')).toBeDisabled();
-    // expect(screen.getByText('testItem2')).toBeDisabled();
+    const checkboxes = screen.getAllByRole('checkbox');
+    for (var c of checkboxes as Array<HTMLElement>) {
+      expect(c).toBeDisabled();
+    }
   });
 });

--- a/src/frontend/src/tests/components/CheckList.test.tsx
+++ b/src/frontend/src/tests/components/CheckList.test.tsx
@@ -22,14 +22,15 @@ const testItems: CheckListItem[] = [
 /**
  * Sets up the component under test with the desired values and renders it.
  */
-const renderComponent = (items: CheckListItem[] = [], title: string = '') => {
+const renderComponent = (items: CheckListItem[] = [], title: string = '', isDisabled: boolean) => {
   const RouterWrapper = routerWrapperBuilder({});
   return render(
     <RouterWrapper>
-      <CheckList items={items} title={title} />
+      <CheckList items={items} title={title} isDisabled={isDisabled} />
     </RouterWrapper>
   );
 };
+
 describe('Rendering CheckList Component', () => {
   beforeEach(() => {
     jest.spyOn(themeHooks, 'useTheme').mockReturnValue(themes[0]);
@@ -38,16 +39,29 @@ describe('Rendering CheckList Component', () => {
   });
 
   it('Renders the CheckList correctly when empty', () => {
-    renderComponent([], 'testTitle');
+    renderComponent([], 'testTitle', false);
     expect(screen.getByText('testTitle')).toBeInTheDocument();
     expect(screen.queryByText('testItem1')).not.toBeInTheDocument();
     expect(screen.queryByText('testItem2')).not.toBeInTheDocument();
   });
 
   it('Renders the CheckList correctly when not empty', () => {
-    renderComponent(testItems, 'testTitle');
+    renderComponent(testItems, 'testTitle', false);
     expect(screen.getByText('testTitle')).toBeInTheDocument();
     expect(screen.getByText('testItem1')).toBeInTheDocument();
-    expect(screen.getByText('testItem2')).toBeInTheDocument();
+  });
+
+  it('Renders the CheckList items as enabled when isDisabled is false', () => {
+    renderComponent(testItems, 'testTitle', false);
+    expect(screen.getByText('testItem1')).toBeEnabled();
+    expect(screen.getByText('testItem2')).toBeEnabled();
+  });
+
+  it('Renders the CheckList items as disabled when isDisabled is true', () => {
+    renderComponent(testItems, 'testTitle', true);
+    expect(screen.getByText('testItem1')).toBeDisabled();
+    expect(screen.getByText('testItem2')).toBeDisabled();
+    // expect(screen.getByText('testItem1')).toBeDisabled();
+    // expect(screen.getByText('testItem2')).toBeDisabled();
   });
 });

--- a/src/frontend/src/tests/components/CheckList.test.tsx
+++ b/src/frontend/src/tests/components/CheckList.test.tsx
@@ -13,8 +13,6 @@ import * as descBulletHooks from '../../hooks/description-bullets.hooks';
 import { mockAuth } from '../test-support/test-data/test-utils.stub';
 import { exampleAdminUser } from '../test-support/test-data/users.stub';
 import { mockCheckDescBulletReturnValue } from '../test-support/mock-hooks';
-import FormCheckInput from 'react-bootstrap/esm/FormCheckInput';
-import { check } from 'prettier';
 
 const testItems: CheckListItem[] = [
   { id: 1, detail: 'testItem1', resolved: false },
@@ -56,7 +54,7 @@ describe('Rendering CheckList Component', () => {
   it('Renders the CheckList items as enabled when isDisabled is false', () => {
     renderComponent(testItems, 'testTitle', false);
     const checkboxes = screen.getAllByRole('checkbox');
-    for (var c of checkboxes as Array<HTMLElement>) {
+    for (const c of checkboxes as Array<HTMLElement>) {
       expect(c).toBeEnabled();
     }
   });
@@ -64,7 +62,7 @@ describe('Rendering CheckList Component', () => {
   it('Renders the CheckList items as disabled when isDisabled is true', () => {
     renderComponent(testItems, 'testTitle', true);
     const checkboxes = screen.getAllByRole('checkbox');
-    for (var c of checkboxes as Array<HTMLElement>) {
+    for (const c of checkboxes as Array<HTMLElement>) {
       expect(c).toBeDisabled();
     }
   });

--- a/src/frontend/src/tests/test-support/test-data/work-packages.stub.ts
+++ b/src/frontend/src/tests/test-support/test-data/work-packages.stub.ts
@@ -12,12 +12,7 @@ import {
   exampleProjectLeadUser,
   exampleProjectManagerUser
 } from './users.stub';
-import {
-  exampleWbsProject1,
-  exampleWbsProject2,
-  exampleWbsWorkPackage1,
-  exampleWbsWorkPackage2
-} from './wbs-numbers.stub';
+import { exampleWbsProject1, exampleWbsProject2, exampleWbsWorkPackage1, exampleWbsWorkPackage2 } from './wbs-numbers.stub';
 
 export const exampleWorkPackage1: WorkPackage = {
   id: 1,
@@ -38,8 +33,7 @@ export const exampleWorkPackage1: WorkPackage = {
   expectedActivities: [
     {
       id: 1,
-      detail:
-        'Assess the bodywork captsone and determine what can be learned from their deliverables',
+      detail: 'Assess the bodywork captsone and determine what can be learned from their deliverables',
       dateAdded: new Date('11/15/20')
     },
     {
@@ -193,8 +187,4 @@ export const exampleWorkPackage3: WorkPackage = {
   ]
 };
 
-export const exampleAllWorkPackages: WorkPackage[] = [
-  exampleWorkPackage1,
-  exampleWorkPackage2,
-  exampleWorkPackage3
-];
+export const exampleAllWorkPackages: WorkPackage[] = [exampleWorkPackage1, exampleWorkPackage2, exampleWorkPackage3];


### PR DESCRIPTION
## Changes

I added a `isDisabled` prop to the CheckList component which would determine whether the checkbox is disabled or not by being what the `disabled` attribute of the checkbox was set to. I also went in and made sure that the checklist in `WorkPackageViewContainer.tsx` had its values disabled based on the project status. 

## Notes

While the UI seems to reflect the new changes, the jest tests do not seem to detect that an item is disabled when `isDisabled` is set to true. This is the only roadblock I have and there is a good chance I'm constructing the tests incorrectly.

## Test Cases

**So far only the enabled test case seems to work on jest, however both test cases seem to work on the website.**

 - Test items have `isDisabled` set to false.
 - Test items have `isDisabled` set to true

## Screenshots

Here's the checkboxes disabled in an inactive WP: 

![image](https://user-images.githubusercontent.com/97998577/198503115-f18bc72d-442d-4b22-adbb-d2838e418f6b.png)

Here they are enabled in an active WP:

![image](https://user-images.githubusercontent.com/97998577/198503276-6da2323c-7929-4485-86fe-5244d928401d.png)

## To Do

_Any remaining things that need to get done_

- [ ] Verify the jest tests are all working, fix any errors I may be making with these tests.

## Checklist

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #325 
