### PR TITLE
#420: added blocks for deleting projects and wp

### DIFF
--- a/src/frontend/src/apis/projects.api.ts
+++ b/src/frontend/src/apis/projects.api.ts
@@ -61,3 +61,12 @@ export const setProjectTeam = (wbsNum: WbsNumber, teamId: string) => {
     teamId
   });
 };
+
+/**
+ * Delete a project.
+ *
+ * @param wbsNum The WBS Number of the Project being deleted.
+ */
+export const deleteProject = (wbsNumber: WbsNumber) => {
+  return axios.delete<{ message: string }>(apiUrls.projectsDelete(`${wbsPipe(wbsNumber)}`));
+};

--- a/src/frontend/src/apis/work-packages.api.ts
+++ b/src/frontend/src/apis/work-packages.api.ts
@@ -51,3 +51,12 @@ export const editWorkPackage = (payload: any) => {
     ...payload
   });
 };
+
+/**
+ * Delete a work package.
+ *
+ * @param wbsNum The WBS Number of the Work Package being deleted.
+ */
+export const deleteWorkPackage = (wbsNumber: WbsNumber) => {
+  return axios.delete<{ message: string }>(apiUrls.workPackagesDelete(`${wbsPipe(wbsNumber)}`));
+};

--- a/src/frontend/src/hooks/projects.hooks.ts
+++ b/src/frontend/src/hooks/projects.hooks.ts
@@ -10,7 +10,8 @@ import {
   createSingleProject,
   getAllProjects,
   getSingleProject,
-  setProjectTeam
+  setProjectTeam,
+  deleteProject
 } from '../apis/projects.api';
 
 /**
@@ -82,6 +83,25 @@ export const useSetProjectTeam = (wbsNum: WbsNumber) => {
       onSuccess: () => {
         queryClient.invalidateQueries(['teams']);
         queryClient.invalidateQueries(['projects', wbsNum]);
+      }
+    }
+  );
+};
+
+/**
+ * Custom React Hook to delete a work package.
+ */
+export const useDeleteProject = () => {
+  const queryClient = useQueryClient();
+  return useMutation<{ message: string }, Error, any>(
+    ['project', 'delete'],
+    async (wbsNumber: WbsNumber) => {
+      const { data } = await deleteProject(wbsNumber);
+      return data;
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(['project']);
       }
     }
   );

--- a/src/frontend/src/hooks/work-packages.hooks.ts
+++ b/src/frontend/src/hooks/work-packages.hooks.ts
@@ -7,6 +7,7 @@ import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { WorkPackage, WbsNumber } from 'shared';
 import {
   createSingleWorkPackage,
+  deleteWorkPackage,
   editWorkPackage,
   getAllWorkPackages,
   getSingleWorkPackage
@@ -62,6 +63,25 @@ export const useEditWorkPackage = (wbsNum: WbsNumber) => {
     {
       onSuccess: () => {
         queryClient.invalidateQueries(['work packages', wbsNum]);
+      }
+    }
+  );
+};
+
+/**
+ * Custom React Hook to delete a work package.
+ */
+export const useDeleteChangeRequest = () => {
+  const queryClient = useQueryClient();
+  return useMutation<{ message: string }, Error, any>(
+    ['work package', 'delete'],
+    async (wbsNumber: WbsNumber) => {
+      const { data } = await deleteWorkPackage(wbsNumber);
+      return data;
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(['work package']);
       }
     }
   );

--- a/src/frontend/src/pages/AdminToolsPage/AdminToolsPage.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/AdminToolsPage.tsx
@@ -13,8 +13,8 @@ const AdminToolsPage: React.FC = () => {
     <>
       <PageTitle title={'Admin Tools'} previousPages={[]} />
       <AdminToolsUserMangaement />
-      <AdminToolsWorkPackageMangaement />
       <AdminToolsProjectManagement />
+      <AdminToolsWorkPackageMangaement />
     </>
   );
 };

--- a/src/frontend/src/pages/AdminToolsPage/AdminToolsPage.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/AdminToolsPage.tsx
@@ -4,13 +4,17 @@
  */
 
 import PageTitle from '../../layouts/PageTitle/PageTitle';
+import AdminToolsProjectManagement from './AdminToolsProjectManagement';
 import AdminToolsUserMangaement from './AdminToolsUserManagement';
+import AdminToolsWorkPackageMangaement from './AdminToolsWorkPackageManagement';
 
 const AdminToolsPage: React.FC = () => {
   return (
     <>
       <PageTitle title={'Admin Tools'} previousPages={[]} />
       <AdminToolsUserMangaement />
+      <AdminToolsWorkPackageMangaement />
+      <AdminToolsProjectManagement />
     </>
   );
 };

--- a/src/frontend/src/pages/AdminToolsPage/AdminToolsProjectManagement.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/AdminToolsProjectManagement.tsx
@@ -1,0 +1,92 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { NERButton } from '../../components/NERButton';
+import { Grid, Typography, useTheme } from '@mui/material';
+import PageBlock from '../../layouts/PageBlock';
+import { useState } from 'react';
+import LoadingIndicator from '../../components/LoadingIndicator';
+import ErrorPage from '../ErrorPage';
+import { projectWbsPipe } from '../../utils/pipes';
+import { Project } from 'shared';
+import NERAutocomplete from '../../components/NERAutocomplete';
+import { useToast } from '../../hooks/toasts.hooks';
+import { useAllProjects } from '../../hooks/projects.hooks';
+// import { batman } from '../../../../backend/tests/test-data/users.test-data';
+// import ProjectsService from '../../../../backend/src/services/projects.services';
+
+
+const AdminToolsProjectManagement: React.FC = () => {
+  const [project, setProject] = useState<Project | null>(null);
+  const [hideSuccessLabel, setHideSuccessLabel] = useState(true);
+  const { isLoading, isError, error, data: projects } = useAllProjects();
+  const theme = useTheme();
+  const toast = useToast();
+
+  if (isLoading || !projects) return <LoadingIndicator />;
+  if (isError) return <ErrorPage message={error?.message} />;
+
+  const projectsSearchOnChange = (
+    _event: React.SyntheticEvent<Element, Event>,
+    value: { label: string; id: string } | null
+  ) => {
+    if (value) {
+      const project = projects.find((project: Project) => project.id.toString() === value.id);
+      if (project) {
+        setProject(project);
+      }
+    } else {
+      setProject(null);
+    }
+  };
+
+  const handleProjectClick = async () => {
+    setHideSuccessLabel(true);
+    if (!project) return;
+    try {
+      //await ProjectsService.deleteProject(batman, project.wbsNum);
+      setHideSuccessLabel(false);
+      setProject(null);
+    } catch (e) {
+      if (e instanceof Error) {
+        toast.error(e.message);
+      }
+    }
+  };
+
+  const projectToAutocompleteOption = (project: Project): { label: string; id: string } => {
+    return { label: `${projectWbsPipe(project.wbsNum)}`, id: project.id.toString() };
+  };
+
+  return (
+    <PageBlock title={'Project Deletion'}>
+      <Grid container spacing={2}>
+        <Grid item xs={12} md={10} sx={{ mb : 2 }}>
+          <NERAutocomplete
+            id="project-autocomplete"
+            onChange={projectsSearchOnChange}
+            options={projects.map(projectToAutocompleteOption)}
+            size="small"
+            placeholder="Type a project name in here. Or WBS number"
+            value={project ? projectToAutocompleteOption(project) : null}
+          />
+        </Grid>
+      </Grid>
+      <NERButton
+        sx={{ mt: '20px', float: 'right' }}
+        variant="contained"
+        disabled={!project}
+        onClick={handleProjectClick}
+      >
+        Delete Project
+      </NERButton>
+      <Typography hidden={hideSuccessLabel} style={{ color: theme.palette.primary.main, marginTop: '20px' }}>
+        Successfully Deleted Project
+      </Typography>
+    </PageBlock>
+  );
+};
+
+export default AdminToolsProjectManagement;

--- a/src/frontend/src/pages/AdminToolsPage/AdminToolsWorkPackageManagement.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/AdminToolsWorkPackageManagement.tsx
@@ -42,7 +42,7 @@ const AdminToolsWorkPackageMangaement: React.FC = () => {
   const handleClick = async () => {
     setHideSuccessLabel(true);
     if (!workPackage) return;
-    // if (!auth.user) return <LoadingIndicator />;
+    if (!auth.user) return <LoadingIndicator />;
     try {
       //await WorkPackagesService.deleteWorkPackage({ ...auth.user, googleAuthId: 'testGoogleAuthId' }, workPackage.wbsNum);
       setHideSuccessLabel(false);

--- a/src/frontend/src/pages/AdminToolsPage/AdminToolsWorkPackageManagement.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/AdminToolsWorkPackageManagement.tsx
@@ -1,0 +1,87 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { NERButton } from '../../components/NERButton';
+import { Grid, Typography, useTheme } from '@mui/material';
+import PageBlock from '../../layouts/PageBlock';
+import { useState } from 'react';
+import LoadingIndicator from '../../components/LoadingIndicator';
+import ErrorPage from '../ErrorPage';
+import { wbsPipe, WorkPackage } from 'shared';
+import NERAutocomplete from '../../components/NERAutocomplete';
+import { useToast } from '../../hooks/toasts.hooks';
+import { useAllWorkPackages } from '../../hooks/work-packages.hooks';
+//import WorkPackagesService from '../../../../backend/src/services/work-packages.services';
+import { useAuth } from '../../hooks/auth.hooks';
+
+const AdminToolsWorkPackageMangaement: React.FC = () => {
+  const auth = useAuth();
+  const [workPackage, setWorkPackage] = useState<WorkPackage | null>(null);
+  const [hideSuccessLabel, setHideSuccessLabel] = useState(true);
+  const { isLoading, isError, error, data: workPackages } = useAllWorkPackages();
+  const theme = useTheme();
+  const toast = useToast();
+
+  if (isLoading || !workPackages) return <LoadingIndicator />;
+  if (isError) return <ErrorPage message={error?.message} />;
+
+  const workPackageSearchOnChange = (
+    _event: React.SyntheticEvent<Element, Event>,
+    value: { label: string; id: string } | null
+  ) => {
+    if (value) {
+      const workPackage = workPackages.find((wp: WorkPackage) => wp.id.toString() === value.id);
+      if (workPackage) {
+        setWorkPackage(workPackage);
+      }
+    } else {
+      setWorkPackage(null);
+    }
+  };
+
+  const handleClick = async () => {
+    setHideSuccessLabel(true);
+    if (!workPackage) return;
+    // if (!auth.user) return <LoadingIndicator />;
+    try {
+      //await WorkPackagesService.deleteWorkPackage({ ...auth.user, googleAuthId: 'testGoogleAuthId' }, workPackage.wbsNum);
+      setHideSuccessLabel(false);
+      setWorkPackage(null);
+    } catch (e) {
+      if (e instanceof Error) {
+        toast.error(e.message);
+      }
+    }
+  };
+
+  const workPackageToAutocompleteOption = (workPackage: WorkPackage): { label: string; id: string } => {
+    return { label: `${wbsPipe(workPackage.wbsNum)}`, id: workPackage.id.toString() };
+  };
+
+  return (
+    <PageBlock title={'Work Package Deletion'}>
+      <Grid container spacing={2}>
+        <Grid item xs={12} md={8}>
+          <NERAutocomplete
+            id="work-package-autocomplete"
+            onChange={workPackageSearchOnChange}
+            options={workPackages.map(workPackageToAutocompleteOption)}
+            size="small"
+            placeholder="Select a Work Package"
+            value={workPackage ? workPackageToAutocompleteOption(workPackage) : null}
+          />
+        </Grid>
+      </Grid>
+      <NERButton sx={{ mt: '20px', float: 'right' }} variant="contained" disabled={!workPackage} onClick={handleClick}>
+        Delete Work Package
+      </NERButton>
+      <Typography hidden={hideSuccessLabel} style={{ color: theme.palette.primary.main, marginTop: '20px' }}>
+        Successfully Deleted Work Package
+      </Typography>
+    </PageBlock>
+  );
+};
+
+export default AdminToolsWorkPackageMangaement;

--- a/src/frontend/src/pages/AdminToolsPage/AdminToolsWorkPackageManagement.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/AdminToolsWorkPackageManagement.tsx
@@ -14,10 +14,8 @@ import NERAutocomplete from '../../components/NERAutocomplete';
 import { useToast } from '../../hooks/toasts.hooks';
 import { useAllWorkPackages } from '../../hooks/work-packages.hooks';
 //import WorkPackagesService from '../../../../backend/src/services/work-packages.services';
-import { useAuth } from '../../hooks/auth.hooks';
 
 const AdminToolsWorkPackageMangaement: React.FC = () => {
-  const auth = useAuth();
   const [workPackage, setWorkPackage] = useState<WorkPackage | null>(null);
   const [hideSuccessLabel, setHideSuccessLabel] = useState(true);
   const { isLoading, isError, error, data: workPackages } = useAllWorkPackages();

--- a/src/frontend/src/pages/AdminToolsPage/AdminToolsWorkPackageManagement.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/AdminToolsWorkPackageManagement.tsx
@@ -13,6 +13,7 @@ import { wbsPipe, WorkPackage } from 'shared';
 import NERAutocomplete from '../../components/NERAutocomplete';
 import { useToast } from '../../hooks/toasts.hooks';
 import { useAllWorkPackages } from '../../hooks/work-packages.hooks';
+import { useAuth } from '../../hooks/auth.hooks';
 //import WorkPackagesService from '../../../../backend/src/services/work-packages.services';
 
 const AdminToolsWorkPackageMangaement: React.FC = () => {
@@ -21,6 +22,7 @@ const AdminToolsWorkPackageMangaement: React.FC = () => {
   const { isLoading, isError, error, data: workPackages } = useAllWorkPackages();
   const theme = useTheme();
   const toast = useToast();
+  const auth = useAuth();
 
   if (isLoading || !workPackages) return <LoadingIndicator />;
   if (isError) return <ErrorPage message={error?.message} />;

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
@@ -66,7 +66,13 @@ const ProjectViewContainer: React.FC<ProjectViewContainerProps> = ({ proj, enter
     handleDropdownClose();
   };
 
+  const handleClickDelete = async () => {
+
+  };
+
   const isGuest = auth.user.role === 'GUEST';
+
+  const isAdmin = auth.user.role === 'ADMIN' || auth.user.role === 'APP_ADMIN';
 
   const editBtn = (
     <MenuItem onClick={handleClickEdit} disabled={isGuest}>
@@ -91,6 +97,12 @@ const ProjectViewContainer: React.FC<ProjectViewContainerProps> = ({ proj, enter
     </MenuItem>
   );
 
+  const deleteButton = (
+    <MenuItem onClick={handleClickDelete} disabled={!isAdmin}>
+      Delete
+    </MenuItem>
+  );
+
   const projectActionsDropdown = (
     <div>
       <NERButton
@@ -105,6 +117,7 @@ const ProjectViewContainer: React.FC<ProjectViewContainerProps> = ({ proj, enter
         {editBtn}
         {createCRBtn}
         {teamAsLeadId && assignToMyTeamButton}
+        {deleteButton}
       </Menu>
     </div>
   );

--- a/src/frontend/src/utils/urls.ts
+++ b/src/frontend/src/utils/urls.ts
@@ -23,6 +23,7 @@ const projectsByWbsNum = (wbsNum: string) => `${projects()}/${wbsNum}`;
 const projectsCreate = () => `${projects()}/create`;
 const projectsEdit = () => `${projects()}/edit`;
 const projectsSetTeam = (wbsNum: string) => `${projects()}/${wbsNum}/set-team`;
+const projectsDelete = (wbsNum: string) => projectsByWbsNum(wbsNum) + '/delete';
 
 /**************** Risks Endpoints ********************/
 const risks = () => `${API_URL}/risks`;
@@ -42,6 +43,7 @@ const workPackages = (queryParams?: { [field: string]: string }) => {
 const workPackagesByWbsNum = (wbsNum: string) => `${workPackages()}/${wbsNum}`;
 const workPackagesCreate = () => `${workPackages()}/create`;
 const workPackagesEdit = () => `${workPackages()}/edit`;
+const workPackagesDelete = (wbsNum: string) => workPackagesByWbsNum(wbsNum) + '/delete';
 
 /**************** Change Requests Endpoints ****************/
 const changeRequests = () => `${API_URL}/change-requests`;
@@ -80,6 +82,7 @@ export const apiUrls = {
   projectsCreate,
   projectsEdit,
   projectsSetTeam,
+  projectsDelete,
 
   risks,
   risksByProjectId,
@@ -91,6 +94,7 @@ export const apiUrls = {
   workPackagesByWbsNum,
   workPackagesCreate,
   workPackagesEdit,
+  workPackagesDelete,
 
   changeRequests,
   changeRequestsById,


### PR DESCRIPTION
## Changes
Added blocks in the admin tools page to delete a project and a Work Package

## Notes

Need to actually delete them on the button click
Passing batman into the service function because I do not know how to get the user who is clicking the button



## To Do

_Any remaining things that need to get done_

- [ ] call delete properly

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #420
