### PR TITLE
#993: Allow Expansion When Clicking On Entire Title of Gantt Row

### DIFF
--- a/src/frontend/src/layouts/PageBlock.tsx
+++ b/src/frontend/src/layouts/PageBlock.tsx
@@ -52,6 +52,9 @@ const PageBlock: React.FC<PageBlockProps> = ({ title, headerRight, children, sty
               onClick={() => {
                 setCollapsed(!collapsed);
               }}
+              sx={{
+                cursor: 'pointer'
+              }}
             >
               {collapsed ? (
                 <ExpandMoreIcon sx={{ ml: -1, paddingRight: 0.5 }} />

--- a/src/frontend/src/pages/GanttPage/GanttPackage/components/task-list/TaskListTable.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttPackage/components/task-list/TaskListTable.tsx
@@ -28,7 +28,12 @@ export const TaskListTableDefault: React.FC<{
         }
 
         return (
-          <div className={styles.taskListTableRow} style={{ height: rowHeight }} key={`${t.id}row`}>
+          <div
+            className={styles.taskListTableRow}
+            style={{ height: rowHeight }}
+            key={`${t.id}row`}
+            onClick={() => onExpanderClick(t)}
+          >
             <div
               className={styles.taskListCell}
               style={{
@@ -38,10 +43,7 @@ export const TaskListTableDefault: React.FC<{
               title={t.name}
             >
               <div className={styles.taskListNameWrapper}>
-                <div
-                  className={expanderSymbol ? styles.taskListExpander : styles.taskListEmptyExpander}
-                  onClick={() => onExpanderClick(t)}
-                >
+                <div className={expanderSymbol ? styles.taskListExpander : styles.taskListEmptyExpander}>
                   {expanderSymbol}
                 </div>
                 <div className={styles.taskListNameText}>{t.name}</div>

--- a/src/frontend/src/stylesheets/pages/gantt-page.module.css
+++ b/src/frontend/src/stylesheets/pages/gantt-page.module.css
@@ -46,6 +46,7 @@
 }
 .taskListNameWrapper {
   display: flex;
+  cursor: pointer;
 }
 
 .taskListNameText {
@@ -59,7 +60,6 @@
   font-size: 0.6rem;
   padding: 0.15rem 0.2rem 0 0.2rem;
   user-select: none;
-  cursor: pointer;
 }
 .taskListEmptyExpander {
   font-size: 0.6rem;


### PR DESCRIPTION
## Changes

Before, Gantt chart rows would only expand if the arrow was clicked. Now, it will expand if you click anywhere in the Name column. I moved the expansion onClick to be on the Name column rather than just the arrow, and changed the CSS to apply a pointer cursor to the entire column rather than just the title.

## Checklist

- [X] All commits are tagged with the ticket number
- [X] No linting errors / newline at end of file warnings
- [X] All code follows repository-configured prettier formatting
- [X] No merge conflicts
- [x] All checks passing
- [X] Remove any non-applicable sections of this template
- [X] Assign the PR to yourself
- [X] No `yarn.lock` changes (unless dependencies have changed)
- [X] Request reviewers & ping on Slack
- [X] PR is linked to the ticket (fill in the closes line below)

Closes #993
