### PR TITLE
#779 - Have Gantt Task Names Cut Off With Ellipses

### DIFF
--- a/src/frontend/src/pages/GanttPage/GanttPackage/components/task-list/TaskListTable.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttPackage/components/task-list/TaskListTable.tsx
@@ -44,7 +44,7 @@ export const TaskListTableDefault: React.FC<{
                 >
                   {expanderSymbol}
                 </div>
-                <div>{t.name}</div>
+                <div className={styles.taskListNameText}>{t.name}</div>
               </div>
             </div>
           </div>

--- a/src/frontend/src/stylesheets/pages/gantt-page.module.css
+++ b/src/frontend/src/stylesheets/pages/gantt-page.module.css
@@ -48,6 +48,12 @@
   display: flex;
 }
 
+.taskListNameText {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
 .taskListExpander {
   color: rgb(86 86 86);
   font-size: 0.6rem;


### PR DESCRIPTION
## Changes

Prevent Gantt chart from being out of alignment with the corresponding project/work package name labels by forcing the labels to fit on one line, with any extra being cut off with ellipses.

## Notes

Full name can still be read by hovering over the label text or the corresponding bar in the Gantt.

## Test Cases

No Jest tests because I [don't think](https://stackoverflow.com/questions/72491509/react-testing-library-verify-text-truncation) Jest allows you to test whether text has been truncated (you can test if overlay is true, though). Test it manually and expect to see something like the attached screenshot.
- Task with short name displays in full
- Task with long name gets cut off

## Screenshots

![Screen Shot 2023-02-05 at 2 43 52 PM](https://user-images.githubusercontent.com/59806366/216842500-09360903-70fd-47ae-b5c5-75c3e94aa9eb.png)
![Screen Shot 2023-02-05 at 2 44 06 PM](https://user-images.githubusercontent.com/59806366/216842503-1e4721ad-dd6a-4bff-966e-52e016d1a7a3.png)

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #779 
