### PR TITLE
#741: Removed budgetimpact from Create CR endpoint

### DIFF
--- a/src/backend/src/controllers/change-requests.controllers.ts
+++ b/src/backend/src/controllers/change-requests.controllers.ts
@@ -75,7 +75,7 @@ export default class ChangeRequestsController {
 
   static async createStandardChangeRequest(req: Request, res: Response, next: NextFunction) {
     try {
-      const { wbsNum, type, what, why, budgetImpact } = req.body;
+      const { wbsNum, type, what, why } = req.body;
       const submitter = await getCurrentUser(res);
       const id = await ChangeRequestsService.createStandardChangeRequest(
         submitter,
@@ -84,8 +84,7 @@ export default class ChangeRequestsController {
         wbsNum.workPackageNumber,
         type,
         what,
-        why,
-        budgetImpact
+        why
       );
       return res.status(200).json({ message: `${id}` });
     } catch (error: unknown) {

--- a/src/backend/src/services/change-request.services.ts
+++ b/src/backend/src/services/change-request.services.ts
@@ -473,8 +473,7 @@ export default class ChangeRequestsService {
     workPackageNumber: number,
     type: CR_Type,
     what: string,
-    why: Scope_CR_Why[],
-    budgetImpact: number
+    why: Scope_CR_Why[]
   ): Promise<Number> {
     // verify user is allowed to create stage gate change requests
     if (submitter.role === Role.GUEST) throw new AccessDeniedException();
@@ -527,7 +526,7 @@ export default class ChangeRequestsService {
       const slackMsg =
         `${type} CR submitted by ${submitter.firstName} ${submitter.lastName} ` +
         `for the ${project.wbsElement.name} project`;
-      await sendSlackChangeRequestNotification(project.team, slackMsg, createdCR.crId, budgetImpact);
+      await sendSlackChangeRequestNotification(project.team, slackMsg, createdCR.crId);
     }
 
     return createdCR.crId;


### PR DESCRIPTION
## Changes

Removed budgetimpact from the Create CR endpoint.


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #741 
