### PR TITLE
#652 Frontend - Make Row Count Persistent on CR Table

### DIFF
--- a/src/frontend/src/pages/ChangeRequestsPage/ChangeRequestsTable.tsx
+++ b/src/frontend/src/pages/ChangeRequestsPage/ChangeRequestsTable.tsx
@@ -22,10 +22,11 @@ import { ChangeRequestType, validateWBS, WbsNumber } from 'shared';
 const ChangeRequestsTable: React.FC = () => {
   const history = useHistory();
   const { isLoading, isError, data, error } = useAllChangeRequests();
-  const savedPageSize = localStorage.getItem('cr-table-row-count');
-  let state: string = savedPageSize != null ? savedPageSize : '50';
+  if (localStorage.getItem('cr-table-row-count') === null) {
+    localStorage.setItem('cr-table-row-count', '50');
+  }
 
-  const [pageSize, setPageSize] = useState(Number(state));
+  const [pageSize, setPageSize] = useState(Number(localStorage.getItem('cr-table-row-count')));
 
   const baseColDef: any = {
     flex: 1,

--- a/src/frontend/src/pages/ChangeRequestsPage/ChangeRequestsTable.tsx
+++ b/src/frontend/src/pages/ChangeRequestsPage/ChangeRequestsTable.tsx
@@ -22,7 +22,10 @@ import { ChangeRequestType, validateWBS, WbsNumber } from 'shared';
 const ChangeRequestsTable: React.FC = () => {
   const history = useHistory();
   const { isLoading, isError, data, error } = useAllChangeRequests();
-  const [pageSize, setPageSize] = useState(50);
+  const savedPageSize = localStorage.getItem('cr-table-row-count');
+  let state: string = savedPageSize != null ? savedPageSize : '50';
+
+  const [pageSize, setPageSize] = useState(Number(state));
 
   const baseColDef: any = {
     flex: 1,
@@ -162,7 +165,10 @@ const ChangeRequestsTable: React.FC = () => {
         density="compact"
         pageSize={pageSize}
         rowsPerPageOptions={[25, 50, 75, 100]}
-        onPageSizeChange={(newPageSize) => setPageSize(newPageSize)}
+        onPageSizeChange={(newPageSize) => {
+          localStorage.setItem('cr-table-row-count', String(newPageSize));
+          setPageSize(newPageSize);
+        }}
         loading={isLoading}
         error={error}
         rows={


### PR DESCRIPTION
## Changes

Changed it so that the Change Requests table will remember the users setting for number of rows, even if the page is left or browser is closed. The data is stored in localStorage. Still defaults to 50 if there is no data in localStorage.

## Notes

Tested functionality manually

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #652
