### PR TITLE
#956 - Remove Task List Loading Indicator With No Team

### DIFF
--- a/src/frontend/src/hooks/tasks.hooks.ts
+++ b/src/frontend/src/hooks/tasks.hooks.ts
@@ -7,7 +7,7 @@ import { useMutation, useQueryClient } from 'react-query';
 import { WbsNumber, TaskPriority, TaskStatus } from 'shared';
 import { createSingleTask, deleteSingleTask, editSingleTaskStatus, editTask, editTaskAssignees } from '../apis/tasks.api';
 
-interface CreateTaskPayload {
+export interface CreateTaskPayload {
   title: string;
   deadline: string;
   priority: TaskPriority;
@@ -38,7 +38,7 @@ export const useCreateTask = (wbsNum: WbsNumber) => {
   );
 };
 
-interface TaskPayload {
+export interface TaskPayload {
   taskId: string;
   notes: string;
   title: string;
@@ -113,7 +113,7 @@ export const useSetTaskStatus = () => {
   );
 };
 
-interface DeleteTaskPayload {
+export interface DeleteTaskPayload {
   taskId: string;
 }
 

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
@@ -134,7 +134,7 @@ const ProjectViewContainer: React.FC<ProjectViewContainerProps> = ({ proj, enter
     </div>
   );
 
-  const hasTaskPermissions =
+  const createTaskPermissions =
     !(auth.user.role === 'GUEST' && !proj.team?.members.map((user) => user.userId).includes(auth.user.userId)) &&
     !(
       auth.user.role === 'MEMBER' &&
@@ -150,7 +150,12 @@ const ProjectViewContainer: React.FC<ProjectViewContainerProps> = ({ proj, enter
         actionButton={projectActionsDropdown}
       />
       <ProjectDetails project={proj} />
-      <TaskList tasks={proj.tasks} team={proj.team} hasTaskPermissions={hasTaskPermissions} currentWbsNumber={proj.wbsNum} />
+      <TaskList
+        tasks={proj.tasks}
+        team={proj.team}
+        hasTaskPermissions={createTaskPermissions}
+        currentWbsNumber={proj.wbsNum}
+      />
       <PageBlock title={'Summary'}>{proj.summary}</PageBlock>
       <RiskLog projectId={proj.id} wbsNum={proj.wbsNum} projLead={proj.projectLead} projManager={proj.projectManager} />
       <ProjectGantt workPackages={proj.workPackages} />

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
@@ -134,14 +134,6 @@ const ProjectViewContainer: React.FC<ProjectViewContainerProps> = ({ proj, enter
     </div>
   );
 
-  const createTaskPermissions =
-    !(auth.user.role === 'GUEST' && !proj.team?.members.map((user) => user.userId).includes(auth.user.userId)) &&
-    !(
-      auth.user.role === 'MEMBER' &&
-      (proj.projectLead?.userId !== auth.user.userId || proj.projectManager?.userId !== auth.user.userId) &&
-      !(proj.team?.leader.userId === auth.user.userId)
-    );
-
   return (
     <>
       <PageTitle
@@ -150,12 +142,7 @@ const ProjectViewContainer: React.FC<ProjectViewContainerProps> = ({ proj, enter
         actionButton={projectActionsDropdown}
       />
       <ProjectDetails project={proj} />
-      <TaskList
-        tasks={proj.tasks}
-        team={proj.team}
-        createTaskPermissions={createTaskPermissions}
-        currentWbsNumber={proj.wbsNum}
-      />
+      <TaskList project={proj} />
       <PageBlock title={'Summary'}>{proj.summary}</PageBlock>
       <RiskLog projectId={proj.id} wbsNum={proj.wbsNum} projLead={proj.projectLead} projManager={proj.projectManager} />
       <ProjectGantt workPackages={proj.workPackages} />

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
@@ -153,7 +153,7 @@ const ProjectViewContainer: React.FC<ProjectViewContainerProps> = ({ proj, enter
       <TaskList
         tasks={proj.tasks}
         team={proj.team}
-        hasTaskPermissions={createTaskPermissions}
+        createTaskPermissions={createTaskPermissions}
         currentWbsNumber={proj.wbsNum}
       />
       <PageBlock title={'Summary'}>{proj.summary}</PageBlock>

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList.tsx
@@ -14,12 +14,12 @@ interface TaskListProps {
   tasks: Task[];
   team?: TeamPreview;
   defaultClosed?: boolean;
-  hasTaskPermissions: boolean;
+  createTaskPermissions: boolean;
   currentWbsNumber: WbsNumber;
 }
 
 // Page block containing task list view
-const TaskList = ({ tasks, currentWbsNumber, defaultClosed, team, hasTaskPermissions }: TaskListProps) => {
+const TaskList = ({ tasks, currentWbsNumber, defaultClosed, team, createTaskPermissions }: TaskListProps) => {
   const taskListTitle: string = 'Task List';
 
   const [value, setValue] = useState<number>(1);
@@ -36,7 +36,7 @@ const TaskList = ({ tasks, currentWbsNumber, defaultClosed, team, hasTaskPermiss
   const addTaskButton: JSX.Element = (
     <Button
       variant="outlined"
-      disabled={!hasTaskPermissions || !team}
+      disabled={!createTaskPermissions || !team}
       startIcon={<AddTask />}
       sx={{
         height: 32,
@@ -68,7 +68,7 @@ const TaskList = ({ tasks, currentWbsNumber, defaultClosed, team, hasTaskPermiss
         onAddCancel={() => setAddTask(false)}
         currentWbsNumber={currentWbsNumber}
         team={team}
-        hasTaskPermissions={hasTaskPermissions}
+        hasTaskPermissions={createTaskPermissions}
       />
       <TaskListTabPanel
         tasks={inProgressTasks}
@@ -79,7 +79,7 @@ const TaskList = ({ tasks, currentWbsNumber, defaultClosed, team, hasTaskPermiss
         onAddCancel={() => setAddTask(false)}
         currentWbsNumber={currentWbsNumber}
         team={team}
-        hasTaskPermissions={hasTaskPermissions}
+        hasTaskPermissions={createTaskPermissions}
       />
 
       <TaskListTabPanel
@@ -88,7 +88,7 @@ const TaskList = ({ tasks, currentWbsNumber, defaultClosed, team, hasTaskPermiss
         index={2}
         status={TaskStatus.DONE}
         team={team}
-        hasTaskPermissions={hasTaskPermissions}
+        hasTaskPermissions={createTaskPermissions}
         addTask={addTask}
         onAddCancel={() => setAddTask(false)}
         currentWbsNumber={currentWbsNumber}

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList.tsx
@@ -7,9 +7,12 @@ import { AddTask } from '@mui/icons-material';
 import { Box, Button, Tab, Tabs } from '@mui/material';
 import { useState } from 'react';
 import { Project, Task, TaskStatus } from 'shared';
+import LoadingIndicator from '../../../components/LoadingIndicator';
 import { useAuth } from '../../../hooks/auth.hooks';
 import PageBlock from '../../../layouts/PageBlock';
 import TaskListTabPanel from './TaskListTabPanel';
+
+const TASK_LIST_TITLE: string = 'Task List';
 
 interface TaskListProps {
   project: Project;
@@ -18,8 +21,6 @@ interface TaskListProps {
 
 // Page block containing task list view
 const TaskList = ({ project, defaultClosed }: TaskListProps) => {
-  const taskListTitle: string = 'Task List';
-
   const auth = useAuth();
   const [value, setValue] = useState<number>(1);
   const [addTask, setAddTask] = useState(false);
@@ -29,11 +30,13 @@ const TaskList = ({ project, defaultClosed }: TaskListProps) => {
   const inProgressTasks = tasks.filter((task: Task) => task.status === TaskStatus.IN_PROGRESS);
   const doneTasks = tasks.filter((task: Task) => task.status === TaskStatus.DONE);
 
-  const handleTabChange = (event: React.SyntheticEvent, newValue: number): void => {
+  const handleTabChange = (_event: React.SyntheticEvent, newValue: number): void => {
     setValue(newValue);
   };
 
-  const user = auth.user!;
+  const { user } = auth;
+  if (!user) return <LoadingIndicator />;
+
   const createTaskPermissions =
     !(user.role === 'GUEST' && !project.team?.members.map((user) => user.userId).includes(user.userId)) &&
     !(
@@ -60,7 +63,7 @@ const TaskList = ({ project, defaultClosed }: TaskListProps) => {
   );
 
   return (
-    <PageBlock title={taskListTitle} headerRight={addTaskButton} defaultClosed={defaultClosed}>
+    <PageBlock title={TASK_LIST_TITLE} headerRight={addTaskButton} defaultClosed={defaultClosed}>
       <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
         <Tabs value={value} onChange={handleTabChange} variant="fullWidth" aria-label="task-list-tabs">
           <Tab label="In Backlog" aria-label="in-backlog" />

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList.tsx
@@ -6,9 +6,7 @@
 import { Box, Button, Tab, Tabs } from '@mui/material';
 import { useState } from 'react';
 import PageBlock from '../../../layouts/PageBlock';
-import { useAuth } from '../../../hooks/auth.hooks';
 import { AddTask } from '@mui/icons-material';
-import { Auth } from '../../../utils/types';
 import TaskListTabPanel from './TaskListTabPanel';
 import { Task, TaskStatus, WbsNumber, TeamPreview } from 'shared';
 
@@ -22,7 +20,6 @@ interface TaskListProps {
 
 // Page block containing task list view
 const TaskList = ({ tasks, currentWbsNumber, defaultClosed, team, hasTaskPermissions }: TaskListProps) => {
-  const auth: Auth = useAuth();
   const taskListTitle: string = 'Task List';
 
   const [value, setValue] = useState<number>(1);
@@ -36,12 +33,10 @@ const TaskList = ({ tasks, currentWbsNumber, defaultClosed, team, hasTaskPermiss
     setValue(newValue);
   };
 
-  const disableAddTask: boolean = auth.user?.role === 'GUEST' || !team;
-
   const addTaskButton: JSX.Element = (
     <Button
       variant="outlined"
-      disabled={disableAddTask}
+      disabled={!hasTaskPermissions}
       startIcon={<AddTask />}
       sx={{
         height: 32,

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList.tsx
@@ -36,7 +36,7 @@ const TaskList = ({ tasks, currentWbsNumber, defaultClosed, team, hasTaskPermiss
   const addTaskButton: JSX.Element = (
     <Button
       variant="outlined"
-      disabled={!hasTaskPermissions}
+      disabled={!hasTaskPermissions || !team}
       startIcon={<AddTask />}
       sx={{
         height: 32,

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList.tsx
@@ -36,10 +36,12 @@ const TaskList = ({ tasks, currentWbsNumber, defaultClosed, team, hasTaskPermiss
     setValue(newValue);
   };
 
+  const disableAddTask: boolean = auth.user?.role === 'GUEST' || !team;
+
   const addTaskButton: JSX.Element = (
     <Button
       variant="outlined"
-      disabled={auth.user?.role === 'GUEST'}
+      disabled={disableAddTask}
       startIcon={<AddTask />}
       sx={{
         height: 32,

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskListNotesModal.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskListNotesModal.tsx
@@ -40,7 +40,7 @@ interface TaskListNotesModalProps {
   modalShow: boolean;
   onHide: () => void;
   onSubmit: (data: FormInput) => Promise<void>;
-  hasTaskPermissions: boolean;
+  hasEditPermissions: boolean;
 }
 
 export interface FormInput {
@@ -66,7 +66,7 @@ const TaskListNotesModal: React.FC<TaskListNotesModalProps> = ({
   modalShow,
   onHide,
   onSubmit,
-  hasTaskPermissions
+  hasEditPermissions
 }: TaskListNotesModalProps) => {
   const auth = useAuth();
   const theme = useTheme();
@@ -121,7 +121,7 @@ const TaskListNotesModal: React.FC<TaskListNotesModalProps> = ({
           <IconButton
             onClick={() => setIsEditMode(true)}
             aria-label="edit"
-            disabled={!hasTaskPermissions}
+            disabled={!hasEditPermissions}
             sx={{
               position: 'absolute',
               right: 40,

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskListTabPanel.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskListTabPanel.tsx
@@ -162,13 +162,14 @@ const TaskListTabPanel = (props: TaskListTabPanelProps) => {
   const editTaskPermissions = (user: User | undefined, task: Task, proj: Project): boolean => {
     if (!user) return false;
     return (
-      user.role === 'APP_ADMIN' ||
-      user.role === 'ADMIN' ||
-      user.role === 'LEADERSHIP' ||
-      proj.projectLead?.userId === user.userId ||
-      proj.projectManager?.userId === user.userId ||
-      task.assignees.map((u) => u.userId).includes(user.userId) ||
-      task.createdBy.userId === user.userId
+      (user.role === 'APP_ADMIN' ||
+        user.role === 'ADMIN' ||
+        user.role === 'LEADERSHIP' ||
+        proj.projectLead?.userId === user.userId ||
+        proj.projectManager?.userId === user.userId ||
+        task.assignees.map((u) => u.userId).includes(user.userId) ||
+        task.createdBy.userId === user.userId) ??
+      false
     );
   };
 

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskListTabPanel.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskListTabPanel.tsx
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { Autocomplete, Box, Link, TextField, Typography, useTheme } from '@mui/material';
+import { Autocomplete, Box, Link, SxProps, TextField, Typography, useTheme } from '@mui/material';
 import {
   DataGrid,
   GridActionsCellItem,
@@ -144,7 +144,11 @@ const TaskListTabPanel = (props: TaskListTabPanelProps) => {
     [assignees]
   );
 
-  if (isLoading || assigneeIsLoading || !auth.user || !team) return <LoadingIndicator />;
+  const failMessageStyle: SxProps = { py: '25px', textAlign: 'center' };
+
+  if (isLoading || assigneeIsLoading || !auth.user) return <LoadingIndicator />;
+  if (!team)
+    return <>{value === index && <Typography sx={failMessageStyle}>No team assigned to this project!</Typography>}</>;
   if (isError) return <ErrorPage message={error?.message} />;
   if (assigneeIsError) return <ErrorPage message={assigneeError?.message} />;
 

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskListTabPanel.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskListTabPanel.tsx
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { Autocomplete, Box, Link, SxProps, TextField, Typography, useTheme } from '@mui/material';
+import { Autocomplete, Box, Link, TextField, Typography, useTheme } from '@mui/material';
 import {
   DataGrid,
   GridActionsCellItem,
@@ -144,11 +144,17 @@ const TaskListTabPanel = (props: TaskListTabPanelProps) => {
     [assignees]
   );
 
-  const failMessageStyle: SxProps = { py: '25px', textAlign: 'center' };
-
   if (isLoading || assigneeIsLoading || !auth.user) return <LoadingIndicator />;
   if (!team)
-    return <>{value === index && <Typography sx={failMessageStyle}>No team assigned to this project!</Typography>}</>;
+    return (
+      <>
+        {value === index && (
+          <Typography sx={{ py: '25px', textAlign: 'center' }}>
+            A project can only have tasks if it is assigned to a team!
+          </Typography>
+        )}
+      </>
+    );
   if (isError) return <ErrorPage message={error?.message} />;
   if (assigneeIsError) return <ErrorPage message={assigneeError?.message} />;
 

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskListTabPanel.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskListTabPanel.tsx
@@ -3,6 +3,11 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
+import CheckIcon from '@mui/icons-material/Check';
+import DeleteIcon from '@mui/icons-material/Delete';
+import PauseIcon from '@mui/icons-material/Pause';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import SaveIcon from '@mui/icons-material/Save';
 import { Autocomplete, Box, Link, TextField, Typography, useTheme } from '@mui/material';
 import {
   DataGrid,
@@ -15,18 +20,10 @@ import {
   GridRowParams,
   useGridApiContext
 } from '@mui/x-data-grid';
-import { Task, TaskPriority, TaskStatus, UserPreview, WbsNumber, TeamPreview, User } from 'shared';
-import { fullNamePipe } from '../../../utils/pipes';
-import { GridColDefStyle } from '../../../utils/tables';
-import PauseIcon from '@mui/icons-material/Pause';
-import DeleteIcon from '@mui/icons-material/Delete';
-import PlayArrowIcon from '@mui/icons-material/PlayArrow';
-import CheckIcon from '@mui/icons-material/Check';
-import SaveIcon from '@mui/icons-material/Save';
-import { useAuth } from '../../../hooks/auth.hooks';
-import LoadingIndicator from '../../../components/LoadingIndicator';
 import React, { useState } from 'react';
-import TaskListNotesModal, { FormInput } from './TaskListNotesModal';
+import { Project, Task, TaskPriority, TaskStatus, User, UserPreview } from 'shared';
+import LoadingIndicator from '../../../components/LoadingIndicator';
+import { useAuth } from '../../../hooks/auth.hooks';
 import {
   useCreateTask,
   useDeleteTask,
@@ -34,8 +31,11 @@ import {
   useEditTaskAssignees,
   useSetTaskStatus
 } from '../../../hooks/tasks.hooks';
-import ErrorPage from '../../ErrorPage';
 import { useToast } from '../../../hooks/toasts.hooks';
+import { fullNamePipe } from '../../../utils/pipes';
+import { GridColDefStyle } from '../../../utils/tables';
+import ErrorPage from '../../ErrorPage';
+import TaskListNotesModal, { FormInput } from './TaskListNotesModal';
 
 //this is needed to fix some weird bug with getActions()
 //see comment by michaldudak commented on Dec 5, 2022
@@ -53,13 +53,11 @@ declare global {
 interface TaskListTabPanelProps {
   index: number;
   value: number;
+  project: Project;
   tasks: Task[];
-  team?: TeamPreview;
   status: TaskStatus;
   addTask: boolean;
   onAddCancel: () => void;
-  currentWbsNumber: WbsNumber;
-  hasTaskPermissions: boolean;
 }
 
 type Row = {
@@ -103,7 +101,7 @@ function TitleEdit(params: GridRenderEditCellParams) {
 }
 
 const TaskListTabPanel = (props: TaskListTabPanelProps) => {
-  const { value, index, tasks, status, addTask, onAddCancel, currentWbsNumber, team, hasTaskPermissions } = props;
+  const { value, index, tasks, status, addTask, onAddCancel, project } = props;
   const [modalShow, setModalShow] = useState(false);
   const [selectedTask, setSelectedTask] = useState<Task | undefined>(undefined);
   const editTaskStatus = useSetTaskStatus();
@@ -111,7 +109,7 @@ const TaskListTabPanel = (props: TaskListTabPanelProps) => {
   const [deadline, setDeadline] = useState(new Date());
   const [priority, setPriority] = useState(TaskPriority.High);
   const [assignees, setAssignees] = useState<UserPreview[]>([]);
-  const { mutateAsync: createTaskMutate } = useCreateTask(currentWbsNumber);
+  const { mutateAsync: createTaskMutate } = useCreateTask(project.wbsNum);
   const { mutateAsync: deleteTaskMutate } = useDeleteTask();
   const { isLoading, isError, mutateAsync: editTaskMutateAsync, error } = useEditTask();
   const {
@@ -124,6 +122,8 @@ const TaskListTabPanel = (props: TaskListTabPanelProps) => {
   const toast = useToast();
   const auth = useAuth();
   const theme = useTheme();
+
+  const team = project.team;
 
   const processRowUpdate = React.useCallback(
     async (newRow: GridRowModel) => {
@@ -158,7 +158,19 @@ const TaskListTabPanel = (props: TaskListTabPanelProps) => {
   if (isError) return <ErrorPage message={error?.message} />;
   if (assigneeIsError) return <ErrorPage message={assigneeError?.message} />;
 
-  const disabled = !hasTaskPermissions;
+  // can the user edit this task?
+  const editTaskPermissions = (user: User | undefined, task: Task, proj: Project): boolean => {
+    if (!user) return false;
+    return (
+      user.role === 'APP_ADMIN' ||
+      user.role === 'ADMIN' ||
+      user.role === 'LEADERSHIP' ||
+      proj.projectLead?.userId === user.userId ||
+      proj.projectManager?.userId === user.userId ||
+      task.assignees.map((u) => u.userId).includes(user.userId) ||
+      task.createdBy.userId === user.userId
+    );
+  };
 
   const renderNotes = (params: GridRenderCellParams<Task>) =>
     params.id === -1 ? (
@@ -338,7 +350,7 @@ const TaskListTabPanel = (props: TaskListTabPanelProps) => {
             label="Move to In Progress"
             onClick={moveToInProgress(params.row.taskId)}
             showInMenu
-            disabled={disabled}
+            disabled={!editTaskPermissions(auth.user, params.row.task, project)}
           />
         );
       } else if (status === TaskStatus.IN_PROGRESS) {
@@ -348,7 +360,7 @@ const TaskListTabPanel = (props: TaskListTabPanelProps) => {
             label="Move to Backlog"
             onClick={moveToBacklog(params.row.taskId)}
             showInMenu
-            disabled={disabled}
+            disabled={!editTaskPermissions(auth.user, params.row.task, project)}
           />
         );
         actions.push(
@@ -357,7 +369,7 @@ const TaskListTabPanel = (props: TaskListTabPanelProps) => {
             label="Move to Done"
             onClick={moveToDone(params.row.taskId)}
             showInMenu
-            disabled={disabled}
+            disabled={!editTaskPermissions(auth.user, params.row.task, project)}
           />
         );
       }
@@ -370,7 +382,7 @@ const TaskListTabPanel = (props: TaskListTabPanelProps) => {
           label="Delete"
           onClick={deleteRow(params.row.taskId)}
           showInMenu
-          disabled={disabled}
+          disabled={!editTaskPermissions(auth.user, params.row.task, project)}
         />
       );
     }
@@ -547,7 +559,7 @@ const TaskListTabPanel = (props: TaskListTabPanelProps) => {
           onSubmit={handleEditTask}
           task={selectedTask!}
           team={team}
-          hasTaskPermissions={hasTaskPermissions}
+          hasEditPermissions={editTaskPermissions(auth.user, selectedTask!, project)}
         />
       )}
     </div>

--- a/src/frontend/src/tests/pages/ProjectDetailPage/TaskList.test.tsx
+++ b/src/frontend/src/tests/pages/ProjectDetailPage/TaskList.test.tsx
@@ -4,56 +4,27 @@
  */
 
 import { render, screen } from '@testing-library/react';
-import { routerWrapperBuilder } from '../../test-support/test-utils';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { TeamPreview } from 'shared';
 import * as authHooks from '../../../hooks/auth.hooks';
+import * as taskHooks from '../../../hooks/tasks.hooks';
+import * as userHooks from '../../../hooks/users.hooks';
+import TaskList from '../../../pages/ProjectDetailPage/ProjectViewContainer/TaskList';
+import {
+  mockCreateTaskReturnValue,
+  mockDeleteTaskReturnValue,
+  mockEditTaskAssigneesReturnValue,
+  mockEditTaskReturnValue,
+  mockUseAllUsersReturnValue
+} from '../../test-support/mock-hooks';
+import { exampleTeam } from '../../test-support/test-data/teams.stub';
 import { mockAuth } from '../../test-support/test-data/test-utils.stub';
 import { exampleAdminUser, exampleLeadershipUser } from '../../test-support/test-data/users.stub';
-import TaskList from '../../../pages/ProjectDetailPage/ProjectViewContainer/TaskList';
-import { useAuth } from '../../../hooks/auth.hooks';
-import { Auth } from '../../../utils/types';
-import { useAllUsers } from '../../../hooks/users.hooks';
-import { UseQueryResult } from 'react-query';
-import { TeamPreview, User } from 'shared';
-import { mockUseQueryResult } from '../../test-support/test-data/test-utils.stub';
-import { useCreateTask, useDeleteTask, useEditTask, useEditTaskAssignees } from '../../../hooks/tasks.hooks';
-import { UseMutationResult } from 'react-query';
-import { mockUseMutationResult } from '../../test-support/test-data/test-utils.stub';
-import { QueryClient, QueryClientProvider } from 'react-query';
 import { exampleWbs1 } from '../../test-support/test-data/wbs-numbers.stub';
-import { exampleTeam } from '../../test-support/test-data/teams.stub';
+import { routerWrapperBuilder } from '../../test-support/test-utils';
 
-jest.mock('../../../hooks/auth.hooks');
 jest.mock('../../../hooks/toasts.hooks');
 
-jest.mock('../../../hooks/auth.hooks');
-const mockedUseAuth = useAuth as jest.Mock<Auth>;
-const mockAuthHook = (user = exampleAdminUser) => {
-  mockedUseAuth.mockReturnValue(mockAuth(false, user));
-};
-
-jest.mock('../../../hooks/tasks.hooks');
-const mockedCreateTask = useCreateTask as jest.Mock<UseMutationResult>;
-const mockCreateTaskHook = (isLoading: boolean, isError: boolean, error?: Error) => {
-  mockedCreateTask.mockReturnValue(mockUseMutationResult<{ in: string }>(isLoading, isError, { in: 'hi' }, error));
-};
-const mockedEditTask = useEditTask as jest.Mock<UseMutationResult>;
-const mockEditTaskHook = (isLoading: boolean, isError: boolean, error?: Error) => {
-  mockedEditTask.mockReturnValue(mockUseMutationResult<{ in: string }>(isLoading, isError, { in: 'hi' }, error));
-};
-const mockedEditTaskAssignees = useEditTaskAssignees as jest.Mock<UseMutationResult>;
-const mockEditTaskHookAssignees = (isLoading: boolean, isError: boolean, error?: Error) => {
-  mockedEditTaskAssignees.mockReturnValue(mockUseMutationResult<{ in: string }>(isLoading, isError, { in: 'hi' }, error));
-};
-const mockedDeleteTask = useDeleteTask as jest.Mock<UseMutationResult>;
-const mockDeleteTaskHook = (isLoading: boolean, isError: boolean, error?: Error) => {
-  mockedDeleteTask.mockReturnValue(mockUseMutationResult<{ in: string }>(isLoading, isError, { in: 'hi' }, error));
-};
-
-jest.mock('../../../hooks/users.hooks');
-const mockedUseAllUsers = useAllUsers as jest.Mock<UseQueryResult<User[]>>;
-const mockUserHook = (isLoading: boolean, isError: boolean, data?: User[], error?: Error) => {
-  mockedUseAllUsers.mockReturnValue(mockUseQueryResult<User[]>(isLoading, isError, data, error));
-};
 const users = [exampleAdminUser, exampleLeadershipUser];
 
 /**
@@ -72,16 +43,16 @@ const renderComponent = (team?: TeamPreview, hasTaskPermissions: boolean = true)
 };
 
 describe('TaskList component', () => {
+  // declaring in this scope allows you to mockReturnValue to a different user in each test
   const spyUseAuthHook = jest.spyOn(authHooks, 'useAuth');
 
   beforeEach(() => {
     spyUseAuthHook.mockReturnValue(mockAuth(false, exampleAdminUser));
-    mockAuthHook();
-    mockUserHook(false, false, users);
-    mockCreateTaskHook(false, false);
-    mockEditTaskHook(false, false);
-    mockEditTaskHookAssignees(false, false);
-    mockDeleteTaskHook(false, false);
+    jest.spyOn(userHooks, 'useAllUsers').mockReturnValue(mockUseAllUsersReturnValue(users));
+    jest.spyOn(taskHooks, 'useCreateTask').mockReturnValue(mockCreateTaskReturnValue);
+    jest.spyOn(taskHooks, 'useEditTask').mockReturnValue(mockEditTaskReturnValue);
+    jest.spyOn(taskHooks, 'useEditTaskAssignees').mockReturnValue(mockEditTaskAssigneesReturnValue);
+    jest.spyOn(taskHooks, 'useDeleteTask').mockReturnValue(mockDeleteTaskReturnValue);
   });
 
   it('renders "Task List" on top', () => {

--- a/src/frontend/src/tests/pages/ProjectDetailPage/TaskList.test.tsx
+++ b/src/frontend/src/tests/pages/ProjectDetailPage/TaskList.test.tsx
@@ -7,7 +7,7 @@ import { render, screen } from '@testing-library/react';
 import { routerWrapperBuilder } from '../../test-support/test-utils';
 import * as authHooks from '../../../hooks/auth.hooks';
 import { mockAuth } from '../../test-support/test-data/test-utils.stub';
-import { exampleAdminUser, exampleGuestUser, exampleLeadershipUser } from '../../test-support/test-data/users.stub';
+import { exampleAdminUser, exampleLeadershipUser } from '../../test-support/test-data/users.stub';
 import TaskList from '../../../pages/ProjectDetailPage/ProjectViewContainer/TaskList';
 import { useAuth } from '../../../hooks/auth.hooks';
 import { Auth } from '../../../utils/types';
@@ -59,13 +59,13 @@ const users = [exampleAdminUser, exampleLeadershipUser];
 /**
  * Sets up the component under test with the desired values and renders it.
  */
-const renderComponent = (team?: TeamPreview) => {
+const renderComponent = (team?: TeamPreview, hasTaskPermissions: boolean = true) => {
   const RouterWrapper = routerWrapperBuilder({});
   const queryClient = new QueryClient();
   return render(
     <QueryClientProvider client={queryClient}>
       <RouterWrapper>
-        <TaskList tasks={[]} team={team} hasTaskPermissions={true} currentWbsNumber={exampleWbs1} />
+        <TaskList tasks={[]} team={team} hasTaskPermissions={hasTaskPermissions} currentWbsNumber={exampleWbs1} />
       </RouterWrapper>
     </QueryClientProvider>
   );
@@ -96,26 +96,24 @@ describe('TaskList component', () => {
     expect(screen.getByText('Done')).toBeInTheDocument();
   });
 
-  describe('New Task button', () => {
+  describe('New Task Button', () => {
     it('renders New Task button', () => {
       renderComponent(exampleTeam);
       expect(screen.getByText('New Task')).toBeInTheDocument();
     });
 
-    it('disables New Task button if there is no associated team', () => {
-      renderComponent();
-      expect(screen.getByText('New Task')).toBeDisabled();
-    });
-
-    it('enables New Task button for leadership', () => {
-      spyUseAuthHook.mockReturnValue(mockAuth(false, exampleLeadershipUser));
+    it('enables New Task button if user has permission', () => {
       renderComponent(exampleTeam);
       expect(screen.getByText('New Task')).toBeEnabled();
     });
 
-    it('disables New Task button for guests', () => {
-      spyUseAuthHook.mockReturnValue(mockAuth(false, exampleGuestUser));
-      renderComponent(exampleTeam);
+    it('disables New Task button if user does not have permission', () => {
+      renderComponent(exampleTeam, false);
+      expect(screen.getByText('New Task')).toBeDisabled();
+    });
+
+    it('disables New Task button if there is no associated team', () => {
+      renderComponent();
       expect(screen.getByText('New Task')).toBeDisabled();
     });
   });

--- a/src/frontend/src/tests/pages/ProjectDetailPage/TaskList.test.tsx
+++ b/src/frontend/src/tests/pages/ProjectDetailPage/TaskList.test.tsx
@@ -20,6 +20,7 @@ import { UseMutationResult } from 'react-query';
 import { mockUseMutationResult } from '../../test-support/test-data/test-utils.stub';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { exampleWbs1 } from '../../test-support/test-data/wbs-numbers.stub';
+import { exampleTeam } from '../../test-support/test-data/teams.stub';
 
 jest.mock('../../../hooks/auth.hooks');
 jest.mock('../../../hooks/toasts.hooks');
@@ -58,13 +59,13 @@ const users = [exampleAdminUser, exampleLeadershipUser];
 /**
  * Sets up the component under test with the desired values and renders it.
  */
-const renderComponent = () => {
+const renderComponent = (team = exampleTeam) => {
   const RouterWrapper = routerWrapperBuilder({});
   const queryClient = new QueryClient();
   return render(
     <QueryClientProvider client={queryClient}>
       <RouterWrapper>
-        <TaskList tasks={[]} team={undefined} hasTaskPermissions={true} currentWbsNumber={exampleWbs1} />
+        <TaskList tasks={[]} team={team} hasTaskPermissions={true} currentWbsNumber={exampleWbs1} />
       </RouterWrapper>
     </QueryClientProvider>
   );

--- a/src/frontend/src/tests/pages/ProjectDetailPage/TaskList.test.tsx
+++ b/src/frontend/src/tests/pages/ProjectDetailPage/TaskList.test.tsx
@@ -3,25 +3,25 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-// import { render } from '@testing-library/react';
-// import { routerWrapperBuilder } from '../../test-support/test-utils';
+import { render, screen } from '@testing-library/react';
+import { routerWrapperBuilder } from '../../test-support/test-utils';
 import * as authHooks from '../../../hooks/auth.hooks';
 import { mockAuth } from '../../test-support/test-data/test-utils.stub';
-import { exampleAdminUser, exampleLeadershipUser } from '../../test-support/test-data/users.stub';
-// import TaskList from '../../../pages/ProjectDetailPage/ProjectViewContainer/TaskList';
+import { exampleAdminUser, exampleGuestUser, exampleLeadershipUser } from '../../test-support/test-data/users.stub';
+import TaskList from '../../../pages/ProjectDetailPage/ProjectViewContainer/TaskList';
 import { useAuth } from '../../../hooks/auth.hooks';
 import { Auth } from '../../../utils/types';
 import { useAllUsers } from '../../../hooks/users.hooks';
 import { UseQueryResult } from 'react-query';
 import { User } from 'shared';
 import { mockUseQueryResult } from '../../test-support/test-data/test-utils.stub';
-import { useEditTask } from '../../../hooks/tasks.hooks';
+import { useCreateTask, useDeleteTask, useEditTask, useEditTaskAssignees } from '../../../hooks/tasks.hooks';
 import { UseMutationResult } from 'react-query';
 import { mockUseMutationResult } from '../../test-support/test-data/test-utils.stub';
-// import { QueryClient, QueryClientProvider } from 'react-query';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { exampleWbs1 } from '../../test-support/test-data/wbs-numbers.stub';
 
 jest.mock('../../../hooks/auth.hooks');
-// TODO: delete me when you actually implement onClick
 jest.mock('../../../hooks/toasts.hooks');
 
 jest.mock('../../../hooks/auth.hooks');
@@ -31,9 +31,21 @@ const mockAuthHook = (user = exampleAdminUser) => {
 };
 
 jest.mock('../../../hooks/tasks.hooks');
+const mockedCreateTask = useCreateTask as jest.Mock<UseMutationResult>;
+const mockCreateTaskHook = (isLoading: boolean, isError: boolean, error?: Error) => {
+  mockedCreateTask.mockReturnValue(mockUseMutationResult<{ in: string }>(isLoading, isError, { in: 'hi' }, error));
+};
 const mockedEditTask = useEditTask as jest.Mock<UseMutationResult>;
 const mockEditTaskHook = (isLoading: boolean, isError: boolean, error?: Error) => {
   mockedEditTask.mockReturnValue(mockUseMutationResult<{ in: string }>(isLoading, isError, { in: 'hi' }, error));
+};
+const mockedEditTaskAssignees = useEditTaskAssignees as jest.Mock<UseMutationResult>;
+const mockEditTaskHookAssignees = (isLoading: boolean, isError: boolean, error?: Error) => {
+  mockedEditTaskAssignees.mockReturnValue(mockUseMutationResult<{ in: string }>(isLoading, isError, { in: 'hi' }, error));
+};
+const mockedDeleteTask = useDeleteTask as jest.Mock<UseMutationResult>;
+const mockDeleteTaskHook = (isLoading: boolean, isError: boolean, error?: Error) => {
+  mockedDeleteTask.mockReturnValue(mockUseMutationResult<{ in: string }>(isLoading, isError, { in: 'hi' }, error));
 };
 
 jest.mock('../../../hooks/users.hooks');
@@ -46,17 +58,17 @@ const users = [exampleAdminUser, exampleLeadershipUser];
 /**
  * Sets up the component under test with the desired values and renders it.
  */
-// const renderComponent = () => {
-//   const RouterWrapper = routerWrapperBuilder({});
-//   const queryClient = new QueryClient();
-//   return render(
-//     <QueryClientProvider client={queryClient}>
-//       <RouterWrapper>
-//         <TaskList tasks={[]} team={undefined} hasPerms={true} />
-//       </RouterWrapper>
-//     </QueryClientProvider>
-//   );
-// };
+const renderComponent = () => {
+  const RouterWrapper = routerWrapperBuilder({});
+  const queryClient = new QueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RouterWrapper>
+        <TaskList tasks={[]} team={undefined} hasTaskPermissions={true} currentWbsNumber={exampleWbs1} />
+      </RouterWrapper>
+    </QueryClientProvider>
+  );
+};
 
 describe('TaskList component', () => {
   const spyUseAuthHook = jest.spyOn(authHooks, 'useAuth');
@@ -65,39 +77,40 @@ describe('TaskList component', () => {
     spyUseAuthHook.mockReturnValue(mockAuth(false, exampleAdminUser));
     mockAuthHook();
     mockUserHook(false, false, users);
+    mockCreateTaskHook(false, false);
     mockEditTaskHook(false, false);
+    mockDeleteTaskHook(false, false);
+    mockEditTaskHookAssignees(false, false);
   });
 
-  it('test test', () => {
-    expect('this').toEqual('this');
+  it('renders "Task List" on top', () => {
+    renderComponent();
+    expect(screen.getByText('Task List')).toBeInTheDocument();
   });
-  // it('renders "Task List" on top', () => {
-  //   renderComponent();
-  //   expect(screen.getByText('Task List')).toBeInTheDocument();
-  // });
 
-  // it('renders all 3 labels', () => {
-  //   renderComponent();
-  //   expect(screen.getByText('In Progress')).toBeInTheDocument();
-  //   expect(screen.getByText('In Backlog')).toBeInTheDocument();
-  //   expect(screen.getByText('Done')).toBeInTheDocument();
-  // });
+  it('renders all 3 labels', () => {
+    renderComponent();
+    expect(screen.getByText('In Progress')).toBeInTheDocument();
+    expect(screen.getByText('In Backlog')).toBeInTheDocument();
+    expect(screen.getByText('Done')).toBeInTheDocument();
+  });
 
-  // describe('New Task button', () => {
-  //   it('renders New Task button', () => {
-  //     renderComponent();
-  //     expect(screen.getByText('New Task')).toBeInTheDocument();
-  //   });
+  describe('New Task button', () => {
+    it('renders New Task button', () => {
+      renderComponent();
+      expect(screen.getByText('New Task')).toBeInTheDocument();
+    });
 
-  // it('enables New Task button for leadership', () => {
-  //   spyUseAuthHook.mockReturnValue(mockAuth(false, exampleLeadershipUser));
-  //   renderComponent();
-  //   expect(screen.getByText('New Task')).toBeEnabled();
-  // });
+    it('enables New Task button for leadership', () => {
+      spyUseAuthHook.mockReturnValue(mockAuth(false, exampleLeadershipUser));
+      renderComponent();
+      expect(screen.getByText('New Task')).toBeEnabled();
+    });
 
-  // it('disables New Task button for guests', () => {
-  //   spyUseAuthHook.mockReturnValue(mockAuth(false, exampleGuestUser));
-  //   renderComponent();
-  //   expect(screen.getByText('New Task')).toBeDisabled();
-  // });
+    it('disables New Task button for guests', () => {
+      spyUseAuthHook.mockReturnValue(mockAuth(false, exampleGuestUser));
+      renderComponent();
+      expect(screen.getByText('New Task')).toBeDisabled();
+    });
+  });
 });

--- a/src/frontend/src/tests/pages/ProjectDetailPage/TaskList.test.tsx
+++ b/src/frontend/src/tests/pages/ProjectDetailPage/TaskList.test.tsx
@@ -5,7 +5,7 @@
 
 import { render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from 'react-query';
-import { TeamPreview } from 'shared';
+import { Project } from 'shared';
 import * as authHooks from '../../../hooks/auth.hooks';
 import * as taskHooks from '../../../hooks/tasks.hooks';
 import * as userHooks from '../../../hooks/users.hooks';
@@ -17,10 +17,9 @@ import {
   mockEditTaskReturnValue,
   mockUseAllUsersReturnValue
 } from '../../test-support/mock-hooks';
-import { exampleTeam } from '../../test-support/test-data/teams.stub';
+import { exampleProject3 } from '../../test-support/test-data/projects.stub';
 import { mockAuth } from '../../test-support/test-data/test-utils.stub';
-import { exampleAdminUser, exampleLeadershipUser } from '../../test-support/test-data/users.stub';
-import { exampleWbs1 } from '../../test-support/test-data/wbs-numbers.stub';
+import { exampleAdminUser, exampleGuestUser2, exampleLeadershipUser } from '../../test-support/test-data/users.stub';
 import { routerWrapperBuilder } from '../../test-support/test-utils';
 
 jest.mock('../../../hooks/toasts.hooks');
@@ -30,13 +29,13 @@ const users = [exampleAdminUser, exampleLeadershipUser];
 /**
  * Sets up the component under test with the desired values and renders it.
  */
-const renderComponent = (team?: TeamPreview, createTaskPermissions: boolean = true) => {
+const renderComponent = (proj: Project = exampleProject3) => {
   const RouterWrapper = routerWrapperBuilder({});
   const queryClient = new QueryClient();
   return render(
     <QueryClientProvider client={queryClient}>
       <RouterWrapper>
-        <TaskList tasks={[]} team={team} createTaskPermissions={createTaskPermissions} currentWbsNumber={exampleWbs1} />
+        <TaskList project={proj} />
       </RouterWrapper>
     </QueryClientProvider>
   );
@@ -56,12 +55,12 @@ describe('TaskList component', () => {
   });
 
   it('renders "Task List" on top', () => {
-    renderComponent(exampleTeam);
+    renderComponent();
     expect(screen.getByText('Task List')).toBeInTheDocument();
   });
 
   it('renders all 3 labels', () => {
-    renderComponent(exampleTeam);
+    renderComponent();
     expect(screen.getByText('In Progress')).toBeInTheDocument();
     expect(screen.getByText('In Backlog')).toBeInTheDocument();
     expect(screen.getByText('Done')).toBeInTheDocument();
@@ -69,34 +68,35 @@ describe('TaskList component', () => {
 
   describe('New Task Button', () => {
     it('renders New Task button', () => {
-      renderComponent(exampleTeam);
+      renderComponent();
       expect(screen.getByText('New Task')).toBeInTheDocument();
     });
 
     it('enables New Task button if user has permission', () => {
-      renderComponent(exampleTeam);
+      renderComponent();
       expect(screen.getByText('New Task')).toBeEnabled();
     });
 
     it('disables New Task button if user does not have permission', () => {
-      renderComponent(exampleTeam, false);
+      spyUseAuthHook.mockReturnValue(mockAuth(false, exampleGuestUser2));
+      renderComponent();
       expect(screen.getByText('New Task')).toBeDisabled();
     });
 
     it('disables New Task button if there is no associated team', () => {
-      renderComponent();
+      renderComponent({ ...exampleProject3, team: undefined });
       expect(screen.getByText('New Task')).toBeDisabled();
     });
   });
 
   describe('Tab Contents', () => {
     it('renders message if there is no associated team', () => {
-      renderComponent();
+      renderComponent({ ...exampleProject3, team: undefined });
       expect(screen.getByText('A project can only have tasks if it is assigned to a team!')).toBeInTheDocument();
     });
 
     it('does not render no-team message if there is an associated team', () => {
-      renderComponent(exampleTeam);
+      renderComponent();
       expect(screen.queryByText('A project can only have tasks if it is assigned to a team!')).toBeNull();
     });
   });

--- a/src/frontend/src/tests/pages/ProjectDetailPage/TaskList.test.tsx
+++ b/src/frontend/src/tests/pages/ProjectDetailPage/TaskList.test.tsx
@@ -121,12 +121,12 @@ describe('TaskList component', () => {
   describe('Tab Contents', () => {
     it('renders message if there is no associated team', () => {
       renderComponent();
-      expect(screen.getByText('No team assigned to this project!')).toBeInTheDocument();
+      expect(screen.getByText('A project can only have tasks if it is assigned to a team!')).toBeInTheDocument();
     });
 
     it('does not render no-team message if there is an associated team', () => {
       renderComponent(exampleTeam);
-      expect(screen.queryByText('No team assigned to this project!')).toBeNull();
+      expect(screen.queryByText('A project can only have tasks if it is assigned to a team!')).toBeNull();
     });
   });
 });

--- a/src/frontend/src/tests/pages/ProjectDetailPage/TaskList.test.tsx
+++ b/src/frontend/src/tests/pages/ProjectDetailPage/TaskList.test.tsx
@@ -30,13 +30,13 @@ const users = [exampleAdminUser, exampleLeadershipUser];
 /**
  * Sets up the component under test with the desired values and renders it.
  */
-const renderComponent = (team?: TeamPreview, hasTaskPermissions: boolean = true) => {
+const renderComponent = (team?: TeamPreview, createTaskPermissions: boolean = true) => {
   const RouterWrapper = routerWrapperBuilder({});
   const queryClient = new QueryClient();
   return render(
     <QueryClientProvider client={queryClient}>
       <RouterWrapper>
-        <TaskList tasks={[]} team={team} hasTaskPermissions={hasTaskPermissions} currentWbsNumber={exampleWbs1} />
+        <TaskList tasks={[]} team={team} createTaskPermissions={createTaskPermissions} currentWbsNumber={exampleWbs1} />
       </RouterWrapper>
     </QueryClientProvider>
   );

--- a/src/frontend/src/tests/pages/ProjectDetailPage/TaskList.test.tsx
+++ b/src/frontend/src/tests/pages/ProjectDetailPage/TaskList.test.tsx
@@ -13,7 +13,7 @@ import { useAuth } from '../../../hooks/auth.hooks';
 import { Auth } from '../../../utils/types';
 import { useAllUsers } from '../../../hooks/users.hooks';
 import { UseQueryResult } from 'react-query';
-import { User } from 'shared';
+import { TeamPreview, User } from 'shared';
 import { mockUseQueryResult } from '../../test-support/test-data/test-utils.stub';
 import { useCreateTask, useDeleteTask, useEditTask, useEditTaskAssignees } from '../../../hooks/tasks.hooks';
 import { UseMutationResult } from 'react-query';
@@ -59,7 +59,7 @@ const users = [exampleAdminUser, exampleLeadershipUser];
 /**
  * Sets up the component under test with the desired values and renders it.
  */
-const renderComponent = (team = exampleTeam) => {
+const renderComponent = (team?: TeamPreview) => {
   const RouterWrapper = routerWrapperBuilder({});
   const queryClient = new QueryClient();
   return render(
@@ -80,17 +80,17 @@ describe('TaskList component', () => {
     mockUserHook(false, false, users);
     mockCreateTaskHook(false, false);
     mockEditTaskHook(false, false);
-    mockDeleteTaskHook(false, false);
     mockEditTaskHookAssignees(false, false);
+    mockDeleteTaskHook(false, false);
   });
 
   it('renders "Task List" on top', () => {
-    renderComponent();
+    renderComponent(exampleTeam);
     expect(screen.getByText('Task List')).toBeInTheDocument();
   });
 
   it('renders all 3 labels', () => {
-    renderComponent();
+    renderComponent(exampleTeam);
     expect(screen.getByText('In Progress')).toBeInTheDocument();
     expect(screen.getByText('In Backlog')).toBeInTheDocument();
     expect(screen.getByText('Done')).toBeInTheDocument();
@@ -98,20 +98,37 @@ describe('TaskList component', () => {
 
   describe('New Task button', () => {
     it('renders New Task button', () => {
-      renderComponent();
+      renderComponent(exampleTeam);
       expect(screen.getByText('New Task')).toBeInTheDocument();
+    });
+
+    it('disables New Task button if there is no associated team', () => {
+      renderComponent();
+      expect(screen.getByText('New Task')).toBeDisabled();
     });
 
     it('enables New Task button for leadership', () => {
       spyUseAuthHook.mockReturnValue(mockAuth(false, exampleLeadershipUser));
-      renderComponent();
+      renderComponent(exampleTeam);
       expect(screen.getByText('New Task')).toBeEnabled();
     });
 
     it('disables New Task button for guests', () => {
       spyUseAuthHook.mockReturnValue(mockAuth(false, exampleGuestUser));
-      renderComponent();
+      renderComponent(exampleTeam);
       expect(screen.getByText('New Task')).toBeDisabled();
+    });
+  });
+
+  describe('Tab Contents', () => {
+    it('renders message if there is no associated team', () => {
+      renderComponent();
+      expect(screen.getByText('No team assigned to this project!')).toBeInTheDocument();
+    });
+
+    it('does not render no-team message if there is an associated team', () => {
+      renderComponent(exampleTeam);
+      expect(screen.queryByText('No team assigned to this project!')).toBeNull();
     });
   });
 });

--- a/src/frontend/src/tests/test-support/mock-hooks.ts
+++ b/src/frontend/src/tests/test-support/mock-hooks.ts
@@ -1,8 +1,9 @@
+import { UseMutationResult } from 'react-query';
 import { AuthenticatedUser, DescriptionBullet, User, WorkPackage } from 'shared';
+import { CreateTaskPayload, DeleteTaskPayload, TaskPayload } from '../../hooks/tasks.hooks';
+import { VersionObject } from '../../utils/types';
 import { mockUseMutationResult, mockUseQueryResult } from './test-data/test-utils.stub';
 import { exampleAdminUser } from './test-data/users.stub';
-import { UseMutationResult } from 'react-query';
-import { VersionObject } from '../../utils/types';
 
 export const mockLogUserInReturnValue = mockUseMutationResult<AuthenticatedUser>(
   false,
@@ -26,6 +27,34 @@ export const mockEditProjectReturnValue = mockUseMutationResult<{ message: strin
   { message: 'hi' },
   new Error()
 );
+
+export const mockCreateTaskReturnValue = mockUseMutationResult<{ message: string }>(
+  false,
+  false,
+  { message: 'hi' },
+  new Error()
+) as UseMutationResult<{ message: string }, Error, CreateTaskPayload, unknown>;
+
+export const mockEditTaskReturnValue = mockUseMutationResult<{ message: string }>(
+  false,
+  false,
+  { message: 'hi' },
+  new Error()
+) as UseMutationResult<{ message: string }, Error, TaskPayload, unknown>;
+
+export const mockEditTaskAssigneesReturnValue = mockUseMutationResult<{ message: string }>(
+  false,
+  false,
+  { message: 'hi' },
+  new Error()
+) as UseMutationResult<{ message: string }, Error, { taskId: string; assignees: number[] }, unknown>;
+
+export const mockDeleteTaskReturnValue = mockUseMutationResult<{ message: string }>(
+  false,
+  false,
+  { message: 'hi' },
+  new Error()
+) as UseMutationResult<{ message: string }, Error, DeleteTaskPayload, unknown>;
 
 export const mockCheckDescBulletReturnValue = mockUseMutationResult<DescriptionBullet>(
   false,

--- a/src/frontend/src/tests/test-support/test-data/projects.stub.ts
+++ b/src/frontend/src/tests/test-support/test-data/projects.stub.ts
@@ -4,6 +4,8 @@
  */
 
 import { Project, WbsElementStatus } from 'shared';
+import { exampleTask1 } from './tasks.stub';
+import { exampleTeam } from './teams.stub';
 import { exampleAdminUser, exampleLeadershipUser, exampleProjectLeadUser, exampleProjectManagerUser } from './users.stub';
 import { exampleWbsProject1, exampleWbsProject2 } from './wbs-numbers.stub';
 import { exampleResearchWorkPackage, exampleDesignWorkPackage, exampleManufacturingWorkPackage } from './work-packages.stub';
@@ -142,8 +144,9 @@ export const exampleProject3: Project = {
   startDate: new Date('01/01/21'),
   endDate: new Date('01/22/21'),
   workPackages: [exampleResearchWorkPackage],
+  team: exampleTeam,
   risks: [],
-  tasks: []
+  tasks: [exampleTask1]
 };
 
 export const exampleProject4: Project = {

--- a/src/frontend/src/tests/test-support/test-data/tasks.stub.ts
+++ b/src/frontend/src/tests/test-support/test-data/tasks.stub.ts
@@ -19,3 +19,16 @@ export const exampleTask1: Task = {
   priority: TaskPriority.Medium,
   status: TaskStatus.IN_PROGRESS
 };
+
+export const exampleTask1DueSoon: Task = {
+  taskId: 'i8f-rotwyv',
+  wbsNum: exampleWbsProject1,
+  title: 'Sketches',
+  notes: 'drafting the sketches with very straight lines',
+  dateCreated: new Date('2023-03-04T00:00:00-05:00'),
+  createdBy: exampleLeadershipUser,
+  assignees: [exampleMemberUser],
+  deadline: new Date('2023-11-01T00:00:00-05:00'),
+  priority: TaskPriority.Medium,
+  status: TaskStatus.IN_PROGRESS
+};

--- a/src/frontend/src/tests/test-support/test-data/tasks.stub.ts
+++ b/src/frontend/src/tests/test-support/test-data/tasks.stub.ts
@@ -1,0 +1,21 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { Task, TaskPriority, TaskStatus } from 'shared';
+import { exampleLeadershipUser, exampleMemberUser } from './users.stub';
+import { exampleWbsProject1 } from './wbs-numbers.stub';
+
+export const exampleTask1: Task = {
+  taskId: 'i8f-rotwyv',
+  wbsNum: exampleWbsProject1,
+  title: 'Sketches',
+  notes: 'drafting the sketches with very straight lines',
+  dateCreated: new Date('2023-03-04T00:00:00-05:00'),
+  createdBy: exampleLeadershipUser,
+  assignees: [exampleMemberUser],
+  deadline: new Date('2024-03-01T00:00:00-05:00'),
+  priority: TaskPriority.Medium,
+  status: TaskStatus.IN_PROGRESS
+};

--- a/src/frontend/src/tests/test-support/test-data/teams.stub.ts
+++ b/src/frontend/src/tests/test-support/test-data/teams.stub.ts
@@ -4,7 +4,7 @@
  */
 
 import { Team } from 'shared';
-import { exampleProject1, exampleProject2 } from './projects.stub';
+import { exampleProject1, exampleProject2, exampleProject3 } from './projects.stub';
 import { exampleAllUsers, exampleAppAdminUser } from './users.stub';
 
 export const exampleTeam: Team = {
@@ -14,5 +14,5 @@ export const exampleTeam: Team = {
   slackId: 'winners-slackid',
   description: 'Are you winning, team?',
   members: exampleAllUsers,
-  projects: [exampleProject1, exampleProject2]
+  projects: [exampleProject1, exampleProject2, exampleProject3]
 };

--- a/src/frontend/src/tests/test-support/test-data/users.stub.ts
+++ b/src/frontend/src/tests/test-support/test-data/users.stub.ts
@@ -77,6 +77,15 @@ export const exampleGuestUser: User = {
   role: RoleEnum.GUEST
 };
 
+export const exampleGuestUser2: User = {
+  userId: 8,
+  firstName: 'James',
+  lastName: 'Jackson',
+  email: 'jackson.j@husky.neu.edu',
+  emailId: 'jackson.j',
+  role: RoleEnum.GUEST
+};
+
 export const exampleAllUsers: User[] = [
   exampleAppAdminUser,
   exampleAdminUser,


### PR DESCRIPTION
## Changes

Instead of displaying loading symbol if a project has no team, display helpful text message instead.

New Task button also disabled if no team. Task edit permission is controlled *per task* now.

Refactor task list test data using mock hooks, and change task list props to pass the whole project. Plus some free task test data I didn't get to use.

## Notes

I chose to display text instead of nothing to make it more user-friendly.

Did not do similar changes for `!auth.user` (will that ever happen?) or `AssigneeEdit` component (does this ever get displayed?)

## Test Cases

- New Task Button
  - Disabled if no team
  - (manual) Assigning a project to a team will instantly refresh component to show table and enable button
- Displaying "no team" message
  - Renders if no associated team
  - No render if there is a team

Manually checking edit permission is controlled per task:
1. Use admin tools to demote Joe Shmoe to guest.
2. Log in as Joe Shmoe
3. Project 1.1.0 > tasks In Progress
4. "Decorate Impact Attenuator" should be enabled
5. "Meet with the Department of Transportation" should be disabled (both in move/delete task menu and in the edit modal)

## Screenshots

![Screen Shot 2023-03-07 at 9 54 06 PM](https://user-images.githubusercontent.com/59806366/223608120-ebe97b70-dcbc-450b-9504-0679d46711ad.png)
![Screen Shot 2023-03-07 at 9 54 52 PM](https://user-images.githubusercontent.com/59806366/223608116-2554223a-7ec1-4688-a557-4a42fe6eec8e.png)
![Screen Shot 2023-03-07 at 9 54 13 PM](https://user-images.githubusercontent.com/59806366/223608119-1e874e90-c486-46ae-b1ef-8574123b1930.png)

## To Do

_Any remaining things that need to get done_

- [x] Disable New Task button if there is no team. (Is there some way to couple all this together?)

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #956 
