### PR TITLE
#505: add quick filters to data grids

### DIFF
--- a/src/frontend/src/pages/ChangeRequestsPage/ChangeRequestsTable.tsx
+++ b/src/frontend/src/pages/ChangeRequestsPage/ChangeRequestsTable.tsx
@@ -177,6 +177,12 @@ const ChangeRequestsTable: React.FC = () => {
           history.push(`${routes.CHANGE_REQUESTS}/${params.row.crId}`);
         }}
         components={{ Toolbar: GridToolbar }}
+        componentsProps={{
+          toolbar: {
+            showQuickFilter: true,
+            quickFilterProps: { debounceMs: 500 }
+          }
+        }}
         initialState={{
           sorting: {
             sortModel: [{ field: 'crId', sort: 'desc' }]

--- a/src/frontend/src/pages/ProjectsPage/ProjectsTable.tsx
+++ b/src/frontend/src/pages/ProjectsPage/ProjectsTable.tsx
@@ -144,6 +144,12 @@ const ProjectsTable: React.FC = () => {
           history.push(`${routes.PROJECTS}/${wbsPipe(params.row.wbsNum)}`);
         }}
         components={{ Toolbar: GridToolbar }}
+        componentsProps={{
+          toolbar: {
+            showQuickFilter: true,
+            quickFilterProps: { debounceMs: 500 }
+          }
+        }}
         initialState={{
           sorting: {
             sortModel: [{ field: 'wbsNum', sort: 'asc' }]


### PR DESCRIPTION
## Changes

Enabled quick filtering for data grids on the Projects Page and Change Requests Page.

## Notes

n/a

## Test Cases

n/a

## Screenshots

Change requests page
<img width="1642" alt="Screenshot 2023-01-03 at 5 50 28 PM" src="https://user-images.githubusercontent.com/51571627/210469953-a7326362-2595-4468-baa6-11ee0d8acd24.png">

projects page
<img width="1642" alt="Screenshot 2023-01-03 at 5 50 49 PM" src="https://user-images.githubusercontent.com/51571627/210469989-3a4392c3-ab95-4016-a189-5725ee076ca6.png">

## To Do

n/a

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #505 (doesn't actually, cuz I just tossed this on the parent epic)
