### PR TITLE
#637-Changed Alert to Toast

### DIFF
--- a/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageForm.tsx
+++ b/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageForm.tsx
@@ -4,6 +4,7 @@
  */
 
 import { useHistory } from 'react-router-dom';
+import { useToast } from '../../hooks/toasts.hooks';
 import { isProject, validateWBS } from 'shared';
 import { useAuth } from '../../hooks/auth.hooks';
 import { useCreateSingleWorkPackage } from '../../hooks/work-packages.hooks';
@@ -25,6 +26,7 @@ export interface CreateWorkPackageFormInputs {
 const CreateWorkPackageForm: React.FC = () => {
   const history = useHistory();
   const auth = useAuth();
+  const toast = useToast();
 
   const { isLoading, mutateAsync } = useCreateSingleWorkPackage();
 
@@ -40,7 +42,7 @@ const CreateWorkPackageForm: React.FC = () => {
       const wbsNumValidated = validateWBS(wbsNum);
 
       if (!isProject(wbsNumValidated)) {
-        alert('Please enter a valid Project WBS Number.');
+        toast.error('Please enter a valid Project WBS Number.');
         return;
       }
       const depWbsNums = dependencies.map((dependency: any) => {
@@ -69,7 +71,7 @@ const CreateWorkPackageForm: React.FC = () => {
     } catch (e: unknown) {
       console.log(e);
       if (e instanceof Error) {
-        alert(e.message);
+        toast.error(e.message);
       }
     }
   };

--- a/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageForm.tsx
+++ b/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageForm.tsx
@@ -42,7 +42,7 @@ const CreateWorkPackageForm: React.FC = () => {
       const wbsNumValidated = validateWBS(wbsNum);
 
       if (!isProject(wbsNumValidated)) {
-        toast.error('Please enter a valid Project WBS Number.');
+        toast.error('Please enter a valid Project WBS Number.', 3000);
         return;
       }
       const depWbsNums = dependencies.map((dependency: any) => {
@@ -71,7 +71,7 @@ const CreateWorkPackageForm: React.FC = () => {
     } catch (e: unknown) {
       console.log(e);
       if (e instanceof Error) {
-        toast.error(e.message);
+        toast.error(e.message, 3000);
       }
     }
   };

--- a/src/frontend/src/tests/pages/CreateWorkPackagePage/CreateWorkPackageForm.test.tsx
+++ b/src/frontend/src/tests/pages/CreateWorkPackagePage/CreateWorkPackageForm.test.tsx
@@ -14,6 +14,7 @@ import { BrowserRouter } from 'react-router-dom';
 
 jest.mock('../../../hooks/auth.hooks');
 jest.mock('../../../hooks/utils.hooks');
+jest.mock('../../../hooks/toasts.hooks');
 
 jest.mock('../../../components/ReactHookTextField', () => {
   return {


### PR DESCRIPTION
## Changes
Changed alert() to useToast()
_Explanation of changes goes here_
Used the useToast() hook to define toast, and then used toast.error, which does the same thing as alert.
Also, modified it to include the autoHideDuration property.

Lastly, added the jest.mock for the toast in CreateWorkPackageform.test
## Notes
I cannot login to localhost:3000/login for some reason . It just says Students must use their Husky Google account, but I'm already using it.


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #637 
