### PR TITLE
#715: Changed Buttons to NER Buttons in CreateWorkPackagePage

### DIFF
--- a/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageFormView.tsx
+++ b/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageFormView.tsx
@@ -20,8 +20,9 @@ import ReactHookTextField from '../../components/ReactHookTextField';
 import { FormControl, FormLabel, IconButton } from '@mui/material';
 import ReactHookEditableList from '../../components/ReactHookEditableList';
 import DeleteIcon from '@mui/icons-material/Delete';
-import { SubmitButton } from '../../components/SubmitButton';
 import { wbsTester } from '../../utils/form';
+import NERFailButton from '../../components/NERFailButton';
+import NERSuccessButton from '../../components/NERSuccessButton';
 
 const schema = yup.object().shape({
   name: yup.string().required('Name is required'),
@@ -221,12 +222,12 @@ const CreateWorkPackageFormView: React.FC<CreateWorkPackageFormViewProps> = ({ a
           </Grid>
         </Grid>
         <Box display="flex" gap={2} sx={{ mt: 2 }}>
-          <SubmitButton variant="contained" color="primary" type="submit" disabled={!allowSubmit}>
+          <NERSuccessButton variant="contained" color="primary" type="submit" disabled={!allowSubmit}>
             Create
-          </SubmitButton>
-          <Button variant="outlined" color="secondary" onClick={onCancel}>
+          </NERSuccessButton>
+          <NERFailButton variant="outlined" color="secondary" onClick={onCancel}>
             Cancel
-          </Button>
+          </NERFailButton>
         </Box>
       </PageBlock>
     </form>

--- a/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageFormView.tsx
+++ b/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageFormView.tsx
@@ -221,13 +221,13 @@ const CreateWorkPackageFormView: React.FC<CreateWorkPackageFormViewProps> = ({ a
             </FormControl>
           </Grid>
         </Grid>
-        <Box display="flex" gap={2} sx={{ mt: 2 }}>
-          <NERSuccessButton variant="contained" color="primary" type="submit" disabled={!allowSubmit}>
-            Create
-          </NERSuccessButton>
-          <NERFailButton variant="outlined" color="secondary" onClick={onCancel}>
+        <Box textAlign="right" gap={2} sx={{ mt: 2 }}>
+          <NERFailButton variant="outlined" onClick={onCancel} sx={{ mx: 1 }}>
             Cancel
           </NERFailButton>
+          <NERSuccessButton variant="contained" type="submit" disabled={!allowSubmit} sx={{ mx: 1 }}>
+            Create
+          </NERSuccessButton>
         </Box>
       </PageBlock>
     </form>


### PR DESCRIPTION
## Changes

I changed the buttons on the Create work package page to the NER buttons so that every button is consistent. Had to make changes so that the buttons were on the right side of the page.

## Screenshots

<img width="1400" alt="Screen Shot 2023-02-05 at 5 11 26 PM" src="https://user-images.githubusercontent.com/44037183/216848892-bc6d455b-11e0-4b45-9f2b-b42863abf089.png">

<img width="223" alt="Screen Shot 2023-02-05 at 5 11 38 PM" src="https://user-images.githubusercontent.com/44037183/216848895-6d2b2281-a7cd-49e7-910f-c94b48891a4e.png">

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #715 
