### PR TITLE
#223 - Use URL Query Strings for Login Redirect

### DIFF
--- a/src/frontend/src/app/AppPublic.tsx
+++ b/src/frontend/src/app/AppPublic.tsx
@@ -37,6 +37,8 @@ const AppPublic: React.FC = () => {
     // otherwise, the user needs to login manually
     // prepare query args to store path after login
     const pathParts: string[] = history.location.pathname.split('/').slice(1);
+    // if the URL ended in an extra '/' we don't want to clutter the query args
+    if (pathParts[pathParts.length - 1] === '') pathParts.pop();
     const asQueryArg = (pathPart: string, idx: number): string => {
       if (idx === 0) return `page=${pathPart}`;
       else return `value${idx}=${pathPart}`;

--- a/src/frontend/src/app/AppPublic.tsx
+++ b/src/frontend/src/app/AppPublic.tsx
@@ -35,10 +35,18 @@ const AppPublic: React.FC = () => {
     }
 
     // otherwise, the user needs to login manually
+    // prepare query args to store path after login
+    const pathParts: string[] = history.location.pathname.split('/').slice(1);
+    const asQueryArg = (pathPart: string, idx: number): string => {
+      if (idx === 0) return `page=${pathPart}`;
+      else return `value${idx}=${pathPart}`;
+    };
+    const pathArgs: string = `?${pathParts.map(asQueryArg).join('&')}`;
     return (
       <Redirect
         to={{
           pathname: routes.LOGIN,
+          search: pathArgs + (history.location.search ? `&${history.location.search.slice(1)}` : ''),
           state: { from: e.location }
         }}
       />

--- a/src/frontend/src/app/AppPublic.tsx
+++ b/src/frontend/src/app/AppPublic.tsx
@@ -58,7 +58,7 @@ const AppPublic: React.FC = () => {
   return (
     <Switch>
       <Route path={routes.LOGIN}>
-        <Login postLoginRedirect={{ url: history.location.pathname, search: history.location.search }} />
+        <Login />
       </Route>
       <Route path="*" render={render} />
     </Switch>

--- a/src/frontend/src/app/AppPublic.tsx
+++ b/src/frontend/src/app/AppPublic.tsx
@@ -36,19 +36,23 @@ const AppPublic: React.FC = () => {
 
     // otherwise, the user needs to login manually
     // prepare query args to store path after login
-    const pathParts: string[] = history.location.pathname.split('/').slice(1);
-    // if the URL ended in an extra '/' we don't want to clutter the query args
-    if (pathParts[pathParts.length - 1] === '') pathParts.pop();
-    const asQueryArg = (pathPart: string, idx: number): string => {
-      if (idx === 0) return `page=${pathPart}`;
-      else return `value${idx}=${pathPart}`;
-    };
-    const pathArgs: string = `?${pathParts.map(asQueryArg).join('&')}`;
+    const redirectPathParts: string[] = history.location.pathname.split('/').slice(1);
+    // if the path ended in an trailing '/' we don't want to clutter the query args with empty param
+    if (redirectPathParts[redirectPathParts.length - 1] === '') redirectPathParts.pop();
+    const redirectPathQueryArgs: string = redirectPathParts
+      .slice(1) // "valueX=" starts from second part of the path
+      .reduce(
+        (prevArgs: string, pathPart: string, idx: number): string => `${prevArgs}&value${idx + 1}=${pathPart}`,
+        `?page=${redirectPathParts[0]}`
+      );
+    const redirectQueryArgs =
+      redirectPathQueryArgs + (history.location.search ? `&${history.location.search.slice(1)}` : '');
+
     return (
       <Redirect
         to={{
           pathname: routes.LOGIN,
-          search: pathArgs + (history.location.search ? `&${history.location.search.slice(1)}` : ''),
+          search: redirectQueryArgs,
           state: { from: e.location }
         }}
       />

--- a/src/frontend/src/pages/LoginPage/Login.tsx
+++ b/src/frontend/src/pages/LoginPage/Login.tsx
@@ -10,27 +10,34 @@ import { useAuth } from '../../hooks/auth.hooks';
 import { routes } from '../../utils/routes';
 import LoginPage from './LoginPage';
 import LoadingIndicator from '../../components/LoadingIndicator';
-
-interface LoginProps {
-  postLoginRedirect: { url: string; search: string };
-}
+import { useQuery } from '../../hooks/utils.hooks';
 
 /**
  * Page for unauthenticated users to do login.
  */
-const Login: React.FC<LoginProps> = ({ postLoginRedirect }) => {
+const Login = () => {
   const [devUserId, setDevUserId] = useState(1);
   const history = useHistory();
+  const query = useQuery();
   const theme = useToggleTheme();
   const auth = useAuth();
 
   if (auth.isLoading) return <LoadingIndicator />;
 
   const redirectAfterLogin = () => {
-    if (postLoginRedirect.url === routes.LOGIN) {
+    if (!query.has('page')) {
       history.push(routes.HOME);
     } else {
-      history.push(`${postLoginRedirect.url}${postLoginRedirect.search}`);
+      const pageName: string = query.get('page')!;
+      query.delete('page');
+      const intermediatePathValues: string[] = [];
+      for (let valueIdx = 1; query.has(`value${valueIdx}`); valueIdx++) {
+        // get all the &valueX=... args from login query args
+        intermediatePathValues.push(`/${query.get(`value${valueIdx}`)!}`);
+        query.delete(`value${valueIdx}`);
+      }
+      const pathString: string = `/${pageName}${intermediatePathValues.join('')}`;
+      history.push(`${pathString}?${query.toString()}`);
     }
   };
 

--- a/src/frontend/src/pages/LoginPage/Login.tsx
+++ b/src/frontend/src/pages/LoginPage/Login.tsx
@@ -32,7 +32,7 @@ const Login = () => {
       query.delete('page');
       const intermediatePathValues: string[] = [];
       for (let valueIdx = 1; query.has(`value${valueIdx}`); valueIdx++) {
-        // get all the &valueX=... args from login query args
+        // collect all the &valueX=... args, in order, from login query args
         intermediatePathValues.push(`/${query.get(`value${valueIdx}`)!}`);
         query.delete(`value${valueIdx}`);
       }

--- a/src/frontend/src/pages/LoginPage/Login.tsx
+++ b/src/frontend/src/pages/LoginPage/Login.tsx
@@ -24,20 +24,31 @@ const Login = () => {
 
   if (auth.isLoading) return <LoadingIndicator />;
 
+  /**
+   * Produce the path of the page redirected from the login page.
+   * @param queryArgs the query args sent from the login page, containing page, value1, value2, ..., and other args
+   * @returns the path, with args, redirected to
+   */
+  const redirectQueryArgsToPath = (queryArgs: URLSearchParams): string => {
+    const pageName: string = queryArgs.get('page')!;
+    queryArgs.delete('page');
+
+    const intermediatePathValues: string[] = [];
+    for (let valueIdx = 1; queryArgs.has(`value${valueIdx}`); valueIdx++) {
+      // collect all the &valueX=... args, in order, from login query args
+      intermediatePathValues.push(`/${queryArgs.get(`value${valueIdx}`)!}`);
+      queryArgs.delete(`value${valueIdx}`);
+    }
+
+    const pathString: string = `/${pageName}${intermediatePathValues.join('')}`;
+    return `${pathString}?${queryArgs.toString()}`;
+  };
+
   const redirectAfterLogin = () => {
     if (!query.has('page')) {
       history.push(routes.HOME);
     } else {
-      const pageName: string = query.get('page')!;
-      query.delete('page');
-      const intermediatePathValues: string[] = [];
-      for (let valueIdx = 1; query.has(`value${valueIdx}`); valueIdx++) {
-        // collect all the &valueX=... args, in order, from login query args
-        intermediatePathValues.push(`/${query.get(`value${valueIdx}`)!}`);
-        query.delete(`value${valueIdx}`);
-      }
-      const pathString: string = `/${pageName}${intermediatePathValues.join('')}`;
-      history.push(`${pathString}?${query.toString()}`);
+      history.push(redirectQueryArgsToPath(query));
     }
   };
 


### PR DESCRIPTION
## Changes

Modify redirect to login page to use URL query strings ("query args"). Loading `https://finishlinebyner.com/a/b/c?sleep=false&abc=123` without logging in will redirect to `https://finishlinebyner.com/login?page=a&value1=b&value2=c&sleep=false&abc=123`, which will send back to the original page after logging in.

This replaces the `postLoginRedirect` prop for the `Login` component, which is removed.

Hard-coded to ignore a single `/` at the end of a path, so `https://finishlinebyner.com/a/b/c/?sleep=false&abc=123` will redirect to the same login query strings.

## Notes

Because we're using `value1`, `value2`, etc... we can't use these query args anywhere else because then login page might get confused with multiple of the same query and send you to the wrong page after logging in. These are pretty common query string names, so if we use query args a lot we might want to rename these.

## Test Cases

No tests written. Try it manually with the above example.

## To Do

_Any remaining things that need to get done_

- Maybe we want to use [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) interface to generate the login query strings. May or may not make the code cleaner.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #223 
