### PR TITLE
#751 make close icon

### DIFF
--- a/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionForm.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionForm.tsx
@@ -4,11 +4,13 @@
  */
 
 import { Box, Button, Dialog, DialogContent, DialogTitle } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
 import * as yup from 'yup';
 import { Controller, useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { ProposedSolution } from 'shared';
 import { TextField, Typography } from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 
 interface ProposedSolutionFormProps {
   description?: string;
@@ -56,6 +58,18 @@ const ProposedSolutionForm: React.FC<ProposedSolutionFormProps> = ({
   return (
     <Dialog open={open} onClose={onClose}>
       <DialogTitle>Propose a Solution</DialogTitle>
+      <IconButton
+        aria-label="close"
+        onClick={onClose}
+        sx={{
+          position: 'absolute',
+          right: 8,
+          top: 8,
+          color: (theme) => theme.palette.grey[500]
+        }}
+      >
+        <CloseIcon />
+      </IconButton>
       <DialogContent
         sx={{
           '&::-webkit-scrollbar': {

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionForm.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionForm.tsx
@@ -9,8 +9,7 @@ import * as yup from 'yup';
 import { Controller, useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { ProposedSolution } from 'shared';
-import { TextField, Typography } from '@mui/material';
-import IconButton from '@mui/material/IconButton';
+import { TextField, Typography, IconButton } from '@mui/material';
 
 interface ProposedSolutionFormProps {
   description?: string;


### PR DESCRIPTION
## Changes

Added a close button on the close modal.


## Screenshots
<img width="1468" alt="스크린샷 2023-02-02 오후 6 24 58" src="https://user-images.githubusercontent.com/58490052/216473734-b3158791-df5a-400a-aa82-f799aa237281.png">
<img width="98" alt="스크린샷 2023-02-02 오후 6 25 18" src="https://user-images.githubusercontent.com/58490052/216473770-6e8a5be3-e692-4131-9a7d-202ff6e8feee.png">




## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #751
