### PR TITLE
#845 Changed Sidebar Icons from Fontawesome

### DIFF
--- a/src/frontend/src/layouts/Sidebar/NavPageLinks.tsx
+++ b/src/frontend/src/layouts/Sidebar/NavPageLinks.tsx
@@ -4,17 +4,16 @@
  */
 
 import { NavLink } from 'react-router-dom';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { LinkItem } from '../../utils/types';
+import { MUILinkItem } from '../../utils/types';
 import { routes } from '../../utils/routes';
 import styles from '../../stylesheets/layouts/sidebar/nav-page-links.module.css';
 
 interface NavPageLinkProps {
-  linkItems: LinkItem[];
+  linkItems: MUILinkItem[];
 }
 
 const NavPageLinks: React.FC<NavPageLinkProps> = ({ linkItems }: NavPageLinkProps) => {
-  const genNavItems = (linkItems: LinkItem[]) => {
+  const genNavItems = (linkItems: MUILinkItem[]) => {
     return linkItems.map((item) => {
       return (
         <NavLink
@@ -24,11 +23,7 @@ const NavPageLinks: React.FC<NavPageLinkProps> = ({ linkItems }: NavPageLinkProp
           activeClassName={styles.activeLink}
           exact={item.route === routes.HOME}
         >
-          {item.icon ? (
-            <FontAwesomeIcon icon={item.icon!} size="2x" className={styles.iconsAndText + ' ' + styles.icon} />
-          ) : (
-            ''
-          )}
+          {item.icon ? <item.icon fontSize="large" className={styles.iconsAndText + ' ' + styles.icon} /> : ''}
           <p className={styles.iconsAndText + ' ' + styles.text}>{item.name}</p>
         </NavLink>
       );

--- a/src/frontend/src/layouts/Sidebar/Sidebar.tsx
+++ b/src/frontend/src/layouts/Sidebar/Sidebar.tsx
@@ -53,7 +53,7 @@ const Sidebar: React.FC = () => {
   return (
     <div className={styles.sidebar}>
       <NavPageLinks linkItems={linkItems} />
-      <Typography className={styles.versionNumber}>3.7.0</Typography>
+      <Typography className={styles.versionNumber}>3.7.2</Typography>
     </div>
   );
 };

--- a/src/frontend/src/layouts/Sidebar/Sidebar.tsx
+++ b/src/frontend/src/layouts/Sidebar/Sidebar.tsx
@@ -3,52 +3,57 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { faExchangeAlt, faFolder, faHome, faQuestionCircle, faUsers, faChartGantt } from '@fortawesome/free-solid-svg-icons';
 import { routes } from '../../utils/routes';
-import { LinkItem } from '../../utils/types';
+import { MUILinkItem } from '../../utils/types';
 import NavPageLinks from './NavPageLinks';
 import styles from '../../stylesheets/layouts/sidebar/sidebar.module.css';
 import { Typography } from '@mui/material';
+import HomeIcon from '@mui/icons-material/Home';
+import AlignHorizontalLeftIcon from '@mui/icons-material/AlignHorizontalLeft';
+import FolderIcon from '@mui/icons-material/Folder';
+import SyncAltIcon from '@mui/icons-material/SyncAlt';
+import GroupIcon from '@mui/icons-material/Group';
+import QuestionMarkIcon from '@mui/icons-material/QuestionMark';
 
 const Sidebar: React.FC = () => {
-  const linkItems: LinkItem[] = [
+  const linkItems: MUILinkItem[] = [
     {
       name: 'Home',
-      icon: faHome,
+      icon: HomeIcon,
       route: routes.HOME
     },
     {
       name: 'Gantt',
-      icon: faChartGantt,
+      icon: AlignHorizontalLeftIcon,
       route: routes.GANTT
     },
     {
       name: 'Projects',
-      icon: faFolder,
+      icon: FolderIcon,
       route: routes.PROJECTS
     },
     {
       name: 'Change Requests',
-      icon: faExchangeAlt,
+      icon: SyncAltIcon,
       route: routes.CHANGE_REQUESTS
     },
     {
       name: 'Teams',
-      icon: faUsers,
+      icon: GroupIcon,
       route: routes.TEAMS
     }
   ];
 
   linkItems.push({
     name: 'Info',
-    icon: faQuestionCircle,
+    icon: QuestionMarkIcon,
     route: routes.INFO
   });
 
   return (
     <div className={styles.sidebar}>
       <NavPageLinks linkItems={linkItems} />
-      <Typography className={styles.versionNumber}>3.7.2</Typography>
+      <Typography className={styles.versionNumber}>3.7.0</Typography>
     </div>
   );
 };

--- a/src/frontend/src/tests/test-support/test-data/test-utils.stub.ts
+++ b/src/frontend/src/tests/test-support/test-data/test-utils.stub.ts
@@ -7,8 +7,10 @@ import { AxiosResponse } from 'axios';
 import { UseMutationResult, UseQueryResult } from 'react-query';
 import { User } from 'shared';
 import { exampleAdminUser } from './users.stub';
-import { Auth, LinkItem } from '../../../utils/types';
-import { faExchangeAlt, faFolder, faHome } from '@fortawesome/free-solid-svg-icons';
+import { Auth, MUILinkItem } from '../../../utils/types';
+import HomeIcon from '@mui/icons-material/Home';
+import FolderIcon from '@mui/icons-material/Folder';
+import SyncAltIcon from '@mui/icons-material/SyncAlt';
 import { routes } from '../../../utils/routes';
 
 export const mockContext = {
@@ -98,20 +100,20 @@ export const mockUtils = {
   update: () => null
 };
 
-export const testLinkItems: LinkItem[] = [
+export const testLinkItems: MUILinkItem[] = [
   {
     name: 'Home',
-    icon: faHome,
+    icon: HomeIcon,
     route: routes.HOME
   },
   {
     name: 'Projects',
-    icon: faFolder,
+    icon: FolderIcon,
     route: routes.PROJECTS
   },
   {
     name: 'Change Requests',
-    icon: faExchangeAlt,
+    icon: SyncAltIcon,
     route: routes.CHANGE_REQUESTS
   }
 ];

--- a/src/frontend/src/utils/types.ts
+++ b/src/frontend/src/utils/types.ts
@@ -5,6 +5,7 @@
 
 import { AuthenticatedUser } from 'shared';
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
+import { SvgIcon } from '@mui/material';
 
 export interface Auth {
   user: AuthenticatedUser | undefined;
@@ -19,6 +20,12 @@ export const themeChoices = ['DARK', 'LIGHT'];
 export interface LinkItem {
   name: string;
   icon?: IconProp;
+  route: string;
+}
+
+export interface MUILinkItem {
+  name: string;
+  icon?: typeof SvgIcon;
   route: string;
 }
 


### PR DESCRIPTION
## Changes

Replaced all instances of a font awesome icon in NavPageLinks.tsx with a corresponding version of that same icon from the library of MUI icons.


## Screenshots
<img width="1666" alt="Screenshot 2023-03-15 at 11 09 18 PM" src="https://user-images.githubusercontent.com/100250311/225502974-855ac0b4-1deb-4197-8893-bcf93301660a.png">
<img width="69" alt="Screenshot 2023-03-15 at 11 09 27 PM" src="https://user-images.githubusercontent.com/100250311/225503008-095f7c64-a719-46ff-a674-d25668d17cc8.png">

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #845 