### PR TITLE
#776 Made the progress % round to 2 decimal places when displayed

### DIFF
--- a/src/frontend/src/pages/GanttPage/GanttPackage/components/other/Tooltip.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttPackage/components/other/Tooltip.tsx
@@ -124,7 +124,7 @@ export const StandardTooltipContent: React.FC<{
           duration > 1 ? 'days' : 'day'
         }`}</p>
       )}
-      <p className={styles.tooltipDefaultContainerParagraph}>{`Percentage done: ${task.progress}%`}</p>
+      <p className={styles.tooltipDefaultContainerParagraph}>{`Percentage done: ${task.progress.toFixed(2)}%`}</p>
       <p className={styles.tooltipDefaultContainerParagraph}>{`End date: ${new Intl.DateTimeFormat('en-US', {
         month: 'long',
         day: 'numeric'


### PR DESCRIPTION
## Changes

I added the .toFixed(2) method to the progress when it's displayed, so that the progress is always rounded to 2 decimal places.

## Notes

The localhost version of the page first rounds all progresses to an integer at some point, so in all testing on that version, the percentage always contained .00
I'm not sure if this needs to be addressed in the scope of this ticket.

## Screenshots
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/114596410/217021818-44e2acf6-db17-4a23-afba-df32707d1cfb.png">


<img width="636" alt="image" src="https://user-images.githubusercontent.com/114596410/217021730-754f7368-3f17-4d36-8d19-4fb1d600fae3.png">



## Checklist

- [ ] All commits are tagged with the ticket number -- forgot to put in commit but put in PR (don't know how to change commit)
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
#776 