### PR TITLE
#403/#720 Updated stage gate buttons and fixed crashing

### DIFF
--- a/src/frontend/src/pages/TeamsPage/DescriptionPageBlock.tsx
+++ b/src/frontend/src/pages/TeamsPage/DescriptionPageBlock.tsx
@@ -7,14 +7,13 @@ import { Button, IconButton, TextField, useTheme } from '@mui/material';
 import { useState } from 'react';
 import { useAuth } from '../../hooks/auth.hooks';
 import { useEditTeamDescription } from '../../hooks/teams.hooks';
-import { Team } from 'shared';
+import { Team, isUnderWordCount, countWords } from 'shared';
 import { Edit } from '@mui/icons-material';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import ErrorPage from '../ErrorPage';
 import PageBlock from '../../layouts/PageBlock';
 import ReactMarkdown from 'react-markdown';
 import styles from '../../stylesheets/pages/teams.module.css';
-import { isUnderWordCount, countWords } from 'shared';
 
 interface DescriptionPageBlockProps {
   team: Team;

--- a/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModal.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModal.tsx
@@ -10,7 +10,6 @@ import { WbsNumber } from 'shared';
 import { FormInput } from './StageGateWorkPackageModalContainer';
 import { wbsPipe } from '../../../utils/pipes';
 import {
-  Button,
   Dialog,
   DialogActions,
   DialogContent,

--- a/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModal.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModal.tsx
@@ -10,7 +10,6 @@ import { WbsNumber } from 'shared';
 import { FormInput } from './StageGateWorkPackageModalContainer';
 import { wbsPipe } from '../../../utils/pipes';
 import {
-  Button,
   Dialog,
   DialogActions,
   DialogContent,
@@ -21,6 +20,8 @@ import {
   TextField,
   Typography
 } from '@mui/material';
+import NERSuccessButton from '../../../components/NERSuccessButton';
+import NERFailButton from '../../../components/NERFailButton';
 
 interface StageGateWorkPackageModalProps {
   wbsNum: WbsNumber;
@@ -113,18 +114,12 @@ const StageGateWorkPackageModal: React.FC<StageGateWorkPackageModalProps> = ({ w
         </form>
       </DialogContent>
       <DialogActions>
-        <Button
-          color="secondary"
-          className={'ml-3'}
-          variant="contained"
-          form="stage-gate-work-package-form"
-          onClick={onHide}
-        >
+        <NERFailButton form="stage-gate-work-package-form" onClick={onHide}>
           Cancel
-        </Button>
-        <Button color="success" variant="contained" type="submit" form="stage-gate-work-package-form">
+        </NERFailButton>
+        <NERSuccessButton type="submit" form="stage-gate-work-package-form">
           Submit
-        </Button>
+        </NERSuccessButton>
       </DialogActions>
     </Dialog>
   );

--- a/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModal.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModal.tsx
@@ -10,6 +10,7 @@ import { WbsNumber } from 'shared';
 import { FormInput } from './StageGateWorkPackageModalContainer';
 import { wbsPipe } from '../../../utils/pipes';
 import {
+  Button,
   Dialog,
   DialogActions,
   DialogContent,
@@ -20,8 +21,6 @@ import {
   TextField,
   Typography
 } from '@mui/material';
-import NERSuccessButton from '../../../components/NERSuccessButton';
-import NERFailButton from '../../../components/NERFailButton';
 
 interface StageGateWorkPackageModalProps {
   wbsNum: WbsNumber;
@@ -114,12 +113,18 @@ const StageGateWorkPackageModal: React.FC<StageGateWorkPackageModalProps> = ({ w
         </form>
       </DialogContent>
       <DialogActions>
-        <NERFailButton form="stage-gate-work-package-form" onClick={onHide}>
+        <Button
+          color="secondary"
+          className={'ml-3'}
+          variant="contained"
+          form="stage-gate-work-package-form"
+          onClick={onHide}
+        >
           Cancel
-        </NERFailButton>
-        <NERSuccessButton type="submit" form="stage-gate-work-package-form">
+        </Button>
+        <Button color="success" variant="contained" type="submit" form="stage-gate-work-package-form">
           Submit
-        </NERSuccessButton>
+        </Button>
       </DialogActions>
     </Dialog>
   );

--- a/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModal.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModal.tsx
@@ -114,10 +114,10 @@ const StageGateWorkPackageModal: React.FC<StageGateWorkPackageModalProps> = ({ w
         </form>
       </DialogContent>
       <DialogActions>
-        <NERFailButton form="stage-gate-work-package-form" onClick={onHide}>
+        <NERFailButton form="stage-gate-work-package-form" sx={{ mx: 1, mb: 1 }} onClick={onHide}>
           Cancel
         </NERFailButton>
-        <NERSuccessButton type="submit" form="stage-gate-work-package-form">
+        <NERSuccessButton type="submit" sx={{ mx: 1, mb: 1 }} form="stage-gate-work-package-form">
           Submit
         </NERSuccessButton>
       </DialogActions>

--- a/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModal.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModal.tsx
@@ -21,6 +21,8 @@ import {
   TextField,
   Typography
 } from '@mui/material';
+import NERSuccessButton from '../../../components/NERSuccessButton';
+import NERFailButton from '../../../components/NERFailButton';
 
 interface StageGateWorkPackageModalProps {
   wbsNum: WbsNumber;
@@ -113,18 +115,12 @@ const StageGateWorkPackageModal: React.FC<StageGateWorkPackageModalProps> = ({ w
         </form>
       </DialogContent>
       <DialogActions>
-        <Button
-          color="secondary"
-          className={'ml-3'}
-          variant="contained"
-          form="stage-gate-work-package-form"
-          onClick={onHide}
-        >
+        <NERFailButton form="stage-gate-work-package-form" onClick={onHide}>
           Cancel
-        </Button>
-        <Button color="success" variant="contained" type="submit" form="stage-gate-work-package-form">
+        </NERFailButton>
+        <NERSuccessButton type="submit" form="stage-gate-work-package-form">
           Submit
-        </Button>
+        </NERSuccessButton>
       </DialogActions>
     </Dialog>
   );

--- a/src/shared/package.json
+++ b/src/shared/package.json
@@ -2,7 +2,7 @@
   "name": "shared",
   "version": "1.0.0",
   "description": "",
-  "main": "dist/index.js",
+  "main": "index.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/src/shared/package.json
+++ b/src/shared/package.json
@@ -2,7 +2,7 @@
   "name": "shared",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "index.ts",
   "types": "dist/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
## Changes

FOR #720:

In StageGateWorkPackageModal.tsx, I first imported the new NER success and fail components on lines 23 and 24. Then, I replaced the buttons that were there with the NER buttons on lines 117-122 and gave them the appropriate properties to function.

FOR #403:

In DescriptionPageBlock.tsx I changed line 10 to include "isUnderWordCount, countWords" in the import statement. I am unsure if this fixed the problem as the problem did not go away until the second change but I digress. In package.json, I changed "dist/index.js" to "index.ts" which solved the problem.

## Notes

This PR is most likely marked under #403 but it also includes #720 I apologize for the confusion next time I will make separate PRs! USE THE LATEST COMMIT AND DISREGARD COMMIT NAMES

## Screenshots

![image](https://user-images.githubusercontent.com/120137306/215360199-282e3927-8788-4e37-a975-6efc602d709c.png)
![image](https://user-images.githubusercontent.com/120137306/215360212-6d19e26d-df2e-4505-a8f3-892d01894793.png)

Closes #403
Closes #720 
