### PR TITLE
#1050: removed task list link from project details page

### DIFF
--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectDetails.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectDetails.tsx
@@ -59,14 +59,6 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ project }) => {
         </Grid>
         <Grid item xs={2} md={2}>
           <Stack direction="row" alignItems="center">
-            <FormatListBulleted sx={{ fontSize: 22, color: theme.palette.text.primary }} />
-            <Link href={project.taskListLink!} target="_blank" underline="always" fontSize={19} sx={{ pl: 1 }}>
-              Task List
-            </Link>
-          </Stack>
-        </Grid>
-        <Grid item xs={2} md={2}>
-          <Stack direction="row" alignItems="center">
             <FormatListNumbered sx={{ fontSize: 22, color: theme.palette.text.primary }} />
             <Link href={project.bomLink!} target="_blank" underline="always" fontSize={19} sx={{ pl: 1 }}>
               BOM


### PR DESCRIPTION
## Changes

deleted the task list tab from project details in the project details file.

## Screenshots

<img width="1304" alt="Screen Shot 2023-03-27 at 7 57 10 PM" src="https://user-images.githubusercontent.com/97249165/228092923-b94d74ea-5e47-4bdf-afde-a411a3f4387c.png">




Closes # 1050
