### PR TITLE
716 changeproposedsolutionform to use nersuccessbutton

### DIFF
--- a/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionForm.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionForm.tsx
@@ -3,14 +3,15 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
+
 import { Box, Button, Dialog, DialogContent, DialogTitle } from '@mui/material';
-import CloseIcon from '@mui/icons-material/Close';
 import * as yup from 'yup';
 import { Controller, useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { ProposedSolution } from 'shared';
-import { TextField, Typography, IconButton } from '@mui/material';
-
+import { TextField, Typography } from '@mui/material';
+import NERFailButton from '../../components/NERFailButton';
+import NERSuccessButton from '../../components/NERSuccessButton';
 interface ProposedSolutionFormProps {
   description?: string;
   budgetImpact?: number;
@@ -22,20 +23,24 @@ interface ProposedSolutionFormProps {
   onClose: () => void;
 }
 
+
 const schema = yup.object().shape({
   description: yup.string().required('Description is required'),
   budgetImpact: yup
     .number()
     .typeError('Budget Impact must be a number')
+    .min(0, 'Budget Impact must be greater than or equal to $0')
     .required('Budget Impact is required')
     .integer('Budget Impact must be an integer'),
   scopeImpact: yup.string().required('Scope Impact is required'),
   timelineImpact: yup
     .number()
     .typeError('Timeline Impact must be a number')
+    .min(0, 'Timeline Impact must be greater than or equal to 0 weeks')
     .required('Timeline Impact is required')
     .integer('Timeline Impact must be an integer')
 });
+
 
 const ProposedSolutionForm: React.FC<ProposedSolutionFormProps> = ({
   description,
@@ -52,21 +57,10 @@ const ProposedSolutionForm: React.FC<ProposedSolutionFormProps> = ({
     defaultValues: { description, budgetImpact, timelineImpact, scopeImpact }
   });
 
+
   return (
     <Dialog open={open} onClose={onClose}>
       <DialogTitle>Propose a Solution</DialogTitle>
-      <IconButton
-        aria-label="close"
-        onClick={onClose}
-        sx={{
-          position: 'absolute',
-          right: 8,
-          top: 8,
-          color: (theme) => theme.palette.grey[500]
-        }}
-      >
-        <CloseIcon />
-      </IconButton>
       <DialogContent
         sx={{
           '&::-webkit-scrollbar': {
@@ -179,7 +173,7 @@ const ProposedSolutionForm: React.FC<ProposedSolutionFormProps> = ({
                   fullWidth
                   sx={{ width: 400 }}
                   disabled={readOnly}
-                  placeholder="# of weeks needed"
+                  placeholder="# needed"
                   error={!!formState.errors.timelineImpact}
                   helperText={formState.errors.timelineImpact?.message}
                 />
@@ -189,16 +183,24 @@ const ProposedSolutionForm: React.FC<ProposedSolutionFormProps> = ({
           {readOnly ? (
             ''
           ) : (
-            <Box display="flex" flexDirection="row-reverse">
-              <Button
+            <Box textAlign="right" sx={{ my: 2 }}>
+              <NERFailButton
+                variant="contained"
+                onClick={onClose}
+                form="individual-proposed-solution-form"
+                sx={{ textTransform: 'none', fontSize: 16, marginTop: 3 }}
+              >
+                Cancel
+              </NERFailButton>
+              <NERSuccessButton
                 color="success"
                 variant="contained"
                 type="submit"
                 form="individual-proposed-solution-form"
                 sx={{ textTransform: 'none', fontSize: 16, marginTop: 3 }}
               >
-                Add
-              </Button>
+                Submit
+              </NERSuccessButton>
             </Box>
           )}
         </form>
@@ -206,5 +208,6 @@ const ProposedSolutionForm: React.FC<ProposedSolutionFormProps> = ({
     </Dialog>
   );
 };
+
 
 export default ProposedSolutionForm;

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionForm.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionForm.tsx
@@ -181,7 +181,7 @@ const ProposedSolutionForm: React.FC<ProposedSolutionFormProps> = ({
                   fullWidth
                   sx={{ width: 400 }}
                   disabled={readOnly}
-                  placeholder="# needed"
+                  placeholder="# of weeks needed"
                   error={!!formState.errors.timelineImpact}
                   helperText={formState.errors.timelineImpact?.message}
                 />

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionForm.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionForm.tsx
@@ -3,15 +3,16 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-
 import { Box, Button, Dialog, DialogContent, DialogTitle } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
 import * as yup from 'yup';
 import { Controller, useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { ProposedSolution } from 'shared';
-import { TextField, Typography } from '@mui/material';
+import { TextField, Typography, IconButton } from '@mui/material';
 import NERFailButton from '../../components/NERFailButton';
 import NERSuccessButton from '../../components/NERSuccessButton';
+
 interface ProposedSolutionFormProps {
   description?: string;
   budgetImpact?: number;
@@ -23,24 +24,20 @@ interface ProposedSolutionFormProps {
   onClose: () => void;
 }
 
-
 const schema = yup.object().shape({
   description: yup.string().required('Description is required'),
   budgetImpact: yup
     .number()
     .typeError('Budget Impact must be a number')
-    .min(0, 'Budget Impact must be greater than or equal to $0')
     .required('Budget Impact is required')
     .integer('Budget Impact must be an integer'),
   scopeImpact: yup.string().required('Scope Impact is required'),
   timelineImpact: yup
     .number()
     .typeError('Timeline Impact must be a number')
-    .min(0, 'Timeline Impact must be greater than or equal to 0 weeks')
     .required('Timeline Impact is required')
     .integer('Timeline Impact must be an integer')
 });
-
 
 const ProposedSolutionForm: React.FC<ProposedSolutionFormProps> = ({
   description,
@@ -57,10 +54,21 @@ const ProposedSolutionForm: React.FC<ProposedSolutionFormProps> = ({
     defaultValues: { description, budgetImpact, timelineImpact, scopeImpact }
   });
 
-
   return (
     <Dialog open={open} onClose={onClose}>
       <DialogTitle>Propose a Solution</DialogTitle>
+      <IconButton
+        aria-label="close"
+        onClick={onClose}
+        sx={{
+          position: 'absolute',
+          right: 8,
+          top: 8,
+          color: (theme) => theme.palette.grey[500]
+        }}
+      >
+        <CloseIcon />
+      </IconButton>
       <DialogContent
         sx={{
           '&::-webkit-scrollbar': {
@@ -208,6 +216,5 @@ const ProposedSolutionForm: React.FC<ProposedSolutionFormProps> = ({
     </Dialog>
   );
 };
-
 
 export default ProposedSolutionForm;


### PR DESCRIPTION
## Changes

Changed button to NER button

## Notes

used ticket 731 as reference

## Screenshots

![image](https://user-images.githubusercontent.com/54865529/226217823-24ee86f2-8030-4ccb-a8c4-c54f38d809ec.png)
![image](https://user-images.githubusercontent.com/54865529/226217835-54e68f9b-1997-47d2-9f05-15f19642d3b7.png)
![image](https://user-images.githubusercontent.com/54865529/226217842-afc2debc-9a99-4c0c-8ae7-8fe804edbf89.png)
![image](https://user-images.githubusercontent.com/54865529/226217844-262e8d0a-917d-4680-929e-a02298d9d19f.png)


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
#716 