### PR TITLE
#747 Removed userID from payload in handleCreate function

### DIFF
--- a/src/backend/src/routes/risks.routes.ts
+++ b/src/backend/src/routes/risks.routes.ts
@@ -9,7 +9,6 @@ risksRouter.get('/:projectId', RisksController.getRisksForProject);
 risksRouter.post(
   '/create',
   intMinZero(body('projectId')),
-  intMinZero(body('createdById')),
   nonEmptyString(body('detail')),
   validateInputs,
   RisksController.createRisk

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/RiskLog.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/RiskLog.tsx
@@ -95,7 +95,6 @@ const RiskLog: React.FC<RiskLogProps> = ({ projectId, wbsNum, projLead, projMana
 
     const payload = {
       projectId: projectId,
-      createdById: userId,
       detail: newDetail
     };
 


### PR DESCRIPTION
## Changes

Removed userId from the payload in the handleCreate function in RiskLog.tsx so that userId is no longer unnecessarily sent to the backend

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
#747 