### PR TITLE
#266 - Add More Tests for Creating Work Packages

### DIFF
--- a/src/backend/tests/work-packages.test.ts
+++ b/src/backend/tests/work-packages.test.ts
@@ -163,9 +163,6 @@ describe('Work Packages', () => {
     });
 
     test("fails if the dependencies include the work package's own project", async () => {
-      jest.spyOn(prisma.change_Request, 'findUnique').mockResolvedValue(prismaChangeRequest1);
-      jest.spyOn(prisma.project, 'findUnique').mockResolvedValue(null);
-
       const argsToTest: [
         User,
         WbsNumber,
@@ -197,7 +194,6 @@ describe('Work Packages', () => {
         ...prismaWorkPackage1,
         wbsElement: { carNumber: 1, projectNumber: 2, workPackageNumber: 3 }
       };
-      jest.spyOn(prisma.change_Request, 'findUnique').mockResolvedValue(prismaChangeRequest1);
       jest.spyOn(prisma.wBS_Element, 'findUnique').mockResolvedValueOnce(foundWbsElem);
       jest.spyOn(prisma.wBS_Element, 'findUnique').mockResolvedValue(prismaWbsElement1);
       jest.spyOn(prisma.work_Package, 'create').mockResolvedValue(newPrismaWp);
@@ -207,7 +203,12 @@ describe('Work Packages', () => {
       };
 
       await expect(callCreateWP()).resolves.toEqual('1.2.3');
+
+      // check that prisma functions (or functions that call prisma functions)
+      // are called exactly as many times as needed
       expect(prisma.work_Package.create).toHaveBeenCalledTimes(1);
+      expect(changeRequestUtils.validateChangeRequestAccepted).toHaveBeenCalledTimes(1);
+      expect(prisma.wBS_Element.findUnique).toHaveBeenCalledTimes(1 + dependencies.length);
     });
   });
 

--- a/src/backend/tests/work-packages.test.ts
+++ b/src/backend/tests/work-packages.test.ts
@@ -6,7 +6,7 @@ import { calculateWorkPackageProgress } from '../src/utils/work-packages.utils';
 import { AccessDeniedException, HttpException, NotFoundException } from '../src/utils/errors.utils';
 import WorkPackageService from '../src/services/work-packages.services';
 import { WbsNumber } from 'shared';
-import { User, WBS_Element, WBS_Element_Status } from '@prisma/client';
+import { User } from '@prisma/client';
 import { WorkPackageStage } from 'shared';
 import * as changeRequestUtils from '../src/utils/change-requests.utils';
 import { prismaProject1 } from './test-data/projects.test-data';
@@ -24,19 +24,11 @@ describe('Work Packages', () => {
   const crId = 1;
   const startDate = '2022-09-18';
   const duration = 5;
-  const dependencies = [
+  const dependencies: WbsNumber[] = [
     {
-      wbsElementId: 65,
-      dateCreated: new Date('11/24/2021'),
       carNumber: 1,
       projectNumber: 1,
-      workPackageNumber: 1,
-      name: 'prereq',
-      status: WBS_Element_Status.COMPLETE,
-      projectLeadId: null,
-      projectManagerId: null,
-      dateDeleted: null,
-      deletedByUserId: null
+      workPackageNumber: 1
     }
   ];
   const expectedActivities = ['ayo'];
@@ -50,7 +42,7 @@ describe('Work Packages', () => {
     WorkPackageStage,
     string,
     number,
-    WBS_Element[],
+    WbsNumber[],
     string[],
     string[]
   ] = [batman, projectWbsNum, name, crId, stage, startDate, duration, dependencies, expectedActivities, deliverables];


### PR DESCRIPTION
## Changes

Write unit tests (see Test Cases), mocking all Prisma calls.

Change `dependencies` to a WbsNumber which is what is actually used as an arg to createWorkPackage.

## Test Cases

- the work package dependencies input has its own project as a dependency
- the endpoint completes successfully (calling the prisma create function once)

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #266 
