### PR TITLE
#333 - Fade unapproved change requests

### DIFF
--- a/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionView.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionView.tsx
@@ -24,8 +24,7 @@ const ProposedSolutionView: React.FC<ProposedSolutionViewProps> = ({ proposedSol
   const faded = !proposedSolution.approved;
 
   return (
-    <PageBlock title=""
-     style={{ opacity:faded ?  0.5 : 1 }}>
+    <PageBlock title="" style={{ opacity: faded ? 0.5 : 1 }}>
       {showDeleteButton && onDelete !== undefined ? (
         <Button
           color="error"

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionView.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionView.tsx
@@ -21,8 +21,11 @@ interface ProposedSolutionViewProps {
 }
 
 const ProposedSolutionView: React.FC<ProposedSolutionViewProps> = ({ proposedSolution, showDeleteButton, onDelete }) => {
+  const faded = !proposedSolution.approved;
+
   return (
-    <PageBlock title="">
+    <PageBlock title=""
+     style={{ opacity:faded ?  0.5 : 1 }}>
       {showDeleteButton && onDelete !== undefined ? (
         <Button
           color="error"

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionView.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionView.tsx
@@ -18,10 +18,16 @@ interface ProposedSolutionViewProps {
   proposedSolution: ProposedSolution;
   showDeleteButton?: boolean;
   onDelete?: (proposedSolution: ProposedSolution) => void;
+  crReviewed?: boolean;
 }
 
-const ProposedSolutionView: React.FC<ProposedSolutionViewProps> = ({ proposedSolution, showDeleteButton, onDelete }) => {
-  const faded = !proposedSolution.approved;
+const ProposedSolutionView: React.FC<ProposedSolutionViewProps> = ({
+  proposedSolution,
+  showDeleteButton,
+  onDelete,
+  crReviewed
+}) => {
+  const faded = crReviewed != null && proposedSolution.approved === false;
 
   return (
     <PageBlock title="" style={{ opacity: faded ? 0.5 : 1 }}>

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionsList.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionsList.tsx
@@ -48,10 +48,9 @@ const ProposedSolutionsList: React.FC<ProposedSolutionsListProps> = ({ proposedS
   return (
     <>
       <div className={styles.proposedSolutionsList}>
-        {proposedSolutions.map((proposedSolution, i) => {
-          const component = <ProposedSolutionView key={i} proposedSolution={proposedSolution} />;
-          return proposedSolution.approved ? component : <div style={{ opacity: 0.5 }}>{component}</div>;
-        })}
+        {proposedSolutions.map((proposedSolution, i) => (
+          <ProposedSolutionView key={i} proposedSolution={proposedSolution} />
+        ))}
       </div>
       {crReviewed === undefined && auth.user?.role !== 'GUEST' ? (
         <Button onClick={() => setShowEditableForm(true)} variant="contained" color="success" sx={{ marginTop: 2 }}>

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionsList.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionsList.tsx
@@ -48,9 +48,10 @@ const ProposedSolutionsList: React.FC<ProposedSolutionsListProps> = ({ proposedS
   return (
     <>
       <div className={styles.proposedSolutionsList}>
-        {proposedSolutions.map((proposedSolution, i) => (
-          <ProposedSolutionView key={i} proposedSolution={proposedSolution} />
-        ))}
+        {proposedSolutions.map((proposedSolution, i) => {
+          const component = <ProposedSolutionView key={i} proposedSolution={proposedSolution} />;
+          return proposedSolution.approved ? component : <div style={{ opacity: 0.5 }}>{component}</div>;
+        })}
       </div>
       {crReviewed === undefined && auth.user?.role !== 'GUEST' ? (
         <Button onClick={() => setShowEditableForm(true)} variant="contained" color="success" sx={{ marginTop: 2 }}>

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionsList.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionsList.tsx
@@ -49,7 +49,7 @@ const ProposedSolutionsList: React.FC<ProposedSolutionsListProps> = ({ proposedS
     <>
       <div className={styles.proposedSolutionsList}>
         {proposedSolutions.map((proposedSolution, i) => (
-          <ProposedSolutionView key={i} proposedSolution={proposedSolution} />
+          <ProposedSolutionView key={i} proposedSolution={proposedSolution} crReviewed={crReviewed} />
         ))}
       </div>
       {crReviewed === undefined && auth.user?.role !== 'GUEST' ? (


### PR DESCRIPTION
## Changes
Change requests that have not been approved appear less opaque as compared to approved requests - similarly to how unselected change requests are translucent in the review selection modal.

## Screenshots
<img width="1695" alt="Screen Shot 2023-02-08 at 8 06 29 PM" src="https://user-images.githubusercontent.com/29807461/217688451-c7043aa1-d078-4c45-aa4e-3fc0b82d1ef4.png">


## To Do
- [x] Verify UI changes look good
- [x] Upload screenshots

## Checklist
- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket

Closes #333 
