### PR TITLE
#924 repositions a few fields and breadcrumbed the project name

### DIFF
--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditContainer.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditContainer.tsx
@@ -149,7 +149,7 @@ const WorkPackageEditContainer: React.FC<WorkPackageEditContainerProps> = ({ wor
         title={`${wbsPipe(workPackage.wbsNum)} - ${workPackage.name}`}
         previousPages={[
           { name: 'Projects', route: routes.PROJECTS },
-          { name: projectWbsString, route: `${routes.PROJECTS}/${projectWbsString}` }
+          { name: `${projectWbsString} - ${workPackage.projectName}`, route: `${routes.PROJECTS}/${projectWbsString}` }
         ]}
         actionButton={
           <ReactHookTextField name="crId" control={control} label="Change Request Id" type="number" size="small" />
@@ -157,21 +157,24 @@ const WorkPackageEditContainer: React.FC<WorkPackageEditContainerProps> = ({ wor
       />
       <WorkPackageEditDetails control={control} errors={errors} users={users} />
       <PageBlock title="Dependencies">
-        {dependencies.map((_element, i) => {
-          return (
-            <Grid item sx={{ display: 'flex', alignItems: 'center' }}>
-              <TextField required autoComplete="off" {...register(`dependencies.${i}.wbsNum`)} sx={{ width: 1 / 10 }} />
-              <IconButton type="button" onClick={() => removeDependency(i)} sx={{ mx: 1, my: 0 }}>
-                <DeleteIcon />
-              </IconButton>
-            </Grid>
-          );
-        })}
-        <Button variant="contained" color="success" onClick={() => appendDependency({ wbsNum: '' })} sx={{ mt: 2 }}>
-          + ADD NEW DEPENDENCY
-        </Button>
+        <Grid container direction="row" alignItems="center" spacing={2}>
+          {dependencies.map((_element, i) => {
+            return (
+              <Grid item key={i}>
+                <TextField required autoComplete="off" {...register(`dependencies.${i}.wbsNum`)} />
+                <IconButton type="button" onClick={() => removeDependency(i)}>
+                  <DeleteIcon />
+                </IconButton>
+              </Grid>
+            );
+          })}
+          <Grid item>
+            <Button variant="contained" color="success" onClick={() => appendDependency({ wbsNum: '' })}>
+              + ADD NEW DEPENDENCY
+            </Button>
+          </Grid>
+        </Grid>
       </PageBlock>
-
       <PageBlock title="Expected Activities">
         <ReactHookEditableList
           name="expectedActivities"

--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditDetails.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditDetails.tsx
@@ -26,7 +26,7 @@ const WorkPackageEditDetails: React.FC<Props> = ({ users, control, errors }) => 
       control={control}
       rules={{ required: true }}
       render={({ field: { onChange, value } }) => (
-        <TextField select onChange={onChange} value={value} label="Status">
+        <TextField select onChange={onChange} value={value} label="Status" fullWidth>
           {statuses.map((t) => (
             <MenuItem key={t} value={t}>
               {t}
@@ -68,16 +68,32 @@ const WorkPackageEditDetails: React.FC<Props> = ({ users, control, errors }) => 
             )}
           />
         </Grid>
-        <Grid item xs={12} md={4} sx={{ mt: 2, mb: 1 }}>
+        <Grid item xs={12} md={2} sx={{ mt: 2, mb: 1 }}>
+          <ReactHookTextField
+            fullWidth
+            name="duration"
+            control={control}
+            type="number"
+            label="Duration"
+            errorMessage={errors.budget}
+          />
+        </Grid>
+        <Grid item xs={12} md={2} sx={{ mt: 2, mb: 1 }}>
           {statusSelect}
         </Grid>
-        <Grid item xs={12} md={6} sx={{ mt: 2, mb: 1 }}>
+        <Grid item xs={12} md={3} sx={{ mt: 2, mb: 1 }}>
           <Controller
             name="projectLead"
             control={control}
             rules={{ required: true }}
             render={({ field: { onChange, value } }) => (
-              <TextField select onChange={onChange} value={value} label="Project Lead" fullWidth>
+              <TextField
+                select
+                onChange={onChange}
+                value={value}
+                label="Project Lead"
+                sx={{ mr: 4, my: 1, minWidth: '45%' }}
+              >
                 {users.map((t) => (
                   <MenuItem key={t.userId} value={t.userId}>
                     {fullNamePipe(t)}
@@ -86,14 +102,12 @@ const WorkPackageEditDetails: React.FC<Props> = ({ users, control, errors }) => 
               </TextField>
             )}
           />
-        </Grid>
-        <Grid item xs={12} md={6} sx={{ mt: 2, mb: 1 }}>
           <Controller
             name="projectManager"
             control={control}
             rules={{ required: true }}
             render={({ field: { onChange, value } }) => (
-              <TextField select onChange={onChange} value={value} label="Project Manager" fullWidth>
+              <TextField select onChange={onChange} value={value} label="Project Manager" sx={{ my: 1, minWidth: '45%' }}>
                 {users.map((t) => (
                   <MenuItem key={t.userId} value={t.userId}>
                     {fullNamePipe(t)}
@@ -101,16 +115,6 @@ const WorkPackageEditDetails: React.FC<Props> = ({ users, control, errors }) => 
                 ))}
               </TextField>
             )}
-          />
-        </Grid>
-        <Grid item xs={12} md={6} sx={{ mt: 2, mb: 1 }}>
-          <ReactHookTextField
-            name="duration"
-            control={control}
-            type="number"
-            label="Duration"
-            sx={{ width: 3 / 10 }}
-            errorMessage={errors.budget}
           />
         </Grid>
       </Grid>


### PR DESCRIPTION
## Changes

Realigned the fields of the Work Package Details. 
Changed it so that the dependancies get added horizontally instead of vertically. 
Breadcrumbed the project name


![Screenshot 2023-03-22 at 8 41 53 PM](https://user-images.githubusercontent.com/76594216/227069896-1a739993-2cdd-471b-9fe8-a353ce1007d0.jpg)

Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #924
