### PR TITLE
#841 Removed the 'Leftover Budget' field from the Stage Gate Modal

### DIFF
--- a/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModal.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModal.tsx
@@ -17,7 +17,6 @@ import {
   FormControlLabel,
   Radio,
   RadioGroup,
-  TextField,
   Typography
 } from '@mui/material';
 import NERSuccessButton from '../../../components/NERSuccessButton';
@@ -31,7 +30,6 @@ interface StageGateWorkPackageModalProps {
 }
 
 const schema = yup.object().shape({
-  leftoverBudget: yup.number().required().min(0),
   confirmDone: yup.boolean().required()
 });
 
@@ -45,7 +43,7 @@ const StageGateWorkPackageModal: React.FC<StageGateWorkPackageModalProps> = ({ w
    */
   const onSubmitWrapper = async (data: FormInput) => {
     await onSubmit(data);
-    reset({ leftoverBudget: 0, confirmDone: false });
+    reset({ confirmDone: false });
   };
 
   return (
@@ -54,28 +52,6 @@ const StageGateWorkPackageModal: React.FC<StageGateWorkPackageModalProps> = ({ w
       <DialogContent>
         <form id={'stage-gate-work-package-form'} onSubmit={handleSubmit(onSubmitWrapper)}>
           <div className={'px-4'}>
-            <Controller
-              name="leftoverBudget"
-              control={control}
-              rules={{ required: true }}
-              render={({ field: { onChange, value } }) => (
-                <>
-                  <Typography sx={{ paddingTop: 1, paddingBottom: 1 }}>{'Leftover Budget'}</Typography>
-                  <TextField
-                    required
-                    variant="outlined"
-                    autoComplete="off"
-                    onChange={onChange}
-                    value={value}
-                    fullWidth
-                    InputProps={{
-                      startAdornment: <Typography sx={{ paddingRight: 1 }}>$</Typography>
-                    }}
-                  />
-                </>
-              )}
-            />
-
             <Controller
               name="confirmDone"
               control={control}
@@ -124,5 +100,4 @@ const StageGateWorkPackageModal: React.FC<StageGateWorkPackageModalProps> = ({ w
     </Dialog>
   );
 };
-
 export default StageGateWorkPackageModal;

--- a/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModal.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModal.tsx
@@ -100,4 +100,5 @@ const StageGateWorkPackageModal: React.FC<StageGateWorkPackageModalProps> = ({ w
     </Dialog>
   );
 };
+
 export default StageGateWorkPackageModal;

--- a/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModalContainer.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModalContainer.tsx
@@ -19,7 +19,6 @@ interface StageGateWorkPackageModalContainerProps {
 }
 
 export interface FormInput {
-  leftoverBudget: number;
   confirmDone: boolean;
 }
 
@@ -32,14 +31,13 @@ const StageGateWorkPackageModalContainer: React.FC<StageGateWorkPackageModalCont
   const history = useHistory();
   const { isLoading, isError, error, mutateAsync } = useCreateStageGateChangeRequest();
 
-  const handleConfirm = async ({ leftoverBudget, confirmDone }: FormInput) => {
+  const handleConfirm = async ({ confirmDone }: FormInput) => {
     handleClose();
     if (auth.user?.userId === undefined) throw new Error('Cannot create stage gate change request without being logged in');
     await mutateAsync({
       submitterId: auth.user?.userId,
       wbsNum,
       type: ChangeRequestType.StageGate,
-      leftoverBudget,
       confirmDone
     });
     history.push(routes.CHANGE_REQUESTS);

--- a/src/frontend/src/tests/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModal.test.tsx
+++ b/src/frontend/src/tests/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModal.test.tsx
@@ -39,9 +39,7 @@ describe('stage gate work package modal test suite', () => {
     renderComponent(true);
 
     expect(screen.queryByText(`Stage Gate #${wbsPipe(exampleWbs1)}`)).toBeInTheDocument();
-    expect(screen.getByText(/Leftover Budget/)).toBeInTheDocument();
     expect(screen.getByText(/done/)).toBeInTheDocument();
-    expect(screen.getByRole('textbox')).toBeInTheDocument();
     expect(screen.getAllByRole('radio').length).toBe(2);
     expect(screen.getByText('Cancel')).toBeInTheDocument();
     expect(screen.getByText('Submit')).toBeInTheDocument();


### PR DESCRIPTION
## Changes

The field asking about leftover budget and all associated code has been removed.

## Notes

The form will still submit correctly sans budget information.

## Screenshots

<img width="499" alt="Screen Shot 2023-03-13 at 7 37 44 PM" src="https://user-images.githubusercontent.com/114596410/224857418-50092a83-1479-4f09-854f-584f657e7be6.png">
<img src="https://user-images.githubusercontent.com/114596410/225348259-38ee1037-cf9c-49a0-ba5b-d624c53bbcd4.png" width="885">

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
#841 