### PR TITLE
#21- Add text wrapping to Projects table

### DIFF
--- a/src/frontend/src/pages/ProjectsPage/ProjectsTable.tsx
+++ b/src/frontend/src/pages/ProjectsPage/ProjectsTable.tsx
@@ -86,28 +86,32 @@ const ProjectsTable: React.FC<DisplayProjectProps> = ({ allProjects }: DisplayPr
       text: 'WBS #',
       align: 'center',
       sort: true,
-      sortFunc: wbsNumSort
+      sortFunc: wbsNumSort,
+      headerStyle: { overflowWrap: 'anywhere' }
     },
     {
       headerAlign: 'center',
       dataField: 'name',
       text: 'Name',
       align: 'left',
-      sort: true
+      sort: true,
+      headerStyle: { overflowWrap: 'anywhere' }
     },
     {
       headerAlign: 'center',
       dataField: 'projectLead',
       text: 'Project Lead',
       align: 'left',
-      sort: true
+      sort: true,
+      headerStyle: { overflowWrap: 'anywhere' }
     },
     {
       headerAlign: 'center',
       dataField: 'projectManager',
       text: 'Project Manager',
       align: 'left',
-      sort: true
+      sort: true,
+      headerStyle: { overflowWrap: 'anywhere' }
     },
     {
       headerAlign: 'center',
@@ -115,7 +119,8 @@ const ProjectsTable: React.FC<DisplayProjectProps> = ({ allProjects }: DisplayPr
       text: 'Duration',
       align: 'center',
       sort: true,
-      sortFunc: durationSort
+      sortFunc: durationSort,
+      headerStyle: { overflowWrap: 'anywhere' }
     }
   ];
 
@@ -146,7 +151,7 @@ const ProjectsTable: React.FC<DisplayProjectProps> = ({ allProjects }: DisplayPr
         defaultSorted={defaultSort}
         rowEvents={rowEvents}
         noDataIndication="No Projects to Display"
-        rowStyle={{ cursor: 'pointer' }}
+        rowStyle={{ cursor: 'pointer', overflowWrap: 'anywhere' }}
       />
     </>
   );


### PR DESCRIPTION
## Changes

Similar deal to Change Requests table. Table now has word wrapping so text will go to the next line if it's about to overflow onto the next column.

## Screenshots

Full Screen
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/15839864/200189340-8d3f1cc7-4367-4086-9923-870889e90084.png">

Smallest Window
<img width="449" alt="image" src="https://user-images.githubusercontent.com/15839864/200189322-576f5a67-6ef8-468c-bfb8-e4199628c62d.png">

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #21
