### PR TITLE
#717 Changed the request view buttons to use NER buttons

### DIFF
--- a/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequestView.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequestView.tsx
@@ -141,7 +141,6 @@ const ReviewChangeRequestsView: React.FC<ReviewChangeRequestViewProps> = ({
         </DialogContent>
         <DialogActions>
           <NERFailButton
-            className={'ml-3'}
             variant="contained"
             type="submit"
             form="review-notes-form"

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequestView.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequestView.tsx
@@ -150,29 +150,27 @@ const ReviewChangeRequestsView: React.FC<ReviewChangeRequestViewProps> = ({
           </form>
         </DialogContent>
         <DialogActions>
-          <Button
-            color="success"
+          <NERFailButton
+            className={'ml-3'}
             variant="contained"
             type="submit"
             form="review-notes-form"
-            sx={{ textTransform: 'none', fontSize: 16 }}
+            sx={{ mx: 1 }}
+            onClick={() => handleAcceptDeny(false)}
+          >
+            Deny
+          </NERFailButton>
+          <NERSuccessButton
+            variant="contained"
+            type="submit"
+            form="review-notes-form"
+            sx={{ mx: 1 }}
             onClick={() => {
               selected > -1 ? handleAcceptDeny(true) : toast.error('Please select a proposed solution!', 4500);
             }}
           >
             Accept
-          </Button>
-          <Button
-            color="error"
-            className={'ml-3'}
-            variant="contained"
-            type="submit"
-            form="review-notes-form"
-            sx={{ textTransform: 'none', fontSize: 16 }}
-            onClick={() => handleAcceptDeny(false)}
-          >
-            Deny
-          </Button>
+          </NERSuccessButton>
         </DialogActions>
       </Dialog>
     );

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequestView.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequestView.tsx
@@ -22,6 +22,8 @@ import {
   Breakpoint
 } from '@mui/material';
 import { useToast } from '../../hooks/toasts.hooks';
+import NERSuccessButton from '../../components/NERSuccessButton';
+import NERFailButton from '../../components/NERFailButton';
 
 interface ReviewChangeRequestViewProps {
   cr: ChangeRequest;
@@ -205,26 +207,24 @@ const ReviewChangeRequestsView: React.FC<ReviewChangeRequestViewProps> = ({
           </form>
         </DialogContent>
         <DialogActions>
-          <Button
-            variant="contained"
-            color="success"
-            type="submit"
-            form="review-notes-form"
-            sx={{ textTransform: 'none', fontSize: 16 }}
-            onClick={() => handleAcceptDeny(true)}
-          >
-            Accept
-          </Button>
-          <Button
+          <NERFailButton
             type="submit"
             form="review-notes-form"
             variant="contained"
-            color="error"
-            sx={{ textTransform: 'none', fontSize: 16 }}
+            sx={{ mx: 1, textTransform: 'none', fontSize: 16 }}
             onClick={() => handleAcceptDeny(false)}
           >
             Deny
-          </Button>
+          </NERFailButton>
+          <NERSuccessButton
+            variant="contained"
+            type="submit"
+            form="review-notes-form"
+            sx={{ mx: 1, textTransform: 'none', fontSize: 16 }}
+            onClick={() => handleAcceptDeny(true)}
+          >
+            Accept
+          </NERSuccessButton>
         </DialogActions>
       </Dialog>
     );

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequestView.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequestView.tsx
@@ -211,7 +211,7 @@ const ReviewChangeRequestsView: React.FC<ReviewChangeRequestViewProps> = ({
             type="submit"
             form="review-notes-form"
             variant="contained"
-            sx={{ mx: 1, textTransform: 'none', fontSize: 16 }}
+            sx={{ mx: 1 }}
             onClick={() => handleAcceptDeny(false)}
           >
             Deny
@@ -220,7 +220,7 @@ const ReviewChangeRequestsView: React.FC<ReviewChangeRequestViewProps> = ({
             variant="contained"
             type="submit"
             form="review-notes-form"
-            sx={{ mx: 1, textTransform: 'none', fontSize: 16 }}
+            sx={{ mx: 1 }}
             onClick={() => handleAcceptDeny(true)}
           >
             Accept

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequestView.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequestView.tsx
@@ -10,17 +10,7 @@ import { FormInput } from './ReviewChangeRequest';
 import { ChangeRequest, ProposedSolution, StandardChangeRequest } from 'shared';
 import { useState } from 'react';
 import ProposedSolutionSelectItem from './ProposedSolutionSelectItem';
-import {
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  Box,
-  TextField,
-  Typography,
-  Breakpoint
-} from '@mui/material';
+import { Dialog, DialogActions, DialogContent, DialogTitle, Box, TextField, Typography, Breakpoint } from '@mui/material';
 import { useToast } from '../../hooks/toasts.hooks';
 import NERSuccessButton from '../../components/NERSuccessButton';
 import NERFailButton from '../../components/NERFailButton';


### PR DESCRIPTION
## Changes

Changed the request view buttons to use NERsuccess/fail buttons

<img width="1510" alt="Screenshot 2023-02-02 at 2 22 32 PM" src="https://user-images.githubusercontent.com/76594216/216429491-d09633b9-5f7e-4ee2-8d95-a067a36dd87d.png">




## To Do


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #717
