### PR TITLE
#848 Removed FontAwesome Icon from UserSettings Page

### DIFF
--- a/src/frontend/src/pages/SettingsPage/UserSettings/UserSettings.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserSettings/UserSettings.tsx
@@ -3,8 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { faPencilAlt } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import EditIcon from '@mui/icons-material/Edit';
 import { useState } from 'react';
 import { ThemeName } from 'shared';
 import { useSingleUserSettings, useUpdateUserSettings } from '../../../hooks/users.hooks';
@@ -45,7 +44,7 @@ const UserSettings: React.FC<UserSettingsProps> = ({ userId }) => {
       headerRight={
         !edit ? (
           <IconButton onClick={() => setEdit(true)}>
-            <FontAwesomeIcon icon={faPencilAlt} size="sm" />
+            <EditIcon fontSize="small" />
           </IconButton>
         ) : (
           <div className="d-flex flex-row">


### PR DESCRIPTION
## Changes

The (FontAwesome) pencil icon on the User Settings page was replaced with a MUI pencil (Edit) icon

## Screenshots

<img width="497" alt="Screen Shot 2023-02-09 at 10 12 18 AM" src="https://user-images.githubusercontent.com/114596410/217859483-05364dc2-37d8-4bef-8e1c-f19ac7fc2edd.png">
<img width="1440" alt="Screen Shot 2023-02-09 at 10 12 22 AM" src="https://user-images.githubusercontent.com/114596410/217859526-5c8fccca-edc0-469a-9b44-d1ffc1cd339c.png">

## Checklist


- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
#848 