### PR TITLE
#849 changed trash icon

### DIFF
--- a/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionView.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionView.tsx
@@ -9,8 +9,7 @@ import Chip from '@mui/material/Chip';
 import Button from '@mui/material/Button';
 import Grid from '@mui/material/Grid';
 import { dollarsPipe, weeksPipe } from '../../utils/pipes';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTrash } from '@fortawesome/free-solid-svg-icons';
+import DeleteIcon from '@mui/icons-material/Delete';
 import DetailDisplay from '../../components/DetailDisplay';
 
 interface ProposedSolutionViewProps {
@@ -39,7 +38,7 @@ const ProposedSolutionView: React.FC<ProposedSolutionViewProps> = ({
           }}
           sx={{ position: 'absolute', right: 75 }}
         >
-          <FontAwesomeIcon icon={faTrash} size="lg" data-testid={'deleteIcon'} />
+          <DeleteIcon data-testid="DeleteIcon" />
         </Button>
       ) : null}
       <Grid container rowSpacing={1} columnSpacing={{ xs: 1, sm: 2, md: 3 }}>

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionView.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ProposedSolutionView.tsx
@@ -38,7 +38,7 @@ const ProposedSolutionView: React.FC<ProposedSolutionViewProps> = ({
           }}
           sx={{ position: 'absolute', right: 75 }}
         >
-          <DeleteIcon data-testid="DeleteIcon" />
+          <DeleteIcon />
         </Button>
       ) : null}
       <Grid container rowSpacing={1} columnSpacing={{ xs: 1, sm: 2, md: 3 }}>


### PR DESCRIPTION
## Changes

The trash icon was changed to another version of the same icon from the library of MUI icons. 

## Screenshots
BEFORE:
// no trash icon
<img width="859" alt="Screen Shot 2023-04-05 at 8 38 46 PM" src="https://user-images.githubusercontent.com/113949833/230244210-9a4e5e47-2a02-4a6c-9dd6-4e3f2280f9ec.png">

AFTER:
// whole image
<img width="1440" alt="Screen Shot 2023-04-05 at 8 37 22 PM" src="https://user-images.githubusercontent.com/113949833/230244229-6601e7e6-16e3-4cd9-ada8-3d916cd34ea4.png">

// smaller image
<img width="122" alt="Screen Shot 2023-04-05 at 8 37 36 PM" src="https://user-images.githubusercontent.com/113949833/230244464-69504890-2475-4bf5-9947-8a6d01bf03cb.png">

_If you made UI changes you must post a screenshot of the whole page for each change in 1) a normal sized window and 2) the smallest possible window_

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #849
