### PR TITLE
#810 Added MUI icons to action menu in Work Package Page

### DIFF
--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.tsx
@@ -20,6 +20,11 @@ import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import { Menu, MenuItem } from '@mui/material';
 import { useAuth } from '../../../hooks/auth.hooks';
 import LoadingIndicator from '../../../components/LoadingIndicator';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import EditIcon from '@mui/icons-material/Edit';
+import SyncAltIcon from '@mui/icons-material/SyncAlt';
+import KeyboardDoubleArrowUpIcon from '@mui/icons-material/KeyboardDoubleArrowUp';
+import DoneOutlineIcon from '@mui/icons-material/DoneOutline';
 
 interface WorkPackageViewContainerProps {
   workPackage: WorkPackage;
@@ -73,16 +78,25 @@ const WorkPackageViewContainer: React.FC<WorkPackageViewContainerProps> = ({
 
   const editBtn = (
     <MenuItem onClick={handleClickEdit} disabled={!allowEdit}>
+      <ListItemIcon>
+        <EditIcon fontSize="small" />
+      </ListItemIcon>
       Edit
     </MenuItem>
   );
   const activateBtn = (
     <MenuItem onClick={handleClickActivate} disabled={!allowActivate}>
+      <ListItemIcon>
+        <KeyboardDoubleArrowUpIcon fontSize="small" />
+      </ListItemIcon>
       Activate
     </MenuItem>
   );
   const stageGateBtn = (
     <MenuItem onClick={handleClickStageGate} disabled={!allowStageGate}>
+      <ListItemIcon>
+        <DoneOutlineIcon fontSize="small" />
+      </ListItemIcon>
       Stage Gate
     </MenuItem>
   );
@@ -93,6 +107,9 @@ const WorkPackageViewContainer: React.FC<WorkPackageViewContainerProps> = ({
       disabled={!allowRequestChange}
       onClick={handleDropdownClose}
     >
+      <ListItemIcon>
+        <SyncAltIcon fontSize="small" />
+      </ListItemIcon>
       Request Change
     </MenuItem>
   );


### PR DESCRIPTION
## Changes

I added MUI icons to the 'Action' menus of the Work Package pages, so that they look like MUI 'icon lists' 

## Screenshots

<img width="1440" alt="Screen Shot 2023-02-13 at 1 33 05 PM" src="https://user-images.githubusercontent.com/114596410/218544653-4764232b-8dfe-4346-a909-ac53bfe3f42d.png">
<img width="499" alt="Screen Shot 2023-02-13 at 1 33 23 PM" src="https://user-images.githubusercontent.com/114596410/218544688-b01dec32-be25-44f0-933c-d6d5c7e88797.png">
<img width="1440" alt="Screen Shot 2023-02-13 at 1 33 36 PM" src="https://user-images.githubusercontent.com/114596410/218544711-ac03d9b1-1596-4937-94b2-7b592fa646fb.png">
<img width="494" alt="Screen Shot 2023-02-13 at 1 33 44 PM" src="https://user-images.githubusercontent.com/114596410/218544740-3a58a93e-0bf2-4af8-a028-63160a0ec3a5.png">

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
#810 