### PR TITLE
Updating rgba values of today bar

### DIFF
--- a/src/frontend/src/pages/GanttPage/GanttPackage/components/gantt/gantt.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttPackage/components/gantt/gantt.tsx
@@ -47,7 +47,7 @@ export const Gantt: React.FunctionComponent<GanttProps> = ({
   fontFamily = 'Arial, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue',
   fontSize = '14px',
   arrowIndent = 20,
-  todayColor = 'rgba(252, 248, 227, 0.5)',
+  todayColor = 'rgba(3, 152, 252, .25)',
   viewDate,
   TooltipContent = StandardTooltipContent,
   TaskListHeader = TaskListHeaderDefault,


### PR DESCRIPTION
## Changes

Refactored the rgba values to updated blue color

## Screenshots
The updated chart, note the blue color under the today column 
<img width="960" alt="GanttColorChange" src="https://user-images.githubusercontent.com/91036922/221437886-48c0dd84-9b8e-45a5-8881-7a97e073f32c.PNG">
## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [X] All commits are tagged with the ticket number
- [X] No linting errors / newline at end of file warnings
- [X] All code follows repository-configured prettier formatting
- [X] No merge conflicts
- [X] All checks passing
- [X] Screenshots of UI changes (see Screenshots section)
- [X] Remove any non-applicable sections of this template
- [X] Assign the PR to yourself
- [X] No `yarn.lock` changes (unless dependencies have changed)
- [X] Request reviewers & ping on Slack
- [X] PR is linked to the ticket (fill in the closes line below)

Closes #815 
