### PR TITLE
#385 - Transition to MUI WbsStatus.tsx

### DIFF
--- a/src/frontend/src/components/WbsStatus.tsx
+++ b/src/frontend/src/components/WbsStatus.tsx
@@ -10,12 +10,12 @@ interface WbsStatusProps {
   status: WbsElementStatus;
 }
 
-type BadgeStatusColor = 'primary' | 'secondary' | 'success';
+type WbsStatusColor = 'primary' | 'secondary' | 'success';
 
 // Convert WBS Element status into badge for display
 const WbsStatus: React.FC<WbsStatusProps> = ({ status }) => {
   // maps status to the desired color state
-  const colorMap: Record<WbsElementStatus, BadgeStatusColor> = {
+  const colorMap: Record<WbsElementStatus, WbsStatusColor> = {
     [WbsElementStatus.Active]: 'primary',
     [WbsElementStatus.Inactive]: 'secondary',
     [WbsElementStatus.Complete]: 'success'
@@ -28,7 +28,7 @@ const WbsStatus: React.FC<WbsStatusProps> = ({ status }) => {
     [WbsElementStatus.Complete]: 'Complete'
   };
 
-  const color: BadgeStatusColor = colorMap[status];
+  const color: WbsStatusColor = colorMap[status];
   const text: string = textMap[status];
 
   return (

--- a/src/frontend/src/components/WbsStatus.tsx
+++ b/src/frontend/src/components/WbsStatus.tsx
@@ -3,32 +3,37 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { Badge } from 'react-bootstrap';
+import Chip from '@mui/material/Chip';
 import { WbsElementStatus } from 'shared';
 
 interface WbsStatusProps {
   status: WbsElementStatus;
 }
 
+type BadgeStatusColor = 'primary' | 'secondary' | 'success';
+
 // Convert WBS Element status into badge for display
 const WbsStatus: React.FC<WbsStatusProps> = ({ status }) => {
-  let color = 'primary';
-  let text = 'Active';
+  // maps status to the desired color state
+  const colorMap: Record<WbsElementStatus, BadgeStatusColor> = {
+    [WbsElementStatus.Active]: 'primary',
+    [WbsElementStatus.Inactive]: 'secondary',
+    [WbsElementStatus.Complete]: 'success'
+  };
 
-  if (status === WbsElementStatus.Inactive) {
-    color = 'secondary';
-    text = 'Inactive';
-  }
-  if (status === WbsElementStatus.Complete) {
-    color = 'success';
-    text = 'Complete';
-  }
+  // maps status to the desired badge display text
+  const textMap: Record<WbsElementStatus, string> = {
+    [WbsElementStatus.Active]: 'Active',
+    [WbsElementStatus.Inactive]: 'Inactive',
+    [WbsElementStatus.Complete]: 'Complete'
+  };
+
+  const color: BadgeStatusColor = colorMap[status];
+  const text: string = textMap[status];
 
   return (
     <b>
-      <Badge pill variant={color}>
-        {text}
-      </Badge>
+      <Chip label={text} color={color} sx={{ fontSize: 14 }} />
     </b>
   );
 };

--- a/src/frontend/src/components/WbsStatus.tsx
+++ b/src/frontend/src/components/WbsStatus.tsx
@@ -12,22 +12,22 @@ interface WbsStatusProps {
 
 type WbsStatusColor = 'primary' | 'secondary' | 'success';
 
+// maps status to the desired color state
+const colorMap: Record<WbsElementStatus, WbsStatusColor> = {
+  [WbsElementStatus.Active]: 'primary',
+  [WbsElementStatus.Inactive]: 'secondary',
+  [WbsElementStatus.Complete]: 'success'
+};
+
+// maps status to the desired badge display text
+const textMap: Record<WbsElementStatus, string> = {
+  [WbsElementStatus.Active]: 'Active',
+  [WbsElementStatus.Inactive]: 'Inactive',
+  [WbsElementStatus.Complete]: 'Complete'
+};
+
 // Convert WBS Element status into badge for display
 const WbsStatus: React.FC<WbsStatusProps> = ({ status }) => {
-  // maps status to the desired color state
-  const colorMap: Record<WbsElementStatus, WbsStatusColor> = {
-    [WbsElementStatus.Active]: 'primary',
-    [WbsElementStatus.Inactive]: 'secondary',
-    [WbsElementStatus.Complete]: 'success'
-  };
-
-  // maps status to the desired badge display text
-  const textMap: Record<WbsElementStatus, string> = {
-    [WbsElementStatus.Active]: 'Active',
-    [WbsElementStatus.Inactive]: 'Inactive',
-    [WbsElementStatus.Complete]: 'Complete'
-  };
-
   const color: WbsStatusColor = colorMap[status];
   const text: string = textMap[status];
 

--- a/src/frontend/src/utils/Themes.ts
+++ b/src/frontend/src/utils/Themes.ts
@@ -65,6 +65,16 @@ export const nerThemeOptions: ThemeOptions = {
         disableRipple: true
       }
     },
+    MuiChip: {
+      styleOverrides: {
+        root: {
+          color: 'white'
+        },
+        colorSecondary: {
+          backgroundColor: 'gray'
+        }
+      }
+    },
     MuiList: {
       defaultProps: {
         dense: true
@@ -78,13 +88,6 @@ export const nerThemeOptions: ThemeOptions = {
     MuiTable: {
       defaultProps: {
         size: 'small'
-      }
-    },
-    MuiChip: {
-      styleOverrides: {
-        colorSecondary: {
-          backgroundColor: 'gray'
-        }
       }
     }
   }

--- a/src/frontend/src/utils/Themes.ts
+++ b/src/frontend/src/utils/Themes.ts
@@ -67,9 +67,6 @@ export const nerThemeOptions: ThemeOptions = {
     },
     MuiChip: {
       styleOverrides: {
-        root: {
-          color: 'white'
-        },
         colorSecondary: {
           backgroundColor: 'gray'
         }

--- a/src/frontend/src/utils/Themes.ts
+++ b/src/frontend/src/utils/Themes.ts
@@ -82,9 +82,9 @@ export const nerThemeOptions: ThemeOptions = {
     },
     MuiChip: {
       styleOverrides: {
-        colorSecondary: ({ theme }) => ({
+        colorSecondary: {
           backgroundColor: 'gray'
-        })
+        }
       }
     }
   }

--- a/src/frontend/src/utils/Themes.ts
+++ b/src/frontend/src/utils/Themes.ts
@@ -79,6 +79,13 @@ export const nerThemeOptions: ThemeOptions = {
       defaultProps: {
         size: 'small'
       }
+    },
+    MuiChip: {
+      styleOverrides: {
+        colorSecondary: ({ theme }) => ({
+          backgroundColor: 'gray'
+        })
+      }
     }
   }
 };


### PR DESCRIPTION
## Changes

Change React Bootstrap Badge component in `WbsStatus.txt` to Material UI Chip component. (Looking at the documentation and trying both out, Chip seems more appropriate than Badge.) Increased text size from defaults for readability.

Refactor code in `WbsStatus.txt` to use mapping objects instead of local variables.

Override the theme to make Chip background gray using technique suggest in [this StackOverflow answer](https://stackoverflow.com/a/72543786). The palette's `secondary` color scheme (dark red) is very different from React Bootstrap's (gray). 

## Notes

An alternative to the `textMap` object would be to do `status.toString()` and change the all-caps string representation to sentence-case. I chose textMap because it was simpler and more robust.

## Test Cases

No tests were made for this specific MUI migration. Unclear if existing component tests work. We will deal with testing when migration is complete.

## Screenshots

_If you made UI changes you must post a screenshot of the whole page for each change in 1) a normal sized window and 2) the smallest possible window_

Left is prod, right is with MUI.

### Active
![Screen Shot 2022-11-14 at 10 17 53 PM](https://user-images.githubusercontent.com/59806366/201820179-7350da09-7483-4d35-a99f-79f539e76bd0.png)
![Screen Shot 2022-11-14 at 10 29 03 PM](https://user-images.githubusercontent.com/59806366/201820228-86ea4695-af50-4a25-ad12-0a11451d103c.png)

### Inactive
![Screen Shot 2022-11-20 at 11 03 44 PM](https://user-images.githubusercontent.com/59806366/202963727-835eff10-9413-4217-a596-9ef26c8535b3.png)
![Screen Shot 2022-11-20 at 11 04 04 PM](https://user-images.githubusercontent.com/59806366/202963738-9fd04282-0cb9-483e-b131-b02c694bcf44.png)

### Completed
![Screen Shot 2022-11-14 at 10 20 07 PM](https://user-images.githubusercontent.com/59806366/201820215-4895baa6-f900-4b1f-b1dd-31f9c91b89f5.png)
![Screen Shot 2022-11-14 at 10 29 47 PM](https://user-images.githubusercontent.com/59806366/201820262-0dcd3777-f117-4b7e-a371-d3151a15c18b.png)

### Active vs Inactive comparison
![Screen Shot 2022-11-20 at 11 05 36 PM](https://user-images.githubusercontent.com/59806366/202963758-699e3044-cbfe-4148-8f08-39d1e18fa6f9.png)

## To Do

_Any remaining things that need to get done_

- [x] Change Inactive chip theme to gray

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [ ] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #385 