### PR TITLE
#843: Remove Leftover Budget From CR Creation Hooks and Backend

### DIFF
--- a/src/backend/src/controllers/change-requests.controllers.ts
+++ b/src/backend/src/controllers/change-requests.controllers.ts
@@ -57,7 +57,7 @@ export default class ChangeRequestsController {
 
   static async createStageGateChangeRequest(req: Request, res: Response, next: NextFunction) {
     try {
-      const { wbsNum, type, leftoverBudget, confirmDone } = req.body;
+      const { wbsNum, type, confirmDone } = req.body;
       const submitter = await getCurrentUser(res);
       const id = await ChangeRequestsService.createStageGateChangeRequest(
         submitter,
@@ -65,7 +65,6 @@ export default class ChangeRequestsController {
         wbsNum.projectNumber,
         wbsNum.workPackageNumber,
         type,
-        leftoverBudget,
         confirmDone
       );
       return res.status(200).json({ message: `Successfully created stage gate request with id #${id}` });

--- a/src/backend/src/prisma/seed.ts
+++ b/src/backend/src/prisma/seed.ts
@@ -326,7 +326,6 @@ const performSeed: () => Promise<void> = async () => {
     workPackage1WbsNumber.projectNumber,
     workPackage1WbsNumber.workPackageNumber,
     CR_Type.STAGE_GATE,
-    0,
     true
   );
 

--- a/src/backend/src/routes/change-requests.routes.ts
+++ b/src/backend/src/routes/change-requests.routes.ts
@@ -44,7 +44,6 @@ changeRequestsRouter.post(
   intMinZero(body('wbsNum.projectNumber')),
   intMinZero(body('wbsNum.workPackageNumber')),
   body('type').custom((value) => value === ChangeRequestType.StageGate),
-  intMinZero(body('leftoverBudget')),
   body('confirmDone').isBoolean(),
   validateInputs,
   ChangeRequestsController.createStageGateChangeRequest

--- a/src/backend/src/services/change-requests.services.ts
+++ b/src/backend/src/services/change-requests.services.ts
@@ -386,7 +386,6 @@ export default class ChangeRequestsService {
    * @param projectNumber  the project number for the wbs element
    * @param workPackageNumber  the work package number for the wbs element
    * @param type  the type of cr
-   * @param leftoverBudget  the leftover budget
    * @param confirmDone  whether or not to confirm
    * @returns the id of the created cr
    * @throws if user is not allowed to create crs, if wbs element does not exist, or if the cr type is not stage gate
@@ -397,7 +396,6 @@ export default class ChangeRequestsService {
     projectNumber: number,
     workPackageNumber: number,
     type: CR_Type,
-    leftoverBudget: number,
     confirmDone: boolean
   ): Promise<Number> {
     // verify user is allowed to create stage gate change requests
@@ -424,7 +422,7 @@ export default class ChangeRequestsService {
         type,
         stageGateChangeRequest: {
           create: {
-            leftoverBudget,
+            leftoverBudget: 0,
             confirmDone
           }
         }

--- a/src/frontend/src/apis/change-requests.api.ts
+++ b/src/frontend/src/apis/change-requests.api.ts
@@ -93,20 +93,13 @@ export const createActivationChangeRequest = (
  * Create a stage gate change request.
  * @param submitterId The ID of the user creating the change request.
  * @param wbsNumber the wbsNumber of the WBS element the change request is for.
- * @param leftoverBudget the amount of leftover budget in the WBS element being stage gated.
  * @param confirmDone are all details of the WBS element being stage gated fully completed?
  */
-export const createStageGateChangeRequest = (
-  submitterId: number,
-  wbsNum: WbsNumber,
-  leftoverBudget: number,
-  confirmDone: boolean
-) => {
+export const createStageGateChangeRequest = (submitterId: number, wbsNum: WbsNumber, confirmDone: boolean) => {
   return axios.post<{ message: string }>(apiUrls.changeRequestsCreateStageGate(), {
     submitterId,
     wbsNum,
     type: ChangeRequestType.StageGate,
-    leftoverBudget,
     confirmDone
   });
 };

--- a/src/frontend/src/hooks/change-requests.hooks.ts
+++ b/src/frontend/src/hooks/change-requests.hooks.ts
@@ -94,12 +94,7 @@ export const useCreateActivationChangeRequest = () => {
  */
 export const useCreateStageGateChangeRequest = () => {
   return useMutation<{ message: string }, Error, any>(['change requests', 'create', 'stage gate'], async (payload: any) => {
-    const { data } = await createStageGateChangeRequest(
-      payload.submitterId,
-      payload.wbsNum,
-      payload.leftoverBudget,
-      payload.confirmDone
-    );
+    const { data } = await createStageGateChangeRequest(payload.submitterId, payload.wbsNum, payload.confirmDone);
     return data;
   });
 };


### PR DESCRIPTION
## Changes

Remove Leftover Budget information from CR creation. Leftover budget is still in the postgres database for backwards compatibility.

## Test Cases

See Postman test below (test BACKEND only, not hook): tested that CR can be created without leftover budget.

## Screenshots

_If you did any manual testing (e.g., with Postman), put screenshots of the http request and before and after of the db_
![Screen Shot 2023-02-19 at 12 02 21 PM](https://user-images.githubusercontent.com/59806366/219962933-45cf4041-6836-4371-bbc6-b93c21cd5418.png)
![Screen Shot 2023-02-19 at 12 02 07 PM](https://user-images.githubusercontent.com/59806366/219962918-4e652c45-8452-4909-9fca-420d7f693949.png)

![Screen Shot 2023-02-19 at 12 15 09 PM](https://user-images.githubusercontent.com/59806366/219963651-f52d5134-2520-4cdd-a62a-5af6da49668b.png)

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [ ] All checks passing
- [x] Screenshots of Postman (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #843 
