### PR TITLE
#373 newProject accounts for team

### DIFF
--- a/src/backend/src/controllers/projects.controllers.ts
+++ b/src/backend/src/controllers/projects.controllers.ts
@@ -54,19 +54,12 @@ export const newProject = async (req: Request, res: Response) => {
 
   await validateChangeRequestAccepted(req.body.crId);
 
-  // check for valid team
-  const team = await prisma.team.findUnique({ where: { teamId: req.body.teamId } });
-  if (!team) {
-    return res.status(404).json({ message: `team with id ${req.body.teamId} not found.` });
-  }
-
   // create the wbs element for the project and document the implemented change request
   const maxProjectNumber = await getHighestProjectNumber(req.body.carNumber);
   const createdProject = await prisma.wBS_Element.create({
     data: {
       carNumber: req.body.carNumber,
       projectNumber: maxProjectNumber + 1,
-      teamId: req.body.teamId,
       workPackageNumber: 0,
       name: req.body.name,
       project: { create: { summary: req.body.summary } },

--- a/src/backend/src/controllers/projects.controllers.ts
+++ b/src/backend/src/controllers/projects.controllers.ts
@@ -54,8 +54,6 @@ export const newProject = async (req: Request, res: Response) => {
 
   await validateChangeRequestAccepted(req.body.crId);
 
-  // check for valid team
-
   if (req.body.teamId !== undefined) {
     const team = await prisma.team.findUnique({ where: { teamId: req.body.teamId } });
     if (!team) {

--- a/src/backend/src/controllers/projects.controllers.ts
+++ b/src/backend/src/controllers/projects.controllers.ts
@@ -54,6 +54,15 @@ export const newProject = async (req: Request, res: Response) => {
 
   await validateChangeRequestAccepted(req.body.crId);
 
+  // check for valid team
+  if (req.body.teamId === undefined) {
+    return res.status(404).json({ message: `team id not supplied.` });
+  }
+  const team = await prisma.team.findUnique({ where: { teamId: req.body.teamId } });
+  if (!team) {
+    return res.status(404).json({ message: `team with id ${req.body.teamId} not found.` });
+  }
+
   // create the wbs element for the project and document the implemented change request
   const maxProjectNumber = await getHighestProjectNumber(req.body.carNumber);
   const createdProject = await prisma.wBS_Element.create({
@@ -61,6 +70,7 @@ export const newProject = async (req: Request, res: Response) => {
       carNumber: req.body.carNumber,
       projectNumber: maxProjectNumber + 1,
       workPackageNumber: 0,
+      teamId: req.body.teamId,
       name: req.body.name,
       project: { create: { summary: req.body.summary } },
       changes: {

--- a/src/backend/src/controllers/projects.controllers.ts
+++ b/src/backend/src/controllers/projects.controllers.ts
@@ -70,9 +70,8 @@ export const newProject = async (req: Request, res: Response) => {
       carNumber: req.body.carNumber,
       projectNumber: maxProjectNumber + 1,
       workPackageNumber: 0,
-      teamId: req.body.teamId,
       name: req.body.name,
-      project: { create: { summary: req.body.summary } },
+      project: { create: { summary: req.body.summary, teamId: req.body.teamId } },
       changes: {
         create: {
           changeRequestId: req.body.crId,

--- a/src/backend/src/controllers/projects.controllers.ts
+++ b/src/backend/src/controllers/projects.controllers.ts
@@ -55,12 +55,12 @@ export const newProject = async (req: Request, res: Response) => {
   await validateChangeRequestAccepted(req.body.crId);
 
   // check for valid team
-  if (req.body.teamId === undefined) {
-    return res.status(404).json({ message: `team id not supplied.` });
-  }
-  const team = await prisma.team.findUnique({ where: { teamId: req.body.teamId } });
-  if (!team) {
-    return res.status(404).json({ message: `team with id ${req.body.teamId} not found.` });
+
+  if (req.body.teamId !== undefined) {
+    const team = await prisma.team.findUnique({ where: { teamId: req.body.teamId } });
+    if (!team) {
+      return res.status(404).json({ message: `team with id ${req.body.teamId} not found.` });
+    }
   }
 
   // create the wbs element for the project and document the implemented change request

--- a/src/backend/src/controllers/projects.controllers.ts
+++ b/src/backend/src/controllers/projects.controllers.ts
@@ -54,12 +54,19 @@ export const newProject = async (req: Request, res: Response) => {
 
   await validateChangeRequestAccepted(req.body.crId);
 
+  // check for valid team
+  const team = await prisma.team.findUnique({ where: { teamId: req.body.teamId } });
+  if (!team) {
+    return res.status(404).json({ message: `team with id ${req.body.teamId} not found.` });
+  }
+
   // create the wbs element for the project and document the implemented change request
   const maxProjectNumber = await getHighestProjectNumber(req.body.carNumber);
   const createdProject = await prisma.wBS_Element.create({
     data: {
       carNumber: req.body.carNumber,
       projectNumber: maxProjectNumber + 1,
+      teamId: req.body.teamId,
       workPackageNumber: 0,
       name: req.body.name,
       project: { create: { summary: req.body.summary } },

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -64,7 +64,6 @@ describe('Projects', () => {
   });
 
   test('newProject fails when unknown team Id provided', async () => {
-    mockGetChangeRequestReviewState.mockResolvedValue(true);
     jest.spyOn(prisma.user, 'findUnique').mockResolvedValue({ ...batman, googleAuthId: 'b' });
     jest.spyOn(prisma.team, 'findUnique').mockResolvedValue(null);
     const proj = { ...newProjectPayload, teamId: 'TEST' };

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -98,6 +98,14 @@ describe('Projects', () => {
     expect(res.body).toStrictEqual('1.2.3');
   });
 
+  test('newProject fails when unknown team Id provided', async () => {
+    const proj = { ...newProjectPayload, teamId: 'TEST' };
+    const res = await request(app).post('/new').send(proj);
+
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toStrictEqual({ message: `team with id TEST not found.` });
+  });
+
   test('editProject fails with feature with no detail', async () => {
     const proj = { ...editProjectPayload, features: [{ id: 4 }] };
     const res = await request(app).post('/edit').send(proj);

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -64,7 +64,7 @@ describe('Projects', () => {
   });
 
   test('newProject fails when unknown team Id provided', async () => {
-    jest.spyOn(prisma.user, 'findUnique').mockResolvedValue({ ...batman, googleAuthId: 'b' });
+    jest.spyOn(prisma.user, 'findUnique').mockResolvedValue(batman);
     jest.spyOn(prisma.team, 'findUnique').mockResolvedValue(null);
     const proj = { ...newProjectPayload, teamId: 'TEST' };
     const res = await request(app).post('/new').send(proj);
@@ -73,7 +73,7 @@ describe('Projects', () => {
   });
   test('newProject works', async () => {
     mockGetHighestProjectNumber.mockResolvedValue(0);
-    jest.spyOn(prisma.user, 'findUnique').mockResolvedValue({ ...batman, googleAuthId: 'b' });
+    jest.spyOn(prisma.user, 'findUnique').mockResolvedValue(batman);
     jest.spyOn(prisma.wBS_Element, 'create').mockResolvedValue({
       wbsElementId: 1,
       status: 'ACTIVE',

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -77,6 +77,7 @@ describe('Projects', () => {
 
   test('newProject fails when unknown team Id provided', async () => {
     mockGetChangeRequestReviewState.mockResolvedValue(true);
+    jest.spyOn(prisma.user, 'findUnique').mockResolvedValue({ ...batman, googleAuthId: 'b' });
     jest.spyOn(prisma.team, 'findUnique').mockResolvedValue(null);
     const proj = { ...newProjectPayload, teamId: 'TEST' };
     const res = await request(app).post('/new').send(proj);

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -55,8 +55,6 @@ describe('Projects', () => {
   });
 
   test('newProject fails with invalid userId', async () => {
-    // you need to add a line here that mocks prisma.team.findunique to return null
-    jest.spyOn(prisma.team, 'findUnique').mockResolvedValue(null);
     const proj = { ...newProjectPayload, userId: -1 };
     const res = await request(app).post('/new').send(proj);
 
@@ -78,6 +76,8 @@ describe('Projects', () => {
   });
 
   test('newProject fails when unknown team Id provided', async () => {
+    mockGetChangeRequestReviewState.mockResolvedValue(true);
+    jest.spyOn(prisma.team, 'findUnique').mockResolvedValue(null);
     const proj = { ...newProjectPayload, teamId: 'TEST' };
     const res = await request(app).post('/new').send(proj);
 

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -75,6 +75,14 @@ describe('Projects', () => {
     expect(res.statusCode).toBe(400);
   });
 
+  test('newProject fails when unknown team Id provided', async () => {
+    const proj = { ...newProjectPayload, teamId: 'TEST' };
+    const res = await request(app).post('/new').send(proj);
+
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toStrictEqual({ message: `team with id TEST not found.` });
+  });
+
   test('newProject works', async () => {
     mockGetHighestProjectNumber.mockResolvedValue(0);
     jest.spyOn(prisma.user, 'findUnique').mockResolvedValue({ ...batman, googleAuthId: 'b' });
@@ -96,14 +104,6 @@ describe('Projects', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.body).toStrictEqual('1.2.3');
-  });
-
-  test('newProject fails when unknown team Id provided', async () => {
-    const proj = { ...newProjectPayload, teamId: 'TEST' };
-    const res = await request(app).post('/new').send(proj);
-
-    expect(res.statusCode).toBe(404);
-    // expect(res.body).toStrictEqual({ message: `team with id TEST not found.` });
   });
 
   test('editProject fails with feature with no detail', async () => {

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -8,16 +8,12 @@ import { aquaman, batman, wonderwoman } from './test-data/users.test-data';
 import { project1, wbsElement1 } from './test-data/projects.test-data';
 import { prismaChangeRequest1 } from './test-data/change-requests.test-data';
 import { prismaTeam1 } from './test-data/teams.test-data';
-
 const app = express();
 app.use(express.json());
 app.use('/', projectRouter);
-
 jest.mock('../src/utils/projects.utils');
 const mockGetHighestProjectNumber = getHighestProjectNumber as jest.Mock<Promise<number>>;
-
 const mockProjectTransformer = projectTransformer as jest.Mock;
-
 const newProjectPayload = {
   userId: 1,
   crId: 2,
@@ -25,7 +21,6 @@ const newProjectPayload = {
   carNumber: 3,
   summary: 'we are building a car'
 };
-
 const editProjectPayload = {
   ...newProjectPayload,
   budget: 100,
@@ -42,7 +37,6 @@ const editProjectPayload = {
   projectLead: 5,
   projectManager: 6
 };
-
 describe('Projects', () => {
   beforeEach(() => {
     jest.spyOn(changeRequestUtils, 'validateChangeRequestAccepted').mockImplementation(async (_crId) => {
@@ -53,42 +47,34 @@ describe('Projects', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
-
   test('newProject fails with invalid userId', async () => {
     const proj = { ...newProjectPayload, userId: -1 };
     const res = await request(app).post('/new').send(proj);
-
     expect(res.statusCode).toBe(400);
   });
-
   test('newProject fails with invalid crId', async () => {
     const proj = { ...newProjectPayload, crId: 'asdf' };
     const res = await request(app).post('/new').send(proj);
-
     expect(res.statusCode).toBe(400);
   });
-
   test('newProject fails with invalid name', async () => {
     const proj = { ...newProjectPayload, name: '' };
     const res = await request(app).post('/new').send(proj);
-
     expect(res.statusCode).toBe(400);
   });
 
   test('newProject fails when unknown team Id provided', async () => {
     mockGetChangeRequestReviewState.mockResolvedValue(true);
-    jest.spyOn(prisma.user, 'findUnique').mockResolvedValue(batman);
+    jest.spyOn(prisma.user, 'findUnique').mockResolvedValue({ ...batman, googleAuthId: 'b' });
     jest.spyOn(prisma.team, 'findUnique').mockResolvedValue(null);
     const proj = { ...newProjectPayload, teamId: 'TEST' };
     const res = await request(app).post('/new').send(proj);
-
     expect(res.statusCode).toBe(404);
     expect(res.body).toStrictEqual({ message: `team with id TEST not found.` });
   });
-
   test('newProject works', async () => {
     mockGetHighestProjectNumber.mockResolvedValue(0);
-    jest.spyOn(prisma.user, 'findUnique').mockResolvedValue(batman);
+    jest.spyOn(prisma.user, 'findUnique').mockResolvedValue({ ...batman, googleAuthId: 'b' });
     jest.spyOn(prisma.wBS_Element, 'create').mockResolvedValue({
       wbsElementId: 1,
       status: 'ACTIVE',
@@ -102,111 +88,84 @@ describe('Projects', () => {
       projectLeadId: 4,
       projectManagerId: 5
     });
-
     const res = await request(app).post('/new').send(newProjectPayload);
-
     expect(res.statusCode).toBe(200);
     expect(res.body).toStrictEqual('1.2.3');
   });
-
   test('editProject fails with feature with no detail', async () => {
     const proj = { ...editProjectPayload, features: [{ id: 4 }] };
     const res = await request(app).post('/edit').send(proj);
-
     expect(res.statusCode).toBe(400);
   });
-
   test('editProject fails with feature with invalid id', async () => {
     const proj = { ...editProjectPayload, features: [{ id: -1, detail: 'alsdjf' }] };
     const res = await request(app).post('/edit').send(proj);
-
     expect(res.statusCode).toBe(400);
   });
-
   test('editProject fails with feature with invalid detail', async () => {
     const proj = { ...editProjectPayload, features: [{ id: 4, detail: '' }] };
     const res = await request(app).post('/edit').send(proj);
-
     expect(res.statusCode).toBe(400);
   });
-
   test('getSingleProject fails given invalid project wbs number', async () => {
     let res = await request(app).get('/1.0.1');
     expect(res.statusCode).toBe(404);
     expect(res.body).toStrictEqual({ message: `1.0.1 is not a valid project WBS #!` });
-
     res = await request(app).get('/2.0.2');
     expect(res.statusCode).toBe(404);
     expect(res.body).toStrictEqual({ message: `2.0.2 is not a valid project WBS #!` });
   });
-
   test('getSingleProject fails when associated wbsElement doesnt exist', async () => {
     jest.spyOn(prisma.wBS_Element, 'findUnique').mockResolvedValue(null);
     let res = await request(app).get('/1.3.0');
     expect(res.statusCode).toBe(404);
     expect(res.body).toStrictEqual({ message: 'project 1.3.0 not found!' });
-
     res = await request(app).get('/2.4.0');
     expect(res.statusCode).toBe(404);
     expect(res.body).toStrictEqual({ message: 'project 2.4.0 not found!' });
   });
-
   test('getSingleProject works', async () => {
     jest.spyOn(prisma.wBS_Element, 'findUnique').mockResolvedValue(wbsElement1);
     mockProjectTransformer.mockReturnValue({ message: 'projectTransformer called' });
     const res = await request(app).get('/1.2.0');
-
     expect(res.statusCode).toBe(200);
     expect(res.body).toStrictEqual({ message: 'projectTransformer called' });
   });
-
   test('getAllProjects works', async () => {
     jest.spyOn(prisma.project, 'findMany').mockResolvedValue([]);
     const res = await request(app).get('');
-
     expect(res.statusCode).toBe(200);
     expect(prisma.project.findMany).toHaveBeenCalledTimes(1);
     expect(res.body).toStrictEqual([]);
   });
-
   test('setProjectTeam fails given invalid project wbs number', async () => {
     const res = await request(app).post('/1.0.1/set-team').send({ teamId: 'test' });
     expect(res.statusCode).toBe(400);
     expect(res.body).toStrictEqual({ message: `1.0.1 is not a valid project WBS #!` });
   });
-
   test('setProjectTeam fails with invalid team id', async () => {
     jest.spyOn(prisma.team, 'findUnique').mockResolvedValue(null);
-
     const res = await request(app).post('/1.2.0/set-team').send({ teamId: 123 });
-
     expect(res.statusCode).toBe(400);
   });
-
   test('setProjectTeam fails with team that does not exist', async () => {
     jest.spyOn(prisma.team, 'findUnique').mockResolvedValue(null);
     jest.spyOn(prisma.project, 'findFirst').mockResolvedValue(project1);
-
     const res = await request(app).post('/1.2.0/set-team').send({ teamId: 'test' });
-
     expect(res.statusCode).toBe(404);
   });
-
   test('setProjectTeam fails with no permission from submitter (guest)', async () => {
     jest.spyOn(prisma.user, 'findUnique').mockResolvedValue(wonderwoman);
     jest.spyOn(prisma.team, 'findUnique').mockResolvedValue(prismaTeam1);
     jest.spyOn(prisma.project, 'findFirst').mockResolvedValue(project1);
     const res = await request(app).post('/1.2.0/set-team').send({ teamId: 'test' });
-
     expect(res.statusCode).toBe(403);
   });
-
   test('setProjectTeam fails with no permission from submitter (leadership)', async () => {
     jest.spyOn(prisma.user, 'findUnique').mockResolvedValue(aquaman);
     jest.spyOn(prisma.team, 'findUnique').mockResolvedValue(prismaTeam1);
     jest.spyOn(prisma.project, 'findFirst').mockResolvedValue(project1);
     const res = await request(app).post('/1.2.0/set-team').send({ teamId: 'test' });
-
     expect(res.statusCode).toBe(403);
   });
 });

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -77,7 +77,7 @@ describe('Projects', () => {
 
   test('newProject fails when unknown team Id provided', async () => {
     mockGetChangeRequestReviewState.mockResolvedValue(true);
-    jest.spyOn(prisma.user, 'findUnique').mockResolvedValue({ ...batman, googleAuthId: 'b' });
+    jest.spyOn(prisma.user, 'findUnique').mockResolvedValue(batman);
     jest.spyOn(prisma.team, 'findUnique').mockResolvedValue(null);
     const proj = { ...newProjectPayload, teamId: 'TEST' };
     const res = await request(app).post('/new').send(proj);
@@ -88,7 +88,7 @@ describe('Projects', () => {
 
   test('newProject works', async () => {
     mockGetHighestProjectNumber.mockResolvedValue(0);
-    jest.spyOn(prisma.user, 'findUnique').mockResolvedValue({ ...batman, googleAuthId: 'b' });
+    jest.spyOn(prisma.user, 'findUnique').mockResolvedValue(batman);
     jest.spyOn(prisma.wBS_Element, 'create').mockResolvedValue({
       wbsElementId: 1,
       status: 'ACTIVE',

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -103,7 +103,7 @@ describe('Projects', () => {
     const res = await request(app).post('/new').send(proj);
 
     expect(res.statusCode).toBe(404);
-    expect(res.body).toStrictEqual({ message: `team with id TEST not found.` });
+    // expect(res.body).toStrictEqual({ message: `team with id TEST not found.` });
   });
 
   test('editProject fails with feature with no detail', async () => {

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -55,6 +55,8 @@ describe('Projects', () => {
   });
 
   test('newProject fails with invalid userId', async () => {
+    // you need to add a line here that mocks prisma.team.findunique to return null
+    jest.spyOn(prisma.team, 'findUnique').mockResolvedValue(null);
     const proj = { ...newProjectPayload, userId: -1 };
     const res = await request(app).post('/new').send(proj);
 


### PR DESCRIPTION
## Changes

Made a check to see if the request body includes teamId. If it does not include teamId, a project is similarly created without any teamId, but if it is provided, it verifies for a valid teamId and if it is not, it will send a 404. if it is, it will create the project with the teamId. 

## Notes

n/a

## Test Cases

passed all tests

## To Do

require a teamId in order to not check for an unprovided one.. transition to requiring teamIds

Closes #373 