### PR TITLE
#714 Updated cancel and submit buttons on the edit work package page

### DIFF
--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditContainer.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditContainer.tsx
@@ -190,7 +190,7 @@ const WorkPackageEditContainer: React.FC<WorkPackageEditContainerProps> = ({ wor
           remove={removeDeliverable}
         />
       </PageBlock>
-      <Box textAlign="center" sx={{ my: 2 }}>
+      <Box textAlign="right" sx={{ my: 2 }}>
         <NERFailButton variant="contained" onClick={exitEditMode} sx={{ mx: 2 }}>
           Cancel
         </NERFailButton>

--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditContainer.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditContainer.tsx
@@ -191,10 +191,10 @@ const WorkPackageEditContainer: React.FC<WorkPackageEditContainerProps> = ({ wor
         />
       </PageBlock>
       <Box textAlign="right" sx={{ my: 2 }}>
-        <NERFailButton variant="contained" onClick={exitEditMode} sx={{ mx: 2 }}>
+        <NERFailButton variant="contained" onClick={exitEditMode} sx={{ mx: 1 }}>
           Cancel
         </NERFailButton>
-        <NERSuccessButton variant="contained" type="submit" sx={{ mx: 2 }}>
+        <NERSuccessButton variant="contained" type="submit" sx={{ mx: 1 }}>
           Submit
         </NERSuccessButton>
       </Box>

--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditContainer.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditContainer.tsx
@@ -23,6 +23,8 @@ import ReactHookEditableList from '../../../components/ReactHookEditableList';
 import { useEditWorkPackage } from '../../../hooks/work-packages.hooks';
 import WorkPackageEditDetails from './WorkPackageEditDetails';
 import { bulletsToObject, mapBulletsToPayload } from '../../../utils/form';
+import NERSuccessButton from '../../../components/NERSuccessButton';
+import NERFailButton from '../../../components/NERFailButton';
 
 const schema = yup.object().shape({
   name: yup.string().required('Name is required!'),
@@ -189,12 +191,12 @@ const WorkPackageEditContainer: React.FC<WorkPackageEditContainerProps> = ({ wor
         />
       </PageBlock>
       <Box textAlign="center" sx={{ my: 2 }}>
-        <Button variant="contained" color="success" type="submit" sx={{ mx: 2 }}>
-          Submit
-        </Button>
-        <Button variant="contained" color="error" onClick={exitEditMode} sx={{ mx: 2 }}>
+        <NERFailButton variant="contained" onClick={exitEditMode} sx={{ mx: 2 }}>
           Cancel
-        </Button>
+        </NERFailButton>
+        <NERSuccessButton variant="contained" type="submit" sx={{ mx: 2 }}>
+          Submit
+        </NERSuccessButton>
       </Box>
     </form>
   );


### PR DESCRIPTION
## Changes
Changed the buttons of the submit and cancel to NERSuccessButton and NERFailButton. Also put the cancel on the left and the submit on the right.

## Screenshots

![image](https://user-images.githubusercontent.com/55457750/216212001-d6b7ace9-9cb6-4b3f-98bf-60790ded6287.png)

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #714 
