### PR TITLE
removed fontawesome, imported MUI

### DIFF
--- a/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionView.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionView.tsx
@@ -9,8 +9,7 @@ import Chip from '@mui/material/Chip';
 import Button from '@mui/material/Button';
 import Grid from '@mui/material/Grid';
 import { dollarsPipe, weeksPipe } from '../../utils/pipes';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTrash } from '@fortawesome/free-solid-svg-icons';
+import DeleteIcon from '@mui/icons-material/Delete';
 import DetailDisplay from '../../components/DetailDisplay';
 
 interface ProposedSolutionViewProps {
@@ -31,7 +30,7 @@ const ProposedSolutionView: React.FC<ProposedSolutionViewProps> = ({ proposedSol
           }}
           sx={{ position: 'absolute', right: 75 }}
         >
-          <FontAwesomeIcon icon={faTrash} size="lg" data-testid={'deleteIcon'} />
+          <DeleteIcon data-testid={'deleteIcon'} />
         </Button>
       ) : null}
       <Grid container rowSpacing={1} columnSpacing={{ xs: 1, sm: 2, md: 3 }}>


### PR DESCRIPTION
## Changes
changed fontawesome trash icon to mui trash icon
## Notes

simply riveting.

there could be a better arrangement of the delete button, since it bleeds over when pictured in the smallest size.

## Screenshots
before
<img width="425" alt="image" src="https://user-images.githubusercontent.com/59621104/217673111-2d9170d8-433d-4cdd-88c9-ec54dea4bedf.png">
<img width="425" alt="image" src="https://user-images.githubusercontent.com/59621104/217673235-61f8243c-ee59-4034-8634-3a221b6b9d2b.png">

after
<img width="425" alt="image" src="https://user-images.githubusercontent.com/59621104/217672938-642af471-afa9-44a4-a720-5d2cb965fc4d.png">

<img width="425" alt="image" src="https://user-images.githubusercontent.com/59621104/217673777-7c7f7686-56e8-45f6-a815-b7d0acbaeed6.png">

Closes #849 
