### PR TITLE
#535 Add Wbs Name to CRTable

### DIFF
--- a/src/backend/src/transformers/change-requests.transformer.ts
+++ b/src/backend/src/transformers/change-requests.transformer.ts
@@ -12,7 +12,7 @@ const changeRequestTransformer = (
   return {
     // all cr fields
     crId: changeRequest.crId,
-    wbs: {wbsNum: wbsNumOf(changeRequest.wbsElement), name: changeRequest.wbsElement.name},
+    wbs: { wbsNum: wbsNumOf(changeRequest.wbsElement), name: changeRequest.wbsElement.name },
     submitter: userTransformer(changeRequest.submitter),
     dateSubmitted: changeRequest.dateSubmitted,
     type: changeRequest.type,
@@ -56,7 +56,7 @@ const changeRequestTransformer = (
     confirmDetails: changeRequest.activationChangeRequest?.confirmDetails ?? undefined,
     // stage gate cr fields
     leftoverBudget: changeRequest.stageGateChangeRequest?.leftoverBudget ?? undefined,
-    confirmDone: changeRequest.stageGateChangeRequest?.confirmDone ?? undefined,
+    confirmDone: changeRequest.stageGateChangeRequest?.confirmDone ?? undefined
   };
 };
 

--- a/src/backend/src/transformers/change-requests.transformer.ts
+++ b/src/backend/src/transformers/change-requests.transformer.ts
@@ -12,7 +12,7 @@ const changeRequestTransformer = (
   return {
     // all cr fields
     crId: changeRequest.crId,
-    wbsNum: wbsNumOf(changeRequest.wbsElement),
+    wbs: {wbsNum: wbsNumOf(changeRequest.wbsElement), name: changeRequest.wbsElement.name},
     submitter: userTransformer(changeRequest.submitter),
     dateSubmitted: changeRequest.dateSubmitted,
     type: changeRequest.type,
@@ -56,7 +56,7 @@ const changeRequestTransformer = (
     confirmDetails: changeRequest.activationChangeRequest?.confirmDetails ?? undefined,
     // stage gate cr fields
     leftoverBudget: changeRequest.stageGateChangeRequest?.leftoverBudget ?? undefined,
-    confirmDone: changeRequest.stageGateChangeRequest?.confirmDone ?? undefined
+    confirmDone: changeRequest.stageGateChangeRequest?.confirmDone ?? undefined,
   };
 };
 

--- a/src/backend/src/transformers/change-requests.transformer.ts
+++ b/src/backend/src/transformers/change-requests.transformer.ts
@@ -12,7 +12,8 @@ const changeRequestTransformer = (
   return {
     // all cr fields
     crId: changeRequest.crId,
-    wbs: { wbsNum: wbsNumOf(changeRequest.wbsElement), name: changeRequest.wbsElement.name },
+    wbsNum: wbsNumOf(changeRequest.wbsElement),
+    wbsName: changeRequest.wbsElement.name,
     submitter: userTransformer(changeRequest.submitter),
     dateSubmitted: changeRequest.dateSubmitted,
     type: changeRequest.type,

--- a/src/backend/tests/test-data/change-requests.test-data.ts
+++ b/src/backend/tests/test-data/change-requests.test-data.ts
@@ -73,11 +73,14 @@ export const whipDeliverables: PrismaDescriptionBullet = {
 
 export const sharedChangeRequest: SharedChangeRequest = {
   crId: 1,
-  wbs: {wbsNum: {
-    carNumber: 1,
-    projectNumber: 2,
-    workPackageNumber: 3
-  }, name: 'whip'},
+  wbs: {
+    wbsNum: {
+      carNumber: 1,
+      projectNumber: 2,
+      workPackageNumber: 3
+    },
+    name: 'whip'
+  },
   submitter: sharedUser1,
   dateSubmitted: new Date('12-25-2000'),
   type: ChangeRequestType.Redefinition

--- a/src/backend/tests/test-data/change-requests.test-data.ts
+++ b/src/backend/tests/test-data/change-requests.test-data.ts
@@ -73,11 +73,11 @@ export const whipDeliverables: PrismaDescriptionBullet = {
 
 export const sharedChangeRequest: SharedChangeRequest = {
   crId: 1,
-  wbsNum: {
+  wbs: {wbsNum: {
     carNumber: 1,
     projectNumber: 2,
     workPackageNumber: 3
-  },
+  }, name: 'whip'},
   submitter: sharedUser1,
   dateSubmitted: new Date('12-25-2000'),
   type: ChangeRequestType.Redefinition

--- a/src/backend/tests/test-data/change-requests.test-data.ts
+++ b/src/backend/tests/test-data/change-requests.test-data.ts
@@ -73,14 +73,12 @@ export const whipDeliverables: PrismaDescriptionBullet = {
 
 export const sharedChangeRequest: SharedChangeRequest = {
   crId: 1,
-  wbs: {
-    wbsNum: {
-      carNumber: 1,
-      projectNumber: 2,
-      workPackageNumber: 3
-    },
-    name: 'whip'
+  wbsNum: {
+    carNumber: 1,
+    projectNumber: 2,
+    workPackageNumber: 3
   },
+  wbsName: 'whip',
   submitter: sharedUser1,
   dateSubmitted: new Date('12-25-2000'),
   type: ChangeRequestType.Redefinition

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ChangeRequestDetailsView.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ChangeRequestDetailsView.tsx
@@ -119,7 +119,7 @@ const ChangeRequestDetailsView: React.FC<ChangeRequestDetailsProps> = ({
         </MenuItem>
         <MenuItem
           component={RouterLink}
-          to={`${routes.WORK_PACKAGE_NEW}?crId=${changeRequest.crId}&wbs=${projectWbsPipe(changeRequest.wbs.wbsNum)}`}
+          to={`${routes.WORK_PACKAGE_NEW}?crId=${changeRequest.crId}&wbs=${projectWbsPipe(changeRequest.wbsNum)}`}
           disabled={!isUserAllowedToImplement}
           onClick={handleDropdownClose}
         >
@@ -127,11 +127,11 @@ const ChangeRequestDetailsView: React.FC<ChangeRequestDetailsProps> = ({
         </MenuItem>
         <MenuItem
           component={RouterLink}
-          to={`${routes.PROJECTS}/${wbsPipe(changeRequest.wbs.wbsNum)}?crId=${changeRequest.crId}&edit=${true}`}
+          to={`${routes.PROJECTS}/${wbsPipe(changeRequest.wbsNum)}?crId=${changeRequest.crId}&edit=${true}`}
           disabled={!isUserAllowedToImplement}
           onClick={handleDropdownClose}
         >
-          Edit {changeRequest.wbs.wbsNum.workPackageNumber === 0 ? 'Project' : 'Work Package'}
+          Edit {changeRequest.wbsNum.workPackageNumber === 0 ? 'Project' : 'Work Package'}
         </MenuItem>
       </Menu>
     </div>
@@ -160,8 +160,8 @@ const ChangeRequestDetailsView: React.FC<ChangeRequestDetailsProps> = ({
             <Typography sx={{ fontWeight: 'bold' }}>WBS #: </Typography>
           </Grid>
           <Grid item xs={10}>
-            <Link component={RouterLink} to={`${routes.PROJECTS}/${wbsPipe(changeRequest.wbs.wbsNum)}`}>
-              {wbsPipe(changeRequest.wbs.wbsNum)}
+            <Link component={RouterLink} to={`${routes.PROJECTS}/${wbsPipe(changeRequest.wbsNum)}`}>
+              {wbsPipe(changeRequest.wbsNum)}
             </Link>
           </Grid>
           <Grid item xs={3} md={2}>

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ChangeRequestDetailsView.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ChangeRequestDetailsView.tsx
@@ -119,7 +119,7 @@ const ChangeRequestDetailsView: React.FC<ChangeRequestDetailsProps> = ({
         </MenuItem>
         <MenuItem
           component={RouterLink}
-          to={`${routes.WORK_PACKAGE_NEW}?crId=${changeRequest.crId}&wbs=${projectWbsPipe(changeRequest.wbsNum)}`}
+          to={`${routes.WORK_PACKAGE_NEW}?crId=${changeRequest.crId}&wbs=${projectWbsPipe(changeRequest.wbs.wbsNum)}`}
           disabled={!isUserAllowedToImplement}
           onClick={handleDropdownClose}
         >
@@ -127,11 +127,11 @@ const ChangeRequestDetailsView: React.FC<ChangeRequestDetailsProps> = ({
         </MenuItem>
         <MenuItem
           component={RouterLink}
-          to={`${routes.PROJECTS}/${wbsPipe(changeRequest.wbsNum)}?crId=${changeRequest.crId}&edit=${true}`}
+          to={`${routes.PROJECTS}/${wbsPipe(changeRequest.wbs.wbsNum)}?crId=${changeRequest.crId}&edit=${true}`}
           disabled={!isUserAllowedToImplement}
           onClick={handleDropdownClose}
         >
-          Edit {changeRequest.wbsNum.workPackageNumber === 0 ? 'Project' : 'Work Package'}
+          Edit {changeRequest.wbs.wbsNum.workPackageNumber === 0 ? 'Project' : 'Work Package'}
         </MenuItem>
       </Menu>
     </div>
@@ -160,8 +160,8 @@ const ChangeRequestDetailsView: React.FC<ChangeRequestDetailsProps> = ({
             <Typography sx={{ fontWeight: 'bold' }}>WBS #: </Typography>
           </Grid>
           <Grid item xs={10}>
-            <Link component={RouterLink} to={`${routes.PROJECTS}/${wbsPipe(changeRequest.wbsNum)}`}>
-              {wbsPipe(changeRequest.wbsNum)}
+            <Link component={RouterLink} to={`${routes.PROJECTS}/${wbsPipe(changeRequest.wbs.wbsNum)}`}>
+              {wbsPipe(changeRequest.wbs.wbsNum)}
             </Link>
           </Grid>
           <Grid item xs={3} md={2}>

--- a/src/frontend/src/pages/ChangeRequestsPage/ChangeRequestsTable.tsx
+++ b/src/frontend/src/pages/ChangeRequestsPage/ChangeRequestsTable.tsx
@@ -17,7 +17,7 @@ import { Link } from 'react-router-dom';
 import { Button } from '@mui/material';
 import { useTheme } from '@mui/system';
 import { useState } from 'react';
-import { ChangeRequestType } from 'shared';
+import { ChangeRequestType, validateWBS, WbsNumber } from 'shared';
 
 const ChangeRequestsTable: React.FC = () => {
   const history = useHistory();
@@ -58,16 +58,20 @@ const ChangeRequestsTable: React.FC = () => {
       ...baseColDef,
       field: 'wbs',
       headerName: 'WBS',
-      filterable: false,
+      filterable: true,
+      sortable: true,
       maxWidth: 300,
-      valueFormatter: (params) => `${wbsPipe(params.value.wbsNum)} - ${params.value.name}`,
-      sortComparator: (v1, v2, param1, param2) => {
-        if (param1.value.wbsNum.carNumber !== param2.value.wbsNum.carNumber) {
-          return param1.value.wbsNum.carNumber - param2.value.wbsNum.carNumber;
-        } else if (param1.value.wbsNum.projectNumber !== param2.value.wbsNum.projectNumber) {
-          return param1.value.wbsNum.projectNumber - param2.value.wbsNum.projectNumber;
-        } else if (param1.value.wbsNum.workPackageNumber !== param2.value.wbsNum.workPackageNumber) {
-          return param1.value.wbsNum.workPackageNumber - param2.value.wbsNum.workPackageNumber;
+      valueGetter: (params) => `${wbsPipe(params.value.wbsNum)} - ${params.value.name}`,
+      sortComparator: (_v1, _v2, param1, param2) => {
+        const wbs1: WbsNumber = validateWBS((param1.value as string).split(' ')[0]);
+        const wbs2: WbsNumber = validateWBS((param2.value as string).split(' ')[0]);
+
+        if (wbs1.carNumber !== wbs2.carNumber) {
+          return wbs1.carNumber - wbs2.carNumber;
+        } else if (wbs1.projectNumber !== wbs2.projectNumber) {
+          return wbs1.projectNumber - wbs2.projectNumber;
+        } else if (wbs1.workPackageNumber !== wbs2.workPackageNumber) {
+          return wbs1.workPackageNumber - wbs2.workPackageNumber;
         } else {
           return 0;
         }

--- a/src/frontend/src/pages/ChangeRequestsPage/ChangeRequestsTable.tsx
+++ b/src/frontend/src/pages/ChangeRequestsPage/ChangeRequestsTable.tsx
@@ -43,7 +43,7 @@ const ChangeRequestsTable: React.FC = () => {
       field: 'crId',
       type: 'number',
       headerName: 'ID',
-      maxWidth: 100
+      maxWidth: 75
     },
     {
       ...baseColDef,
@@ -56,11 +56,11 @@ const ChangeRequestsTable: React.FC = () => {
     { ...baseColDef, field: 'carNumber', headerName: 'Car #', type: 'number', maxWidth: 50 },
     {
       ...baseColDef,
-      field: 'wbsNum',
-      headerName: 'WBS #',
+      field: 'wbs',
+      headerName: 'WBS',
       filterable: false,
-      maxWidth: 100,
-      valueFormatter: (params) => wbsPipe(params.value),
+      maxWidth: 300,
+      valueFormatter: (params) => `${wbsPipe(params.value.wbsNum)} - ${params.value.name}`,
       sortComparator: (v1, v2, param1, param2) => {
         if (param1.value.carNumber !== param2.value.carNumber) {
           return param1.value.carNumber - param2.value.carNumber;
@@ -165,7 +165,7 @@ const ChangeRequestsTable: React.FC = () => {
           // flatten some complex data to allow MUI to sort/filter yet preserve the original data being available to the front-end
           data?.map((v) => ({
             ...v,
-            carNumber: v.wbsNum.carNumber,
+            carNumber: v.wbs.wbsNum.carNumber,
             submitter: fullNamePipe(v.submitter),
             reviewer: fullNamePipe(v.reviewer)
           })) || []

--- a/src/frontend/src/pages/ChangeRequestsPage/ChangeRequestsTable.tsx
+++ b/src/frontend/src/pages/ChangeRequestsPage/ChangeRequestsTable.tsx
@@ -165,7 +165,8 @@ const ChangeRequestsTable: React.FC = () => {
           // flatten some complex data to allow MUI to sort/filter yet preserve the original data being available to the front-end
           data?.map((v) => ({
             ...v,
-            carNumber: v.wbs.wbsNum.carNumber,
+            carNumber: v.wbsNum.carNumber,
+            wbs: { wbsNum: v.wbsNum, name: v.wbsName },
             submitter: fullNamePipe(v.submitter),
             reviewer: fullNamePipe(v.reviewer)
           })) || []

--- a/src/frontend/src/pages/ChangeRequestsPage/ChangeRequestsTable.tsx
+++ b/src/frontend/src/pages/ChangeRequestsPage/ChangeRequestsTable.tsx
@@ -62,12 +62,12 @@ const ChangeRequestsTable: React.FC = () => {
       maxWidth: 300,
       valueFormatter: (params) => `${wbsPipe(params.value.wbsNum)} - ${params.value.name}`,
       sortComparator: (v1, v2, param1, param2) => {
-        if (param1.value.carNumber !== param2.value.carNumber) {
-          return param1.value.carNumber - param2.value.carNumber;
-        } else if (param1.value.projectNumber !== param2.value.projectNumber) {
-          return param1.value.projectNumber - param2.value.projectNumber;
-        } else if (param1.value.workPackageNumber !== param2.value.workPackageNumber) {
-          return param1.value.workPackageNumber - param2.value.workPackageNumber;
+        if (param1.value.wbsNum.carNumber !== param2.value.wbsNum.carNumber) {
+          return param1.value.wbsNum.carNumber - param2.value.wbsNum.carNumber;
+        } else if (param1.value.wbsNum.projectNumber !== param2.value.wbsNum.projectNumber) {
+          return param1.value.wbsNum.projectNumber - param2.value.wbsNum.projectNumber;
+        } else if (param1.value.wbsNum.workPackageNumber !== param2.value.wbsNum.workPackageNumber) {
+          return param1.value.wbsNum.workPackageNumber - param2.value.wbsNum.workPackageNumber;
         } else {
           return 0;
         }

--- a/src/frontend/src/tests/test-support/test-data/change-requests.stub.ts
+++ b/src/frontend/src/tests/test-support/test-data/change-requests.stub.ts
@@ -17,7 +17,7 @@ import { exampleWbsWorkPackage1 } from './wbs-numbers.stub';
 
 export const exampleStandardChangeRequest: StandardChangeRequest = {
   crId: 37,
-  wbsNum: exampleWbsWorkPackage1,
+  wbs: { wbsNum: exampleWbsWorkPackage1, name: 'Example Work Package 1' },
   submitter: exampleAdminUser,
   dateSubmitted: new Date('02/25/21'),
   type: ChangeRequestType.Issue,
@@ -61,7 +61,7 @@ export const exampleStandardChangeRequest: StandardChangeRequest = {
 
 export const exampleActivationChangeRequest: ActivationChangeRequest = {
   crId: 69,
-  wbsNum: exampleWbsWorkPackage1,
+  wbs: { wbsNum: exampleWbsWorkPackage1, name: 'Example Work Package 1' },
   submitter: exampleAdminUser,
   dateSubmitted: new Date('02/25/21'),
   type: ChangeRequestType.Activation,
@@ -73,7 +73,7 @@ export const exampleActivationChangeRequest: ActivationChangeRequest = {
 
 export const exampleStageGateChangeRequest: StageGateChangeRequest = {
   crId: 93,
-  wbsNum: exampleWbsWorkPackage1,
+  wbs: { wbsNum: exampleWbsWorkPackage1, name: 'Example Work Package 1'},
   submitter: exampleAdminUser,
   dateSubmitted: new Date('02/25/21'),
   type: ChangeRequestType.StageGate,
@@ -83,7 +83,7 @@ export const exampleStageGateChangeRequest: StageGateChangeRequest = {
 
 export const exampleStandardImplementedChangeRequest: StandardChangeRequest = {
   crId: 37,
-  wbsNum: exampleWbsWorkPackage1,
+  wbs: { wbsNum: exampleWbsWorkPackage1, name: 'Example Work Package 1' },
   submitter: exampleAdminUser,
   dateSubmitted: new Date('02/25/21'),
   type: ChangeRequestType.Issue,

--- a/src/frontend/src/tests/test-support/test-data/change-requests.stub.ts
+++ b/src/frontend/src/tests/test-support/test-data/change-requests.stub.ts
@@ -73,7 +73,7 @@ export const exampleActivationChangeRequest: ActivationChangeRequest = {
 
 export const exampleStageGateChangeRequest: StageGateChangeRequest = {
   crId: 93,
-  wbs: { wbsNum: exampleWbsWorkPackage1, name: 'Example Work Package 1'},
+  wbs: { wbsNum: exampleWbsWorkPackage1, name: 'Example Work Package 1' },
   submitter: exampleAdminUser,
   dateSubmitted: new Date('02/25/21'),
   type: ChangeRequestType.StageGate,

--- a/src/frontend/src/tests/test-support/test-data/change-requests.stub.ts
+++ b/src/frontend/src/tests/test-support/test-data/change-requests.stub.ts
@@ -17,7 +17,8 @@ import { exampleWbsWorkPackage1 } from './wbs-numbers.stub';
 
 export const exampleStandardChangeRequest: StandardChangeRequest = {
   crId: 37,
-  wbs: { wbsNum: exampleWbsWorkPackage1, name: 'Example Work Package 1' },
+  wbsNum: exampleWbsWorkPackage1,
+  wbsName: 'Example Work Package 1',
   submitter: exampleAdminUser,
   dateSubmitted: new Date('02/25/21'),
   type: ChangeRequestType.Issue,
@@ -61,7 +62,8 @@ export const exampleStandardChangeRequest: StandardChangeRequest = {
 
 export const exampleActivationChangeRequest: ActivationChangeRequest = {
   crId: 69,
-  wbs: { wbsNum: exampleWbsWorkPackage1, name: 'Example Work Package 1' },
+  wbsNum: exampleWbsWorkPackage1,
+  wbsName: 'Example Work Package 1',
   submitter: exampleAdminUser,
   dateSubmitted: new Date('02/25/21'),
   type: ChangeRequestType.Activation,
@@ -73,7 +75,8 @@ export const exampleActivationChangeRequest: ActivationChangeRequest = {
 
 export const exampleStageGateChangeRequest: StageGateChangeRequest = {
   crId: 93,
-  wbs: { wbsNum: exampleWbsWorkPackage1, name: 'Example Work Package 1' },
+  wbsNum: exampleWbsWorkPackage1,
+  wbsName: 'Example Work Package 1',
   submitter: exampleAdminUser,
   dateSubmitted: new Date('02/25/21'),
   type: ChangeRequestType.StageGate,
@@ -83,7 +86,8 @@ export const exampleStageGateChangeRequest: StageGateChangeRequest = {
 
 export const exampleStandardImplementedChangeRequest: StandardChangeRequest = {
   crId: 37,
-  wbs: { wbsNum: exampleWbsWorkPackage1, name: 'Example Work Package 1' },
+  wbsNum: exampleWbsWorkPackage1,
+  wbsName: 'Example Work Package 1',
   submitter: exampleAdminUser,
   dateSubmitted: new Date('02/25/21'),
   type: ChangeRequestType.Issue,

--- a/src/shared/src/types/change-request-types.ts
+++ b/src/shared/src/types/change-request-types.ts
@@ -8,7 +8,10 @@ import { WbsNumber } from './project-types';
 
 export interface ChangeRequest {
   crId: number;
-  wbsNum: WbsNumber;
+  wbs: {
+    wbsNum: WbsNumber,
+    name: string;
+  };
   submitter: User;
   dateSubmitted: Date;
   type: ChangeRequestType;

--- a/src/shared/src/types/change-request-types.ts
+++ b/src/shared/src/types/change-request-types.ts
@@ -8,10 +8,8 @@ import { WbsNumber } from './project-types';
 
 export interface ChangeRequest {
   crId: number;
-  wbs: {
-    wbsNum: WbsNumber;
-    name: string;
-  };
+  wbsNum: WbsNumber;
+  wbsName: string;
   submitter: User;
   dateSubmitted: Date;
   type: ChangeRequestType;

--- a/src/shared/src/types/change-request-types.ts
+++ b/src/shared/src/types/change-request-types.ts
@@ -9,7 +9,7 @@ import { WbsNumber } from './project-types';
 export interface ChangeRequest {
   crId: number;
   wbs: {
-    wbsNum: WbsNumber,
+    wbsNum: WbsNumber;
     name: string;
   };
   submitter: User;


### PR DESCRIPTION
## Changes

Added WBS Name to cr

## Notes

Restructured change request type to take in an object for wbs that includes both number and name, because you can only pass in one field to a column from what I could see. 

## Screenshots
<img width="1728" alt="Screen Shot 2023-01-11 at 5 24 07 PM" src="https://user-images.githubusercontent.com/113635669/211931165-fd05bded-0e9b-4864-ba29-85a611cc2b91.png">

<img width="493" alt="Screen Shot 2023-01-11 at 5 24 15 PM" src="https://user-images.githubusercontent.com/113635669/211931172-d81fd53e-9f39-4c39-b35a-4b5e5098819e.png">

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #535  (issue #)
