### PR TITLE
#944: allow neg vals in TLI and Budget

### DIFF
--- a/src/backend/src/routes/change-requests.routes.ts
+++ b/src/backend/src/routes/change-requests.routes.ts
@@ -75,8 +75,8 @@ changeRequestsRouter.post(
   intMinZero(body('crId')),
   nonEmptyString(body('description')),
   nonEmptyString(body('scopeImpact')),
-  intMinZero(body('timelineImpact')),
-  intMinZero(body('budgetImpact')),
+  body('timelineImpact').isInt(),
+  body('budgetImpact').isInt(),
   validateInputs,
   ChangeRequestsController.addProposedSolution
 );

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionForm.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionForm.tsx
@@ -27,14 +27,12 @@ const schema = yup.object().shape({
   budgetImpact: yup
     .number()
     .typeError('Budget Impact must be a number')
-    .min(0, 'Budget Impact must be greater than or equal to $0')
     .required('Budget Impact is required')
     .integer('Budget Impact must be an integer'),
   scopeImpact: yup.string().required('Scope Impact is required'),
   timelineImpact: yup
     .number()
     .typeError('Timeline Impact must be a number')
-    .min(0, 'Timeline Impact must be greater than or equal to 0 weeks')
     .required('Timeline Impact is required')
     .integer('Timeline Impact must be an integer')
 });

--- a/src/frontend/src/pages/CreateChangeRequestPage/CreateChangeRequest.tsx
+++ b/src/frontend/src/pages/CreateChangeRequestPage/CreateChangeRequest.tsx
@@ -13,6 +13,7 @@ import ErrorPage from '../ErrorPage';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import CreateChangeRequestsView from './CreateChangeRequestView';
 import { useState } from 'react';
+import { useToast } from '../../hooks/toasts.hooks';
 
 interface CreateChangeRequestProps {}
 
@@ -35,6 +36,7 @@ const CreateChangeRequest: React.FC<CreateChangeRequestProps> = () => {
   } = useCreateProposeSolution();
   const [proposedSolutions, setProposedSolutions] = useState<ProposedSolution[]>([]);
   const [wbsNum, setWbsNum] = useState(query.get('wbsNum') || '');
+  const toast = useToast();
 
   if (isLoading || cpsIsLoading || !auth.user) return <LoadingIndicator />;
   if (isError) return <ErrorPage message={error?.message} />;
@@ -51,14 +53,20 @@ const CreateChangeRequest: React.FC<CreateChangeRequestProps> = () => {
     const crId = parseInt(cr.message);
     proposedSolutions.forEach(async (ps) => {
       const { description, timelineImpact, scopeImpact, budgetImpact } = ps;
-      await cpsMutateAsync({
-        crId,
-        submitterId: userId,
-        description,
-        timelineImpact,
-        scopeImpact,
-        budgetImpact
-      });
+      try {
+        await cpsMutateAsync({
+          crId,
+          submitterId: userId,
+          description,
+          timelineImpact,
+          scopeImpact,
+          budgetImpact
+        });
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          toast.error(error.message);
+        }
+      }
     });
 
     history.push(routes.CHANGE_REQUESTS);


### PR DESCRIPTION
## Changes

Fixed the bug that wouldn't allow for negative values in timelineimpact and budgetimpact

## Test Cases
- Put a negative TLI and BI

## Screenshots
<img width="1009" alt="Screen Shot 2023-03-03 at 2 38 35 AM" src="https://user-images.githubusercontent.com/122840604/222660283-23d54e73-1d46-4691-82de-12229189f74d.png">


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #944
