### PR TITLE
#997 Wrap project datagrid row with link

### DIFF
--- a/src/frontend/src/pages/ProjectsPage/ProjectsTable.tsx
+++ b/src/frontend/src/pages/ProjectsPage/ProjectsTable.tsx
@@ -3,22 +3,21 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { useHistory } from 'react-router-dom';
-import { DataGrid, GridColDef, GridToolbar } from '@mui/x-data-grid';
-import { routes } from '../../utils/routes';
-import { useAllProjects } from '../../hooks/projects.hooks';
-import { fullNamePipe, wbsPipe, weeksPipe } from '../../utils/pipes';
-import PageTitle from '../../layouts/PageTitle/PageTitle';
-import { useTheme } from '@mui/material';
+import { Link, useTheme } from '@mui/material';
+import { DataGrid, GridColDef, GridRow, GridRowProps, GridToolbar } from '@mui/x-data-grid';
 import { useState } from 'react';
-import { WbsElementStatus } from 'shared';
+import { Link as RouterLink } from 'react-router-dom';
+import { Project, WbsElementStatus } from 'shared';
+import { useAllProjects } from '../../hooks/projects.hooks';
+import PageTitle from '../../layouts/PageTitle/PageTitle';
+import { fullNamePipe, wbsPipe, weeksPipe } from '../../utils/pipes';
+import { routes } from '../../utils/routes';
 import { GridColDefStyle } from '../../utils/tables';
 
 /**
  * Table of all projects.
  */
 const ProjectsTable: React.FC = () => {
-  const history = useHistory();
   const { isLoading, data, error } = useAllProjects();
   if (!localStorage.getItem('projectsTableRowCount')) localStorage.setItem('projectsTableRowCount', '30');
   const [pageSize, setPageSize] = useState(localStorage.getItem('projectsTableRowCount'));
@@ -144,10 +143,21 @@ const ProjectsTable: React.FC = () => {
         }
         columns={columns}
         sx={{ background: theme.palette.background.paper }}
-        onRowClick={(params) => {
-          history.push(`${routes.PROJECTS}/${wbsPipe(params.row.wbsNum)}`);
+        components={{
+          Toolbar: GridToolbar,
+          Row: (props: GridRowProps & { row: Project }) => {
+            const wbsNum = props.row.wbsNum;
+            return (
+              <Link
+                component={RouterLink}
+                to={`${routes.PROJECTS}/${wbsPipe(wbsNum)}`}
+                sx={{ color: 'inherit', textDecoration: 'none' }}
+              >
+                <GridRow {...props} />
+              </Link>
+            );
+          }
         }}
-        components={{ Toolbar: GridToolbar }}
         componentsProps={{
           toolbar: {
             showQuickFilter: true,


### PR DESCRIPTION
## Changes

Wrap the data grid row component with a link, so it gets the default link behavior (can be right clicked and opened in new tab or command clicked)

## Test Cases

Tested manually

## Screenshots

<img width="643" alt="image" src="https://user-images.githubusercontent.com/34677361/225481336-e19e122d-623d-4751-ac01-12c2567799ec.png">


## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #997
