### PR TITLE
#727 Fix logout button padding

### DIFF
--- a/src/frontend/src/layouts/NavTopBar/NavUserMenu.tsx
+++ b/src/frontend/src/layouts/NavTopBar/NavUserMenu.tsx
@@ -72,9 +72,9 @@ const NavUserMenu: React.FC = () => {
         <MenuItem component={RouterLink} to={routes.SETTINGS} onClick={handleClose} sx={{ py: 0 }}>
           Settings
         </MenuItem>
-        {googleAuthClientId ? (
+        {googleAuthClientId && (
           <GoogleLogout
-            clientId={process.env.REACT_APP_GOOGLE_AUTH_CLIENT_ID!}
+            clientId={googleAuthClientId}
             //jsSrc={'accounts.google.com/gsi/client'}
             onLogoutSuccess={logout}
             render={(renderProps) => (
@@ -83,11 +83,10 @@ const NavUserMenu: React.FC = () => {
               </MenuItem>
             )}
           />
-        ) : (
-          <MenuItem onClick={logout} component="div" sx={{ py: 0 }}>
-            <Button sx={{ padding: 0, minHeight: 0, minWidth: 0 }}>Logout</Button>
-          </MenuItem>
         )}
+        <MenuItem onClick={logout} component="div" sx={{ py: 0 }}>
+          <Button sx={{ padding: 0, minHeight: 0, minWidth: 0 }}>Logout</Button>
+        </MenuItem>
       </Menu>
     </>
   );

--- a/src/frontend/src/layouts/NavTopBar/NavUserMenu.tsx
+++ b/src/frontend/src/layouts/NavTopBar/NavUserMenu.tsx
@@ -72,28 +72,22 @@ const NavUserMenu: React.FC = () => {
         <MenuItem component={RouterLink} to={routes.SETTINGS} onClick={handleClose} sx={{ py: 0 }}>
           Settings
         </MenuItem>
-        <MenuItem onClick={handleClose} component="div" sx={{ py: 0 }}>
-          {googleAuthClientId ? (
-            <GoogleLogout
-              clientId={process.env.REACT_APP_GOOGLE_AUTH_CLIENT_ID!}
-              //jsSrc={'accounts.google.com/gsi/client'}
-              onLogoutSuccess={logout}
-              render={(renderProps) => (
-                <Button
-                  onClick={renderProps.onClick}
-                  disabled={renderProps.disabled}
-                  sx={{ padding: 0, minHeight: 0, minWidth: 0 }}
-                >
-                  Logout
-                </Button>
-              )}
-            />
-          ) : (
-            <Button onClick={logout} sx={{ padding: 0, minHeight: 0, minWidth: 0 }}>
-              Logout
-            </Button>
-          )}
-        </MenuItem>
+        {googleAuthClientId ? (
+          <GoogleLogout
+            clientId={process.env.REACT_APP_GOOGLE_AUTH_CLIENT_ID!}
+            //jsSrc={'accounts.google.com/gsi/client'}
+            onLogoutSuccess={logout}
+            render={(renderProps) => (
+              <MenuItem component="div" sx={{ py: 0 }}>
+                Logout
+              </MenuItem>
+            )}
+          />
+        ) : (
+          <MenuItem onClick={logout} component="div" sx={{ py: 0 }}>
+            <Button sx={{ padding: 0, minHeight: 0, minWidth: 0 }}>Logout</Button>
+          </MenuItem>
+        )}
       </Menu>
     </>
   );

--- a/src/frontend/src/pages/LoginPage/LoginPage.tsx
+++ b/src/frontend/src/pages/LoginPage/LoginPage.tsx
@@ -21,24 +21,31 @@ interface LoginPageProps {
  * Page for unauthenticated users to do login.
  */
 const LoginPage: React.FC<LoginPageProps> = ({ devSetUser, devFormSubmit, prodSuccess, prodFailure }) => {
+  const googleAuthClientId = process.env.REACT_APP_GOOGLE_AUTH_CLIENT_ID;
+
+  const googleLogin = (
+    <GoogleLogin
+      clientId={googleAuthClientId!}
+      //jsSrc={'accounts.google.com/gsi/client.js'}
+      buttonText="Login"
+      onSuccess={prodSuccess}
+      onFailure={prodFailure}
+      cookiePolicy={'single_host_origin'}
+      isSignedIn={true}
+    />
+  );
+
+  const loginDev = <LoginDev devSetUser={devSetUser} devFormSubmit={devFormSubmit} />;
+
   return (
     <Card sx={{ marginX: 'auto', maxWidth: '25em', marginTop: 5 }}>
       <CardContent>
         <Typography variant="h5">FinishLine by NER</Typography>
-        <Typography variant="body1">Login Required. Students must use their Husky Google account.</Typography>
-        {process.env.NODE_ENV === 'development' ? (
-          <LoginDev devSetUser={devSetUser} devFormSubmit={devFormSubmit} />
-        ) : (
-          <GoogleLogin
-            clientId={process.env.REACT_APP_GOOGLE_AUTH_CLIENT_ID!}
-            //jsSrc={'accounts.google.com/gsi/client.js'}
-            buttonText="Login"
-            onSuccess={prodSuccess}
-            onFailure={prodFailure}
-            cookiePolicy={'single_host_origin'}
-            isSignedIn={true}
-          />
-        )}
+        <Typography variant="body1" sx={{ mb: 1 }}>
+          Login Required. Students must use their Husky Google account.
+        </Typography>
+        {googleAuthClientId && googleLogin}
+        {process.env.NODE_ENV === 'development' && loginDev}
       </CardContent>
       <CardActions>
         <Typography variant="caption">


### PR DESCRIPTION
## Changes

Move `GoogleLogout` outside `MenuItem` so clicking anywhere on the `MenuItem` logs you out.

## Notes

`GoogleLogout` with a [`render` prop seems to be a HOC](https://github.com/anthonyjgrove/react-google-login#login-props), so putting the menu item inside is okay.

## Test Cases

(all pass)

## Screenshots

<img width="221" alt="image" src="https://user-images.githubusercontent.com/34677361/214746758-77f5b94d-8e95-4de2-9d9a-a1ce34cad7cc.png">

## Checklist


- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #727
