### PR TITLE
#817 dynamically change the dropdown width based on the contents

### DIFF
--- a/src/frontend/src/pages/GanttPage/GanttPageFilter.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttPageFilter.tsx
@@ -136,7 +136,7 @@ const GanttPageFilter: FC<GanttPageFilterProps> = ({
         <Grid item xs={12} md={2}>
           <FormControl sx={{ width: '100%' }}>
             <FormLabel>Status</FormLabel>
-            <Select value={status} onChange={statusHandler}>
+            <Select value={status} onChange={statusHandler} autoWidth>
               <MenuItem value="All Statuses">All Statuses</MenuItem>
               {Object.values(WbsElementStatus).map((status) => {
                 return (
@@ -151,7 +151,7 @@ const GanttPageFilter: FC<GanttPageFilterProps> = ({
         <Grid item xs={12} md={2}>
           <FormControl sx={{ width: '100%' }}>
             <FormLabel>Team</FormLabel>
-            <Select value={selectedTeam} onChange={teamHandler}>
+            <Select value={selectedTeam} onChange={teamHandler} autoWidth>
               <MenuItem value="All Teams">All Teams</MenuItem>
               {teamList.map((team) => (
                 <MenuItem key={team} value={team}>

--- a/src/frontend/src/pages/GanttPage/GanttPageFilter.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttPageFilter.tsx
@@ -141,7 +141,7 @@ const GanttPageFilter: FC<GanttPageFilterProps> = ({
               {Object.values(WbsElementStatus).map((status) => {
                 return (
                   <MenuItem key={status} value={status}>
-                    {status.length > 25 ? `${status.substring(0, 25)}...` : status}
+                    {status.length > 50 ? `${status.substring(0, 50)}...` : status}
                   </MenuItem>
                 );
               })}
@@ -155,7 +155,7 @@ const GanttPageFilter: FC<GanttPageFilterProps> = ({
               <MenuItem value="All Teams">All Teams</MenuItem>
               {teamList.map((team) => (
                 <MenuItem key={team} value={team}>
-                  {team.length > 25 ? `${team.substring(0, 25)}...` : team}
+                  {team.length > 50 ? `${team.substring(0, 50)}...` : team}
                 </MenuItem>
               ))}
             </Select>

--- a/src/frontend/src/pages/GanttPage/GanttPageFilter.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttPageFilter.tsx
@@ -134,14 +134,14 @@ const GanttPageFilter: FC<GanttPageFilterProps> = ({
       <Grid container rowSpacing={1} columnSpacing={1} sx={{ justifyContent: 'start', alignItems: 'start' }}>
         {carFilters}
         <Grid item xs={12} md={2}>
-          <FormControl sx={{ maxWidth: '100%', wordBreak: 'break-all' }}>
+          <FormControl sx={{ width: '100%' }}>
             <FormLabel>Status</FormLabel>
-            <Select value={status} onChange={statusHandler} autoWidth>
+            <Select value={status} onChange={statusHandler}>
               <MenuItem value="All Statuses">All Statuses</MenuItem>
               {Object.values(WbsElementStatus).map((status) => {
                 return (
                   <MenuItem key={status} value={status}>
-                    {status}
+                    {status.length > 25 ? `${status.substring(0, 25)}...` : status}
                   </MenuItem>
                 );
               })}
@@ -149,13 +149,13 @@ const GanttPageFilter: FC<GanttPageFilterProps> = ({
           </FormControl>
         </Grid>
         <Grid item xs={12} md={2}>
-          <FormControl sx={{ maxWidth: '100%', wordBreak: 'break-all' }}>
+          <FormControl sx={{ width: '100%' }}>
             <FormLabel>Team</FormLabel>
-            <Select value={selectedTeam} onChange={teamHandler} autoWidth>
+            <Select value={selectedTeam} onChange={teamHandler}>
               <MenuItem value="All Teams">All Teams</MenuItem>
               {teamList.map((team) => (
                 <MenuItem key={team} value={team}>
-                  {team}
+                  {team.length > 25 ? `${team.substring(0, 25)}...` : team}
                 </MenuItem>
               ))}
             </Select>

--- a/src/frontend/src/pages/GanttPage/GanttPageFilter.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttPageFilter.tsx
@@ -134,7 +134,7 @@ const GanttPageFilter: FC<GanttPageFilterProps> = ({
       <Grid container rowSpacing={1} columnSpacing={1} sx={{ justifyContent: 'start', alignItems: 'start' }}>
         {carFilters}
         <Grid item xs={12} md={2}>
-          <FormControl sx={{ width: '100%' }}>
+          <FormControl sx={{ maxWidth: '100%', wordBreak: 'break-all' }}>
             <FormLabel>Status</FormLabel>
             <Select value={status} onChange={statusHandler} autoWidth>
               <MenuItem value="All Statuses">All Statuses</MenuItem>
@@ -149,7 +149,7 @@ const GanttPageFilter: FC<GanttPageFilterProps> = ({
           </FormControl>
         </Grid>
         <Grid item xs={12} md={2}>
-          <FormControl sx={{ width: '100%' }}>
+          <FormControl sx={{ maxWidth: '100%', wordBreak: 'break-all' }}>
             <FormLabel>Team</FormLabel>
             <Select value={selectedTeam} onChange={teamHandler} autoWidth>
               <MenuItem value="All Teams">All Teams</MenuItem>


### PR DESCRIPTION
Changes the Gantt dropdown filters to adjust their width based on the contents

<img width="1087" alt="image" src="https://user-images.githubusercontent.com/76594216/217978287-843d1e0b-17ba-46fd-9522-458a965c08d2.png">

Test:
![image](https://user-images.githubusercontent.com/76594216/218891418-b7273040-3e31-4b36-8157-01dfbcfb7239.png)

The length of the dropdown is at most 50 characters

<img width="1453" alt="image" src="https://user-images.githubusercontent.com/76594216/218891587-ce87d810-a493-48ce-be50-7f4395e228fd.png">
The length of the select is as many letters that can fit in it

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #817 
