### PR TITLE
#740: Review CR Modal Responsive Layout

### DIFF
--- a/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequestView.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequestView.tsx
@@ -10,7 +10,17 @@ import { FormInput } from './ReviewChangeRequest';
 import { ChangeRequest, ProposedSolution, StandardChangeRequest } from 'shared';
 import { useState } from 'react';
 import ProposedSolutionSelectItem from './ProposedSolutionSelectItem';
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Box, TextField, Typography } from '@mui/material';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Box,
+  TextField,
+  Typography,
+  Breakpoint
+} from '@mui/material';
 import { useToast } from '../../hooks/toasts.hooks';
 
 interface ReviewChangeRequestViewProps {
@@ -69,9 +79,12 @@ const ReviewChangeRequestsView: React.FC<ReviewChangeRequestViewProps> = ({
     display: 'block'
   };
 
+  const dialogWidth: Breakpoint = 'md';
+  const dialogContentWidthRatio: number = 1; // dialog contents fit 100% width
+
   const renderProposedSolutionModal: (scr: StandardChangeRequest) => JSX.Element = (scr: StandardChangeRequest) => {
     return (
-      <Dialog open={modalShow} onClose={onHide} style={{ color: 'black' }}>
+      <Dialog fullWidth maxWidth={dialogWidth} open={modalShow} onClose={onHide} style={{ color: 'black' }}>
         <DialogTitle className={'font-weight-bold'}>{`Review Change Request #${cr.crId}`}</DialogTitle>
         <DialogContent
           sx={{
@@ -83,7 +96,7 @@ const ReviewChangeRequestsView: React.FC<ReviewChangeRequestViewProps> = ({
           <Typography sx={{ paddingBottom: 1 }}>{'Select Proposed Solution'}</Typography>
           <Box
             sx={{
-              width: 400,
+              width: dialogContentWidthRatio,
               '&::-webkit-scrollbar': {
                 display: 'none'
               },
@@ -127,7 +140,7 @@ const ReviewChangeRequestsView: React.FC<ReviewChangeRequestViewProps> = ({
                     onChange={onChange}
                     value={value}
                     fullWidth
-                    sx={{ width: 400 }}
+                    sx={{ width: dialogContentWidthRatio }}
                   />
                 </>
               )}
@@ -165,7 +178,7 @@ const ReviewChangeRequestsView: React.FC<ReviewChangeRequestViewProps> = ({
 
   const renderModal: () => JSX.Element = () => {
     return (
-      <Dialog open={modalShow} onClose={onHide}>
+      <Dialog fullWidth maxWidth={dialogWidth} open={modalShow} onClose={onHide}>
         <DialogTitle className={'font-weight-bold'}>{`Review Change Request #${cr.crId}`}</DialogTitle>
         <DialogContent>
           <form id={'review-notes-form'} onSubmit={handleSubmit(onSubmitWrapper)}>
@@ -185,7 +198,6 @@ const ReviewChangeRequestsView: React.FC<ReviewChangeRequestViewProps> = ({
                     onChange={onChange}
                     value={value}
                     fullWidth
-                    sx={{ width: 500 }}
                   />
                 </>
               )}


### PR DESCRIPTION
## Changes

Make the modals to review CR resize with the width of the page (currently still stops at max 900x700 modal size).

I think this has the good side effect of not having the modal extend beyond the screen size on mobile devices too.

## Notes

Text box height resizes only in the basic `renderModal()` box, not the more complex `renderProposedSolutionModal()` box. This allows us to view the proposed solution and the additional comments on the same screen.

## Test Cases

No tests written :(

## Screenshots

_If you made UI changes you must post a screenshot of the whole page for each change in 1) a normal sized window and 2) the smallest possible window_

#### `renderProposedSolutionModal()` 
![Screen Shot 2023-01-29 at 8 45 15 PM](https://user-images.githubusercontent.com/59806366/215371430-d42fc4f3-1514-4e3a-9635-3aca3c826568.png)
![Screen Shot 2023-01-29 at 8 45 41 PM](https://user-images.githubusercontent.com/59806366/215371449-ad9cff8e-e304-45f2-9c1e-a5a5b4be51d8.png)

#### `renderModal()`
![Screen Shot 2023-01-29 at 8 52 31 PM](https://user-images.githubusercontent.com/59806366/215371472-dcd45c01-c020-4ea7-a3b7-9312e5dc780f.png)
![Screen Shot 2023-01-29 at 8 52 24 PM](https://user-images.githubusercontent.com/59806366/215371459-71225a8f-4c7b-4cae-aca8-0b6235328010.png)
![Screen Shot 2023-01-29 at 8 52 49 PM](https://user-images.githubusercontent.com/59806366/215371478-901aad96-832f-4420-80fc-caa219edb321.png)

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #740 
