### PR TITLE
#744 Rename to projectLeadId and projectManagerId

### DIFF
--- a/src/backend/src/controllers/projects.controllers.ts
+++ b/src/backend/src/controllers/projects.controllers.ts
@@ -56,8 +56,8 @@ export default class ProjectsController {
         slideDeckLink,
         bomLink,
         taskListLink,
-        projectLead,
-        projectManager
+        projectLeadId,
+        projectManagerId
       } = req.body;
 
       const editedProject: Project = await ProjectsService.editProject(
@@ -75,8 +75,8 @@ export default class ProjectsController {
         slideDeckLink,
         bomLink,
         taskListLink,
-        projectLead || null,
-        projectManager || null
+        projectLeadId || null,
+        projectManagerId || null
       );
 
       return res.status(200).json(editedProject);

--- a/src/backend/src/routes/projects.routes.ts
+++ b/src/backend/src/routes/projects.routes.ts
@@ -39,8 +39,8 @@ projectRouter.post(
   nonEmptyString(body('slideDeckLink')),
   nonEmptyString(body('bomLink')),
   nonEmptyString(body('taskListLink')),
-  intMinZero(body('projectLead').optional()),
-  intMinZero(body('projectManager').optional()),
+  intMinZero(body('projectLeadId').optional()),
+  intMinZero(body('projectManagerId').optional()),
   validateInputs,
   ProjectsController.editProject
 );

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -122,8 +122,8 @@ export default class ProjectsService {
    * @param slideDeckLink the new slideDeckLink of the project
    * @param bomLink the new bomLink of the project
    * @param taskListLink the new taskListLink of the project
-   * @param projectLead the new projectLead of the project
-   * @param projectManager the new projectManager of the project
+   * @param projectLeadId the new projectLead of the project
+   * @param projectManagerId the new projectManager of the project
    * @returns the edited project
    */
   static async editProject(
@@ -141,8 +141,8 @@ export default class ProjectsService {
     slideDeckLink: string | null,
     bomLink: string | null,
     taskListLink: string | null,
-    projectLead: number | null,
-    projectManager: number | null
+    projectLeadId: number | null,
+    projectManagerId: number | null
   ): Promise<Project> {
     if (user.role === Role.GUEST) throw new AccessDeniedException('Guests cannot edit projects');
     const { userId } = user;
@@ -215,7 +215,7 @@ export default class ProjectsService {
     const projectManagerChangeJson = createChangeJsonNonList(
       'project manager',
       await getUserFullName(originalProject.wbsElement.projectManagerId),
-      await getUserFullName(projectManager),
+      await getUserFullName(projectManagerId),
       crId,
       userId,
       wbsElementId
@@ -223,7 +223,7 @@ export default class ProjectsService {
     const projectLeadChangeJson = createChangeJsonNonList(
       'project lead',
       await getUserFullName(originalProject.wbsElement.projectLeadId),
-      await getUserFullName(projectLead),
+      await getUserFullName(projectLeadId),
       crId,
       userId,
       wbsElementId
@@ -309,8 +309,8 @@ export default class ProjectsService {
         wbsElement: {
           update: {
             name,
-            projectLeadId: projectLead,
-            projectManagerId: projectManager
+            projectLeadId: projectLeadId,
+            projectManagerId: projectManagerId
           }
         }
       },

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -309,8 +309,8 @@ export default class ProjectsService {
         wbsElement: {
           update: {
             name,
-            projectLeadId: projectLeadId,
-            projectManagerId: projectManagerId
+            projectLeadId,
+            projectManagerId
           }
         }
       },

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditContainer.tsx
@@ -88,7 +88,17 @@ const ProjectEditContainer: React.FC<ProjectEditContainerProps> = ({ project, ex
   const users = allUsers.data.filter((u) => u.role !== 'GUEST');
 
   const onSubmit = async (data: any) => {
-    const { name, budget, summary, bomLink, googleDriveFolderLink, taskListLink, slideDeckLink } = data;
+    const {
+      name,
+      budget,
+      summary,
+      bomLink,
+      googleDriveFolderLink,
+      taskListLink,
+      slideDeckLink,
+      projectLeadId,
+      projectManagerId
+    } = data;
     const rules = data.rules.map((rule: any) => rule.rule || rule);
     const goals = mapBulletsToPayload(data.goals);
     const features = mapBulletsToPayload(data.features);
@@ -108,8 +118,8 @@ const ProjectEditContainer: React.FC<ProjectEditContainerProps> = ({ project, ex
       goals,
       features,
       otherConstraints,
-      projectLead: data.projectLeadId,
-      projectManager: data.projectManagerId
+      projectLeadId,
+      projectManagerId
     };
 
     try {


### PR DESCRIPTION
## Changes

Rename `projectLead` and `projectManager` to `projectLeadId` and `projectManagerId` in the projects controller, route, service, and frontend payload.

## Test Cases

(all pass)

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #744
