### PR TITLE
#719: RogerHuang-ActivateWorkPackageModal changed to use NER buttons

### DIFF
--- a/src/frontend/src/pages/WorkPackageDetailPage/ActivateWorkPackageModalContainer/ActivateWorkPackageModal.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/ActivateWorkPackageModalContainer/ActivateWorkPackageModal.tsx
@@ -143,8 +143,8 @@ const ActivateWorkPackageModal: React.FC<ActivateWorkPackageModalProps> = ({
           </div>
         </DialogContent>
         <DialogActions>
-          <Box textAlign="left" sx={{ my: 2 }}>
-            <NERFailButton variant="outlined" form="activate-work-package-form" onClick={onHide} sx={{ mx: 2 }}>
+          <Box textAlign="right" sx={{ my: 2 }}>
+            <NERFailButton variant="outlined" form="activate-work-package-form" onClick={onHide} sx={{ mx: 1 }}>
               Cancel
             </NERFailButton>
 

--- a/src/frontend/src/pages/WorkPackageDetailPage/ActivateWorkPackageModalContainer/ActivateWorkPackageModal.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/ActivateWorkPackageModalContainer/ActivateWorkPackageModal.tsx
@@ -10,12 +10,14 @@ import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { User, WbsNumber } from 'shared';
 import { FormInput } from './ActivateWorkPackageModalContainer';
 import { fullNamePipe, wbsPipe } from '../../../utils/pipes';
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField, Typography } from '@mui/material';
+import { Box, Dialog, DialogActions, DialogContent, DialogTitle, TextField, Typography } from '@mui/material';
 import { Select } from '@mui/material';
 import { MenuItem } from '@mui/material';
 import { RadioGroup } from '@mui/material';
 import { FormControlLabel } from '@mui/material';
 import { Radio } from '@mui/material';
+import NERSuccessButton from '../../../components/NERSuccessButton';
+import NERFailButton from '../../../components/NERFailButton';
 
 interface ActivateWorkPackageModalProps {
   allUsers: User[];
@@ -141,12 +143,27 @@ const ActivateWorkPackageModal: React.FC<ActivateWorkPackageModalProps> = ({
           </div>
         </DialogContent>
         <DialogActions>
-          <Button color="secondary" variant="outlined" form="activate-work-package-form" onClick={onHide}>
-            Cancel
-          </Button>
-          <Button color="success" variant="contained" type="submit" form="activate-work-package-form">
-            Submit
-          </Button>
+          <Box textAlign="left" sx={{ my: 2 }}>
+            <NERFailButton
+              color="secondary"
+              variant="outlined"
+              form="activate-work-package-form"
+              onClick={onHide}
+              sx={{ mx: 1 }}
+            >
+              Cancel
+            </NERFailButton>
+
+            <NERSuccessButton
+              color="success"
+              variant="contained"
+              type="submit"
+              form="activate-work-package-form"
+              sx={{ mx: 1 }}
+            >
+              Submit
+            </NERSuccessButton>
+          </Box>
         </DialogActions>
       </Dialog>
     </form>

--- a/src/frontend/src/pages/WorkPackageDetailPage/ActivateWorkPackageModalContainer/ActivateWorkPackageModal.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/ActivateWorkPackageModalContainer/ActivateWorkPackageModal.tsx
@@ -144,23 +144,11 @@ const ActivateWorkPackageModal: React.FC<ActivateWorkPackageModalProps> = ({
         </DialogContent>
         <DialogActions>
           <Box textAlign="left" sx={{ my: 2 }}>
-            <NERFailButton
-              color="secondary"
-              variant="outlined"
-              form="activate-work-package-form"
-              onClick={onHide}
-              sx={{ mx: 1 }}
-            >
+            <NERFailButton variant="outlined" form="activate-work-package-form" onClick={onHide} sx={{ mx: 2 }}>
               Cancel
             </NERFailButton>
 
-            <NERSuccessButton
-              color="success"
-              variant="contained"
-              type="submit"
-              form="activate-work-package-form"
-              sx={{ mx: 1 }}
-            >
+            <NERSuccessButton variant="contained" type="submit" form="activate-work-package-form" sx={{ mx: 1 }}>
               Submit
             </NERSuccessButton>
           </Box>


### PR DESCRIPTION
## Changes
Changed the Cancel and Submit buttons to use NERFailButton and NERSuccessButton respectively in ActivateWorkPackageModal.


## Screenshots

<img width="1245" alt="image" src="https://user-images.githubusercontent.com/55080943/215901345-0e53bdb1-59c3-46ed-a9a9-f0cf9a9f20fe.png">

<img width="210" alt="image" src="https://user-images.githubusercontent.com/55080943/215901904-20bfd656-215e-4595-ad1f-b9f7fe23755a.png">




## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #719  
