### PR TITLE
#414 - More Auth

### DIFF
--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import cors from 'cors';
 import cookieParser from 'cookie-parser';
-import { prodHeaders, requireJwt } from './src/utils/utils';
+import { prodHeaders, requireJwtDev, requireJwtProd } from './src/utils/utils';
 import userRouter from './src/routes/users.routes';
 import projectRouter from './src/routes/projects.routes';
 import teamsRouter from './src/routes/teams.routes';
@@ -12,9 +12,10 @@ import descriptionBulletsRouter from './src/routes/description-bullets.routes';
 
 const app = express();
 const port = process.env.PORT || 3001;
+const isProd = process.env.NODE_ENV === 'production';
 
 // cors options
-const allowedHeaders = process.env.NODE_ENV === 'production' ? prodHeaders : '*';
+const allowedHeaders = isProd ? prodHeaders : '*';
 const options: cors.CorsOptions = {
   origin: ['http://localhost:3000', 'https://finishlinebyner.com', 'https://qa.finishlinebyner.com'],
   methods: 'GET, POST',
@@ -33,7 +34,7 @@ app.use(express.json());
 app.use(cors(options));
 
 // ensure each request is authorized using JWT
-app.use(requireJwt);
+app.use(isProd ? requireJwtProd : requireJwtDev);
 
 // routes
 app.use('/users', userRouter);

--- a/src/backend/src/controllers/users.controllers.ts
+++ b/src/backend/src/controllers/users.controllers.ts
@@ -104,7 +104,7 @@ export const logUserIn = async (req: Request, res: Response) => {
     }
   });
 
-  const token = generateAccessToken({ firstName: user.firstName, lastName: user.lastName });
+  const token = generateAccessToken({ userId: user.userId, firstName: user.firstName, lastName: user.lastName });
   res.cookie('token', token, { httpOnly: true, sameSite: 'none', secure: true });
 
   return res.status(200).json(authenticatedUserTransformer(user));

--- a/src/backend/src/utils/utils.ts
+++ b/src/backend/src/utils/utils.ts
@@ -99,8 +99,12 @@ export const requireJwtDev = (req: Request, res: Response, next: any) => {
   }
 };
 
-// get the user making the request. returns null if they dont exist for some reason
-export const getUser = async (res: Response): Promise<User | null> => {
+/**
+ * get the user making the request.
+ * @param res - we use the response because that's where we stored the userId data during jwt validation
+ * @returns the user or null if not found for some reason (although that should really never happen because of the validation)
+ */
+export const getCurrentUser = async (res: Response): Promise<User | null> => {
   const { userId } = res.locals;
   const user = await prisma.user.findUnique({ where: { userId } });
   return user;

--- a/src/backend/src/utils/utils.ts
+++ b/src/backend/src/utils/utils.ts
@@ -60,14 +60,12 @@ export const requireJwt = (req: Request, res: Response, next: any) => {
 
     if (!token) return res.status(401).json({ message: 'Authentication Failed: Cookie not found!' });
 
-    const decoded: any = jwt.verify(token, TOKEN_SECRET);
+    jwt.verify(token, TOKEN_SECRET, (err: any, decoded: any) => {
+      if (err) return res.status(401).json({ message: 'Authentication Failed: Invalid JWT!' });
 
-    const { userId } = decoded;
+      res.locals.userId = decoded.userId;
 
-    if (req.method === 'POST' && req.body.userId !== userId) {
-      return res.status(401).json({ message: 'Authentication Failed: userId sent in body does not match token!' });
-    }
-
-    next();
+      next();
+    });
   }
 };

--- a/src/backend/src/utils/utils.ts
+++ b/src/backend/src/utils/utils.ts
@@ -1,7 +1,8 @@
-import { Description_Bullet, WBS_Element, WBS_Element_Status } from '@prisma/client';
+import { Description_Bullet, User, WBS_Element, WBS_Element_Status } from '@prisma/client';
 import { DescriptionBullet, WbsElementStatus, WbsNumber } from 'shared';
 import jwt from 'jsonwebtoken';
 import { Request, Response } from 'express';
+import prisma from '../prisma/prisma';
 
 export const descBulletConverter = (descBullet: Description_Bullet): DescriptionBullet => ({
   id: descBullet.descriptionId,
@@ -46,10 +47,9 @@ export const prodHeaders = [
   'Client-Security-Token'
 ];
 
-// middleware function that will enforce jwt except in some circumstances
-export const requireJwt = (req: Request, res: Response, next: any) => {
+// middleware function for production that will enforce jwt authorization
+export const requireJwtProd = (req: Request, res: Response, next: any) => {
   if (
-    process.env.NODE_ENV !== 'production' || // only on prod
     req.path === '/users/auth/login' || // logins dont have cookies yet
     req.path === '/' || // base route is available so aws can listen and check the health
     req.method === 'OPTIONS' // this is a pre-flight request and those don't send cookies
@@ -63,9 +63,36 @@ export const requireJwt = (req: Request, res: Response, next: any) => {
     jwt.verify(token, TOKEN_SECRET, (err: any, decoded: any) => {
       if (err) return res.status(401).json({ message: 'Authentication Failed: Invalid JWT!' });
 
-      res.locals.userId = decoded.userId;
+      res.locals.userId = parseInt(decoded.userId);
 
       next();
     });
   }
+};
+
+// middleware function for development that will enforce jwt authorization
+export const requireJwtDev = (req: Request, res: Response, next: any) => {
+  if (
+    req.path === '/users/auth/login/dev' || // logins dont have cookies yet
+    req.path === '/' || // base route is available so aws can listen and check the health
+    req.method === 'OPTIONS' || // this is a pre-flight request and those don't send cookies
+    req.path === '/users' // dev login needs the list of users to log in
+  ) {
+    next();
+  } else {
+    const devUserId = req.headers.authorization;
+
+    if (!devUserId) return res.status(401).json({ message: 'Authentication Failed: Not logged in (dev)!' });
+
+    res.locals.userId = parseInt(devUserId);
+
+    next();
+  }
+};
+
+// get the user making the request. returns null if they dont exist for some reason
+export const getUser = async (res: Response): Promise<User | null> => {
+  const { userId } = res.locals;
+  const user = await prisma.user.findUnique({ where: { userId } });
+  return user;
 };

--- a/src/frontend/src/utils/axios.ts
+++ b/src/frontend/src/utils/axios.ts
@@ -18,7 +18,7 @@ axios.interceptors.response.use(
 
 axios.interceptors.request.use(
   (request) => {
-    request.headers!.from = localStorage.getItem('userId') || '';
+    if (process.env.NODE_ENV === 'development') request.headers!['Authorization'] = localStorage.getItem('devUserId') || '';
     return request;
   },
   (error) => {

--- a/src/frontend/src/utils/axios.ts
+++ b/src/frontend/src/utils/axios.ts
@@ -16,4 +16,14 @@ axios.interceptors.response.use(
   }
 );
 
+axios.interceptors.request.use(
+  (request) => {
+    request.headers!.from = localStorage.getItem('userId') || '';
+    return request;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
 export default axios;


### PR DESCRIPTION
## Changes

this pr will actually prevent people from impersonating other users in requests which might be the last step in our auth journey. well, except we have to replace every instance of the userid in a request with getting it from the res object. I did this for a few risk endpoints as an example, it's very easy. We can turn that into easy tickets which is always nice.

it can be sorta weird to understand this since we have two totally different flows for login on dev and prod but here's the easiest way to explain them:

**Dev**: choose a user to login as >> backend is cool with it as long as the user exists >> save that userId in localstorage >> send that userId as a header with every request >> backend gets the userid from the header and puts it on the res.locals

**Prod**: login with google >> backend verifies that google was cool with it and if so generates the jwt >> jwt is a cookie so automatically gets sent back to the backend on every request >> backend decodes the jwt and says that this request is coming from whoever the jwt is for >> this userId is put on the res.locals

res.locals is the intended way to pass data between middleware. this means that we now know who a user is based off of their credentials, instead of just believing whoever they say they are in a post body. Right now, even though we have jwt, you can send a post with the userId being anyone you want and it doesn't check that that user lines up with whoever the jwt is issued for. that changes with this pr (after we convert all the endpoints to use the res.locals) which gets rid of impersonation and should be good enough auth for us for the foreseeable future.

## Test Cases

it works on dev

## To Do

- test on the QA environment
- remove all userId stuff from post bodies

Closes #414
