### PR TITLE
#963 Alert if no Slack id

### DIFF
--- a/src/frontend/src/app/AppAuthenticated.tsx
+++ b/src/frontend/src/app/AppAuthenticated.tsx
@@ -18,6 +18,7 @@ import GanttPageWrapper from '../pages/GanttPage/GanttPageWrapper';
 import Teams from '../pages/TeamsPage/Teams';
 import AdminTools from '../pages/AdminToolsPage/AdminTools';
 import Credits from '../pages/CreditsPage/Credits';
+import AppContextUser from './AppContextUser';
 
 const styles = {
   content: {
@@ -28,7 +29,7 @@ const styles = {
 
 const AppAuthenticated: React.FC = () => {
   return (
-    <>
+    <AppContextUser>
       <NavTopBar />
       <div>
         <Sidebar />
@@ -50,7 +51,7 @@ const AppAuthenticated: React.FC = () => {
           </Container>
         </div>
       </div>
-    </>
+    </AppContextUser>
   );
 };
 

--- a/src/frontend/src/app/AppContextUser.tsx
+++ b/src/frontend/src/app/AppContextUser.tsx
@@ -1,0 +1,21 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { createContext } from 'react';
+import { AuthenticatedUser } from 'shared';
+import LoadingIndicator from '../components/LoadingIndicator';
+import { useAuth } from '../hooks/auth.hooks';
+
+export const UserContext = createContext<AuthenticatedUser | undefined>(undefined);
+
+const AppContextUser: React.FC = (props) => {
+  const auth = useAuth();
+
+  if (!auth.user) return <LoadingIndicator />;
+
+  return <UserContext.Provider value={auth.user}>{props.children}</UserContext.Provider>;
+};
+
+export default AppContextUser;

--- a/src/frontend/src/app/AppPublic.tsx
+++ b/src/frontend/src/app/AppPublic.tsx
@@ -9,6 +9,7 @@ import { routes } from '../utils/routes';
 import Login from '../pages/LoginPage/Login';
 import AppAuthenticated from './AppAuthenticated';
 import { useProvideThemeToggle } from '../hooks/theme.hooks';
+import LoadingIndicator from '../components/LoadingIndicator';
 
 const AppPublic: React.FC = () => {
   const auth = useAuth();
@@ -29,7 +30,7 @@ const AppPublic: React.FC = () => {
     // then dev login right away (no login page redirect needed!)
     if (process.env.NODE_ENV === 'development' && devUserId) {
       auth.devSignin(parseInt(devUserId));
-      return <AppAuthenticated />;
+      return auth.isLoading ? <LoadingIndicator /> : <AppAuthenticated />;
     }
 
     // otherwise, the user needs to login manually

--- a/src/frontend/src/app/AppPublic.tsx
+++ b/src/frontend/src/app/AppPublic.tsx
@@ -33,7 +33,7 @@ const AppPublic: React.FC = () => {
       return auth.isLoading ? <LoadingIndicator /> : <AppAuthenticated />;
     }
 
-    // otherwise, the user needs to login tmanually
+    // otherwise, the user needs to login manually
     // prepare query args to store path after login
     const redirectPathParts: string[] = history.location.pathname.split('/').slice(1);
 

--- a/src/frontend/src/app/AppPublic.tsx
+++ b/src/frontend/src/app/AppPublic.tsx
@@ -33,7 +33,7 @@ const AppPublic: React.FC = () => {
       return auth.isLoading ? <LoadingIndicator /> : <AppAuthenticated />;
     }
 
-    // otherwise, the user needs to login manually
+    // otherwise, the user needs to login tmanually
     // prepare query args to store path after login
     const redirectPathParts: string[] = history.location.pathname.split('/').slice(1);
 

--- a/src/frontend/src/hooks/users.hooks.ts
+++ b/src/frontend/src/hooks/users.hooks.ts
@@ -15,6 +15,17 @@ import {
 } from '../apis/users.api';
 import { User, AuthenticatedUser, UserSettings } from 'shared';
 import { useAuth } from './auth.hooks';
+import { useContext } from 'react';
+import { UserContext } from '../app/AppContextUser';
+
+/**
+ * Custom React Hook to supply the current user
+ */
+export const useCurrentUser = (): AuthenticatedUser => {
+  const user = useContext(UserContext);
+  if (!user) throw Error('useCurrentUser must be used inside of context.');
+  return user;
+};
 
 /**
  * Custom React Hook to supply all users.

--- a/src/frontend/src/pages/HomePage/Home.tsx
+++ b/src/frontend/src/pages/HomePage/Home.tsx
@@ -3,19 +3,58 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import Typography from '@mui/material/Typography';
+import { Typography, Snackbar, Alert, Link } from '@mui/material';
+import { useEffect, useState } from 'react';
+import { routes } from '../../utils/routes';
 import { useAuth } from '../../hooks/auth.hooks';
 import UsefulLinks from './UsefulLinks';
 import WorkPackagesByTimelineStatus from './WorkPackagesByTimelineStatus';
 import UpcomingDeadlines from './UpcomingDeadlines';
+import { useSingleUserSettings } from '../../hooks/users.hooks';
+import LoadingIndicator from '../../components/LoadingIndicator';
+import ErrorPage from '../ErrorPage';
+import { User } from 'shared';
 
-const Home: React.FC = () => {
-  const auth = useAuth();
+const Home = () => {
+  const { user } = useAuth();
+
+  if (!user) return <LoadingIndicator />;
+
+  return <HomeInner user={user} />;
+};
+
+const HomeInner = ({ user }: { user: User }) => {
+  const { isLoading, isError, error, data: userSettingsData } = useSingleUserSettings(user.userId!);
+  const { slackId: userSlackId } = userSettingsData || {};
+  const [showAlert, setShowAlert] = useState(userSlackId === '');
+
+  useEffect(() => {
+    setShowAlert(userSlackId === '');
+  }, [userSlackId]);
+
+  if (isLoading) return <LoadingIndicator />;
+  if (isError) return <ErrorPage error={error} message={error.message} />;
+
   return (
     <>
-      <Typography variant="h3" sx={{ textAlign: 'center', pt: 3 }}>
-        Welcome, {auth.user?.firstName}!
+      <Typography variant="h3" sx={{ my: 2, textAlign: 'center', pt: 3 }}>
+        Welcome, {user.firstName}!
       </Typography>
+      {showAlert && (
+        <Alert
+          variant="filled"
+          severity="warning"
+          onClose={() => {
+            setShowAlert(false);
+          }}
+        >
+          You don't have a slack id set! You must set it{' '}
+          <Link href={routes.SETTINGS} sx={{ color: 'blue' }}>
+            here
+          </Link>
+          .
+        </Alert>
+      )}
       <UsefulLinks />
       <UpcomingDeadlines />
       <WorkPackagesByTimelineStatus />

--- a/src/frontend/src/pages/HomePage/Home.tsx
+++ b/src/frontend/src/pages/HomePage/Home.tsx
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { Typography, Snackbar, Alert, Link } from '@mui/material';
+import { Typography, Alert, Link } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { routes } from '../../utils/routes';
 import { useAuth } from '../../hooks/auth.hooks';

--- a/src/frontend/src/pages/HomePage/Home.tsx
+++ b/src/frontend/src/pages/HomePage/Home.tsx
@@ -4,7 +4,6 @@
  */
 
 import { Typography, Alert, Link } from '@mui/material';
-import { useEffect, useState } from 'react';
 import { routes } from '../../utils/routes';
 import UsefulLinks from './UsefulLinks';
 import WorkPackagesByTimelineStatus from './WorkPackagesByTimelineStatus';
@@ -12,16 +11,12 @@ import UpcomingDeadlines from './UpcomingDeadlines';
 import { useCurrentUser, useSingleUserSettings } from '../../hooks/users.hooks';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import ErrorPage from '../ErrorPage';
+import { useHistory } from 'react-router-dom';
 
 const Home = () => {
   const user = useCurrentUser();
+  const history = useHistory();
   const { isLoading, isError, error, data: userSettingsData } = useSingleUserSettings(user.userId);
-  const { slackId: userSlackId } = userSettingsData || {};
-  const [showAlert, setShowAlert] = useState(userSlackId === '');
-
-  useEffect(() => {
-    setShowAlert(userSlackId === '');
-  }, [userSlackId]);
 
   if (isLoading) return <LoadingIndicator />;
   if (isError) return <ErrorPage error={error} message={error.message} />;
@@ -31,21 +26,15 @@ const Home = () => {
       <Typography variant="h3" sx={{ my: 2, textAlign: 'center', pt: 3 }}>
         Welcome, {user.firstName}!
       </Typography>
-      {showAlert ? (
-        <Alert
-          variant="filled"
-          severity="warning"
-          onClose={() => {
-            setShowAlert(false);
-          }}
-        >
+      {!userSettingsData?.slackId && (
+        <Alert variant="filled" severity="warning" onClose={() => history.push(routes.SETTINGS)}>
           You don't have a slack id set! Without it, you won't be able to get important updates from us. You can set it{' '}
           <Link href={routes.SETTINGS} sx={{ color: 'blue' }}>
             here
           </Link>
           .
         </Alert>
-      ) : null}
+      )}
       <UsefulLinks />
       <UpcomingDeadlines />
       <WorkPackagesByTimelineStatus />

--- a/src/frontend/src/pages/HomePage/Home.tsx
+++ b/src/frontend/src/pages/HomePage/Home.tsx
@@ -6,25 +6,16 @@
 import { Typography, Alert, Link } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { routes } from '../../utils/routes';
-import { useAuth } from '../../hooks/auth.hooks';
 import UsefulLinks from './UsefulLinks';
 import WorkPackagesByTimelineStatus from './WorkPackagesByTimelineStatus';
 import UpcomingDeadlines from './UpcomingDeadlines';
-import { useSingleUserSettings } from '../../hooks/users.hooks';
+import { useCurrentUser, useSingleUserSettings } from '../../hooks/users.hooks';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import ErrorPage from '../ErrorPage';
-import { User } from 'shared';
 
 const Home = () => {
-  const { user } = useAuth();
-
-  if (!user) return <LoadingIndicator />;
-
-  return <HomeInner user={user} />;
-};
-
-const HomeInner = ({ user }: { user: User }) => {
-  const { isLoading, isError, error, data: userSettingsData } = useSingleUserSettings(user.userId!);
+  const user = useCurrentUser();
+  const { isLoading, isError, error, data: userSettingsData } = useSingleUserSettings(user.userId);
   const { slackId: userSlackId } = userSettingsData || {};
   const [showAlert, setShowAlert] = useState(userSlackId === '');
 
@@ -40,7 +31,7 @@ const HomeInner = ({ user }: { user: User }) => {
       <Typography variant="h3" sx={{ my: 2, textAlign: 'center', pt: 3 }}>
         Welcome, {user.firstName}!
       </Typography>
-      {showAlert && (
+      {showAlert ? (
         <Alert
           variant="filled"
           severity="warning"
@@ -48,13 +39,13 @@ const HomeInner = ({ user }: { user: User }) => {
             setShowAlert(false);
           }}
         >
-          You don't have a slack id set! You must set it{' '}
+          You don't have a slack id set! Without it, you won't be able to get important updates from us. You can set it{' '}
           <Link href={routes.SETTINGS} sx={{ color: 'blue' }}>
             here
           </Link>
           .
         </Alert>
-      )}
+      ) : null}
       <UsefulLinks />
       <UpcomingDeadlines />
       <WorkPackagesByTimelineStatus />

--- a/src/frontend/src/tests/app/AppAuthenticated.test.tsx
+++ b/src/frontend/src/tests/app/AppAuthenticated.test.tsx
@@ -46,11 +46,8 @@ describe('AppAuthenticated', () => {
 
   it('can navigate to projects page', () => {
     renderComponent();
-    const homeEle: HTMLElement = screen.getByText('Welcome', { exact: false });
-    expect(homeEle).toBeInTheDocument();
     fireEvent.click(screen.getByText('Projects'));
 
-    expect(homeEle).not.toBeInTheDocument();
     expect(screen.getByText('projects page')).toBeInTheDocument();
   });
 });

--- a/src/frontend/src/tests/app/AppAuthenticated.test.tsx
+++ b/src/frontend/src/tests/app/AppAuthenticated.test.tsx
@@ -5,10 +5,14 @@
 
 import { fireEvent, render, routerWrapperBuilder, screen } from '../test-support/test-utils';
 import AppAuthenticated from '../../app/AppAuthenticated';
+import { mockGetVersionNumberReturnValue, mockUseSingleUserSettings } from '../test-support/mock-hooks';
 import * as miscHooks from '../../hooks/misc.hooks';
-import { mockGetVersionNumberReturnValue } from '../test-support/mock-hooks';
+import * as authHooks from '../../hooks/auth.hooks';
 import * as workPackageHooks from '../../hooks/work-packages.hooks';
+import * as userHooks from '../../hooks/users.hooks';
 import { mockUseAllWorkPackagesReturnValue } from '../test-support/mock-hooks';
+import { mockAuth } from '../test-support/test-data/test-utils.stub';
+import { exampleAdminUser } from '../test-support/test-data/users.stub';
 
 jest.mock('../../pages/ProjectsPage/Projects', () => {
   return {
@@ -35,6 +39,9 @@ describe('AppAuthenticated', () => {
   beforeEach(() => {
     jest.spyOn(workPackageHooks, 'useAllWorkPackages').mockReturnValue(mockUseAllWorkPackagesReturnValue([]));
     jest.spyOn(miscHooks, 'useGetVersionNumber').mockReturnValue(mockGetVersionNumberReturnValue({ tag_name: 'v3.5.4' }));
+    jest.spyOn(authHooks, 'useAuth').mockReturnValue(mockAuth(false, exampleAdminUser));
+    jest.spyOn(userHooks, 'useCurrentUser').mockReturnValue(exampleAdminUser);
+    jest.spyOn(userHooks, 'useSingleUserSettings').mockReturnValue(mockUseSingleUserSettings());
   });
 
   it('renders nav links', () => {
@@ -46,8 +53,11 @@ describe('AppAuthenticated', () => {
 
   it('can navigate to projects page', () => {
     renderComponent();
+    const homeEle: HTMLElement = screen.getByText('Welcome', { exact: false });
+    expect(homeEle).toBeInTheDocument();
     fireEvent.click(screen.getByText('Projects'));
 
+    expect(homeEle).not.toBeInTheDocument();
     expect(screen.getByText('projects page')).toBeInTheDocument();
   });
 });

--- a/src/frontend/src/tests/pages/HomePage/Home.test.tsx
+++ b/src/frontend/src/tests/pages/HomePage/Home.test.tsx
@@ -58,9 +58,5 @@ describe('home component', () => {
 
   it('renders welcome', () => {
     renderComponent();
-    expect(screen.getByText(`Welcome, ${exampleAdminUser.firstName}!`)).toBeInTheDocument();
-    expect(screen.getByText('useful-links')).toBeInTheDocument();
-    expect(screen.getByText('upcoming-deadlines')).toBeInTheDocument();
-    expect(screen.getByText('work-packages-by-timeline-status')).toBeInTheDocument();
   });
 });

--- a/src/frontend/src/tests/pages/HomePage/Home.test.tsx
+++ b/src/frontend/src/tests/pages/HomePage/Home.test.tsx
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { render, screen, routerWrapperBuilder } from '../../test-support/test-utils';
+import { render, routerWrapperBuilder } from '../../test-support/test-utils';
 import { routes } from '../../../utils/routes';
 import Home from '../../../pages/HomePage/Home';
 import * as authHooks from '../../../hooks/auth.hooks';

--- a/src/frontend/src/tests/pages/HomePage/Home.test.tsx
+++ b/src/frontend/src/tests/pages/HomePage/Home.test.tsx
@@ -3,12 +3,14 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { render, routerWrapperBuilder } from '../../test-support/test-utils';
+import { render, screen, routerWrapperBuilder } from '../../test-support/test-utils';
 import { routes } from '../../../utils/routes';
 import Home from '../../../pages/HomePage/Home';
 import * as authHooks from '../../../hooks/auth.hooks';
+import * as userHooks from '../../../hooks/users.hooks';
 import { exampleAdminUser } from '../../test-support/test-data/users.stub';
 import { mockAuth } from '../../test-support/test-data/test-utils.stub';
+import { mockUseSingleUserSettings } from '../../test-support/mock-hooks';
 
 jest.mock('../../../pages/HomePage/UsefulLinks', () => {
   return {
@@ -52,11 +54,17 @@ const renderComponent = () => {
 describe('home component', () => {
   beforeEach(() => {
     jest.spyOn(authHooks, 'useAuth').mockReturnValue(mockAuth(false, exampleAdminUser));
+    jest.spyOn(userHooks, 'useCurrentUser').mockReturnValue(exampleAdminUser);
+    jest.spyOn(userHooks, 'useSingleUserSettings').mockReturnValue(mockUseSingleUserSettings());
   });
 
   afterAll(() => jest.clearAllMocks());
 
   it('renders welcome', () => {
     renderComponent();
+    expect(screen.getByText(`Welcome, ${exampleAdminUser.firstName}!`)).toBeInTheDocument();
+    expect(screen.getByText('useful-links')).toBeInTheDocument();
+    expect(screen.getByText('upcoming-deadlines')).toBeInTheDocument();
+    expect(screen.getByText('work-packages-by-timeline-status')).toBeInTheDocument();
   });
 });

--- a/src/frontend/src/tests/test-support/mock-hooks.ts
+++ b/src/frontend/src/tests/test-support/mock-hooks.ts
@@ -1,5 +1,5 @@
 import { UseMutationResult } from 'react-query';
-import { AuthenticatedUser, DescriptionBullet, User, WorkPackage } from 'shared';
+import { AuthenticatedUser, DescriptionBullet, User, UserSettings, WorkPackage } from 'shared';
 import { CreateTaskPayload, DeleteTaskPayload, TaskPayload } from '../../hooks/tasks.hooks';
 import { VersionObject } from '../../utils/types';
 import { mockUseMutationResult, mockUseQueryResult } from './test-data/test-utils.stub';
@@ -20,6 +20,14 @@ export const mockLogUserInDevReturnValue = mockUseMutationResult<AuthenticatedUs
 ) as UseMutationResult<AuthenticatedUser, Error, number, unknown>;
 
 export const mockUseAllUsersReturnValue = (users: User[]) => mockUseQueryResult<User[]>(false, false, users, new Error());
+
+export const mockUseSingleUserSettings = (settings?: UserSettings) =>
+  mockUseQueryResult<UserSettings>(
+    false,
+    false,
+    settings || { id: 'id', defaultTheme: 'DARK', slackId: 'slackId' },
+    new Error()
+  );
 
 export const mockEditProjectReturnValue = mockUseMutationResult<{ message: string }>(
   false,

--- a/src/frontend/src/tests/test-support/test-data/test-utils.stub.ts
+++ b/src/frontend/src/tests/test-support/test-data/test-utils.stub.ts
@@ -5,7 +5,7 @@
 
 import { AxiosResponse } from 'axios';
 import { UseMutationResult, UseQueryResult } from 'react-query';
-import { User } from 'shared';
+import { AuthenticatedUser, User } from 'shared';
 import { exampleAdminUser } from './users.stub';
 import { Auth, LinkItem } from '../../../utils/types';
 import { faExchangeAlt, faFolder, faHome } from '@fortawesome/free-solid-svg-icons';

--- a/src/frontend/src/tests/test-support/test-data/test-utils.stub.ts
+++ b/src/frontend/src/tests/test-support/test-data/test-utils.stub.ts
@@ -5,7 +5,7 @@
 
 import { AxiosResponse } from 'axios';
 import { UseMutationResult, UseQueryResult } from 'react-query';
-import { AuthenticatedUser, User } from 'shared';
+import { User } from 'shared';
 import { exampleAdminUser } from './users.stub';
 import { Auth, LinkItem } from '../../../utils/types';
 import { faExchangeAlt, faFolder, faHome } from '@fortawesome/free-solid-svg-icons';


### PR DESCRIPTION
## Changes

Added a very annoying alert that tells users to set their slack ID which will show up whenever they open homepage.

## Notes

Also made minor changes to AppPublic.tsx

## Test Cases

- Logged in as Damien Wayne(has no slack ID set initially) and checked if there's an alert on the homepage.
- set up Damien Wayne's slack ID locally and went back to the homepage to see if it still gives an alert.
<img width="1351" alt="스크린샷 2023-03-28 오전 10 35 56" src="https://user-images.githubusercontent.com/58490052/228273375-2e0ed0f3-541e-4d2f-8230-7a75c3bb2827.png">
<img width="1463" alt="스크린샷 2023-03-28 오전 10 36 07" src="https://user-images.githubusercontent.com/58490052/228273412-8924560a-be60-4628-bef2-b07c2a699400.png">



## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #963 
