### PR TITLE
#103 Make PageBlock Collapsable

### DIFF
--- a/src/frontend/src/components/BulletList.tsx
+++ b/src/frontend/src/components/BulletList.tsx
@@ -13,6 +13,7 @@ interface BulletListProps {
   ordered?: boolean;
   readOnly?: boolean;
   fieldName?: string;
+  defaultClosed?: boolean;
 }
 
 const styles = {
@@ -22,14 +23,14 @@ const styles = {
   }
 };
 
-const BulletList: React.FC<BulletListProps> = ({ title, headerRight, list, ordered }) => {
+const BulletList: React.FC<BulletListProps> = ({ title, headerRight, list, ordered, defaultClosed }) => {
   const listPrepared = list.map((bullet, idx) => <li key={idx}>{bullet}</li>);
   let builtList = <ul style={styles.bulletList}>{listPrepared}</ul>;
   if (ordered) {
     builtList = <ol style={styles.bulletList}>{listPrepared}</ol>;
   }
   return (
-    <PageBlock title={title} headerRight={headerRight}>
+    <PageBlock title={title} headerRight={headerRight} defaultClosed={!!defaultClosed}>
       {builtList}
     </PageBlock>
   );

--- a/src/frontend/src/components/BulletList.tsx
+++ b/src/frontend/src/components/BulletList.tsx
@@ -30,7 +30,7 @@ const BulletList: React.FC<BulletListProps> = ({ title, headerRight, list, order
     builtList = <ol style={styles.bulletList}>{listPrepared}</ol>;
   }
   return (
-    <PageBlock title={title} headerRight={headerRight} defaultClosed={!!defaultClosed}>
+    <PageBlock title={title} headerRight={headerRight} defaultClosed={defaultClosed}>
       {builtList}
     </PageBlock>
   );

--- a/src/frontend/src/components/ChangesList.tsx
+++ b/src/frontend/src/components/ChangesList.tsx
@@ -39,6 +39,7 @@ const ChangesList: React.FC<ChangesListProps> = ({ changes }) => {
         </>
       ))}
       readOnly={true}
+      defaultClosed
     />
   );
 };

--- a/src/frontend/src/layouts/PageBlock.tsx
+++ b/src/frontend/src/layouts/PageBlock.tsx
@@ -17,7 +17,7 @@ interface PageBlockProps {
   title: string;
   headerRight?: ReactNode;
   style?: SxProps<Theme>;
-  defaultOpen?: boolean;
+  defaultClosed?: boolean;
 }
 
 /**
@@ -26,11 +26,11 @@ interface PageBlockProps {
  * @param headerRight The optional stuff to display on the right side of the header
  * @param children The children of the pageblock
  * @param style Optional styling for the pageblock
- * @param defaultOpen Sets the pageblock to be open (uncollapsed) by default.
+ * @param defaultClosed Sets the pageblock to be closed (collapsed) by default.
  */
-const PageBlock: React.FC<PageBlockProps> = ({ title, headerRight, children, style, defaultOpen }) => {
+const PageBlock: React.FC<PageBlockProps> = ({ title, headerRight, children, style, defaultClosed }) => {
   const theme = useTheme();
-  const [collapsed, setCollapsed] = useState(!defaultOpen);
+  const [collapsed, setCollapsed] = useState(defaultClosed);
 
   return (
     <Card sx={{ my: 2, background: theme.palette.background.paper, ...style }} variant="outlined">

--- a/src/frontend/src/layouts/PageBlock.tsx
+++ b/src/frontend/src/layouts/PageBlock.tsx
@@ -7,13 +7,17 @@ import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
-import { ReactNode } from 'react';
+import Collapse from '@mui/material/Collapse';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { ReactNode, useState } from 'react';
 import { SxProps, Theme, useTheme } from '@mui/material';
 
 interface PageBlockProps {
   title: string;
   headerRight?: ReactNode;
   style?: SxProps<Theme>;
+  defaultOpen?: boolean;
 }
 
 /**
@@ -22,9 +26,11 @@ interface PageBlockProps {
  * @param headerRight The optional stuff to display on the right side of the header
  * @param children The children of the pageblock
  * @param style Optional styling for the pageblock
+ * @param defaultOpen Sets the pageblock to be open (uncollapsed) by default.
  */
-const PageBlock: React.FC<PageBlockProps> = ({ title, headerRight, children, style }) => {
+const PageBlock: React.FC<PageBlockProps> = ({ title, headerRight, children, style, defaultOpen }) => {
   const theme = useTheme();
+  const [collapsed, setCollapsed] = useState(!defaultOpen);
 
   return (
     <Card sx={{ my: 2, background: theme.palette.background.paper, ...style }} variant="outlined">
@@ -34,8 +40,13 @@ const PageBlock: React.FC<PageBlockProps> = ({ title, headerRight, children, sty
             {title}
           </Typography>
           {headerRight}
+          {collapsed ? (
+            <ExpandMoreIcon sx={{ ml: 2 }} onClick={() => setCollapsed(false)} />
+          ) : (
+            <ExpandLessIcon sx={{ ml: 2 }} onClick={() => setCollapsed(true)} />
+          )}
         </Box>
-        {children}
+        <Collapse in={!collapsed}>{children}</Collapse>
       </CardContent>
     </Card>
   );

--- a/src/frontend/src/tests/layouts/PageBlock.test.tsx
+++ b/src/frontend/src/tests/layouts/PageBlock.test.tsx
@@ -6,9 +6,9 @@
 import { render, screen } from '../test-support/test-utils';
 import PageBlock from '../../layouts/PageBlock';
 
-const renderComponent = (headerRight = false) => {
+const renderComponent = (headerRight = false, defaultOpen: boolean) => {
   return render(
-    <PageBlock title={'test'} headerRight={headerRight ? <p>hi</p> : undefined}>
+    <PageBlock title={'test'} headerRight={headerRight ? <p>hi</p> : undefined} defaultOpen={defaultOpen}>
       hello
     </PageBlock>
   );
@@ -16,15 +16,22 @@ const renderComponent = (headerRight = false) => {
 
 describe('card component', () => {
   it('renders title', () => {
-    renderComponent(true);
+    renderComponent(true, true);
 
     expect(screen.getByText('test')).toBeInTheDocument();
     expect(screen.getByText('hi')).toBeInTheDocument();
     expect(screen.getByText('hello')).toBeInTheDocument();
   });
 
+  it('renders title and headerRight but not children if collapsed', () => {
+    renderComponent(true, false);
+
+    expect(screen.getByText('test')).toBeInTheDocument();
+    expect(screen.getByText('hi')).toBeInTheDocument();
+  });
+
   it('doesnt render headerRight if none is given', () => {
-    renderComponent(false);
+    renderComponent(false, true);
 
     expect(screen.queryByText('hi')).not.toBeInTheDocument();
   });


### PR DESCRIPTION
## Changes

Added functionality to PageBlocks to make them collapse/expand on icon click in the upper right corner.

## Notes

PageBlocks are open by default. I added a prop that allows it to be closed by default just in case it might be needed.

## Test Cases

- Attempted to test if the content still renders when collapsed, apparently it does in the DOM but is just not visible.

## Screenshots

Collapsed
![image](https://user-images.githubusercontent.com/80188262/203920793-92b2d088-f182-4539-81c9-201eab3aea74.png)

Expanded
![image](https://user-images.githubusercontent.com/80188262/203920874-aaab0eb5-4e34-4b0d-9d02-a63d620687a1.png)

Collapsed (small)
![image](https://user-images.githubusercontent.com/80188262/203920971-9d3a2870-0a6f-400a-a9d4-8f54cf0317d1.png)

Expanded (small)
![image](https://user-images.githubusercontent.com/80188262/203921089-6905cd77-798b-4c83-97a6-695622283afe.png)

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #103
