### PR TITLE
#814 - removed fontawesome icons from external link

### DIFF
--- a/src/frontend/src/components/ExternalLink.tsx
+++ b/src/frontend/src/components/ExternalLink.tsx
@@ -3,12 +3,12 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { IconProp } from '@fortawesome/fontawesome-svg-core';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Stack } from '@mui/material';
 import Link from '@mui/material/Link';
+import { ReactNode } from 'react';
 
 interface ExternalLinkProps {
-  icon?: IconProp;
+  icon?: ReactNode;
   link: string;
   description: string;
 }
@@ -16,12 +16,12 @@ interface ExternalLinkProps {
 // Common component for all external links to open in new tab
 const ExternalLink: React.FC<ExternalLinkProps> = ({ icon, link, description }) => {
   return (
-    <div key={description} className="d-flex flex-row align-items-center px-3">
-      {icon !== undefined ? <FontAwesomeIcon icon={icon} size="lg" className="pr-1" data-testid={'icon'} /> : ' '}
+    <Stack direction="row" alignItems="center">
+      {icon}
       <Link href={link} sx={{ pl: 1 }} target="_blank" rel="noopener noreferrer">
         {description}
       </Link>
-    </div>
+    </Stack>
   );
 };
 

--- a/src/frontend/src/pages/InfoPage.tsx
+++ b/src/frontend/src/pages/InfoPage.tsx
@@ -6,7 +6,10 @@
 import Grid from '@mui/material/Grid';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
-import { faScroll, faCode, faCommentAlt, faBolt, faCog, faDollarSign, faSearch } from '@fortawesome/free-solid-svg-icons';
+import { faScroll, faCode, faBolt, faCog, faDollarSign, faSearch } from '@fortawesome/free-solid-svg-icons';
+import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile';
+import CodeIcon from '@mui/icons-material/Code';
+import ChatIcon from '@mui/icons-material/Chat';
 import ExternalLink from '../components/ExternalLink';
 import PageTitle from '../layouts/PageTitle/PageTitle';
 import PageBlock from '../layouts/PageBlock';
@@ -23,7 +26,7 @@ const InfoPage: React.FC = () => {
         <Grid container spacing={2}>
           <Grid item md={4} lg={3}>
             <ExternalLink
-              icon={faScroll}
+              icon={<InsertDriveFileIcon />}
               description={'Glossary Document'}
               link={'https://docs.google.com/document/d/1_kr7PQxjYKvBTmZc8cxeSv5xx0lE88v0wVXkVg3Mez8/edit?usp=sharing'}
             />
@@ -34,22 +37,20 @@ const InfoPage: React.FC = () => {
         </Grid>
       </PageBlock>
       <PageBlock title="Support">
-        <Box>
-          <Typography>
-            Any and all questions, comments, suggestions, bugs, or other issues can be directed to the resources below:
-          </Typography>
-        </Box>
+        <Typography>
+          Any and all questions, comments, suggestions, bugs, or other issues can be directed to the resources below:
+        </Typography>
         <Grid container spacing={2}>
           <Grid item sm={5} md={4} lg={3}>
             <ExternalLink
-              icon={faCommentAlt}
+              icon={<ChatIcon />}
               link={'slack://channel?team=T7MHAQ5TL&id=C02U5TKHLER'}
               description={'Message in Slack'}
             />
           </Grid>
           <Grid item sm={6} md={4} lg={3}>
             <ExternalLink
-              icon={faCode}
+              icon={<CodeIcon />}
               description={'Submit a ticket on GitHub'}
               link={'https://github.com/Northeastern-Electric-Racing/FinishLine/issues/new/choose'}
             />
@@ -59,112 +60,76 @@ const InfoPage: React.FC = () => {
       <PageBlock title="Calendars">
         <Grid container>
           <Grid item md={4} lg={3}>
-            <Box>
-              <FontAwesomeIcon icon={faScroll} className="mx-2" style={{ margin: '0px 5px' }} />{' '}
-              <Typography display="inline">Club-Wide Meetings & Events</Typography>
-            </Box>
-            <Box>
-              <ExternalLink
-                description="Public URL"
-                link="https://calendar.google.com/calendar/embed?src=l2vtfdaeu2lisoip58tijijtvc%40group.calendar.google.com&ctz=America%2FNew_York"
-              ></ExternalLink>
-            </Box>
-            <Box>
-              <ExternalLink
-                description="iCal URL"
-                link="https://calendar.google.com/calendar/ical/l2vtfdaeu2lisoip58tijijtvc%40group.calendar.google.com/public/basic.ics"
-              ></ExternalLink>
-            </Box>
+            <FontAwesomeIcon icon={faScroll} className="mx-2" style={{ margin: '0px 5px' }} />{' '}
+            <Typography display="inline">Club-Wide Meetings & Events</Typography>
+            <ExternalLink
+              description="Public URL"
+              link="https://calendar.google.com/calendar/embed?src=l2vtfdaeu2lisoip58tijijtvc%40group.calendar.google.com&ctz=America%2FNew_York"
+            />
+            <ExternalLink
+              description="iCal URL"
+              link="https://calendar.google.com/calendar/ical/l2vtfdaeu2lisoip58tijijtvc%40group.calendar.google.com/public/basic.ics"
+            />
           </Grid>
           <Grid item md={4} lg={3}>
-            <Box>
-              <FontAwesomeIcon icon={faBolt} className="mx-2" style={{ margin: '0px 5px' }} />{' '}
-              <Typography display="inline">Electrical Meetings</Typography>
-            </Box>
-            <Box>
-              <ExternalLink
-                description="Public URL"
-                link="https://calendar.google.com/calendar/embed?src=npitbmnpkcnpcftfu259tthq6g%40group.calendar.google.com&ctz=America%2FNew_York"
-              ></ExternalLink>
-            </Box>
-            <Box>
-              <ExternalLink
-                description="iCal URL"
-                link="https://calendar.google.com/calendar/ical/npitbmnpkcnpcftfu259tthq6g%40group.calendar.google.com/public/basic.ics"
-              ></ExternalLink>
-            </Box>
+            <FontAwesomeIcon icon={faBolt} className="mx-2" style={{ margin: '0px 5px' }} />{' '}
+            <Typography display="inline">Electrical Meetings</Typography>
+            <ExternalLink
+              description="Public URL"
+              link="https://calendar.google.com/calendar/embed?src=npitbmnpkcnpcftfu259tthq6g%40group.calendar.google.com&ctz=America%2FNew_York"
+            />
+            <ExternalLink
+              description="iCal URL"
+              link="https://calendar.google.com/calendar/ical/npitbmnpkcnpcftfu259tthq6g%40group.calendar.google.com/public/basic.ics"
+            />
           </Grid>
           <Grid item md={4} lg={6}>
-            <Box>
-              <FontAwesomeIcon icon={faCog} className="mx-2" style={{ margin: '0px 5px' }} />{' '}
-              <Typography display="inline">Mechanical Meetings</Typography>
-            </Box>
-            <Box>
-              <ExternalLink
-                description="Public URL"
-                link="https://calendar.google.com/calendar/embed?src=qrtikitnuchp43873l1h17mhe8%40group.calendar.google.com&ctz=America%2FNew_York"
-              ></ExternalLink>
-            </Box>
-            <Box>
-              <ExternalLink
-                description="iCal URL"
-                link="https://calendar.google.com/calendar/ical/qrtikitnuchp43873l1h17mhe8%40group.calendar.google.com/public/basic.ics"
-              ></ExternalLink>
-            </Box>
+            <FontAwesomeIcon icon={faCog} className="mx-2" style={{ margin: '0px 5px' }} />{' '}
+            <Typography display="inline">Mechanical Meetings</Typography>
+            <ExternalLink
+              description="Public URL"
+              link="https://calendar.google.com/calendar/embed?src=qrtikitnuchp43873l1h17mhe8%40group.calendar.google.com&ctz=America%2FNew_York"
+            />
+            <ExternalLink
+              description="iCal URL"
+              link="https://calendar.google.com/calendar/ical/qrtikitnuchp43873l1h17mhe8%40group.calendar.google.com/public/basic.ics"
+            />
           </Grid>
           <Grid item md={4} lg={3}>
-            <Box>
-              <FontAwesomeIcon icon={faDollarSign} className="mx-2" style={{ margin: '0px 5px' }} />{' '}
-              <Typography display="inline">Business Meetings</Typography>
-            </Box>
-            <Box>
-              <ExternalLink
-                description="Public URL"
-                link="https://calendar.google.com/calendar/embed?src=j3hkd9o6onheu4fvhojno6qdf4%40group.calendar.google.com&ctz=America%2FNew_York"
-              ></ExternalLink>
-            </Box>
-            <Box>
-              <ExternalLink
-                description="iCal URL"
-                link="https://calendar.google.com/calendar/ical/j3hkd9o6onheu4fvhojno6qdf4%40group.calendar.google.com/public/basic.ics"
-              ></ExternalLink>
-            </Box>
+            <FontAwesomeIcon icon={faDollarSign} className="mx-2" style={{ margin: '0px 5px' }} />{' '}
+            <Typography display="inline">Business Meetings</Typography>
+            <ExternalLink
+              description="Public URL"
+              link="https://calendar.google.com/calendar/embed?src=j3hkd9o6onheu4fvhojno6qdf4%40group.calendar.google.com&ctz=America%2FNew_York"
+            />
+            <ExternalLink
+              description="iCal URL"
+              link="https://calendar.google.com/calendar/ical/j3hkd9o6onheu4fvhojno6qdf4%40group.calendar.google.com/public/basic.ics"
+            />
           </Grid>
           <Grid item md={4} lg={3}>
-            <Box>
-              <FontAwesomeIcon icon={faCode} className="mx-2" style={{ margin: '0px 5px' }} />{' '}
-              <Typography display="inline">Software Meetings</Typography>
-            </Box>
-            <Box>
-              <ExternalLink
-                description="Public URL"
-                link="https://calendar.google.com/calendar/embed?src=55gqs0qvt4mjcmsqn8ln8a5njg%40group.calendar.google.com&ctz=America%2FNew_York"
-              ></ExternalLink>
-            </Box>
-            <Box>
-              <ExternalLink
-                description="iCal URL"
-                link="https://calendar.google.com/calendar/ical/55gqs0qvt4mjcmsqn8ln8a5njg%40group.calendar.google.com/public/basic.ics"
-              ></ExternalLink>
-            </Box>
+            <FontAwesomeIcon icon={faCode} className="mx-2" style={{ margin: '0px 5px' }} />{' '}
+            <Typography display="inline">Software Meetings</Typography>
+            <ExternalLink
+              description="Public URL"
+              link="https://calendar.google.com/calendar/embed?src=55gqs0qvt4mjcmsqn8ln8a5njg%40group.calendar.google.com&ctz=America%2FNew_York"
+            />
+            <ExternalLink
+              description="iCal URL"
+              link="https://calendar.google.com/calendar/ical/55gqs0qvt4mjcmsqn8ln8a5njg%40group.calendar.google.com/public/basic.ics"
+            />
           </Grid>
           <Grid item md={4} lg={6}>
-            <Box>
-              <FontAwesomeIcon icon={faSearch} className="mx-2" style={{ margin: '0px 5px' }} />{' '}
-              <Typography display="inline">Engineering Reviews</Typography>
-            </Box>
-            <Box>
-              <ExternalLink
-                description="Public URL"
-                link="https://calendar.google.com/calendar/embed?src=qqojrdj50ob1m79vt2h3blmn1s%40group.calendar.google.com&ctz=America%2FNew_York"
-              ></ExternalLink>
-            </Box>
-            <Box>
-              <ExternalLink
-                description="iCal URL"
-                link="https://calendar.google.com/calendar/ical/qqojrdj50ob1m79vt2h3blmn1s%40group.calendar.google.com/public/basic.ics"
-              ></ExternalLink>
-            </Box>
+            <FontAwesomeIcon icon={faSearch} className="mx-2" style={{ margin: '0px 5px' }} />{' '}
+            <Typography display="inline">Engineering Reviews</Typography>
+            <ExternalLink
+              description="Public URL"
+              link="https://calendar.google.com/calendar/embed?src=qqojrdj50ob1m79vt2h3blmn1s%40group.calendar.google.com&ctz=America%2FNew_York"
+            />
+            <ExternalLink
+              description="iCal URL"
+              link="https://calendar.google.com/calendar/ical/qqojrdj50ob1m79vt2h3blmn1s%40group.calendar.google.com/public/basic.ics"
+            />
           </Grid>
         </Grid>
       </PageBlock>

--- a/src/frontend/src/tests/components/ExternalLink.test.tsx
+++ b/src/frontend/src/tests/components/ExternalLink.test.tsx
@@ -3,23 +3,22 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { faScroll } from '@fortawesome/free-solid-svg-icons';
 import { render, screen, fireEvent } from '../test-support/test-utils';
 import ExternalLink from '../../components/ExternalLink';
+import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile';
 
 const TEST_DESCRIPTION = 'test';
 const TEST_LINK = 'github.com';
 
 // Sets up the component under test with the desired values and renders it.
 const renderComponent = () => {
-  return render(<ExternalLink icon={faScroll} link={TEST_LINK} description={TEST_DESCRIPTION} />);
+  return render(<ExternalLink icon={<InsertDriveFileIcon />} link={TEST_LINK} description={TEST_DESCRIPTION} />);
 };
 
 describe('external link', () => {
   it('has correct href', () => {
     renderComponent();
     expect(screen.getByText(TEST_DESCRIPTION)).toBeInTheDocument();
-    expect(screen.getByTestId('icon')).toHaveAttribute('data-icon', 'scroll');
     expect(screen.getByText(TEST_DESCRIPTION)).toHaveAttribute('href', TEST_LINK);
     expect(screen.getByText(TEST_DESCRIPTION)).toHaveAttribute('target', '_blank');
     expect(screen.getByText(TEST_DESCRIPTION)).toHaveAttribute('rel', 'noopener noreferrer');


### PR DESCRIPTION
## Changes

Made ExternalLink use MUI Icons instead of fontawesome icons. Had to update where this was being used in the info page. Cleaned up the info page file a bit as well.

## Screenshots

![image](https://user-images.githubusercontent.com/29521172/216793739-5772f594-009e-48ec-b1c1-dd4fd513e9e0.png)


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #814 
