### PR TITLE
#888 - Work Package Stage Chip on Detail Page

### DIFF
--- a/src/frontend/src/components/WorkPackageStageChip.tsx
+++ b/src/frontend/src/components/WorkPackageStageChip.tsx
@@ -42,7 +42,7 @@ const WorkPackageStageChip: React.FC<WorkPackageStageChipProps> = ({ stage }) =>
         variant="outlined"
         sx={{
           fontSize: 14,
-          mx: '5px'
+          mr: '5px'
         }}
       />
     </b>

--- a/src/frontend/src/components/WorkPackageStageChip.tsx
+++ b/src/frontend/src/components/WorkPackageStageChip.tsx
@@ -1,0 +1,52 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import Chip from '@mui/material/Chip';
+import { WorkPackageStage } from 'shared';
+
+interface WorkPackageStageChipProps {
+  stage: WorkPackageStage;
+}
+
+type WorkPackageStageChipColor = 'primary' | 'secondary' | 'success' | 'default' | 'error' | 'info' | 'warning';
+
+// maps stage to the desired color state
+const colorMap: Record<WorkPackageStage, WorkPackageStageChipColor> = {
+  [WorkPackageStage.Research]: 'success',
+  [WorkPackageStage.Design]: 'success',
+  [WorkPackageStage.Manufacturing]: 'success',
+  [WorkPackageStage.Integration]: 'success'
+};
+
+// maps stage to the desired badge display text
+const textMap: Record<WorkPackageStage, string> = {
+  [WorkPackageStage.Research]: 'Research',
+  [WorkPackageStage.Design]: 'Design',
+  [WorkPackageStage.Manufacturing]: 'Manufacturing',
+  [WorkPackageStage.Integration]: 'Integration'
+};
+
+// Convert work package stage into badge for display
+const WorkPackageStageChip: React.FC<WorkPackageStageChipProps> = ({ stage }) => {
+  const color: WorkPackageStageChipColor = colorMap[stage];
+  const text: string = textMap[stage];
+
+  return (
+    <b>
+      <Chip
+        size="small"
+        label={text}
+        color={color}
+        variant="outlined"
+        sx={{
+          fontSize: 14,
+          mx: '5px'
+        }}
+      />
+    </b>
+  );
+};
+
+export default WorkPackageStageChip;

--- a/src/frontend/src/components/WorkPackageStageChip.tsx
+++ b/src/frontend/src/components/WorkPackageStageChip.tsx
@@ -11,7 +11,7 @@ interface WorkPackageStageChipProps {
   stage: WorkPackageStage;
 }
 
-// maps stage to the desired color state
+// maps stage to the desired color
 const colorMap: Record<WorkPackageStage, string> = {
   [WorkPackageStage.Research]: yellow[900],
   [WorkPackageStage.Design]: green[600],

--- a/src/frontend/src/components/WorkPackageStageChip.tsx
+++ b/src/frontend/src/components/WorkPackageStageChip.tsx
@@ -4,20 +4,19 @@
  */
 
 import Chip from '@mui/material/Chip';
+import { yellow, green, blue, purple } from '@mui/material/colors';
 import { WorkPackageStage } from 'shared';
 
 interface WorkPackageStageChipProps {
   stage: WorkPackageStage;
 }
 
-type WorkPackageStageChipColor = 'primary' | 'secondary' | 'success' | 'default' | 'error' | 'info' | 'warning';
-
 // maps stage to the desired color state
-const colorMap: Record<WorkPackageStage, WorkPackageStageChipColor> = {
-  [WorkPackageStage.Research]: 'success',
-  [WorkPackageStage.Design]: 'success',
-  [WorkPackageStage.Manufacturing]: 'success',
-  [WorkPackageStage.Integration]: 'success'
+const colorMap: Record<WorkPackageStage, string> = {
+  [WorkPackageStage.Research]: yellow[900],
+  [WorkPackageStage.Design]: green[600],
+  [WorkPackageStage.Manufacturing]: blue[600],
+  [WorkPackageStage.Integration]: purple[400]
 };
 
 // maps stage to the desired badge display text
@@ -30,7 +29,8 @@ const textMap: Record<WorkPackageStage, string> = {
 
 // Convert work package stage into badge for display
 const WorkPackageStageChip: React.FC<WorkPackageStageChipProps> = ({ stage }) => {
-  const color: WorkPackageStageChipColor = colorMap[stage];
+  const color: string = colorMap[stage];
+
   const text: string = textMap[stage];
 
   return (
@@ -38,11 +38,12 @@ const WorkPackageStageChip: React.FC<WorkPackageStageChipProps> = ({ stage }) =>
       <Chip
         size="small"
         label={text}
-        color={color}
         variant="outlined"
         sx={{
           fontSize: 14,
-          mr: '5px'
+          mr: '5px',
+          color,
+          borderColor: color
         }}
       />
     </b>

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/WorkPackageSummary.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/WorkPackageSummary.tsx
@@ -17,6 +17,7 @@ import WbsStatus from '../../../components/WbsStatus';
 import Grid from '@mui/material/Grid';
 import { useTheme } from '@mui/material';
 import DetailDisplay from '../../../components/DetailDisplay';
+import WorkPackageStageChip from '../../../components/WorkPackageStageChip';
 
 interface WorkPackageSummaryProps {
   workPackage: WorkPackage;
@@ -58,6 +59,7 @@ const WorkPackageSummary: React.FC<WorkPackageSummaryProps> = ({ workPackage }) 
             {workPackage.name}
           </Link>
         </Box>
+        {workPackage.stage ? <WorkPackageStageChip stage={workPackage.stage} /> : null}
         <WbsStatus status={workPackage.status} />
         <Typography paddingLeft={2}>{weeksPipe(workPackage.duration)}</Typography>
       </AccordionSummary>

--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageDetails.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageDetails.tsx
@@ -28,7 +28,18 @@ const WorkPackageDetails: React.FC<WorkPackageDetailsProps> = ({ workPackage }) 
       headerRight={
         <>
           {workPackage.stage ? (
-            <Chip size="small" label={workPackageStageLabelMap[workPackage.stage]} sx={{ fontSize: 14 }} />
+            <b>
+              <Chip
+                size="small"
+                label={workPackageStageLabelMap[workPackage.stage]}
+                color="success"
+                variant="outlined"
+                sx={{
+                  fontSize: 14,
+                  mx: '5px'
+                }}
+              />
+            </b>
           ) : null}
           <WbsStatus status={workPackage.status} />
         </>

--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageDetails.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageDetails.tsx
@@ -3,20 +3,39 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { WorkPackage } from 'shared';
+import { WorkPackage, WorkPackageStage } from 'shared';
 import { percentPipe, fullNamePipe, datePipe, weeksPipe } from '../../../utils/pipes';
 import WbsStatus from '../../../components/WbsStatus';
 import PageBlock from '../../../layouts/PageBlock';
-import { Grid } from '@mui/material';
+import { Chip, Grid } from '@mui/material';
 import DetailDisplay from '../../../components/DetailDisplay';
 
 interface WorkPackageDetailsProps {
   workPackage: WorkPackage;
 }
 
+const workPackageStageLabelMap: Record<WorkPackageStage, string> = {
+  [WorkPackageStage.Research]: 'Research',
+  [WorkPackageStage.Design]: 'Design',
+  [WorkPackageStage.Manufacturing]: 'Manufacturing',
+  [WorkPackageStage.Integration]: 'Integration'
+};
+
 const WorkPackageDetails: React.FC<WorkPackageDetailsProps> = ({ workPackage }) => {
+  console.log(workPackage);
+
   return (
-    <PageBlock title={'Work Package Details'} headerRight={<WbsStatus status={workPackage.status} />}>
+    <PageBlock
+      title={'Work Package Details'}
+      headerRight={
+        <>
+          {workPackage.stage ? (
+            <Chip size="small" label={workPackageStageLabelMap[workPackage.stage]} sx={{ fontSize: 14 }} />
+          ) : null}
+          <WbsStatus status={workPackage.status} />
+        </>
+      }
+    >
       <Grid container spacing={1}>
         <Grid item xs={4} md={4}>
           <DetailDisplay label="Project Lead" content={fullNamePipe(workPackage.projectLead)} paddingRight={2} />

--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageDetails.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageDetails.tsx
@@ -3,23 +3,17 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { WorkPackage, WorkPackageStage } from 'shared';
+import { WorkPackage } from 'shared';
 import { percentPipe, fullNamePipe, datePipe, weeksPipe } from '../../../utils/pipes';
 import WbsStatus from '../../../components/WbsStatus';
 import PageBlock from '../../../layouts/PageBlock';
-import { Chip, Grid } from '@mui/material';
+import { Grid } from '@mui/material';
 import DetailDisplay from '../../../components/DetailDisplay';
+import WorkPackageStageChip from '../../../components/WorkPackageStageChip';
 
 interface WorkPackageDetailsProps {
   workPackage: WorkPackage;
 }
-
-const workPackageStageLabelMap: Record<WorkPackageStage, string> = {
-  [WorkPackageStage.Research]: 'Research',
-  [WorkPackageStage.Design]: 'Design',
-  [WorkPackageStage.Manufacturing]: 'Manufacturing',
-  [WorkPackageStage.Integration]: 'Integration'
-};
 
 const WorkPackageDetails: React.FC<WorkPackageDetailsProps> = ({ workPackage }) => {
   return (
@@ -27,20 +21,7 @@ const WorkPackageDetails: React.FC<WorkPackageDetailsProps> = ({ workPackage }) 
       title={'Work Package Details'}
       headerRight={
         <>
-          {workPackage.stage ? (
-            <b>
-              <Chip
-                size="small"
-                label={workPackageStageLabelMap[workPackage.stage]}
-                color="success"
-                variant="outlined"
-                sx={{
-                  fontSize: 14,
-                  mx: '5px'
-                }}
-              />
-            </b>
-          ) : null}
+          {workPackage.stage ? <WorkPackageStageChip stage={workPackage.stage} /> : null}
           <WbsStatus status={workPackage.status} />
         </>
       }

--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageDetails.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageDetails.tsx
@@ -22,8 +22,6 @@ const workPackageStageLabelMap: Record<WorkPackageStage, string> = {
 };
 
 const WorkPackageDetails: React.FC<WorkPackageDetailsProps> = ({ workPackage }) => {
-  console.log(workPackage);
-
   return (
     <PageBlock
       title={'Work Package Details'}

--- a/src/frontend/src/tests/apis/work-packages.api.test.ts
+++ b/src/frontend/src/tests/apis/work-packages.api.test.ts
@@ -6,7 +6,7 @@
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { apiUrls } from '../../utils/urls';
-import { exampleAllWorkPackages, exampleWorkPackage1 } from '../test-support/test-data/work-packages.stub';
+import { exampleAllWorkPackages, exampleResearchWorkPackage } from '../test-support/test-data/work-packages.stub';
 import { getAllWorkPackages, getSingleWorkPackage } from '../../apis/work-packages.api';
 
 // Mock the server endpoint(s) that the component will hit
@@ -38,7 +38,7 @@ describe('work package api methods', () => {
   it('handles getting a single work packages', async () => {
     server.use(
       rest.get(apiUrls.workPackagesByWbsNum('1.1.1'), (req, res, ctx) => {
-        return res(ctx.status(200), ctx.json(exampleWorkPackage1));
+        return res(ctx.status(200), ctx.json(exampleResearchWorkPackage));
       })
     );
 

--- a/src/frontend/src/tests/components/ChangesList.test.tsx
+++ b/src/frontend/src/tests/components/ChangesList.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import { render, screen, routerWrapperBuilder } from '../test-support/test-utils';
-import { exampleWorkPackage2 } from '../test-support/test-data/work-packages.stub';
+import { exampleDesignWorkPackage } from '../test-support/test-data/work-packages.stub';
 import ChangesList from '../../components/ChangesList';
 
 /**
@@ -14,7 +14,7 @@ const renderComponent = () => {
   const RouterWrapper = routerWrapperBuilder({});
   return render(
     <RouterWrapper>
-      <ChangesList changes={exampleWorkPackage2.changes} />
+      <ChangesList changes={exampleDesignWorkPackage.changes} />
     </RouterWrapper>
   );
 };

--- a/src/frontend/src/tests/components/DescriptionList.test.tsx
+++ b/src/frontend/src/tests/components/DescriptionList.test.tsx
@@ -4,18 +4,18 @@
  */
 
 import { render, screen } from '@testing-library/react';
-import { exampleWorkPackage2 } from '../test-support/test-data/work-packages.stub';
+import { exampleDesignWorkPackage } from '../test-support/test-data/work-packages.stub';
 import DescriptionList from '../../components/DescriptionList';
 
 describe('Rendering Description List Component', () => {
   it('renders the component title', () => {
-    render(<DescriptionList title={'Description'} items={exampleWorkPackage2.expectedActivities} />);
+    render(<DescriptionList title={'Description'} items={exampleDesignWorkPackage.expectedActivities} />);
 
     expect(screen.getByText('Description')).toBeInTheDocument();
   });
 
   it('renders all bullets', () => {
-    render(<DescriptionList title={'test'} items={exampleWorkPackage2.expectedActivities} />);
+    render(<DescriptionList title={'test'} items={exampleDesignWorkPackage.expectedActivities} />);
 
     expect(
       screen.getByText(

--- a/src/frontend/src/tests/hooks/WorkPackages.hooks.test.tsx
+++ b/src/frontend/src/tests/hooks/WorkPackages.hooks.test.tsx
@@ -8,7 +8,7 @@ import { AxiosResponse } from 'axios';
 import { WorkPackage } from 'shared';
 import wrapper from '../../app/AppContextQuery';
 import { mockPromiseAxiosResponse } from '../test-support/test-data/test-utils.stub';
-import { exampleAllWorkPackages, exampleWorkPackage1 } from '../test-support/test-data/work-packages.stub';
+import { exampleAllWorkPackages, exampleResearchWorkPackage } from '../test-support/test-data/work-packages.stub';
 import { exampleWbsWorkPackage1 } from '../test-support/test-data/wbs-numbers.stub';
 import { getAllWorkPackages, getSingleWorkPackage } from '../../apis/work-packages.api';
 import { useAllWorkPackages, useSingleWorkPackage } from '../../hooks/work-packages.hooks';
@@ -27,12 +27,12 @@ describe('work package hooks', () => {
 
   it('handles getting a single work package', async () => {
     const mockedGetSingleWorkPackage = getSingleWorkPackage as jest.Mock<Promise<AxiosResponse<WorkPackage>>>;
-    mockedGetSingleWorkPackage.mockReturnValue(mockPromiseAxiosResponse<WorkPackage>(exampleWorkPackage1));
+    mockedGetSingleWorkPackage.mockReturnValue(mockPromiseAxiosResponse<WorkPackage>(exampleResearchWorkPackage));
 
     const { result, waitFor } = renderHook(() => useSingleWorkPackage(exampleWbsWorkPackage1), {
       wrapper
     });
     await waitFor(() => result.current.isSuccess);
-    expect(result.current.data).toEqual(exampleWorkPackage1);
+    expect(result.current.data).toEqual(exampleResearchWorkPackage);
   });
 });

--- a/src/frontend/src/tests/pages/ProjectDetailPage/ProjectViewContainer.test.tsx
+++ b/src/frontend/src/tests/pages/ProjectDetailPage/ProjectViewContainer.test.tsx
@@ -10,6 +10,7 @@ import { exampleProject1 } from '../../test-support/test-data/projects.stub';
 import { mockAuth } from '../../test-support/test-data/test-utils.stub';
 import { exampleAdminUser, exampleGuestUser } from '../../test-support/test-data/users.stub';
 import ProjectViewContainer from '../../../pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer';
+import { WorkPackageStage } from 'shared/src/types/work-package-types';
 
 jest.mock('../../../utils/axios');
 jest.mock('../../../hooks/auth.hooks');
@@ -62,5 +63,33 @@ describe('Rendering Project View Container', () => {
     });
     expect(screen.getByText('Edit')).not.toHaveAttribute('aria-disabled', 'true');
     expect(screen.getByText('Request Change')).not.toHaveAttribute('aria-disabled', 'true');
+  });
+
+  describe('Work Package Preview', () => {
+    it('renders the work package names', () => {
+      mockAuthHook();
+      renderComponent();
+
+      exampleProject1.workPackages.forEach((wp) => {
+        expect(screen.getByText(wp.name)).toBeInTheDocument();
+      });
+    });
+
+    it('renders the work package statuses', () => {
+      mockAuthHook();
+      renderComponent();
+
+      // should be the same as textMap in the WorkPackageStageChip component
+      const statusLabels: Record<WorkPackageStage, string> = {
+        [WorkPackageStage.Research]: 'Research',
+        [WorkPackageStage.Design]: 'Design',
+        [WorkPackageStage.Manufacturing]: 'Manufacturing',
+        [WorkPackageStage.Integration]: 'Integration'
+      };
+
+      exampleProject1.workPackages.forEach((wp) => {
+        if (wp.stage) expect(screen.getByText(statusLabels[wp.stage])).toBeInTheDocument();
+      });
+    });
   });
 });

--- a/src/frontend/src/tests/pages/WorkPackageDetailPage/WorkPackagePage.test.tsx
+++ b/src/frontend/src/tests/pages/WorkPackageDetailPage/WorkPackagePage.test.tsx
@@ -10,7 +10,7 @@ import { Auth } from '../../../utils/types';
 import { useSingleWorkPackage } from '../../../hooks/work-packages.hooks';
 import { useAuth } from '../../../hooks/auth.hooks';
 import { mockAuth, mockUseQueryResult } from '../../test-support/test-data/test-utils.stub';
-import { exampleWorkPackage1 } from '../../test-support/test-data/work-packages.stub';
+import { exampleResearchWorkPackage } from '../../test-support/test-data/work-packages.stub';
 import { exampleWbsProject1 } from '../../test-support/test-data/wbs-numbers.stub';
 import { exampleAdminUser, exampleGuestUser } from '../../test-support/test-data/users.stub';
 import WorkPackagePage from '../../../pages/WorkPackageDetailPage/WorkPackagePage';
@@ -51,7 +51,7 @@ describe('work package container', () => {
   });
 
   it('renders the loaded project', () => {
-    mockSingleWPHook(false, false, exampleWorkPackage1);
+    mockSingleWPHook(false, false, exampleResearchWorkPackage);
     mockAuthHook();
     renderComponent();
 
@@ -84,7 +84,7 @@ describe('work package container', () => {
   });
 
   it('enables the edit button for non-guest user', () => {
-    mockSingleWPHook(false, false, exampleWorkPackage1);
+    mockSingleWPHook(false, false, exampleResearchWorkPackage);
     mockAuthHook(exampleAdminUser);
     renderComponent();
 
@@ -95,7 +95,7 @@ describe('work package container', () => {
   });
 
   it('disables the edit button for guest user', () => {
-    mockSingleWPHook(false, false, exampleWorkPackage1);
+    mockSingleWPHook(false, false, exampleResearchWorkPackage);
     mockAuthHook(exampleGuestUser);
     renderComponent();
 

--- a/src/frontend/src/tests/pages/WorkPackageDetailPage/WorkPackageViewContainer/DependenciesList.test.tsx
+++ b/src/frontend/src/tests/pages/WorkPackageDetailPage/WorkPackageViewContainer/DependenciesList.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import { render, screen, routerWrapperBuilder } from '../../../test-support/test-utils';
-import { exampleWorkPackage2 } from '../../../test-support/test-data/work-packages.stub';
+import { exampleDesignWorkPackage } from '../../../test-support/test-data/work-packages.stub';
 import { wbsPipe } from '../../../../utils/pipes';
 // import DependenciesList from './dependencies-list';
 // import { FormContext } from '../../work-package-container';
@@ -20,10 +20,10 @@ const renderComponent = (editMode?: boolean, path?: string, route?: string) => {
     // <RouterWrapper>
     //   {editMode ? (
     //     <FormContext.Provider value={{ editMode, setField }}>
-    //       <DependenciesList dependencies={exampleWorkPackage2.dependencies} />
+    //       <DependenciesList dependencies={exampleDesignWorkPackage.dependencies} />
     //     </FormContext.Provider>
     //   ) : (
-    //     <DependenciesList dependencies={exampleWorkPackage2.dependencies} />
+    //     <DependenciesList dependencies={exampleDesignWorkPackage.dependencies} />
     //   )}
     // </RouterWrapper>
   );
@@ -34,7 +34,7 @@ describe.skip('Rendering Work Package Dependencies Component', () => {
     renderComponent();
     expect(screen.getByText(`Dependencies`)).toBeInTheDocument();
 
-    exampleWorkPackage2.dependencies.forEach((wbs) => {
+    exampleDesignWorkPackage.dependencies.forEach((wbs) => {
       expect(screen.getByText(`${wbsPipe(wbs)}`)).toBeInTheDocument();
     });
   });
@@ -42,7 +42,7 @@ describe.skip('Rendering Work Package Dependencies Component', () => {
     renderComponent(true);
     expect(screen.getByText(`Dependencies`)).toBeInTheDocument();
 
-    exampleWorkPackage2.dependencies.forEach((wbs) => {
+    exampleDesignWorkPackage.dependencies.forEach((wbs) => {
       expect(screen.getByText(`${wbsPipe(wbs)}`)).toBeInTheDocument();
     });
     expect(screen.getByPlaceholderText('New WBS #')).toBeInTheDocument();

--- a/src/frontend/src/tests/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageDetails.test.tsx
+++ b/src/frontend/src/tests/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageDetails.test.tsx
@@ -85,19 +85,18 @@ describe('Work Package Details Component', () => {
     });
   });
 
-  describe.skip('Work Package Detail Fields', () => {
+  describe('Work Package Detail Fields', () => {
     it('renders all the fields, example 1', () => {
       mockHook(false, false, users);
       const wp: WorkPackage = exampleResearchWorkPackage;
       render(<WorkPackageDetails workPackage={wp} />);
       expect(screen.getByText(`Work Package Details`)).toBeInTheDocument();
       expect(screen.getByText(`${wp.status}`, { exact: false })).toBeInTheDocument();
-      expect(screen.getByText(`${wp.name}`, { exact: false })).toBeInTheDocument();
       expect(screen.getByText(`${fullNamePipe(wp.projectLead)}`, { exact: false })).toBeInTheDocument();
       expect(screen.getByText(`${fullNamePipe(wp.projectManager)}`, { exact: false })).toBeInTheDocument();
 
       expect(screen.getByText(`${weeksPipe(wp.duration)}`, { exact: false })).toBeInTheDocument();
-      expect(screen.getByText(`${wp.startDate.toLocaleDateString()}`, { exact: false })).toBeInTheDocument();
+      expect(screen.getByText(`${datePipe(wp.startDate)}`, { exact: false })).toBeInTheDocument();
       expect(screen.getByText(`${datePipe(wp.endDate)}`, { exact: false })).toBeInTheDocument();
       expect(screen.getByText(`${wp.progress}%`, { exact: false })).toBeInTheDocument();
       expect(screen.getByText(`${wp.timelineStatus}`, { exact: false })).toBeInTheDocument();
@@ -110,12 +109,11 @@ describe('Work Package Details Component', () => {
       render(<WorkPackageDetails workPackage={wp} />);
       expect(screen.getByText(`Work Package Details`)).toBeInTheDocument();
       expect(screen.getByText(`${wp.status}`, { exact: false })).toBeInTheDocument();
-      expect(screen.getByText(`${wp.name}`, { exact: false })).toBeInTheDocument();
       expect(screen.getByText(`${fullNamePipe(wp.projectLead)}`, { exact: false })).toBeInTheDocument();
       expect(screen.getByText(`${fullNamePipe(wp.projectManager)}`, { exact: false })).toBeInTheDocument();
 
       expect(screen.getByText(`${weeksPipe(wp.duration)}`, { exact: false })).toBeInTheDocument();
-      expect(screen.getByText(`${wp.startDate.toLocaleDateString()}`, { exact: false })).toBeInTheDocument();
+      expect(screen.getByText(`${datePipe(wp.startDate)}`, { exact: false })).toBeInTheDocument();
       expect(screen.getByText(`${datePipe(wp.endDate)}`, { exact: false })).toBeInTheDocument();
       const progresses = screen.getAllByText(`${percentPipe(wp.progress)}`); // progress and expectedProgress should be equal and return 2 results
       expect(progresses.length).toBe(2);
@@ -128,11 +126,10 @@ describe('Work Package Details Component', () => {
       render(<WorkPackageDetails workPackage={wp} />);
       expect(screen.getByText(`Work Package Details`)).toBeInTheDocument();
       expect(screen.getByText(`${wp.status}`, { exact: false })).toBeInTheDocument();
-      expect(screen.getByText(`${wp.name}`, { exact: false })).toBeInTheDocument();
       expect(screen.getByText(`${fullNamePipe(wp.projectLead)}`, { exact: false })).toBeInTheDocument();
       expect(screen.getByText(`${fullNamePipe(wp.projectManager)}`, { exact: false })).toBeInTheDocument();
       expect(screen.getByText(`${weeksPipe(wp.duration)}`, { exact: false })).toBeInTheDocument();
-      expect(screen.getByText(`${wp.startDate.toLocaleDateString()}`, { exact: false })).toBeInTheDocument();
+      expect(screen.getByText(`${datePipe(wp.startDate)}`, { exact: false })).toBeInTheDocument();
       expect(screen.getByText(`${datePipe(wp.endDate)}`, { exact: false })).toBeInTheDocument();
       const progresses = screen.getAllByText(`${percentPipe(wp.progress)}`); // progress and expectedProgress should be equal and return 2 results
       expect(progresses.length).toBe(2);

--- a/src/frontend/src/tests/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageDetails.test.tsx
+++ b/src/frontend/src/tests/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageDetails.test.tsx
@@ -3,82 +3,140 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { render, screen } from '../../../test-support/test-utils';
+import { render, routerWrapperBuilder, screen } from '../../../test-support/test-utils';
 import { WorkPackage } from 'shared';
 import { datePipe, fullNamePipe, weeksPipe, percentPipe } from '../../../../utils/pipes';
 import {
-  exampleWorkPackage1,
-  exampleWorkPackage2,
-  exampleWorkPackage3
+  exampleResearchWorkPackage,
+  exampleDesignWorkPackage,
+  exampleManufacturingWorkPackage,
+  exampleIntegrationWorkPackage,
+  exampleWorkPackage5
 } from '../../../test-support/test-data/work-packages.stub';
 import WorkPackageDetails from '../../../../pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageDetails';
 import { useAllUsers } from '../../../../hooks/users.hooks';
+import { useAuth } from '../../../../hooks/auth.hooks';
 import { User } from 'shared';
-import { mockUseQueryResult } from '../../../test-support/test-data/test-utils.stub';
+import { mockAuth, mockUseQueryResult } from '../../../test-support/test-data/test-utils.stub';
 import { UseQueryResult } from 'react-query';
 import { exampleAdminUser, exampleAppAdminUser, exampleLeadershipUser } from '../../../test-support/test-data/users.stub';
+import { Auth } from '../../../../utils/types';
 
 jest.mock('../../../../hooks/users.hooks');
+jest.mock('../../../../hooks/auth.hooks');
 
 const mockedUseAllUsers = useAllUsers as jest.Mock<UseQueryResult<User[]>>;
+const mockedUseAuth = useAuth as jest.Mock<Auth>;
 
 const mockHook = (isLoading: boolean, isError: boolean, data?: User[], error?: Error) => {
   mockedUseAllUsers.mockReturnValue(mockUseQueryResult<User[]>(isLoading, isError, data, error));
+  mockedUseAuth.mockReturnValue(mockAuth(isLoading, exampleAppAdminUser));
 };
 
 const users = [exampleAdminUser, exampleAppAdminUser, exampleLeadershipUser];
 
-describe.skip('Rendering Work Package Details Component', () => {
-  it('renders all the fields, example 1', () => {
-    mockHook(false, false, users);
-    const wp: WorkPackage = exampleWorkPackage1;
-    render(<WorkPackageDetails workPackage={wp} />);
-    expect(screen.getByText(`Work Package Details`)).toBeInTheDocument();
-    expect(screen.getByText(`${wp.status}`, { exact: false })).toBeInTheDocument();
-    expect(screen.getByText(`${wp.name}`, { exact: false })).toBeInTheDocument();
-    expect(screen.getByText(`${fullNamePipe(wp.projectLead)}`, { exact: false })).toBeInTheDocument();
-    expect(screen.getByText(`${fullNamePipe(wp.projectManager)}`, { exact: false })).toBeInTheDocument();
+const renderComponent = (workPackage = exampleWorkPackage5) => {
+  const RouterWrapper = routerWrapperBuilder({});
+  return render(
+    <RouterWrapper>
+      <WorkPackageDetails workPackage={workPackage} />
+    </RouterWrapper>
+  );
+};
 
-    expect(screen.getByText(`${weeksPipe(wp.duration)}`, { exact: false })).toBeInTheDocument();
-    expect(screen.getByText(`${wp.startDate.toLocaleDateString()}`, { exact: false })).toBeInTheDocument();
-    expect(screen.getByText(`${datePipe(wp.endDate)}`, { exact: false })).toBeInTheDocument();
-    expect(screen.getByText(`${wp.progress}%`, { exact: false })).toBeInTheDocument();
-    expect(screen.getByText(`${wp.timelineStatus}`, { exact: false })).toBeInTheDocument();
-    expect(screen.getByText(`${percentPipe(wp.expectedProgress)}`, { exact: false })).toBeInTheDocument();
+describe('Work Package Details Component', () => {
+  describe('WP Stage Button', () => {
+    it('does not render a label when work package has no stage', () => {
+      mockHook(false, false, users);
+      const { container } = renderComponent();
+      expect(container.getElementsByClassName('MuiChip-label').length).toBe(1);
+    });
+
+    it('renders work package research stage label', () => {
+      mockHook(false, false, users);
+      const { container } = renderComponent(exampleResearchWorkPackage);
+      const chips = Array.from(container.getElementsByClassName('MuiChip-label'));
+      expect(chips.length).toBe(2);
+      expect(chips[0]).toHaveTextContent('Research');
+    });
+
+    it('renders work package design stage label', () => {
+      mockHook(false, false, users);
+      const { container } = renderComponent(exampleDesignWorkPackage);
+      const chips = Array.from(container.getElementsByClassName('MuiChip-label'));
+      expect(chips.length).toBe(2);
+      expect(chips[0]).toHaveTextContent('Design');
+    });
+
+    it('renders work package manufacturing stage label', () => {
+      mockHook(false, false, users);
+      const { container } = renderComponent(exampleManufacturingWorkPackage);
+      const chips = Array.from(container.getElementsByClassName('MuiChip-label'));
+      expect(chips.length).toBe(2);
+      expect(chips[0]).toHaveTextContent('Manufacturing');
+    });
+
+    it('renders work package integration stage label', () => {
+      mockHook(false, false, users);
+      const { container } = renderComponent(exampleIntegrationWorkPackage);
+      const chips = Array.from(container.getElementsByClassName('MuiChip-label'));
+      expect(chips.length).toBe(2);
+      expect(chips[0]).toHaveTextContent('Integration');
+    });
   });
 
-  it('renders all the fields, example 2', () => {
-    mockHook(false, false, users);
-    const wp: WorkPackage = exampleWorkPackage2;
-    render(<WorkPackageDetails workPackage={wp} />);
-    expect(screen.getByText(`Work Package Details`)).toBeInTheDocument();
-    expect(screen.getByText(`${wp.status}`, { exact: false })).toBeInTheDocument();
-    expect(screen.getByText(`${wp.name}`, { exact: false })).toBeInTheDocument();
-    expect(screen.getByText(`${fullNamePipe(wp.projectLead)}`, { exact: false })).toBeInTheDocument();
-    expect(screen.getByText(`${fullNamePipe(wp.projectManager)}`, { exact: false })).toBeInTheDocument();
+  describe.skip('WP Fields', () => {
+    it('renders all the fields, example 1', () => {
+      mockHook(false, false, users);
+      const wp: WorkPackage = exampleResearchWorkPackage;
+      render(<WorkPackageDetails workPackage={wp} />);
+      expect(screen.getByText(`Work Package Details`)).toBeInTheDocument();
+      expect(screen.getByText(`${wp.status}`, { exact: false })).toBeInTheDocument();
+      expect(screen.getByText(`${wp.name}`, { exact: false })).toBeInTheDocument();
+      expect(screen.getByText(`${fullNamePipe(wp.projectLead)}`, { exact: false })).toBeInTheDocument();
+      expect(screen.getByText(`${fullNamePipe(wp.projectManager)}`, { exact: false })).toBeInTheDocument();
 
-    expect(screen.getByText(`${weeksPipe(wp.duration)}`, { exact: false })).toBeInTheDocument();
-    expect(screen.getByText(`${wp.startDate.toLocaleDateString()}`, { exact: false })).toBeInTheDocument();
-    expect(screen.getByText(`${datePipe(wp.endDate)}`, { exact: false })).toBeInTheDocument();
-    const progresses = screen.getAllByText(`${percentPipe(wp.progress)}`); // progress and expectedProgress should be equal and return 2 results
-    expect(progresses.length).toBe(2);
-    expect(screen.getByText(`${wp.timelineStatus}`, { exact: false })).toBeInTheDocument();
-  });
+      expect(screen.getByText(`${weeksPipe(wp.duration)}`, { exact: false })).toBeInTheDocument();
+      expect(screen.getByText(`${wp.startDate.toLocaleDateString()}`, { exact: false })).toBeInTheDocument();
+      expect(screen.getByText(`${datePipe(wp.endDate)}`, { exact: false })).toBeInTheDocument();
+      expect(screen.getByText(`${wp.progress}%`, { exact: false })).toBeInTheDocument();
+      expect(screen.getByText(`${wp.timelineStatus}`, { exact: false })).toBeInTheDocument();
+      expect(screen.getByText(`${percentPipe(wp.expectedProgress)}`, { exact: false })).toBeInTheDocument();
+    });
 
-  it('renders all the fields, example 3', () => {
-    mockHook(false, false, users);
-    const wp: WorkPackage = exampleWorkPackage3;
-    render(<WorkPackageDetails workPackage={wp} />);
-    expect(screen.getByText(`Work Package Details`)).toBeInTheDocument();
-    expect(screen.getByText(`${wp.status}`, { exact: false })).toBeInTheDocument();
-    expect(screen.getByText(`${wp.name}`, { exact: false })).toBeInTheDocument();
-    expect(screen.getByText(`${fullNamePipe(wp.projectLead)}`, { exact: false })).toBeInTheDocument();
-    expect(screen.getByText(`${fullNamePipe(wp.projectManager)}`, { exact: false })).toBeInTheDocument();
-    expect(screen.getByText(`${weeksPipe(wp.duration)}`, { exact: false })).toBeInTheDocument();
-    expect(screen.getByText(`${wp.startDate.toLocaleDateString()}`, { exact: false })).toBeInTheDocument();
-    expect(screen.getByText(`${datePipe(wp.endDate)}`, { exact: false })).toBeInTheDocument();
-    const progresses = screen.getAllByText(`${percentPipe(wp.progress)}`); // progress and expectedProgress should be equal and return 2 results
-    expect(progresses.length).toBe(2);
-    expect(screen.getByText(`${wp.timelineStatus}`, { exact: false })).toBeInTheDocument();
+    it('renders all the fields, example 2', () => {
+      mockHook(false, false, users);
+      const wp: WorkPackage = exampleDesignWorkPackage;
+      render(<WorkPackageDetails workPackage={wp} />);
+      expect(screen.getByText(`Work Package Details`)).toBeInTheDocument();
+      expect(screen.getByText(`${wp.status}`, { exact: false })).toBeInTheDocument();
+      expect(screen.getByText(`${wp.name}`, { exact: false })).toBeInTheDocument();
+      expect(screen.getByText(`${fullNamePipe(wp.projectLead)}`, { exact: false })).toBeInTheDocument();
+      expect(screen.getByText(`${fullNamePipe(wp.projectManager)}`, { exact: false })).toBeInTheDocument();
+
+      expect(screen.getByText(`${weeksPipe(wp.duration)}`, { exact: false })).toBeInTheDocument();
+      expect(screen.getByText(`${wp.startDate.toLocaleDateString()}`, { exact: false })).toBeInTheDocument();
+      expect(screen.getByText(`${datePipe(wp.endDate)}`, { exact: false })).toBeInTheDocument();
+      const progresses = screen.getAllByText(`${percentPipe(wp.progress)}`); // progress and expectedProgress should be equal and return 2 results
+      expect(progresses.length).toBe(2);
+      expect(screen.getByText(`${wp.timelineStatus}`, { exact: false })).toBeInTheDocument();
+    });
+
+    it('renders all the fields, example 3', () => {
+      mockHook(false, false, users);
+      const wp: WorkPackage = exampleManufacturingWorkPackage;
+      render(<WorkPackageDetails workPackage={wp} />);
+      expect(screen.getByText(`Work Package Details`)).toBeInTheDocument();
+      expect(screen.getByText(`${wp.status}`, { exact: false })).toBeInTheDocument();
+      expect(screen.getByText(`${wp.name}`, { exact: false })).toBeInTheDocument();
+      expect(screen.getByText(`${fullNamePipe(wp.projectLead)}`, { exact: false })).toBeInTheDocument();
+      expect(screen.getByText(`${fullNamePipe(wp.projectManager)}`, { exact: false })).toBeInTheDocument();
+      expect(screen.getByText(`${weeksPipe(wp.duration)}`, { exact: false })).toBeInTheDocument();
+      expect(screen.getByText(`${wp.startDate.toLocaleDateString()}`, { exact: false })).toBeInTheDocument();
+      expect(screen.getByText(`${datePipe(wp.endDate)}`, { exact: false })).toBeInTheDocument();
+      const progresses = screen.getAllByText(`${percentPipe(wp.progress)}`); // progress and expectedProgress should be equal and return 2 results
+      expect(progresses.length).toBe(2);
+      expect(screen.getByText(`${wp.timelineStatus}`, { exact: false })).toBeInTheDocument();
+    });
   });
 });

--- a/src/frontend/src/tests/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageDetails.test.tsx
+++ b/src/frontend/src/tests/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageDetails.test.tsx
@@ -45,8 +45,8 @@ const renderComponent = (workPackage = exampleWorkPackage5) => {
 };
 
 describe('Work Package Details Component', () => {
-  describe('WP Stage Button', () => {
-    it('does not render a label when work package has no stage', () => {
+  describe('Work Package Stage Button', () => {
+    it('does not render a stage label when work package has no stage', () => {
       mockHook(false, false, users);
       const { container } = renderComponent();
       expect(container.getElementsByClassName('MuiChip-label').length).toBe(1);
@@ -85,7 +85,7 @@ describe('Work Package Details Component', () => {
     });
   });
 
-  describe.skip('WP Fields', () => {
+  describe.skip('Work Package Detail Fields', () => {
     it('renders all the fields, example 1', () => {
       mockHook(false, false, users);
       const wp: WorkPackage = exampleResearchWorkPackage;

--- a/src/frontend/src/tests/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.test.tsx
+++ b/src/frontend/src/tests/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import { render, screen, routerWrapperBuilder, act, fireEvent } from '../../../test-support/test-utils';
-import { exampleWorkPackage1, exampleWorkPackage2 } from '../../../test-support/test-data/work-packages.stub';
+import { exampleResearchWorkPackage, exampleDesignWorkPackage } from '../../../test-support/test-data/work-packages.stub';
 import WorkPackageViewContainer from '../../../../pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer';
 import * as authHooks from '../../../../hooks/auth.hooks';
 import { mockAuth } from '../../../test-support/test-data/test-utils.stub';
@@ -12,7 +12,7 @@ import { exampleAdminUser } from '../../../test-support/test-data/users.stub';
 
 // Sets up the component under test with the desired values and renders it.
 const renderComponent = (
-  workPackage = exampleWorkPackage2,
+  workPackage = exampleDesignWorkPackage,
   allowEdit = true,
   allowActivate = true,
   allowStageGate = true,
@@ -62,7 +62,7 @@ describe('work package container view', () => {
   });
 
   it('renders action menu buttons for active work package', () => {
-    renderComponent(exampleWorkPackage1);
+    renderComponent(exampleResearchWorkPackage);
 
     expect(screen.getByText('Actions')).toBeInTheDocument();
     act(() => {
@@ -74,7 +74,7 @@ describe('work package container view', () => {
   });
 
   it('disables edit button when not allowed', () => {
-    renderComponent(exampleWorkPackage2, false);
+    renderComponent(exampleDesignWorkPackage, false);
 
     act(() => {
       fireEvent.click(screen.getByText('Actions'));
@@ -83,7 +83,7 @@ describe('work package container view', () => {
   });
 
   it('disables activate button when not allowed', () => {
-    renderComponent(exampleWorkPackage2, true, false);
+    renderComponent(exampleDesignWorkPackage, true, false);
 
     act(() => {
       fireEvent.click(screen.getByText('Actions'));
@@ -92,7 +92,7 @@ describe('work package container view', () => {
   });
 
   it('disables stage gate button when not allowed', () => {
-    renderComponent(exampleWorkPackage1, true, true, false);
+    renderComponent(exampleResearchWorkPackage, true, true, false);
 
     act(() => {
       fireEvent.click(screen.getByText('Actions'));
@@ -101,7 +101,7 @@ describe('work package container view', () => {
   });
 
   it('disables request change button when not allowed', () => {
-    renderComponent(exampleWorkPackage1, true, true, true, false);
+    renderComponent(exampleResearchWorkPackage, true, true, true, false);
 
     act(() => {
       fireEvent.click(screen.getByText(/Actions/));

--- a/src/frontend/src/tests/test-support/test-data/projects.stub.ts
+++ b/src/frontend/src/tests/test-support/test-data/projects.stub.ts
@@ -6,7 +6,7 @@
 import { Project, WbsElementStatus } from 'shared';
 import { exampleAdminUser, exampleLeadershipUser, exampleProjectLeadUser, exampleProjectManagerUser } from './users.stub';
 import { exampleWbsProject1, exampleWbsProject2 } from './wbs-numbers.stub';
-import { exampleWorkPackage1, exampleWorkPackage2, exampleWorkPackage3 } from './work-packages.stub';
+import { exampleResearchWorkPackage, exampleDesignWorkPackage, exampleManufacturingWorkPackage } from './work-packages.stub';
 
 export const exampleProject1: Project = {
   id: 4,
@@ -57,7 +57,7 @@ export const exampleProject1: Project = {
   duration: 8,
   startDate: new Date('01/01/21'),
   endDate: new Date('02/26/21'),
-  workPackages: [exampleWorkPackage1, exampleWorkPackage2],
+  workPackages: [exampleResearchWorkPackage, exampleDesignWorkPackage],
   risks: [],
   tasks: []
 };
@@ -141,7 +141,7 @@ export const exampleProject3: Project = {
   duration: 3,
   startDate: new Date('01/01/21'),
   endDate: new Date('01/22/21'),
-  workPackages: [exampleWorkPackage1],
+  workPackages: [exampleResearchWorkPackage],
   risks: [],
   tasks: []
 };
@@ -180,7 +180,7 @@ export const exampleProject4: Project = {
   duration: 5,
   startDate: new Date('01/22/21'),
   endDate: new Date('02/26/21'),
-  workPackages: [exampleWorkPackage2],
+  workPackages: [exampleDesignWorkPackage],
   risks: [],
   tasks: []
 };
@@ -219,7 +219,7 @@ export const exampleProject5: Project = {
   duration: 2,
   startDate: new Date('01/01/21'),
   endDate: new Date('01/15/21'),
-  workPackages: [exampleWorkPackage3],
+  workPackages: [exampleManufacturingWorkPackage],
   risks: [],
   tasks: []
 };

--- a/src/frontend/src/tests/test-support/test-data/wbs-numbers.stub.ts
+++ b/src/frontend/src/tests/test-support/test-data/wbs-numbers.stub.ts
@@ -12,9 +12,27 @@ export const exampleWbsWorkPackage1: WbsNumber = {
 };
 
 export const exampleWbsWorkPackage2: WbsNumber = {
+  carNumber: 1,
+  projectNumber: 1,
+  workPackageNumber: 2
+};
+
+export const exampleWbsWorkPackage3: WbsNumber = {
   carNumber: 2,
   projectNumber: 7,
   workPackageNumber: 3
+};
+
+export const exampleWbsWorkPackage4: WbsNumber = {
+  carNumber: 2,
+  projectNumber: 7,
+  workPackageNumber: 4
+};
+
+export const exampleWbsWorkPackage5: WbsNumber = {
+  carNumber: 2,
+  projectNumber: 7,
+  workPackageNumber: 5
 };
 
 export const exampleWbsProject1: WbsNumber = {
@@ -49,7 +67,7 @@ export const exampleWbs3: WbsNumber = {
 
 export const exampleAllWbsNums: WbsNumber[] = [
   exampleWbsWorkPackage1,
-  exampleWbsWorkPackage2,
+  exampleWbsWorkPackage3,
   exampleWbsProject1,
   exampleWbsProject2,
   exampleWbs1,

--- a/src/frontend/src/tests/test-support/test-data/work-packages.stub.ts
+++ b/src/frontend/src/tests/test-support/test-data/work-packages.stub.ts
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { WbsElementStatus, WorkPackage, TimelineStatus } from 'shared';
+import { WbsElementStatus, WorkPackage, TimelineStatus, WorkPackageStage } from 'shared';
 import {
   exampleAdminUser,
   exampleAppAdminUser,
@@ -12,9 +12,17 @@ import {
   exampleProjectLeadUser,
   exampleProjectManagerUser
 } from './users.stub';
-import { exampleWbsProject1, exampleWbsProject2, exampleWbsWorkPackage1, exampleWbsWorkPackage2 } from './wbs-numbers.stub';
+import {
+  exampleWbsProject1,
+  exampleWbsProject2,
+  exampleWbsWorkPackage1,
+  exampleWbsWorkPackage2,
+  exampleWbsWorkPackage3,
+  exampleWbsWorkPackage4,
+  exampleWbsWorkPackage5
+} from './wbs-numbers.stub';
 
-export const exampleWorkPackage1: WorkPackage = {
+export const exampleResearchWorkPackage: WorkPackage = {
   id: 1,
   wbsNum: exampleWbsWorkPackage1,
   dateCreated: new Date('11/15/20'),
@@ -54,22 +62,19 @@ export const exampleWorkPackage1: WorkPackage = {
     {
       changeId: 1,
       changeRequestId: 33,
-      wbsNum: exampleWbsWorkPackage2,
+      wbsNum: exampleWbsWorkPackage3,
       implementer: exampleGuestUser,
       detail: 'Increased funding by $500.',
       dateImplemented: new Date('11/15/2003')
     }
   ],
-  projectName: 'project1'
+  projectName: 'project1',
+  stage: WorkPackageStage.Research
 };
 
-export const exampleWorkPackage2: WorkPackage = {
+export const exampleDesignWorkPackage: WorkPackage = {
   id: 2,
-  wbsNum: {
-    carNumber: 1,
-    projectNumber: 1,
-    workPackageNumber: 2
-  },
+  wbsNum: exampleWbsWorkPackage2,
   dateCreated: new Date('10/02/20'),
   name: 'Adhesive Shear Strength Test',
   status: WbsElementStatus.Inactive,
@@ -113,7 +118,7 @@ export const exampleWorkPackage2: WorkPackage = {
     {
       changeId: 2,
       changeRequestId: 1,
-      wbsNum: exampleWbsWorkPackage2,
+      wbsNum: exampleWbsWorkPackage3,
       implementer: exampleAppAdminUser,
       detail: 'Decreased duration from 10 weeks to 7 weeks.',
       dateImplemented: new Date('03/24/21')
@@ -128,12 +133,13 @@ export const exampleWorkPackage2: WorkPackage = {
       dateImplemented: new Date('03/24/21')
     }
   ],
-  projectName: 'project2'
+  projectName: 'project2',
+  stage: WorkPackageStage.Design
 };
 
-export const exampleWorkPackage3: WorkPackage = {
+export const exampleManufacturingWorkPackage: WorkPackage = {
   id: 3,
-  wbsNum: exampleWbsWorkPackage2,
+  wbsNum: exampleWbsWorkPackage3,
   dateCreated: new Date('09/27/20'),
   name: 'Manufacture Wiring Harness',
   status: WbsElementStatus.Complete,
@@ -187,7 +193,109 @@ export const exampleWorkPackage3: WorkPackage = {
       dateImplemented: new Date('03/24/21')
     }
   ],
+  projectName: 'project3',
+  stage: WorkPackageStage.Manufacturing
+};
+
+export const exampleIntegrationWorkPackage: WorkPackage = {
+  id: 4,
+  wbsNum: exampleWbsWorkPackage4,
+  dateCreated: new Date('2022-02-20'),
+  name: 'Install Wiring Harness',
+  status: WbsElementStatus.Complete,
+  projectLead: exampleLeadershipUser,
+  projectManager: exampleProjectManagerUser,
+  orderInProject: 4,
+  progress: 0,
+  expectedProgress: 100,
+  timelineStatus: TimelineStatus.VeryBehind,
+  startDate: new Date('2022-02-20'),
+  endDate: new Date('2022-02-27'),
+  duration: 1,
+  dependencies: [exampleWbsWorkPackage3],
+  expectedActivities: [
+    {
+      id: 10,
+      detail: 'Purchase attachment hardware',
+      dateAdded: new Date('2022-02-20')
+    },
+    {
+      id: 11,
+      detail: 'Complete installation',
+      dateAdded: new Date('2022-02-20')
+    },
+    {
+      id: 12,
+      detail: 'Check for safety and rules compliance',
+      dateAdded: new Date('2022-02-20')
+    }
+  ],
+  deliverables: [
+    {
+      id: 28,
+      detail: 'Harness is attached strongly and in compliance with the rules',
+      dateAdded: new Date('2022-02-20')
+    }
+  ],
+  changes: [
+    {
+      changeId: 8,
+      changeRequestId: 15,
+      wbsNum: exampleWbsWorkPackage1,
+      implementer: exampleAdminUser,
+      detail: 'New Work Package Created',
+      dateImplemented: new Date('2022-02-20')
+    }
+  ],
+  projectName: 'project3',
+  stage: WorkPackageStage.Integration
+};
+
+export const exampleWorkPackage5: WorkPackage = {
+  id: 5,
+  wbsNum: exampleWbsWorkPackage5,
+  dateCreated: new Date('2022-02-20'),
+  name: 'Party In Celebration',
+  status: WbsElementStatus.Complete,
+  projectLead: exampleLeadershipUser,
+  projectManager: exampleProjectManagerUser,
+  orderInProject: 5,
+  progress: 100,
+  expectedProgress: 100,
+  timelineStatus: TimelineStatus.OnTrack,
+  startDate: new Date('2022-02-21'),
+  endDate: new Date('2022-02-28'),
+  duration: 1,
+  dependencies: [],
+  expectedActivities: [
+    {
+      id: 13,
+      detail: 'YAYYYYYYY',
+      dateAdded: new Date('2022-02-21')
+    }
+  ],
+  deliverables: [
+    {
+      id: 29,
+      detail: 'Stomachs full with CAKE',
+      dateAdded: new Date('2022-02-21')
+    }
+  ],
+  changes: [
+    {
+      changeId: 9,
+      changeRequestId: 16,
+      wbsNum: exampleWbsWorkPackage1,
+      implementer: exampleAdminUser,
+      detail: 'New Work Package Created',
+      dateImplemented: new Date('2022-02-21')
+    }
+  ],
   projectName: 'project3'
 };
 
-export const exampleAllWorkPackages: WorkPackage[] = [exampleWorkPackage1, exampleWorkPackage2, exampleWorkPackage3];
+export const exampleAllWorkPackages: WorkPackage[] = [
+  exampleResearchWorkPackage,
+  exampleDesignWorkPackage,
+  exampleManufacturingWorkPackage
+];

--- a/src/frontend/src/utils/themes.ts
+++ b/src/frontend/src/utils/themes.ts
@@ -79,7 +79,7 @@ export const nerThemeOptions: ThemeOptions = {
     },
     MuiChip: {
       styleOverrides: {
-        colorSecondary: {
+        filledSecondary: {
           backgroundColor: 'gray'
         }
       }


### PR DESCRIPTION
## Changes

Add label (new component) to work package detail page and work package preview for the stage of the work package. See the colors below.

Refactor test data a bit to name the work packages after their stages and refactor WBS numbers.

## Notes

As you can see in the screenshots, putting two chips side by side doesn't look so good for the work package preview. Maybe we can try to stack them top-down when the screen gets small enough. (Thought that might be tricky because I hard coded the margin-right of the stage chip component...)

## Test Cases

Tested in both WP detail page and WP preview (part of the project detail page tests, we can move it to a separate file if you want).
- If no stages then don't show anything
- If it has a stage then display the correct label
  - Research
  - Design
  - Manufacturing
  - Integration

## Screenshots

_If you made UI changes you must post a screenshot of the whole page for each change in 1) a normal sized window and 2) the smallest possible window_

![Screen Shot 2023-02-21 at 10 48 53 PM](https://user-images.githubusercontent.com/59806366/220517283-c9cdb067-e097-4f61-94db-0814ed075aa6.png)
![Screen Shot 2023-02-21 at 10 49 19 PM](https://user-images.githubusercontent.com/59806366/220517292-7de1a187-da3e-47e6-ad3f-864844abfa5e.png)
![Screen Shot 2023-02-21 at 10 50 11 PM](https://user-images.githubusercontent.com/59806366/220517297-a825a1d3-b6ca-4265-aa54-296001680be3.png)
![Screen Shot 2023-02-21 at 10 50 33 PM](https://user-images.githubusercontent.com/59806366/220517304-f01443b4-167e-40f4-b2b1-b43da9562355.png)
![Screen Shot 2023-02-21 at 10 50 50 PM](https://user-images.githubusercontent.com/59806366/220517311-b93ca36a-a2c3-45e9-bc78-b977e4cd4edc.png)
![Screen Shot 2023-02-21 at 10 51 04 PM](https://user-images.githubusercontent.com/59806366/220517333-57c48624-fb06-4f7e-9c30-1cf90d883fc2.png)


## To Do

_Any remaining things that need to get done_

- [x] figure out how to do seed data to get it to display on the front end
- [x] tweak UI
- [x] badge colors

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #888 
