### PR TITLE
#635 replaced alert() with useToast in ReviewChangesRequest page

### DIFF
--- a/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequest.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequest.tsx
@@ -10,6 +10,7 @@ import ErrorPage from '../ErrorPage';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import ReviewChangeRequestsView from './ReviewChangeRequestView';
 import { ChangeRequest } from 'shared';
+import { useToast } from '../../hooks/toasts.hooks';
 
 interface ReviewChangeRequestProps {
   modalShow: boolean;
@@ -46,7 +47,7 @@ const ReviewChangeRequest: React.FC<ReviewChangeRequestProps> = ({
       accepted,
       psId
     }).catch((error) => {
-      alert(error);
+      useToast();
       throw new Error(error);
     });
   };


### PR DESCRIPTION
## Changes

replaced alert() call in ReviewChangeRequest Page with useToast().


## To Do

_Any remaining things that need to get done_

- [ ] item 1
- [ ] ...

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #635 
