### PR TITLE
#738: Added X button to Review CR Modal UI

### DIFF
--- a/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequestView.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequestView.tsx
@@ -10,10 +10,21 @@ import { FormInput } from './ReviewChangeRequest';
 import { ChangeRequest, ProposedSolution, StandardChangeRequest } from 'shared';
 import { useState } from 'react';
 import ProposedSolutionSelectItem from './ProposedSolutionSelectItem';
-import { Dialog, DialogActions, DialogContent, DialogTitle, Box, TextField, Typography, Breakpoint } from '@mui/material';
+import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Box,
+  TextField,
+  Typography,
+  Breakpoint,
+  IconButton
+} from '@mui/material';
 import { useToast } from '../../hooks/toasts.hooks';
 import NERSuccessButton from '../../components/NERSuccessButton';
 import NERFailButton from '../../components/NERFailButton';
+import CloseIcon from '@mui/icons-material/Close';
 
 interface ReviewChangeRequestViewProps {
   cr: ChangeRequest;
@@ -77,6 +88,18 @@ const ReviewChangeRequestsView: React.FC<ReviewChangeRequestViewProps> = ({
   const renderProposedSolutionModal: (scr: StandardChangeRequest) => JSX.Element = (scr: StandardChangeRequest) => {
     return (
       <Dialog fullWidth maxWidth={dialogWidth} open={modalShow} onClose={onHide} style={{ color: 'black' }}>
+        <IconButton
+          aria-label="close"
+          onClick={onHide}
+          sx={{
+            position: 'absolute',
+            right: 8,
+            top: 8,
+            color: (theme) => theme.palette.grey[500]
+          }}
+        >
+          <CloseIcon />
+        </IconButton>
         <DialogTitle className={'font-weight-bold'}>{`Review Change Request #${cr.crId}`}</DialogTitle>
         <DialogContent
           sx={{

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequestView.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequestView.tsx
@@ -191,6 +191,18 @@ const ReviewChangeRequestsView: React.FC<ReviewChangeRequestViewProps> = ({
   const renderModal: () => JSX.Element = () => {
     return (
       <Dialog fullWidth maxWidth={dialogWidth} open={modalShow} onClose={onHide}>
+        <IconButton
+          aria-label="close"
+          onClick={onHide}
+          sx={{
+            position: 'absolute',
+            right: 8,
+            top: 8,
+            color: (theme) => theme.palette.grey[500]
+          }}
+        >
+          <CloseIcon />
+        </IconButton>
         <DialogTitle className={'font-weight-bold'}>{`Review Change Request #${cr.crId}`}</DialogTitle>
         <DialogContent>
           <form id={'review-notes-form'} onSubmit={handleSubmit(onSubmitWrapper)}>


### PR DESCRIPTION
## Changes

Added CloseIcon button to Review CR Modal UI in the ReviewChangeRequestView.tsx file.

## Notes

Copied code for CloseIcon button from the DeleteChangeRequestView.tsx file.

## Test Cases

- Ran yarn:test frontend + backend
- Manually tested on FinishLine

## Screenshots

<img width="1010" alt="Screen Shot 2023-03-03 at 2 54 26 AM" src="https://user-images.githubusercontent.com/60333735/222663277-2486c4f3-62e3-48e4-a2b7-a75ad181a72d.png">

<img width="896" alt="Screen Shot 2023-03-03 at 2 53 33 AM" src="https://user-images.githubusercontent.com/60333735/222663160-8143d249-d9fc-426d-9144-48158b2a1324.png">

## To Do

Not sure if I should add anything to 'const renderModal'?

<img width="922" alt="Screen Shot 2023-03-03 at 2 55 56 AM" src="https://user-images.githubusercontent.com/60333735/222663627-687c33e4-2464-4f6b-9cb9-d562cac2e763.png">

## Checklist

- [X] All commits are tagged with the ticket number
- [X] No linting errors / newline at end of file warnings
- [X] All code follows repository-configured prettier formatting
- [X] No merge conflicts
- [X] All checks passing
- [X] Screenshots of UI changes (see Screenshots section)
- [X] Remove any non-applicable sections of this template
- [X] Assign the PR to yourself
- [X] No `yarn.lock` changes (unless dependencies have changed)
- [X] Request reviewers & ping on Slack
- [X] PR is linked to the ticket (fill in the closes line below)

Closes #738 
