### PR TITLE
#713: Change EditProjectPage to use NER Buttons

### DIFF
--- a/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditContainer.tsx
@@ -193,10 +193,10 @@ const ProjectEditContainer: React.FC<ProjectEditContainerProps> = ({ project, ex
       </PageBlock>
 
       <Box textAlign="right" sx={{ my: 2 }}>
-        <NERFailButton variant="contained" onClick={exitEditMode} sx={{ mx: 2 }}>
+        <NERFailButton variant="contained" onClick={exitEditMode} sx={{ mx: 1 }}>
           Cancel
         </NERFailButton>
-        <NERSuccessButton variant="contained" type="submit" sx={{ mx: 2 }}>
+        <NERSuccessButton variant="contained" type="submit" sx={{ mx: 1 }}>
           Submit
         </NERSuccessButton>
       </Box>

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditContainer.tsx
@@ -22,6 +22,8 @@ import ReactHookTextField from '../../../components/ReactHookTextField';
 import ProjectEditDetails from './ProjectEditDetails';
 import ReactHookEditableList from '../../../components/ReactHookEditableList';
 import { bulletsToObject, mapBulletsToPayload } from '../../../utils/form';
+import NERSuccessButton from '../../../components/NERSuccessButton';
+import NERFailButton from '../../../components/NERFailButton';
 
 const schema = yup.object().shape({
   name: yup.string().required('Name is required!'),
@@ -191,12 +193,12 @@ const ProjectEditContainer: React.FC<ProjectEditContainerProps> = ({ project, ex
       </PageBlock>
 
       <Box textAlign="center" sx={{ my: 2 }}>
-        <Button variant="contained" color="success" type="submit" sx={{ mx: 2 }}>
-          Submit
-        </Button>
-        <Button variant="contained" color="error" onClick={exitEditMode} sx={{ mx: 2 }}>
+        <NERFailButton variant="contained" color="error" onClick={exitEditMode} sx={{ mx: 2 }}>
           Cancel
-        </Button>
+        </NERFailButton>
+        <NERSuccessButton variant="contained" type="submit" sx={{ mx: 2 }}>
+          Submit
+        </NERSuccessButton>
       </Box>
     </form>
   );

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditContainer.tsx
@@ -193,7 +193,7 @@ const ProjectEditContainer: React.FC<ProjectEditContainerProps> = ({ project, ex
       </PageBlock>
 
       <Box textAlign="center" sx={{ my: 2 }}>
-        <NERFailButton variant="contained" color="error" onClick={exitEditMode} sx={{ mx: 2 }}>
+        <NERFailButton variant="contained" onClick={exitEditMode} sx={{ mx: 2 }}>
           Cancel
         </NERFailButton>
         <NERSuccessButton variant="contained" type="submit" sx={{ mx: 2 }}>

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditContainer.tsx
@@ -192,7 +192,7 @@ const ProjectEditContainer: React.FC<ProjectEditContainerProps> = ({ project, ex
         </Button>
       </PageBlock>
 
-      <Box textAlign="center" sx={{ my: 2 }}>
+      <Box textAlign="right" sx={{ my: 2 }}>
         <NERFailButton variant="contained" onClick={exitEditMode} sx={{ mx: 2 }}>
           Cancel
         </NERFailButton>


### PR DESCRIPTION
## Changes

Changed the buttons of the submit and cancel to NERSuccessButton and NERFailButton. Also put the cancel on the left and the submit on the right.

## Screenshots
<img width="1428" alt="Screen Shot 2023-01-27 at 1 21 06 PM" src="https://user-images.githubusercontent.com/122840604/215165527-38978dd9-b5cf-463e-b197-5dace6b712b4.png">


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #713 
