### PR TITLE
#882 Editing WP Status should no longer be allowed

### DIFF
--- a/src/backend/src/controllers/work-packages.controllers.ts
+++ b/src/backend/src/controllers/work-packages.controllers.ts
@@ -72,7 +72,6 @@ export default class WorkPackagesController {
         dependencies,
         expectedActivities,
         deliverables,
-        wbsElementStatus,
         projectLead,
         projectManager
       } = req.body;
@@ -95,7 +94,6 @@ export default class WorkPackagesController {
         dependencies,
         expectedActivities,
         deliverables,
-        wbsElementStatus,
         projectLead,
         projectManager
       );

--- a/src/backend/src/prisma/seed-data/work-packages.seed.ts
+++ b/src/backend/src/prisma/seed-data/work-packages.seed.ts
@@ -72,7 +72,6 @@ export const seedWorkPackage = async (
     workPackage.dependencies,
     workPackage.expectedActivities.map(descBulletConverter),
     workPackage.deliverables.map(descBulletConverter),
-    status,
     projectLead,
     projectManager
   );

--- a/src/backend/src/routes/work-packages.routes.ts
+++ b/src/backend/src/routes/work-packages.routes.ts
@@ -1,6 +1,5 @@
 import express from 'express';
 import { body } from 'express-validator';
-import { WbsElementStatus } from 'shared';
 import WorkPackagesController from '../controllers/work-packages.controllers';
 import { validateInputs } from '../utils/utils';
 import { intMinZero, isDate, isWorkPackageStageOrNone, nonEmptyString } from '../utils/validation.utils';
@@ -45,7 +44,6 @@ workPackagesRouter.post(
   body('deliverables').isArray(),
   body('deliverables.*.id').isInt({ min: -1 }).not().isString(),
   nonEmptyString(body('deliverables.*.detail')),
-  body('wbsElementStatus').custom((value) => Object.values(WbsElementStatus).includes(value)),
   intMinZero(body('projectLead').optional()),
   intMinZero(body('projectManager').optional()),
   validateInputs,

--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -255,7 +255,6 @@ export default class WorkPackagesService {
    * @param dependencies the new WBS elements to be completed before this WP
    * @param expectedActivities the new expected activities descriptions for this WP
    * @param deliverables the new expected deliverables descriptions for this WP
-   * @param WbsElementStatus the new status for this work package
    * @param projectLead the new lead for this work package
    * @param projectManager the new manager for this work package
    */
@@ -270,7 +269,6 @@ export default class WorkPackagesService {
     dependencies: WbsNumber[],
     expectedActivities: DescriptionBullet[],
     deliverables: DescriptionBullet[],
-    wbsElementStatus: WbsElementStatus,
     projectLead: number,
     projectManager: number
   ): Promise<void> {
@@ -371,14 +369,6 @@ export default class WorkPackagesService {
       userId,
       wbsElementId!
     );
-    const wbsElementStatusChangeJson = createChangeJsonNonList(
-      'status',
-      originalWorkPackage.wbsElement.status,
-      wbsElementStatus,
-      crId,
-      userId,
-      wbsElementId!
-    );
     const dependenciesChangeJson = await createDependenciesChangesJson(
       originalWorkPackage.dependencies.map((element) => element.wbsElementId),
       depsIds.map((elem) => elem as number),
@@ -410,7 +400,6 @@ export default class WorkPackagesService {
     if (nameChangeJson !== undefined) changes.push(nameChangeJson);
     if (startDateChangeJson !== undefined) changes.push(startDateChangeJson);
     if (durationChangeJson !== undefined) changes.push(durationChangeJson);
-    if (wbsElementStatusChangeJson !== undefined) changes.push(wbsElementStatusChangeJson);
     if (stageChangeJson !== undefined) changes.push(stageChangeJson);
 
     const projectManagerChangeJson = createChangeJsonNonList(
@@ -457,7 +446,6 @@ export default class WorkPackagesService {
           update: {
             name,
             projectLeadId: projectLead,
-            status: wbsElementStatus,
             projectManagerId: projectManager
           }
         },

--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -4,6 +4,7 @@ import {
   equalsWbsNumber,
   isProject,
   TimelineStatus,
+  WbsElementStatus,
   WbsNumber,
   wbsPipe,
   WorkPackage,
@@ -33,6 +34,7 @@ export default class WorkPackagesService {
    * @returns a list of work packages
    */
   static async getAllWorkPackages(query: {
+    status?: WbsElementStatus;
     timelineStatus?: TimelineStatus;
     daysUntilDeadline?: string;
   }): Promise<WorkPackage[]> {
@@ -43,6 +45,7 @@ export default class WorkPackagesService {
 
     const outputWorkPackages = workPackages.map(workPackageTransformer).filter((wp) => {
       let passes = true;
+      if (query.status) passes &&= wp.status === query.status;
       if (query.timelineStatus) passes &&= wp.timelineStatus === query.timelineStatus;
       if (query.daysUntilDeadline) {
         const daysToDeadline = Math.round((wp.endDate.getTime() - new Date().getTime()) / 86400000);
@@ -252,6 +255,7 @@ export default class WorkPackagesService {
    * @param dependencies the new WBS elements to be completed before this WP
    * @param expectedActivities the new expected activities descriptions for this WP
    * @param deliverables the new expected deliverables descriptions for this WP
+   * @param WbsElementStatus the new status for this work package
    * @param projectLead the new lead for this work package
    * @param projectManager the new manager for this work package
    */
@@ -266,6 +270,7 @@ export default class WorkPackagesService {
     dependencies: WbsNumber[],
     expectedActivities: DescriptionBullet[],
     deliverables: DescriptionBullet[],
+    wbsElementStatus: WbsElementStatus,
     projectLead: number,
     projectManager: number
   ): Promise<void> {
@@ -366,6 +371,14 @@ export default class WorkPackagesService {
       userId,
       wbsElementId!
     );
+    const wbsElementStatusChangeJson = createChangeJsonNonList(
+      'status',
+      originalWorkPackage.wbsElement.status,
+      wbsElementStatus,
+      crId,
+      userId,
+      wbsElementId!
+    );
     const dependenciesChangeJson = await createDependenciesChangesJson(
       originalWorkPackage.dependencies.map((element) => element.wbsElementId),
       depsIds.map((elem) => elem as number),
@@ -397,6 +410,7 @@ export default class WorkPackagesService {
     if (nameChangeJson !== undefined) changes.push(nameChangeJson);
     if (startDateChangeJson !== undefined) changes.push(startDateChangeJson);
     if (durationChangeJson !== undefined) changes.push(durationChangeJson);
+    if (wbsElementStatusChangeJson !== undefined) changes.push(wbsElementStatusChangeJson);
     if (stageChangeJson !== undefined) changes.push(stageChangeJson);
 
     const projectManagerChangeJson = createChangeJsonNonList(
@@ -443,6 +457,7 @@ export default class WorkPackagesService {
           update: {
             name,
             projectLeadId: projectLead,
+            status: wbsElementStatus,
             projectManagerId: projectManager
           }
         },

--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -4,7 +4,6 @@ import {
   equalsWbsNumber,
   isProject,
   TimelineStatus,
-  WbsElementStatus,
   WbsNumber,
   wbsPipe,
   WorkPackage,
@@ -34,7 +33,6 @@ export default class WorkPackagesService {
    * @returns a list of work packages
    */
   static async getAllWorkPackages(query: {
-    status?: WbsElementStatus;
     timelineStatus?: TimelineStatus;
     daysUntilDeadline?: string;
   }): Promise<WorkPackage[]> {
@@ -45,7 +43,6 @@ export default class WorkPackagesService {
 
     const outputWorkPackages = workPackages.map(workPackageTransformer).filter((wp) => {
       let passes = true;
-      if (query.status) passes &&= wp.status === query.status;
       if (query.timelineStatus) passes &&= wp.timelineStatus === query.timelineStatus;
       if (query.daysUntilDeadline) {
         const daysToDeadline = Math.round((wp.endDate.getTime() - new Date().getTime()) / 86400000);
@@ -255,7 +252,6 @@ export default class WorkPackagesService {
    * @param dependencies the new WBS elements to be completed before this WP
    * @param expectedActivities the new expected activities descriptions for this WP
    * @param deliverables the new expected deliverables descriptions for this WP
-   * @param WbsElementStatus the new status for this work package
    * @param projectLead the new lead for this work package
    * @param projectManager the new manager for this work package
    */
@@ -270,7 +266,6 @@ export default class WorkPackagesService {
     dependencies: WbsNumber[],
     expectedActivities: DescriptionBullet[],
     deliverables: DescriptionBullet[],
-    wbsElementStatus: WbsElementStatus,
     projectLead: number,
     projectManager: number
   ): Promise<void> {
@@ -371,14 +366,6 @@ export default class WorkPackagesService {
       userId,
       wbsElementId!
     );
-    const wbsElementStatusChangeJson = createChangeJsonNonList(
-      'status',
-      originalWorkPackage.wbsElement.status,
-      wbsElementStatus,
-      crId,
-      userId,
-      wbsElementId!
-    );
     const dependenciesChangeJson = await createDependenciesChangesJson(
       originalWorkPackage.dependencies.map((element) => element.wbsElementId),
       depsIds.map((elem) => elem as number),
@@ -410,7 +397,6 @@ export default class WorkPackagesService {
     if (nameChangeJson !== undefined) changes.push(nameChangeJson);
     if (startDateChangeJson !== undefined) changes.push(startDateChangeJson);
     if (durationChangeJson !== undefined) changes.push(durationChangeJson);
-    if (wbsElementStatusChangeJson !== undefined) changes.push(wbsElementStatusChangeJson);
     if (stageChangeJson !== undefined) changes.push(stageChangeJson);
 
     const projectManagerChangeJson = createChangeJsonNonList(
@@ -456,7 +442,6 @@ export default class WorkPackagesService {
         wbsElement: {
           update: {
             name,
-            status: wbsElementStatus,
             projectLeadId: projectLead,
             projectManagerId: projectManager
           }

--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditContainer.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditContainer.tsx
@@ -41,7 +41,7 @@ const WorkPackageEditContainer: React.FC<WorkPackageEditContainerProps> = ({ wor
   const auth = useAuth();
   const query = useQuery();
   const allUsers = useAllUsers();
-  const { name, startDate, duration, status } = workPackage;
+  const { name, startDate, duration } = workPackage;
   const {
     register,
     handleSubmit,
@@ -63,8 +63,7 @@ const WorkPackageEditContainer: React.FC<WorkPackageEditContainerProps> = ({ wor
         return { wbsNum };
       }),
       expectedActivities: bulletsToObject(workPackage.expectedActivities),
-      deliverables: bulletsToObject(workPackage.deliverables),
-      wbsElementStatus: status
+      deliverables: bulletsToObject(workPackage.deliverables)
     }
   });
   // lists of stuff
@@ -101,7 +100,7 @@ const WorkPackageEditContainer: React.FC<WorkPackageEditContainerProps> = ({ wor
   };
 
   const onSubmit = async (data: any) => {
-    const { name, projectLead, projectManager, startDate, duration, wbsElementStatus, crId, dependencies, stage } = data;
+    const { name, projectLead, projectManager, startDate, duration, crId, dependencies, stage } = data;
     const expectedActivities = mapBulletsToPayload(data.expectedActivities);
     const deliverables = mapBulletsToPayload(data.deliverables);
 
@@ -120,7 +119,6 @@ const WorkPackageEditContainer: React.FC<WorkPackageEditContainerProps> = ({ wor
         }),
         expectedActivities,
         deliverables,
-        wbsElementStatus,
         stage
       };
       await mutateAsync(payload);

--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditDetails.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditDetails.tsx
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { User, WbsElementStatus, WorkPackageStage } from 'shared';
+import { User, WorkPackageStage } from 'shared';
 import { fullNamePipe } from '../../../utils/pipes';
 import PageBlock from '../../../layouts/PageBlock';
 import { Grid, MenuItem, TextField } from '@mui/material';
@@ -17,26 +17,7 @@ interface Props {
   errors: any;
 }
 
-const statuses = Object.values(WbsElementStatus);
-
 const WorkPackageEditDetails: React.FC<Props> = ({ users, control, errors }) => {
-  const StatusSelect = () => (
-    <Controller
-      name="wbsElementStatus"
-      control={control}
-      rules={{ required: true }}
-      render={({ field: { onChange, value } }) => (
-        <TextField select onChange={onChange} value={value} label="Status" fullWidth>
-          {statuses.map((t) => (
-            <MenuItem key={t} value={t}>
-              {t}
-            </MenuItem>
-          ))}
-        </TextField>
-      )}
-    />
-  );
-
   const StageSelect = () => (
     <Controller
       name="stage"

--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditDetails.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditDetails.tsx
@@ -73,36 +73,42 @@ const WorkPackageEditDetails: React.FC<Props> = ({ users, control, errors }) => 
           </FormControl>
         </Grid>
         <Grid item xs={12} md={6} sx={{ mt: 2, mb: 1 }}>
-          <Controller
-            name="projectLead"
-            control={control}
-            rules={{ required: true }}
-            render={({ field: { onChange, value } }) => (
-              <TextField select onChange={onChange} value={value} label="Project Lead" fullWidth>
-                {users.map((t) => (
-                  <MenuItem key={t.userId} value={t.userId}>
-                    {fullNamePipe(t)}
-                  </MenuItem>
-                ))}
-              </TextField>
-            )}
-          />
+          <FormControl sx={{ width: '90%' }}>
+            <FormLabel>Project Lead</FormLabel>
+            <Controller
+              name="projectLead"
+              control={control}
+              rules={{ required: true }}
+              render={({ field: { onChange, value } }) => (
+                <TextField select onChange={onChange} value={value} fullWidth>
+                  {users.map((t) => (
+                    <MenuItem key={t.userId} value={t.userId}>
+                      {fullNamePipe(t)}
+                    </MenuItem>
+                  ))}
+                </TextField>
+              )}
+            />
+          </FormControl>
         </Grid>
         <Grid item xs={12} md={6} sx={{ mt: 2, mb: 1 }}>
-          <Controller
-            name="projectManager"
-            control={control}
-            rules={{ required: true }}
-            render={({ field: { onChange, value } }) => (
-              <TextField select onChange={onChange} value={value} label="Project Manager" fullWidth>
-                {users.map((t) => (
-                  <MenuItem key={t.userId} value={t.userId}>
-                    {fullNamePipe(t)}
-                  </MenuItem>
-                ))}
-              </TextField>
-            )}
-          />
+          <FormControl sx={{ width: '90%' }}>
+            <FormLabel>Project Manager</FormLabel>
+            <Controller
+              name="projectManager"
+              control={control}
+              rules={{ required: true }}
+              render={({ field: { onChange, value } }) => (
+                <TextField select onChange={onChange} value={value} fullWidth>
+                  {users.map((t) => (
+                    <MenuItem key={t.userId} value={t.userId}>
+                      {fullNamePipe(t)}
+                    </MenuItem>
+                  ))}
+                </TextField>
+              )}
+            />
+          </FormControl>
         </Grid>
         <Grid item xs={12} md={6} sx={{ my: 1 }}>
           <FormControl>

--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditDetails.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditDetails.tsx
@@ -79,9 +79,6 @@ const WorkPackageEditDetails: React.FC<Props> = ({ users, control, errors }) => 
             )}
           />
         </Grid>
-        <Grid item xs={12} md={4} sx={{ mt: 2, mb: 1 }}>
-          <StatusSelect />
-        </Grid>
         <Grid item xs={12} md={6} sx={{ mt: 2, mb: 1 }}>
           <Controller
             name="projectLead"


### PR DESCRIPTION
## Changes

Removed Status from form, from payload, and from route, controller, and service.

## Screenshots

<img width="1260" alt="Screen Shot 2023-02-27 at 2 51 24 AM" src="https://user-images.githubusercontent.com/87815804/221504962-b9fe3824-dbf4-47f9-8653-de9d8865c47f.png">


## To Do

_Any remaining things that need to get done_

- [ ] write tests for edit WP

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #882 
