### PR TITLE
#983 Added pagination to TaskLisk

### DIFF
--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskListTabPanel.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskListTabPanel.tsx
@@ -109,6 +109,7 @@ const TaskListTabPanel = (props: TaskListTabPanelProps) => {
   const [deadline, setDeadline] = useState(new Date());
   const [priority, setPriority] = useState(TaskPriority.High);
   const [assignees, setAssignees] = useState<UserPreview[]>([]);
+  const [pageSize, setPageSize] = useState(Number(localStorage.getItem('tl-table-row-count')));
   const { mutateAsync: createTaskMutate } = useCreateTask(project.wbsNum);
   const { mutateAsync: deleteTaskMutate } = useDeleteTask();
   const { isLoading, isError, mutateAsync: editTaskMutateAsync, error } = useEditTask();
@@ -157,6 +158,9 @@ const TaskListTabPanel = (props: TaskListTabPanelProps) => {
     );
   if (isError) return <ErrorPage message={error?.message} />;
   if (assigneeIsError) return <ErrorPage message={assigneeError?.message} />;
+  if (localStorage.getItem('tl-table-row-count') === null) {
+    localStorage.setItem('tl-table-row-count', '5');
+  }
 
   // can the user edit this task?
   const editTaskPermissions = (user: User | undefined, task: Task, proj: Project): boolean => {
@@ -522,11 +526,15 @@ const TaskListTabPanel = (props: TaskListTabPanelProps) => {
           <DataGrid
             columns={columns}
             rows={rows}
-            pageSize={5}
             isCellEditable={isCellEditable}
             experimentalFeatures={{ newEditingApi: true }}
             processRowUpdate={processRowUpdate}
-            rowsPerPageOptions={[5]}
+            pageSize={pageSize}
+            rowsPerPageOptions={[5, 10, 15, 100]}
+            onPageSizeChange={(newPageSize) => {
+              localStorage.setItem('tl-table-row-count', String(newPageSize));
+              setPageSize(newPageSize);
+            }}
             sx={{
               '&.MuiDataGrid-root .MuiDataGrid-cell:focus': {
                 outline: 'none'

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskListTabPanel.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskListTabPanel.tsx
@@ -533,7 +533,7 @@ const TaskListTabPanel = (props: TaskListTabPanelProps) => {
             pageSize={pageSize}
             rowsPerPageOptions={[5, 10, 15, 100]}
             onPageSizeChange={(newPageSize) => {
-              localStorage.setItem('tl-table-row-count', String(newPageSize));
+              localStorage.setItem(TABLE_ROW_COUNT, String(newPageSize));
               setPageSize(newPageSize);
             }}
             sx={{

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskListTabPanel.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskListTabPanel.tsx
@@ -109,7 +109,8 @@ const TaskListTabPanel = (props: TaskListTabPanelProps) => {
   const [deadline, setDeadline] = useState(new Date());
   const [priority, setPriority] = useState(TaskPriority.High);
   const [assignees, setAssignees] = useState<UserPreview[]>([]);
-  const [pageSize, setPageSize] = useState(Number(localStorage.getItem('tl-table-row-count')));
+  const TABLE_ROW_COUNT = 'tl-table-row-count';
+  const [pageSize, setPageSize] = useState(Number(localStorage.getItem(TABLE_ROW_COUNT)));
   const { mutateAsync: createTaskMutate } = useCreateTask(project.wbsNum);
   const { mutateAsync: deleteTaskMutate } = useDeleteTask();
   const { isLoading, isError, mutateAsync: editTaskMutateAsync, error } = useEditTask();
@@ -158,8 +159,8 @@ const TaskListTabPanel = (props: TaskListTabPanelProps) => {
     );
   if (isError) return <ErrorPage message={error?.message} />;
   if (assigneeIsError) return <ErrorPage message={assigneeError?.message} />;
-  if (localStorage.getItem('tl-table-row-count') === null) {
-    localStorage.setItem('tl-table-row-count', '5');
+  if (!localStorage.getItem(TABLE_ROW_COUNT)) {
+    localStorage.setItem(TABLE_ROW_COUNT, '5');
   }
 
   // can the user edit this task?


### PR DESCRIPTION
## Changes

Added Pagination to the task list of a project. Pagination options are 5, 10, 15, and 100.

## Screenshots

Task list pagination in normal sized window:
<img width="960" alt="image" src="https://user-images.githubusercontent.com/123038068/226642787-23a8c410-eb99-425e-8e2d-bfc85b037566.png">

Task list pagination in smallest possible window:
<img width="363" alt="image" src="https://user-images.githubusercontent.com/123038068/226643152-7494bfb7-7add-48a8-a314-d875972e3f71.png">

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #983
