### PR TITLE
#64: Fix tooltips extending past screen

### DIFF
--- a/src/frontend/src/pages/ChangeRequestDetailPage/ImplementedChangesList.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ImplementedChangesList.tsx
@@ -24,9 +24,9 @@ const ImplementedChangesList: React.FC<ImplementedChangesListProps> = ({ changes
         <>
           [<Link to={`${routes.PROJECTS}/${wbsPipe(ic.wbsNum)}`}>{wbsPipe(ic.wbsNum)}</Link>]{' '}
           <OverlayTrigger
-            placement="right"
+            placement={`${window.innerWidth < 600 ? 'top' : 'right'}`}
             overlay={
-              <Tooltip id="tooltip">
+              <Tooltip id="tooltip" style={{ maxWidth: '170px' }}>
                 {fullNamePipe(ic.implementer)} - {datePipe(ic.dateImplemented)}
               </Tooltip>
             }


### PR DESCRIPTION
## Changes

Before, the tooltips were to the right and would cut off past the screen if they were too long. I was playing around with either just keeping them always on the top, or changing them from right to top depending on the size of the screen

## Notes

The tooltips were working before, but I'm having an issue now where the tooltips are just defaulting to how they're implemented currently and not updating. I even tested changing the text of the tooltips to see if something was just weird with the tooltip position, but the text won't update either. The React Developer tools also shows the OverlayTrigger's placement prop being set to 'right', even when I remove what I currently have committed and just replace all of it with 'top' (so no mention of 'right' anywhere in the prop value). I'm trying to figure out what the issue is but I'm getting stuck, especially since this exact code was working a couple weeks ago.

## Screenshots

*Need to insert once I can figure out why the tooltips aren't updating*

## To Do

- [ ] Make sure tooltips display properly and the way that's expected

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #64
