### PR TITLE
#712: Change CreateProjectPage to use NER Buttons

### DIFF
--- a/src/frontend/src/pages/CreateProjectPage/CreateProjectFormView.tsx
+++ b/src/frontend/src/pages/CreateProjectPage/CreateProjectFormView.tsx
@@ -151,7 +151,7 @@ const CreateProjectFormView: React.FC<CreateProjectFormViewProps> = ({ allowSubm
           <NERFailButton variant="contained" onClick={onCancel} sx={{ mx: 1 }}>
             Cancel
           </NERFailButton>
-          <NERSuccessButton variant="contained" type="submit" sx={{ mx: 1 }}>
+          <NERSuccessButton variant="contained" type="submit" disabled={!allowSubmit} sx={{ mx: 1 }}>
             Create
           </NERSuccessButton>
         </Box>

--- a/src/frontend/src/pages/CreateProjectPage/CreateProjectFormView.tsx
+++ b/src/frontend/src/pages/CreateProjectPage/CreateProjectFormView.tsx
@@ -147,16 +147,14 @@ const CreateProjectFormView: React.FC<CreateProjectFormViewProps> = ({ allowSubm
             </FormControl>
           </Grid>
         </Grid>
-        <Grid container justifyContent="flex-end">
-          <Box display="flex" sx={{ mt: 2 }}>
-            <NERFailButton variant="contained" onClick={onCancel} sx={{ mx: 1 }}>
-              Cancel
-            </NERFailButton>
-            <NERSuccessButton variant="contained" type="submit" disabled={!allowSubmit} sx={{ mx: 1 }}>
-              Create
-            </NERSuccessButton>
-          </Box>
-        </Grid>
+        <Box justifyContent="flex-end" display="flex" sx={{ mt: 2 }}>
+          <NERFailButton variant="contained" onClick={onCancel} sx={{ mx: 1 }}>
+            Cancel
+          </NERFailButton>
+          <NERSuccessButton variant="contained" type="submit" disabled={!allowSubmit} sx={{ mx: 1 }}>
+            Create
+          </NERSuccessButton>
+        </Box>
       </PageBlock>
     </form>
   );

--- a/src/frontend/src/pages/CreateProjectPage/CreateProjectFormView.tsx
+++ b/src/frontend/src/pages/CreateProjectPage/CreateProjectFormView.tsx
@@ -147,14 +147,16 @@ const CreateProjectFormView: React.FC<CreateProjectFormViewProps> = ({ allowSubm
             </FormControl>
           </Grid>
         </Grid>
-        <Box display="flex" gap={2} sx={{ mt: 2 }}>
-          <NERFailButton variant="contained" onClick={onCancel} sx={{ mx: 1 }}>
-            Cancel
-          </NERFailButton>
-          <NERSuccessButton variant="contained" type="submit" disabled={!allowSubmit} sx={{ mx: 1 }}>
-            Create
-          </NERSuccessButton>
-        </Box>
+        <Grid container justifyContent="flex-end">
+          <Box display="flex" sx={{ mt: 2 }}>
+            <NERFailButton variant="contained" onClick={onCancel} sx={{ mx: 1 }}>
+              Cancel
+            </NERFailButton>
+            <NERSuccessButton variant="contained" type="submit" disabled={!allowSubmit} sx={{ mx: 1 }}>
+              Create
+            </NERSuccessButton>
+          </Box>
+        </Grid>
       </PageBlock>
     </form>
   );

--- a/src/frontend/src/pages/CreateProjectPage/CreateProjectFormView.tsx
+++ b/src/frontend/src/pages/CreateProjectPage/CreateProjectFormView.tsx
@@ -19,6 +19,8 @@ import { useQuery } from '../../hooks/utils.hooks';
 import { SubmitButton } from '../../components/SubmitButton';
 import { useAllTeams } from '../../hooks/teams.hooks';
 import LoadingIndicator from '../../components/LoadingIndicator';
+import NERFailButton from '../../components/NERFailButton';
+import NERSuccessButton from '../../components/NERSuccessButton';
 
 const schema = yup.object().shape({
   name: yup.string().required('Name is required'),
@@ -148,12 +150,12 @@ const CreateProjectFormView: React.FC<CreateProjectFormViewProps> = ({ allowSubm
           </Grid>
         </Grid>
         <Box display="flex" gap={2} sx={{ mt: 2 }}>
-          <SubmitButton variant="contained" color="primary" type="submit" disabled={!allowSubmit}>
-            Create
-          </SubmitButton>
-          <Button variant="outlined" color="secondary" onClick={onCancel}>
+          <NERFailButton variant="contained" onClick={onCancel} sx={{ mx: 1 }}>
             Cancel
-          </Button>
+          </NERFailButton>
+          <NERSuccessButton variant="contained" type="submit" sx={{ mx: 1 }}>
+            Submit
+          </NERSuccessButton>
         </Box>
       </PageBlock>
     </form>

--- a/src/frontend/src/pages/CreateProjectPage/CreateProjectFormView.tsx
+++ b/src/frontend/src/pages/CreateProjectPage/CreateProjectFormView.tsx
@@ -152,7 +152,7 @@ const CreateProjectFormView: React.FC<CreateProjectFormViewProps> = ({ allowSubm
             Cancel
           </NERFailButton>
           <NERSuccessButton variant="contained" type="submit" sx={{ mx: 1 }}>
-            Submit
+            Create
           </NERSuccessButton>
         </Box>
       </PageBlock>

--- a/src/frontend/src/pages/CreateProjectPage/CreateProjectFormView.tsx
+++ b/src/frontend/src/pages/CreateProjectPage/CreateProjectFormView.tsx
@@ -4,7 +4,6 @@
  */
 
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
 import PageBlock from '../../layouts/PageBlock';
 import Grid from '@mui/material/Grid';
 import PageTitle from '../../layouts/PageTitle/PageTitle';
@@ -16,7 +15,6 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { CreateProjectFormInputs } from './CreateProjectForm';
 import ReactHookTextField from '../../components/ReactHookTextField';
 import { useQuery } from '../../hooks/utils.hooks';
-import { SubmitButton } from '../../components/SubmitButton';
 import { useAllTeams } from '../../hooks/teams.hooks';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import NERFailButton from '../../components/NERFailButton';


### PR DESCRIPTION
## Changes

Changed the save/cancel buttons in the CreateProjectPage component to use the NERSuccessButton/NERFailButton component rather than just the plain MUI button. Cancel on the left and submit on the right. 

## Test Cases

- yarn test:frontend

## Screenshots

![image](https://user-images.githubusercontent.com/118306244/223556611-25d5cc0d-a7d2-400e-8025-4f50edabd3c2.png)


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #712
