### PR TITLE
#635-Replaced-alert()-with-useToast()-in-ReviewChangeRequest

### DIFF
--- a/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequest.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequest.tsx
@@ -10,6 +10,7 @@ import ErrorPage from '../ErrorPage';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import ReviewChangeRequestsView from './ReviewChangeRequestView';
 import { ChangeRequest } from 'shared';
+import { useToast } from '../../hooks/toasts.hooks';
 
 interface ReviewChangeRequestProps {
   modalShow: boolean;
@@ -35,6 +36,7 @@ const ReviewChangeRequest: React.FC<ReviewChangeRequestProps> = ({
   const crId = parseInt(id);
   const auth = useAuth();
   const { isLoading, isError, error, mutateAsync } = useReviewChangeRequest();
+  const toast = useToast();
 
   const handleConfirm = async ({ reviewNotes, accepted, psId }: FormInput) => {
     handleClose();
@@ -46,7 +48,7 @@ const ReviewChangeRequest: React.FC<ReviewChangeRequestProps> = ({
       accepted,
       psId
     }).catch((error) => {
-      alert(error);
+      toast.error(error);
       throw new Error(error);
     });
   };

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequest.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequest.tsx
@@ -48,7 +48,9 @@ const ReviewChangeRequest: React.FC<ReviewChangeRequestProps> = ({
       accepted,
       psId
     }).catch((error) => {
-      toast.error(error);
+      if (error instanceof Error) {
+        toast.error(error.message);
+      }
       throw new Error(error);
     });
   };

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequest.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequest.tsx
@@ -51,7 +51,6 @@ const ReviewChangeRequest: React.FC<ReviewChangeRequestProps> = ({
       if (error instanceof Error) {
         toast.error(error.message);
       }
-      throw new Error(error);
     });
   };
 


### PR DESCRIPTION
## Changes

Replaced all instances of alert() with useToast() in ReviewChangeRequest

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #635
