### PR TITLE
#549 Fixed color of change requests button on default and on hover

### DIFF
--- a/src/frontend/src/components/NERButton.tsx
+++ b/src/frontend/src/components/NERButton.tsx
@@ -3,9 +3,9 @@ import { Button, styled } from '@mui/material';
 export const NERButton = styled(Button)({
   textTransform: 'none',
   fontSize: 16,
+  borderColor: '#0062cc',
+  boxShadow: 'none',
   '&:hover': {
-    backgroundColor: '#ff0000',
-    borderColor: '#0062cc',
-    boxShadow: 'none'
+    backgroundColor: '#ff0000'
   }
 });

--- a/src/frontend/src/pages/ChangeRequestsPage/ChangeRequestsTable.tsx
+++ b/src/frontend/src/pages/ChangeRequestsPage/ChangeRequestsTable.tsx
@@ -18,6 +18,7 @@ import { Button } from '@mui/material';
 import { useTheme } from '@mui/system';
 import { useState } from 'react';
 import { ChangeRequestType, validateWBS, WbsNumber } from 'shared';
+import { NERButton } from '../../components/NERButton';
 
 const ChangeRequestsTable: React.FC = () => {
   const history = useHistory();
@@ -137,25 +138,14 @@ const ChangeRequestsTable: React.FC = () => {
           title={'Change Requests'}
           previousPages={[]}
           actionButton={
-            <Button
-              sx={{
-                textTransform: 'none',
-                fontSize: 16,
-                backgroundColor: '#ef4345',
-                borderColor: '#0062cc',
-                boxShadow: 'none',
-                '&:hover': {
-                  backgroundColor: '#ff0000'
-                }
-              }}
-              component={Link}
-              to={routes.CHANGE_REQUESTS_NEW}
+            <NERButton
               variant="contained"
               disabled={auth.user?.role === 'GUEST'}
               startIcon={<Add />}
+              onClick={() => history.push(routes.CHANGE_REQUESTS_NEW)}
             >
               New Change Request
-            </Button>
+            </NERButton>
           }
         />
       </div>

--- a/src/frontend/src/pages/ChangeRequestsPage/ChangeRequestsTable.tsx
+++ b/src/frontend/src/pages/ChangeRequestsPage/ChangeRequestsTable.tsx
@@ -13,8 +13,6 @@ import ErrorPage from '../ErrorPage';
 import { Add } from '@mui/icons-material';
 import PageTitle from '../../layouts/PageTitle/PageTitle';
 import { useAuth } from '../../hooks/auth.hooks';
-import { Link } from 'react-router-dom';
-import { Button } from '@mui/material';
 import { useTheme } from '@mui/system';
 import { useState } from 'react';
 import { ChangeRequestType, validateWBS, WbsNumber } from 'shared';

--- a/src/frontend/src/pages/ChangeRequestsPage/ChangeRequestsTable.tsx
+++ b/src/frontend/src/pages/ChangeRequestsPage/ChangeRequestsTable.tsx
@@ -138,12 +138,15 @@ const ChangeRequestsTable: React.FC = () => {
           previousPages={[]}
           actionButton={
             <Button
-              style={{
+              sx={{
                 textTransform: 'none',
                 fontSize: 16,
-                backgroundColor: '#ff0000',
+                backgroundColor: '#ef4345',
                 borderColor: '#0062cc',
-                boxShadow: 'none'
+                boxShadow: 'none',
+                '&:hover': {
+                  backgroundColor: '#ff0000'
+                }
               }}
               component={Link}
               to={routes.CHANGE_REQUESTS_NEW}

--- a/src/frontend/src/utils/themes.ts
+++ b/src/frontend/src/utils/themes.ts
@@ -73,7 +73,8 @@ export const nerThemeOptions: ThemeOptions = {
   components: {
     MuiButtonBase: {
       defaultProps: {
-        disableRipple: true
+        disableRipple: true,
+        color: 'primary'
       }
     },
     MuiChip: {


### PR DESCRIPTION
## Changes

Updated the "new change request" button to match the color of NER red and added hover functionality

## Screenshots
![image](https://user-images.githubusercontent.com/55457750/214753965-155d2778-e4b6-4cd9-b289-5123a74a78ad.png)

![image](https://user-images.githubusercontent.com/55457750/214754327-c619110f-637a-458c-9606-afd0e5a51a14.png)

## Checklist

Please request reviewers and ping on slack only after you've gone through this whole checklist.

Closes #549 
