### PR TITLE
#386 Transition Sidebar to MUI

### DIFF
--- a/src/frontend/src/layouts/Sidebar/Sidebar.tsx
+++ b/src/frontend/src/layouts/Sidebar/Sidebar.tsx
@@ -9,7 +9,7 @@ import { LinkItem } from '../../utils/Types';
 import NavPageLinks from './NavPageLinks';
 import styles from '../../stylesheets/layouts/sidebar/sidebar.module.css';
 
-const Sidebar = () => {
+const Sidebar: React.FC = () => {
   const linkItems: LinkItem[] = [
     {
       name: 'Home',

--- a/src/frontend/src/layouts/Sidebar/Sidebar.tsx
+++ b/src/frontend/src/layouts/Sidebar/Sidebar.tsx
@@ -3,14 +3,13 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { Nav } from 'react-bootstrap';
 import { faExchangeAlt, faFolder, faHome, faQuestionCircle, faUsers } from '@fortawesome/free-solid-svg-icons';
 import { routes } from '../../utils/Routes';
 import { LinkItem } from '../../utils/Types';
 import NavPageLinks from './NavPageLinks';
 import styles from '../../stylesheets/layouts/sidebar/sidebar.module.css';
 
-const Sidebar: React.FC = () => {
+const Sidebar = () => {
   const linkItems: LinkItem[] = [
     {
       name: 'Home',
@@ -39,9 +38,9 @@ const Sidebar: React.FC = () => {
     }
   ];
   return (
-    <Nav className={styles.sidebar}>
+    <div className={styles.sidebar}>
       <NavPageLinks linkItems={linkItems} />
-    </Nav>
+    </div>
   );
 };
 

--- a/src/frontend/src/stylesheets/layouts/sidebar/nav-page-links.module.css
+++ b/src/frontend/src/stylesheets/layouts/sidebar/nav-page-links.module.css
@@ -21,6 +21,7 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  text-decoration: none;
 }
 
 .row:hover {
@@ -37,7 +38,6 @@
 
 .row:hover .iconsAndText {
   color: #ef4345;
-  text-decoration: underline;
   text-decoration-color: inherit;
 }
 


### PR DESCRIPTION
## Changes

- Removed React-Bootstrap import from Sidebar
- Changed some CSS to remove the link underlines

## Notes

Removing the underline was not part of the ticket, but to be honest it looked really ugly, especially how it would turn purple if previously clicked (at least on my machine). Makes it look a lot cleaner + neater without it.

## Test Cases

Existing tests were used.

## Screenshots

Sidebar (Large)
![image](https://user-images.githubusercontent.com/80188262/205672072-2688f934-8897-4eaa-a261-d0b3e4774f73.png)

Sidebar (Small)
![image](https://user-images.githubusercontent.com/80188262/205672462-f3b3e483-0684-4bcc-9485-99b2aa275ee6.png)

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #386 
