### PR TITLE
#831 Removed redirectQueryArgs so user is not brought to undefined page

### DIFF
--- a/src/frontend/src/app/AppPublic.tsx
+++ b/src/frontend/src/app/AppPublic.tsx
@@ -43,14 +43,11 @@ const AppPublic: React.FC = () => {
         (prevArgs: string, pathPart: string, idx: number): string => `${prevArgs}&value${idx + 1}=${pathPart}`,
         `?page=${redirectPathParts[0]}`
       );
-    const redirectQueryArgs =
-      redirectPathQueryArgs + (history.location.search ? `&${history.location.search.slice(1)}` : '');
 
     return (
       <Redirect
         to={{
           pathname: routes.LOGIN,
-          search: redirectQueryArgs,
           state: { from: e.location }
         }}
       />

--- a/src/frontend/src/app/AppPublic.tsx
+++ b/src/frontend/src/app/AppPublic.tsx
@@ -38,7 +38,7 @@ const AppPublic: React.FC = () => {
 
     // if the path ended in an trailing '/' we don't want to clutter the query args with empty param
     if (redirectPathParts[redirectPathParts.length - 1] === '') redirectPathParts.pop();
-    console.log(redirectPathParts);
+
     const redirectPathQueryArgs: string =
       redirectPathParts.length === 0
         ? ''

--- a/src/frontend/src/app/AppPublic.tsx
+++ b/src/frontend/src/app/AppPublic.tsx
@@ -35,19 +35,28 @@ const AppPublic: React.FC = () => {
     // otherwise, the user needs to login manually
     // prepare query args to store path after login
     const redirectPathParts: string[] = history.location.pathname.split('/').slice(1);
+
     // if the path ended in an trailing '/' we don't want to clutter the query args with empty param
     if (redirectPathParts[redirectPathParts.length - 1] === '') redirectPathParts.pop();
-    const redirectPathQueryArgs: string = redirectPathParts
-      .slice(1) // "valueX=" starts from second part of the path
-      .reduce(
-        (prevArgs: string, pathPart: string, idx: number): string => `${prevArgs}&value${idx + 1}=${pathPart}`,
-        `?page=${redirectPathParts[0]}`
-      );
+    console.log(redirectPathParts);
+    const redirectPathQueryArgs: string =
+      redirectPathParts.length === 0
+        ? ''
+        : redirectPathParts
+            .slice(1) // "valueX=" starts from second part of the path
+            .reduce(
+              (prevArgs: string, pathPart: string, idx: number): string => `${prevArgs}&value${idx + 1}=${pathPart}`,
+              `?page=${redirectPathParts[0]}`
+            );
+
+    const redirectQueryArgs =
+      redirectPathQueryArgs + (history.location.search.length > 0 ? `&${history.location.search.slice(1)}` : '');
 
     return (
       <Redirect
         to={{
           pathname: routes.LOGIN,
+          search: redirectQueryArgs,
           state: { from: e.location }
         }}
       />


### PR DESCRIPTION
## Changes

I removed the const redirectQueryArgs and removed it from the redirect for users that need to login manually, stopping them from being brought to a 404 page.

## Notes

I don't see another use for redirectQueryArgs, but if there does happen to be another use, deleting it fully could have consequences.

## Screenshots

<img width="497" alt="Screen Shot 2023-02-15 at 12 21 19 AM" src="https://user-images.githubuse
<img width="498" alt="Screen Shot 2023-02-15 at 12 21 27 AM" src="https://user-images.githubusercontent.com/114596410/218940653-bfa293b5-710d-4e47-9a0d-f2b7b79f1134.png">
rcontent.com/11459
<img width="499" alt="Screen Shot 2023-02-15 at 12 21 53 AM" src="https://user-images.githubusercontent.com/114596410/218940689-02c4c9f6-939a-4b3a-94c1-76e683dd978a.png">
6410/218940640-4a810957-fe
<img width="1440" alt="Screen Shot 2023-02-15 at 12 22 12 AM" src="https://user-images.githubusercontent.com/114596410/218940700-3ead99bb-200c-4239-b642-1a56ecd116a0.png">
b7-4697-8087-90c324d43fd1.png">
<img width="1440" alt="Screen Shot 2023-02-15 at 12 22 15 AM" src="https://user-images.githubusercontent.com/114596410/218940708-e7b85174-b1a1-411e-9105-4fc68384a629.png">
<img width="1440" alt="Screen Shot 2023-02-15 at 12 22 20 AM" src="https://user-images.githubusercontent.com/114596410/218940715-7db13843-54b4-446b-a7b9-5c7a28a09132.png">

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
#831 