### PR TITLE
#240 test create risk endpoint

### DIFF
--- a/src/backend/tests/risks.test.ts
+++ b/src/backend/tests/risks.test.ts
@@ -159,19 +159,18 @@ describe('Risks', () => {
       expect(prisma.risk.create).toHaveBeenCalledTimes(0);
     });
 
-    test('the projectId cannot be found', async () => {
-      jest.spyOn(prisma.project, 'findUnique').mockResolvedValue(null);
-      jest.spyOn(prisma.risk, 'create').mockResolvedValue(prismaRisk2);
-      jest.spyOn(prisma.risk, 'update').mockResolvedValue(prismaRisk2);
+    test('the endpoint works as intended', async () => {
+      jest.spyOn(prisma.project, 'findUnique').mockResolvedValue(prismaProject1);
+      jest.spyOn(prisma.risk, 'create').mockResolvedValue(prismaRisk1);
+      jest.spyOn(prisma.risk, 'update').mockResolvedValue(prismaRisk1);
       jest.spyOn(riskUtils, 'hasRiskPermissions').mockResolvedValue(true);
 
-      const projectId = 1;
+      const { projectId } = prismaProject1;
       const detail = 'detail';
-      await expect(() => RisksService.createRisk(batman, projectId, detail)).rejects.toThrow(
-        new NotFoundException('Project', projectId)
-      );
+      const res = await RisksService.createRisk(batman, projectId, detail);
+      expect(res).toStrictEqual(prismaRisk1.id);
       expect(prisma.project.findUnique).toHaveBeenCalledTimes(1);
-      expect(prisma.risk.create).toHaveBeenCalledTimes(0);
+      expect(prisma.risk.create).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/backend/tests/risks.test.ts
+++ b/src/backend/tests/risks.test.ts
@@ -144,37 +144,37 @@ describe('Risks', () => {
       expect(prisma.risk.findUnique).toHaveBeenCalledTimes(1);
       expect(prisma.risk.update).toHaveBeenCalledTimes(0);
     });
+  });
 
-    describe('createRisk', () => {
-      test('the user does not have permissions to create the risk', async () => {
-        jest.spyOn(prisma.project, 'findUnique').mockResolvedValue(null);
-        jest.spyOn(prisma.risk, 'create').mockResolvedValue(prismaRisk2);
-        jest.spyOn(prisma.risk, 'update').mockResolvedValue(prismaRisk2);
-        jest.spyOn(riskUtils, 'hasRiskPermissions').mockResolvedValue(true);
+  describe('createRisk', () => {
+    test('the user does not have permissions to create the risk', async () => {
+      jest.spyOn(prisma.project, 'findUnique').mockResolvedValue(null);
+      jest.spyOn(prisma.risk, 'create').mockResolvedValue(prismaRisk2);
+      jest.spyOn(prisma.risk, 'update').mockResolvedValue(prismaRisk2);
+      jest.spyOn(riskUtils, 'hasRiskPermissions').mockResolvedValue(true);
 
-        const projectId = 1;
-        const detail = 'detail';
-        await expect(() => RisksService.createRisk(wonderwoman, projectId, detail)).rejects.toThrow(
-          new AccessDeniedException('Guests cannot create risks!')
-        );
+      const projectId = 1;
+      const detail = 'detail';
+      await expect(() => RisksService.createRisk(wonderwoman, projectId, detail)).rejects.toThrow(
+        new AccessDeniedException('Guests cannot create risks!')
+      );
 
-        expect(prisma.project.findUnique).toHaveBeenCalledTimes(0);
-        expect(prisma.risk.create).toHaveBeenCalledTimes(0);
-      });
+      expect(prisma.project.findUnique).toHaveBeenCalledTimes(0);
+      expect(prisma.risk.create).toHaveBeenCalledTimes(0);
+    });
 
-      test('the createRisk endpoint works as intended', async () => {
-        jest.spyOn(prisma.project, 'findUnique').mockResolvedValue(prismaProject1);
-        jest.spyOn(prisma.risk, 'create').mockResolvedValue(prismaRisk1);
-        jest.spyOn(prisma.risk, 'update').mockResolvedValue(prismaRisk1);
-        jest.spyOn(riskUtils, 'hasRiskPermissions').mockResolvedValue(true);
+    test('the createRisk endpoint works as intended', async () => {
+      jest.spyOn(prisma.project, 'findUnique').mockResolvedValue(prismaProject1);
+      jest.spyOn(prisma.risk, 'create').mockResolvedValue(prismaRisk1);
+      jest.spyOn(prisma.risk, 'update').mockResolvedValue(prismaRisk1);
+      jest.spyOn(riskUtils, 'hasRiskPermissions').mockResolvedValue(true);
 
-        const projectId = 1;
-        const detail = 'detail';
-        const res = await RisksService.createRisk(batman, projectId, detail);
-        expect(res).toStrictEqual(prismaRisk1.id);
-        expect(prisma.project.findUnique).toHaveBeenCalledTimes(1);
-        expect(prisma.risk.create).toHaveBeenCalledTimes(1);
-      });
+      const projectId = 1;
+      const detail = 'detail';
+      const res = await RisksService.createRisk(batman, projectId, detail);
+      expect(res).toStrictEqual(prismaRisk1.id);
+      expect(prisma.project.findUnique).toHaveBeenCalledTimes(1);
+      expect(prisma.risk.create).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/backend/tests/risks.test.ts
+++ b/src/backend/tests/risks.test.ts
@@ -159,7 +159,7 @@ describe('Risks', () => {
       expect(prisma.risk.create).toHaveBeenCalledTimes(0);
     });
 
-    test('the user has permissions to create the risk', async () => {
+    test('the projectId cannot be found', async () => {
       jest.spyOn(prisma.project, 'findUnique').mockResolvedValue(null);
       jest.spyOn(prisma.risk, 'create').mockResolvedValue(prismaRisk2);
       jest.spyOn(prisma.risk, 'update').mockResolvedValue(prismaRisk2);
@@ -167,8 +167,9 @@ describe('Risks', () => {
 
       const projectId = 1;
       const detail = 'detail';
-      await expect(() => RisksService.createRisk(batman, projectId, detail)).rejects.toThrow();
-
+      await expect(() => RisksService.createRisk(batman, projectId, detail)).rejects.toThrow(
+        new NotFoundException('Project', projectId)
+      );
       expect(prisma.project.findUnique).toHaveBeenCalledTimes(1);
       expect(prisma.risk.create).toHaveBeenCalledTimes(0);
     });

--- a/src/backend/tests/risks.test.ts
+++ b/src/backend/tests/risks.test.ts
@@ -165,7 +165,7 @@ describe('Risks', () => {
       jest.spyOn(prisma.risk, 'update').mockResolvedValue(prismaRisk1);
       jest.spyOn(riskUtils, 'hasRiskPermissions').mockResolvedValue(true);
 
-      const { projectId } = prismaProject1;
+      const projectId = 1;
       const detail = 'detail';
       const res = await RisksService.createRisk(batman, projectId, detail);
       expect(res).toStrictEqual(prismaRisk1.id);

--- a/src/backend/tests/risks.test.ts
+++ b/src/backend/tests/risks.test.ts
@@ -172,6 +172,5 @@ describe('Risks', () => {
       expect(prisma.project.findUnique).toHaveBeenCalledTimes(1);
       expect(prisma.risk.create).toHaveBeenCalledTimes(0);
     });
-
   });
 });

--- a/src/backend/tests/risks.test.ts
+++ b/src/backend/tests/risks.test.ts
@@ -3,7 +3,7 @@ import RisksService from '../src/services/risks.services';
 import prisma from '../src/prisma/prisma';
 import riskQueryArgs from '../src/prisma-query-args/risks.query-args';
 import { prismaRisk1, prismaRisk2, sharedRisk1 } from './test-data/risks.test-data';
-import { batman } from './test-data/users.test-data';
+import { batman, wonderwoman } from './test-data/users.test-data';
 import * as riskUtils from '../src/utils/risks.utils';
 import * as riskTransformer from '../src/transformers/risks.transformer';
 import { AccessDeniedException, NotFoundException } from '../src/utils/errors.utils';
@@ -144,5 +144,21 @@ describe('Risks', () => {
       expect(prisma.risk.findUnique).toHaveBeenCalledTimes(1);
       expect(prisma.risk.update).toHaveBeenCalledTimes(0);
     });
+
+    test('the user does not have permissions to create the risk', async () => {
+      jest.spyOn(prisma.project, 'findUnique').mockResolvedValue(null);
+      jest.spyOn(prisma.risk, 'create').mockResolvedValue(prismaRisk2);
+      jest.spyOn(prisma.risk, 'update').mockResolvedValue(prismaRisk2);
+      jest.spyOn(riskUtils, 'hasRiskPermissions').mockResolvedValue(true);
+
+      const projectId = 1;
+      const detail = 'detail';
+      await expect(() => RisksService.createRisk(wonderwoman, projectId, detail)).rejects.toThrow();
+
+      expect(prisma.project.findUnique).toHaveBeenCalledTimes(0);
+      expect(prisma.risk.create).toHaveBeenCalledTimes(0);
+    });
+
+    
   });
 });

--- a/src/backend/tests/risks.test.ts
+++ b/src/backend/tests/risks.test.ts
@@ -145,32 +145,36 @@ describe('Risks', () => {
       expect(prisma.risk.update).toHaveBeenCalledTimes(0);
     });
 
-    test('the user does not have permissions to create the risk', async () => {
-      jest.spyOn(prisma.project, 'findUnique').mockResolvedValue(null);
-      jest.spyOn(prisma.risk, 'create').mockResolvedValue(prismaRisk2);
-      jest.spyOn(prisma.risk, 'update').mockResolvedValue(prismaRisk2);
-      jest.spyOn(riskUtils, 'hasRiskPermissions').mockResolvedValue(true);
+    describe('createRisk', () => {
+      test('the user does not have permissions to create the risk', async () => {
+        jest.spyOn(prisma.project, 'findUnique').mockResolvedValue(null);
+        jest.spyOn(prisma.risk, 'create').mockResolvedValue(prismaRisk2);
+        jest.spyOn(prisma.risk, 'update').mockResolvedValue(prismaRisk2);
+        jest.spyOn(riskUtils, 'hasRiskPermissions').mockResolvedValue(true);
 
-      const projectId = 1;
-      const detail = 'detail';
-      await expect(() => RisksService.createRisk(wonderwoman, projectId, detail)).rejects.toThrow();
+        const projectId = 1;
+        const detail = 'detail';
+        await expect(() => RisksService.createRisk(wonderwoman, projectId, detail)).rejects.toThrow(
+          new AccessDeniedException('Guests cannot create risks!')
+        );
 
-      expect(prisma.project.findUnique).toHaveBeenCalledTimes(0);
-      expect(prisma.risk.create).toHaveBeenCalledTimes(0);
-    });
+        expect(prisma.project.findUnique).toHaveBeenCalledTimes(0);
+        expect(prisma.risk.create).toHaveBeenCalledTimes(0);
+      });
 
-    test('the endpoint works as intended', async () => {
-      jest.spyOn(prisma.project, 'findUnique').mockResolvedValue(prismaProject1);
-      jest.spyOn(prisma.risk, 'create').mockResolvedValue(prismaRisk1);
-      jest.spyOn(prisma.risk, 'update').mockResolvedValue(prismaRisk1);
-      jest.spyOn(riskUtils, 'hasRiskPermissions').mockResolvedValue(true);
+      test('the createRisk endpoint works as intended', async () => {
+        jest.spyOn(prisma.project, 'findUnique').mockResolvedValue(prismaProject1);
+        jest.spyOn(prisma.risk, 'create').mockResolvedValue(prismaRisk1);
+        jest.spyOn(prisma.risk, 'update').mockResolvedValue(prismaRisk1);
+        jest.spyOn(riskUtils, 'hasRiskPermissions').mockResolvedValue(true);
 
-      const projectId = 1;
-      const detail = 'detail';
-      const res = await RisksService.createRisk(batman, projectId, detail);
-      expect(res).toStrictEqual(prismaRisk1.id);
-      expect(prisma.project.findUnique).toHaveBeenCalledTimes(1);
-      expect(prisma.risk.create).toHaveBeenCalledTimes(1);
+        const projectId = 1;
+        const detail = 'detail';
+        const res = await RisksService.createRisk(batman, projectId, detail);
+        expect(res).toStrictEqual(prismaRisk1.id);
+        expect(prisma.project.findUnique).toHaveBeenCalledTimes(1);
+        expect(prisma.risk.create).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });

--- a/src/backend/tests/risks.test.ts
+++ b/src/backend/tests/risks.test.ts
@@ -159,6 +159,19 @@ describe('Risks', () => {
       expect(prisma.risk.create).toHaveBeenCalledTimes(0);
     });
 
-    
+    test('the user has permissions to create the risk', async () => {
+      jest.spyOn(prisma.project, 'findUnique').mockResolvedValue(null);
+      jest.spyOn(prisma.risk, 'create').mockResolvedValue(prismaRisk2);
+      jest.spyOn(prisma.risk, 'update').mockResolvedValue(prismaRisk2);
+      jest.spyOn(riskUtils, 'hasRiskPermissions').mockResolvedValue(true);
+
+      const projectId = 1;
+      const detail = 'detail';
+      await expect(() => RisksService.createRisk(batman, projectId, detail)).rejects.toThrow();
+
+      expect(prisma.project.findUnique).toHaveBeenCalledTimes(1);
+      expect(prisma.risk.create).toHaveBeenCalledTimes(0);
+    });
+
   });
 });


### PR DESCRIPTION
## Changes

Added two tests for createRisk:

The endpoint works as intended
The user does not have permissions to create the risk
## Notes

The tests pass:

When the endpoint correctly,  and all permissions are correct
When the user does not have permissions to create the risk, an appropriate exception is thrown.

## Test Cases

- The user creating the risk is an admin and is able to create a risk
- The user creating the risk is a guest and is not allowed to create a risk

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #240
