### PR TITLE
#910 Use task transformer instead of shared version

### DIFF
--- a/src/backend/tests/tasks.test.ts
+++ b/src/backend/tests/tasks.test.ts
@@ -3,8 +3,9 @@ import { batman, wonderwoman } from './test-data/users.test-data';
 import { AccessDeniedException, HttpException, NotFoundException } from '../src/utils/errors.utils';
 import TasksService from '../src/services/tasks.services';
 import { prismaWbsElement1 } from './test-data/wbs-element.test-data';
-import { invalidTaskNotes, taskSaveTheDayPrisma, taskSaveTheDayShared } from './test-data/tasks.test-data';
+import { invalidTaskNotes, taskSaveTheDayPrisma } from './test-data/tasks.test-data';
 import { WbsNumber } from 'shared';
+import taskTransformer from '../src/transformers/tasks.transformer';
 
 describe('Tasks', () => {
   const mockDate = new Date('2022-12-25T00:00:00.000Z');
@@ -91,7 +92,7 @@ describe('Tasks', () => {
         wonderwoman.userId
       ]);
 
-      expect(task).toStrictEqual(taskSaveTheDayShared);
+      expect(task).toStrictEqual(taskTransformer(taskSaveTheDayPrisma));
       expect(prisma.wBS_Element.findUnique).toHaveBeenCalledTimes(1);
       expect(prisma.task.create).toHaveBeenCalledTimes(1);
       expect(prisma.user.findMany).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Changes
Changed the strict equal to use task transformer instead of a stored variable because on init the dates might be a tiny bit off based off of when they are initialized

## Test Cases
Succeeded 20 times in a row

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #910  (issue #)
