### PR TITLE
#22: Add text wrapping to Change Requests table

### DIFF
--- a/src/frontend/src/pages/ChangeRequestsPage/ChangeRequestsTableView.tsx
+++ b/src/frontend/src/pages/ChangeRequestsPage/ChangeRequestsTableView.tsx
@@ -35,56 +35,64 @@ const ChangeRequestsTableView: React.FC<ChangeRequestsTableProps> = ({ changeReq
       dataField: 'id',
       text: 'ID',
       align: 'center',
-      sort: true
+      sort: true,
+      headerStyle: { overflowWrap: 'anywhere' }
     },
     {
       headerAlign: 'center',
       dataField: 'dateSubmitted',
       text: 'Date Submitted',
       align: 'left',
-      sort: true
+      sort: true,
+      headerStyle: { overflowWrap: 'anywhere' }
     },
     {
       headerAlign: 'center',
       dataField: 'submitterName',
       text: 'Submitter',
       align: 'left',
-      sort: true
+      sort: true,
+      headerStyle: { overflowWrap: 'anywhere' }
     },
     {
       headerAlign: 'center',
       dataField: 'wbsNum',
       text: 'WBS #',
       align: 'left',
-      sort: true
+      sort: true,
+      headerStyle: { overflowWrap: 'anywhere' }
     },
     {
       headerAlign: 'center',
       dataField: 'type',
       text: 'Type',
       align: 'left',
-      sort: true
+      sort: true,
+      headerStyle: { overflowWrap: 'anywhere' }
     },
     {
       headerAlign: 'center',
       dataField: 'dateReviewed',
       text: 'Reviewed',
       align: 'left',
-      sort: true
+      sort: true,
+      headerStyle: { overflowWrap: 'anywhere' }
     },
     {
       headerAlign: 'center',
       dataField: 'accepted',
       text: 'Accepted',
       align: 'center',
-      sort: true
+      sort: true,
+      headerStyle: { overflowWrap: 'anywhere' }
     },
     {
       headerAlign: 'center',
       dataField: 'dateImplemented',
       text: 'Implemented',
       align: 'left',
-      sort: true
+      sort: true,
+      headerStyle: { overflowWrap: 'anywhere' }
     }
   ];
 
@@ -115,7 +123,7 @@ const ChangeRequestsTableView: React.FC<ChangeRequestsTableProps> = ({ changeReq
         defaultSorted={defaultSort}
         rowEvents={rowEvents}
         noDataIndication="No Change Requests to Display"
-        rowStyle={{ cursor: 'pointer' }}
+        rowStyle={{ cursor: 'pointer', overflowWrap: 'anywhere' }}
       />
     </>
   );


### PR DESCRIPTION
## Changes

Before, if the text didn't fit within the cell of the Change Requests table, the text would overflow onto the next column. Now, the text wraps and will go onto a new line if it overflows.

## Screenshots

Full screen:
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/15839864/200184214-33f562b3-0605-403f-a774-ddd0ecbef0c2.png">

Smallest window:
<img width="498" alt="image" src="https://user-images.githubusercontent.com/15839864/200184261-37e36a25-538f-4ce1-9cfb-5f1dba7f6596.png">

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #22
