### PR TITLE
#336 Sort items before passing to checklist

### DIFF
--- a/src/frontend/src/components/CheckList.tsx
+++ b/src/frontend/src/components/CheckList.tsx
@@ -30,6 +30,14 @@ const CheckList: React.FC<CheckListProps> = ({ title, headerRight, items }) => {
     await mutateAsync({ userId: auth.user!.userId, descriptionId: items[idx].id });
   };
 
+  items.sort((a: CheckListItem, b: CheckListItem) => {
+    if (a.resolved !== b.resolved) {
+      return a.resolved ? 1 : -1;
+    }
+
+    return a.detail.localeCompare(b.detail);
+  });
+
   return (
     <PageBlock title={title} headerRight={headerRight}>
       <Form>


### PR DESCRIPTION
## Changes

Added custom sort function ensure items being properly sorted, first based on whether bullet point is checked, and then based on alphanumeric order. Sorting based on resolved parameter ensures that even if bullet unchecked after being checked, will sort properly

## Screenshots

Pre-Change:
![image](https://user-images.githubusercontent.com/83421421/200154337-6239a052-ac9f-40dc-a7fd-cbd61fa23ede.png)
Post-Change:
![image](https://user-images.githubusercontent.com/83421421/200154319-1d658d5f-3f9c-4345-888b-f4efffdd361d.png)

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #336
