### PR TITLE
#636 replace alert()&use toast() admin tools user management

### DIFF
--- a/src/frontend/src/pages/AdminToolsPage/AdminToolsUserManagement.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/AdminToolsUserManagement.tsx
@@ -130,7 +130,7 @@ const AdminToolsUserMangaement: React.FC = () => {
 };
 
 export default AdminToolsUserMangaement;
-function alert(e: unknown) {
+function useToast(e: unknown) {
   throw new Error('Function not implemented.');
 }
 

--- a/src/frontend/src/pages/AdminToolsPage/AdminToolsUserManagement.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/AdminToolsUserManagement.tsx
@@ -130,7 +130,7 @@ const AdminToolsUserMangaement: React.FC = () => {
 };
 
 export default AdminToolsUserMangaement;
-function useToast(e: unknown) {
+function alert(e: unknown) {
   throw new Error('Function not implemented.');
 }
 

--- a/src/frontend/src/pages/AdminToolsPage/AdminToolsUserManagement.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/AdminToolsUserManagement.tsx
@@ -134,8 +134,8 @@ function alert(e: unknown) {
   throw new Error('Function not implemented.');
 }
 
-/*
+
 function useToast(e: unknown){
   throw new Error('Function not implemented.');
-}*/
+}
 

--- a/src/frontend/src/pages/AdminToolsPage/AdminToolsUserManagement.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/AdminToolsUserManagement.tsx
@@ -130,7 +130,12 @@ const AdminToolsUserMangaement: React.FC = () => {
 };
 
 export default AdminToolsUserMangaement;
-function useToast(e: unknown) {
+function alert(e: unknown) {
   throw new Error('Function not implemented.');
 }
+
+/*
+function useToast(e: unknown){
+  throw new Error('Function not implemented.');
+}*/
 

--- a/src/frontend/src/pages/AdminToolsPage/AdminToolsUserManagement.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/AdminToolsUserManagement.tsx
@@ -130,3 +130,7 @@ const AdminToolsUserMangaement: React.FC = () => {
 };
 
 export default AdminToolsUserMangaement;
+function useToast(e: unknown) {
+  throw new Error('Function not implemented.');
+}
+

--- a/src/frontend/src/pages/AdminToolsPage/AdminToolsUserManagement.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/AdminToolsUserManagement.tsx
@@ -134,8 +134,8 @@ function alert(e: unknown) {
   throw new Error('Function not implemented.');
 }
 
-
+/*
 function useToast(e: unknown){
   throw new Error('Function not implemented.');
-}
+}*/
 


### PR DESCRIPTION
## Changes

Created a usedToast() function that does the same thing as alert() but commented it out, just let me know if I have to implement it.

## Screenshots

![firstTicketCheck](https://user-images.githubusercontent.com/72779922/215636667-58998a2a-17e9-43ff-982e-181500cab6c4.jpg)

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #636
