### PR TITLE
switched to MUI icons && aligned them

### DIFF
--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectDetails.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectDetails.tsx
@@ -3,21 +3,25 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { faFilePowerpoint, faFolderOpen, faList, faListOl } from '@fortawesome/free-solid-svg-icons';
+//import { faFilePowerpoint, faFolderOpen, faList, faListOl } from '@fortawesome/free-solid-svg-icons';
+import { Folder, FormatListBulleted, FormatListNumbered, Slideshow } from '@mui/icons-material';
+import Link from '@mui/material/Link';
 import { Project } from 'shared';
 import { datePipe, dollarsPipe, fullNamePipe, weeksPipe } from '../../../utils/pipes';
-import ExternalLink from '../../../components/ExternalLink';
 import WbsStatus from '../../../components/WbsStatus';
 import PageBlock from '../../../layouts/PageBlock';
 import Grid from '@mui/material/Grid';
+import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import DetailDisplay from '../../../components/DetailDisplay';
+import { useTheme } from '@mui/material';
 
 interface ProjectDetailsProps {
   project: Project;
 }
 
 const ProjectDetails: React.FC<ProjectDetailsProps> = ({ project }) => {
+  const theme = useTheme();
   return (
     <PageBlock title={'Project Details'} headerRight={<WbsStatus status={project.status} />}>
       <Grid container spacing={1}>
@@ -47,16 +51,36 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ project }) => {
           <Typography sx={{ fontWeight: 'bold', paddingRight: 2, display: 'inline' }}>Links: </Typography>
         </Grid>
         <Grid item xs={2} md={2}>
-          <ExternalLink icon={faFilePowerpoint} link={project.slideDeckLink!} description={'Slide Deck'} />
+          <Stack direction="row" alignItems="center">
+            <Slideshow sx={{ fontSize: 22, color: theme.palette.text.primary }} />
+            <Link href={project.slideDeckLink!} underline="always" fontSize={19} sx={{ pl: 1 }}>
+              Slide Deck
+            </Link>
+          </Stack>
         </Grid>
         <Grid item xs={2} md={2}>
-          <ExternalLink icon={faList} link={project.taskListLink!} description={'Task List'} />
+          <Stack direction="row" alignItems="center">
+            <FormatListBulleted sx={{ fontSize: 22, color: theme.palette.text.primary }} />
+            <Link href={project.taskListLink!} underline="always" fontSize={19} sx={{ pl: 1 }}>
+              Task List
+            </Link>
+          </Stack>
         </Grid>
         <Grid item xs={2} md={2}>
-          <ExternalLink icon={faListOl} link={project.bomLink!} description={'BOM'} />
+          <Stack direction="row" alignItems="center">
+            <FormatListNumbered sx={{ fontSize: 22, color: theme.palette.text.primary }} />
+            <Link href={project.bomLink!} underline="always" fontSize={19} sx={{ pl: 1 }}>
+              BOM
+            </Link>
+          </Stack>
         </Grid>
         <Grid item xs={2} md={2}>
-          <ExternalLink icon={faFolderOpen} link={project.gDriveLink!} description={'Google Drive'} />
+          <Stack direction="row" alignItems="center">
+            <Folder sx={{ fontSize: 22, color: theme.palette.text.primary }} />
+            <Link href={project.gDriveLink!} underline="always" fontSize={19} sx={{ pl: 1 }}>
+              Google Drive
+            </Link>
+          </Stack>
         </Grid>
       </Grid>
     </PageBlock>

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectDetails.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectDetails.tsx
@@ -3,7 +3,6 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-//import { faFilePowerpoint, faFolderOpen, faList, faListOl } from '@fortawesome/free-solid-svg-icons';
 import { Folder, FormatListBulleted, FormatListNumbered, Slideshow } from '@mui/icons-material';
 import Link from '@mui/material/Link';
 import { Project } from 'shared';

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectDetails.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectDetails.tsx
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { Folder, FormatListBulleted, FormatListNumbered, Slideshow } from '@mui/icons-material';
+import { Folder, FormatListBulleted, FormatListNumbered, CoPresent } from '@mui/icons-material';
 import Link from '@mui/material/Link';
 import { Project } from 'shared';
 import { datePipe, dollarsPipe, fullNamePipe, weeksPipe } from '../../../utils/pipes';
@@ -51,7 +51,7 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ project }) => {
         </Grid>
         <Grid item xs={2} md={2}>
           <Stack direction="row" alignItems="center">
-            <Slideshow sx={{ fontSize: 22, color: theme.palette.text.primary }} />
+            <CoPresent sx={{ fontSize: 22, color: theme.palette.text.primary }} />
             <Link href={project.slideDeckLink!} underline="always" fontSize={19} sx={{ pl: 1 }}>
               Slide Deck
             </Link>


### PR DESCRIPTION
## Changes

Swapped from using fortawesome icons to Material UI Icons.
Made the necessary import changes.
Added stack tag formatting for alignment.

## Screenshots
1) Before
![before](https://user-images.githubusercontent.com/15187574/214760532-c208eeb1-7d1b-4591-b305-a095096f4687.jpg)

1) After
![after](https://user-images.githubusercontent.com/15187574/214760537-ccfaf887-9433-4d8e-bd99-97c6d34df2b6.jpg)

After Version 2 (Switched slideshow to copresent)
![image](https://user-images.githubusercontent.com/15187574/215857682-0fdec33f-7fe5-4cbf-abd2-f1e5d0b779f2.png)


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #278 
