### PR TITLE
#842 Remove Leftoer budget from SG Details

### DIFF
--- a/src/frontend/src/pages/ChangeRequestDetailPage/StageGateDetails.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/StageGateDetails.tsx
@@ -5,7 +5,7 @@
 
 import { Grid, Typography } from '@mui/material';
 import { StageGateChangeRequest } from 'shared';
-import { booleanPipe, dollarsPipe } from '../../utils/pipes';
+import { booleanPipe } from '../../utils/pipes';
 import PageBlock from '../../layouts/PageBlock';
 
 interface StageGateDetailsProps {
@@ -16,17 +16,11 @@ const StageGateDetails: React.FC<StageGateDetailsProps> = ({ cr }) => {
   return (
     <PageBlock title={'Stage Gate Change Request Details'}>
       <Grid container spacing={1}>
-        <Grid item xs={2}>
-          <Typography sx={{ maxWidth: '140px', fontWeight: 'bold' }}>Leftover Budget</Typography>
+        <Grid item xs={3}>
+          <Typography sx={{ fontWeight: 'bold' }}>Confirm WP Completed</Typography>
         </Grid>
-        <Grid item xs={10}>
-          <Typography sx={{ maxWidth: '140px' }}>{dollarsPipe(cr.leftoverBudget)}</Typography>
-        </Grid>
-        <Grid item xs={2}>
-          <Typography sx={{ maxWidth: '140px', fontWeight: 'bold' }}>Confirm WP Completed</Typography>
-        </Grid>
-        <Grid item xs={10}>
-          <Typography sx={{ maxWidth: '140px' }}>{booleanPipe(cr.confirmDone)}</Typography>
+        <Grid item xs={9}>
+          <Typography>{booleanPipe(cr.confirmDone)}</Typography>
         </Grid>
       </Grid>
     </PageBlock>

--- a/src/frontend/src/tests/pages/ChangeRequestDetailPage/StageGateDetails.test.tsx
+++ b/src/frontend/src/tests/pages/ChangeRequestDetailPage/StageGateDetails.test.tsx
@@ -21,7 +21,5 @@ describe('Change request details stage gate cr display element tests', () => {
     renderComponent(cr);
     expect(screen.getByText(`Confirm WP Completed`)).toBeInTheDocument();
     expect(screen.getByText(`${cr.confirmDone ? 'YES' : 'NO'}`)).toBeInTheDocument();
-    expect(screen.getByText(`Leftover Budget`)).toBeInTheDocument();
-    expect(screen.getByText(`$${cr.leftoverBudget}`)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Changes

Remove the leftover budget part of stage gate details

## Notes

I made it so that Work Package Done is on one line by removing max width, dont know why we need max width when using a grid?

## Screenshots
<img width="525" alt="Screen Shot 2023-03-01 at 11 31 37 AM" src="https://user-images.githubusercontent.com/113635669/222202599-2de23721-dec7-4323-a566-f2646d1687bb.png">

<img width="1317" alt="Screen Shot 2023-03-01 at 11 30 04 AM" src="https://user-images.githubusercontent.com/113635669/222202624-13797b47-8f1e-4101-9749-610d88a8f576.png">


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #842  (issue #)
