### PR TITLE
#409 Allow project leads to check description bullets

### DIFF
--- a/src/backend/src/utils/description-bullets.utils.ts
+++ b/src/backend/src/utils/description-bullets.utils.ts
@@ -22,7 +22,7 @@ export const hasBulletCheckingPermissions = async (userId: number, descriptionId
     where: { descriptionId },
     include: {
       workPackageDeliverables: { include: { wbsElement: { include: { projectLead: true } } } },
-      workPackageExpectedActivities: { include: { wbsElement: {include: {projectLead: true } } } } 
+      workPackageExpectedActivities: { include: { wbsElement: { include: { projectLead: true } } } }
     }
   });
 
@@ -33,14 +33,13 @@ export const hasBulletCheckingPermissions = async (userId: number, descriptionId
   const leader =
     descriptionBullet.workPackageDeliverables?.wbsElement.projectLead ||
     descriptionBullet.workPackageExpectedActivities?.wbsElement.projectLead;
-  
+
   console.log(leader);
   if (
     user.role === Role.APP_ADMIN ||
     user.role === Role.ADMIN ||
     user.role === Role.LEADERSHIP ||
-    (leader &&
-      leader.userId === user.userId)
+    (leader && leader.userId === user.userId)
   ) {
     return true;
   }

--- a/src/backend/src/utils/description-bullets.utils.ts
+++ b/src/backend/src/utils/description-bullets.utils.ts
@@ -21,10 +21,8 @@ export const hasBulletCheckingPermissions = async (userId: number, descriptionId
   const descriptionBullet = await prisma.description_Bullet.findUnique({
     where: { descriptionId },
     include: {
-      workPackageDeliverables: { include: { wbsElement: { include: { projectLead: true,
-      projectManager: true } } } },
-      workPackageExpectedActivities: { include: { wbsElement: { include: { projectLead: true,
-      projectManager: true } } } }
+      workPackageDeliverables: { include: { wbsElement: { include: { projectLead: true, projectManager: true } } } },
+      workPackageExpectedActivities: { include: { wbsElement: { include: { projectLead: true, projectManager: true } } } }
     }
   });
 
@@ -43,7 +41,8 @@ export const hasBulletCheckingPermissions = async (userId: number, descriptionId
     user.role === Role.APP_ADMIN ||
     user.role === Role.ADMIN ||
     user.role === Role.LEADERSHIP ||
-    (leader && leader.userId === user.userId) || (manager && manager.userId === user.userId)
+    (leader && leader.userId === user.userId) ||
+    (manager && manager.userId === user.userId)
   ) {
     return true;
   }

--- a/src/backend/src/utils/description-bullets.utils.ts
+++ b/src/backend/src/utils/description-bullets.utils.ts
@@ -21,8 +21,10 @@ export const hasBulletCheckingPermissions = async (userId: number, descriptionId
   const descriptionBullet = await prisma.description_Bullet.findUnique({
     where: { descriptionId },
     include: {
-      workPackageDeliverables: { include: { wbsElement: { include: { projectLead: true } } } },
-      workPackageExpectedActivities: { include: { wbsElement: { include: { projectLead: true } } } }
+      workPackageDeliverables: { include: { wbsElement: { include: { projectLead: true,
+      projectManager: true } } } },
+      workPackageExpectedActivities: { include: { wbsElement: { include: { projectLead: true,
+      projectManager: true } } } }
     }
   });
 
@@ -33,12 +35,15 @@ export const hasBulletCheckingPermissions = async (userId: number, descriptionId
   const leader =
     descriptionBullet.workPackageDeliverables?.wbsElement.projectLead ||
     descriptionBullet.workPackageExpectedActivities?.wbsElement.projectLead;
+  const manager =
+    descriptionBullet.workPackageDeliverables?.wbsElement.projectManager ||
+    descriptionBullet.workPackageExpectedActivities?.wbsElement.projectManager;
 
   if (
     user.role === Role.APP_ADMIN ||
     user.role === Role.ADMIN ||
     user.role === Role.LEADERSHIP ||
-    (leader && leader.userId === user.userId)
+    (leader && leader.userId === user.userId) || (manager && manager.userId === user.userId)
   ) {
     return true;
   }

--- a/src/backend/src/utils/description-bullets.utils.ts
+++ b/src/backend/src/utils/description-bullets.utils.ts
@@ -19,14 +19,29 @@ export const hasBulletCheckingPermissions = async (userId: number, descriptionId
   const user = await prisma.user.findUnique({ where: { userId } });
 
   const descriptionBullet = await prisma.description_Bullet.findUnique({
-    where: { descriptionId }
+    where: { descriptionId },
+    include: {
+      workPackageDeliverables: { include: { wbsElement: { include: { projectLead: true } } } },
+      workPackageExpectedActivities: { include: { wbsElement: {include: {projectLead: true } } } } 
+    }
   });
 
   if (!descriptionBullet) return false;
 
   if (!user) return false;
 
-  if (user.role === Role.APP_ADMIN || user.role === Role.ADMIN || user.role === Role.LEADERSHIP) {
+  const leader =
+    descriptionBullet.workPackageDeliverables?.wbsElement.projectLead ||
+    descriptionBullet.workPackageExpectedActivities?.wbsElement.projectLead;
+  
+  console.log(leader);
+  if (
+    user.role === Role.APP_ADMIN ||
+    user.role === Role.ADMIN ||
+    user.role === Role.LEADERSHIP ||
+    (leader &&
+      leader.userId === user.userId)
+  ) {
     return true;
   }
   return false;

--- a/src/backend/src/utils/description-bullets.utils.ts
+++ b/src/backend/src/utils/description-bullets.utils.ts
@@ -34,7 +34,6 @@ export const hasBulletCheckingPermissions = async (userId: number, descriptionId
     descriptionBullet.workPackageDeliverables?.wbsElement.projectLead ||
     descriptionBullet.workPackageExpectedActivities?.wbsElement.projectLead;
 
-  console.log(leader);
   if (
     user.role === Role.APP_ADMIN ||
     user.role === Role.ADMIN ||


### PR DESCRIPTION
## Changes

Added another check to see if the project lead is editing the description bullets even if they are a member 

## Test Cases

Case A: Member who is project lead checking description bullet 

<img width="956" alt="Screen Shot 2022-11-07 at 4 59 30 PM" src="https://user-images.githubusercontent.com/113635669/200424650-ec1273c7-9d4e-4544-97fb-749d4077c90f.png">


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #409  (issue #)
