### PR TITLE
#1058 Added Icons to the project page menu action items icon

### DIFF
--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
@@ -29,6 +29,8 @@ import { useSetProjectTeam } from '../../../hooks/projects.hooks';
 import { useToast } from '../../../hooks/toasts.hooks';
 import TaskList from './TaskList';
 import DeleteProject from '../DeleteProject';
+import GroupIcon from '@mui/icons-material/Group';
+import DeleteIcon from '@mui/icons-material/Delete';
 
 interface ProjectViewContainerProps {
   proj: Project;
@@ -105,12 +107,18 @@ const ProjectViewContainer: React.FC<ProjectViewContainerProps> = ({ proj, enter
 
   const assignToMyTeamButton = (
     <MenuItem disabled={proj.team?.teamId === teamAsLeadId} onClick={handleAssignToMyTeam}>
+      <ListItemIcon>
+        <GroupIcon fontSize="small" />
+      </ListItemIcon>
       Assign to My Team
     </MenuItem>
   );
 
   const deleteButton = (
     <MenuItem onClick={handleClickDelete} disabled={!isAdmin}>
+      <ListItemIcon>
+        <DeleteIcon fontSize="small" />
+      </ListItemIcon>
       Delete
     </MenuItem>
   );


### PR DESCRIPTION
## Changes

Added Icons to the project page menu action items icon, specifically delete Icon and Group Icon


## Screenshots
<img width="1506" alt="Screenshot 2023-03-29 at 9 27 40 PM" src="https://user-images.githubusercontent.com/96765261/228704364-038b8303-423e-4bfe-82c9-ed9db71a731f.png">
<img width="208" alt="Screenshot 2023-03-29 at 9 27 49 PM" src="https://user-images.githubusercontent.com/96765261/228704384-885117da-0e6d-431b-af71-495a137b6bbe.png">
<img width="488" alt="Screenshot 2023-03-29 at 9 28 02 PM" src="https://user-images.githubusercontent.com/96765261/228704411-329c63b1-46d1-404b-851e-8e8e31bddde0.png">



## To Do


## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1058 
