### PR TITLE
#962 create deleted exception

### DIFF
--- a/src/backend/src/services/change-requests.services.ts
+++ b/src/backend/src/services/change-requests.services.ts
@@ -71,7 +71,7 @@ export default class ChangeRequestsService {
     if (!foundCR) throw new NotFoundException('Change Request', crId);
     if (foundCR.accepted) throw new HttpException(400, `This change request is already approved!`);
     if (foundCR.dateDeleted) throw new DeletedException('Change Request', crId);
-    if (foundCR.wbsElement.dateDeleted) throw new DeletedException('WBS Element', foundCR.wbsElementId);
+    if (foundCR.wbsElement.dateDeleted) throw new DeletedException('WBS Element', wbsPipe(foundCR.wbsElement));
 
     // verify that the user is not reviewing their own change request
     if (reviewer.userId === foundCR.submitterId) throw new AccessDeniedException();

--- a/src/backend/src/services/description-bullets.services.ts
+++ b/src/backend/src/services/description-bullets.services.ts
@@ -1,7 +1,7 @@
 import { User, WBS_Element_Status } from '@prisma/client';
 import prisma from '../prisma/prisma';
 import { hasBulletCheckingPermissions } from '../utils/description-bullets.utils';
-import { AccessDeniedException, HttpException, NotFoundException } from '../utils/errors.utils';
+import { AccessDeniedException, HttpException, NotFoundException, DeletedException } from '../utils/errors.utils';
 import descriptionBulletTransformer from '../transformers/description-bullets.transformer';
 import descriptionBulletQueryArgs from '../prisma-query-args/description-bullets.query-args';
 import { DescriptionBullet } from 'shared';
@@ -24,7 +24,7 @@ export default class DescriptionBulletsService {
     });
     if (!originalDB) throw new NotFoundException('Description Bullet', descriptionId);
 
-    if (originalDB.dateDeleted) throw new HttpException(400, 'Cant edit a deleted Description Bullet!');
+    if (originalDB.dateDeleted) throw new DeletedException('Description Bullet', descriptionId);
 
     const workPackage = originalDB.workPackageDeliverables || originalDB.workPackageExpectedActivities;
 

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -4,7 +4,7 @@ import projectQueryArgs from '../prisma-query-args/projects.query-args';
 import prisma from '../prisma/prisma';
 import projectTransformer from '../transformers/projects.transformer';
 import { validateChangeRequestAccepted } from '../utils/change-requests.utils';
-import { AccessDeniedException, HttpException, NotFoundException } from '../utils/errors.utils';
+import { AccessDeniedException, HttpException, NotFoundException, DeletedException } from '../utils/errors.utils';
 import {
   addDescriptionBullets,
   createChangeJsonNonList,
@@ -50,7 +50,7 @@ export default class ProjectsService {
     });
 
     if (!project) throw new NotFoundException('Project', wbsPipe(wbsNumber));
-    if (project.wbsElement.dateDeleted) throw new HttpException(400, 'This project has been deleted!');
+    if (project.wbsElement.dateDeleted) throw new DeletedException('Project', project.projectId);
 
     return projectTransformer(project);
   }
@@ -165,7 +165,7 @@ export default class ProjectsService {
 
     // if it doesn't exist we error
     if (!originalProject) throw new NotFoundException('Project', projectId);
-    if (originalProject.wbsElement.dateDeleted) throw new HttpException(400, 'This project has been deleted!');
+    if (originalProject.wbsElement.dateDeleted) throw new DeletedException('Project', projectId);
 
     const { wbsElementId } = originalProject;
 
@@ -421,7 +421,7 @@ export default class ProjectsService {
     });
 
     if (!project) throw new NotFoundException('Project', wbsPipe(wbsNumber));
-    if (project.wbsElement.dateDeleted) throw new HttpException(400, 'This project has been deleted!');
+    if (project.wbsElement.dateDeleted) throw new DeletedException('Project', project.projectId);
 
     const { projectId, wbsElementId } = project;
 

--- a/src/backend/src/services/risks.services.ts
+++ b/src/backend/src/services/risks.services.ts
@@ -120,7 +120,7 @@ export default class RisksService {
     const targetRisk = await prisma.risk.findUnique({ where: { id: riskId }, ...riskQueryArgs });
     if (!targetRisk) throw new NotFoundException('Risk', riskId);
 
-    if (targetRisk.dateDeleted || targetRisk.deletedBy) throw new HttpException(400, 'This risk has already been deleted!');
+    if (targetRisk.dateDeleted || targetRisk.deletedBy) throw new DeletedException('Risk', riskId);
 
     const selfDelete = targetRisk.createdByUserId === user.userId;
     const hasPerms = await hasRiskPermissions(user.userId, targetRisk.projectId);

--- a/src/backend/src/services/risks.services.ts
+++ b/src/backend/src/services/risks.services.ts
@@ -1,7 +1,7 @@
 import { Role, User } from '@prisma/client';
 import { Risk } from 'shared';
 import prisma from '../prisma/prisma';
-import { NotFoundException, AccessDeniedException, HttpException } from '../utils/errors.utils';
+import { NotFoundException, AccessDeniedException, HttpException, DeletedException } from '../utils/errors.utils';
 import { hasRiskPermissions } from '../utils/risks.utils';
 import riskQueryArgs from '../prisma-query-args/risks.query-args';
 import riskTransformer from '../transformers/risks.transformer';
@@ -16,7 +16,7 @@ export default class RisksService {
     const requestedProject = await prisma.project.findUnique({ where: { projectId }, include: { wbsElement: true } });
 
     if (!requestedProject) throw new NotFoundException('Project', projectId);
-    if (requestedProject.wbsElement.dateDeleted) throw new HttpException(400, 'This risks project has been deleted!');
+    if (requestedProject.wbsElement.dateDeleted) throw new DeletedException('Project', projectId);
 
     const risks = await prisma.risk.findMany({ where: { projectId, dateDeleted: null }, ...riskQueryArgs });
 
@@ -37,7 +37,7 @@ export default class RisksService {
     const requestedProject = await prisma.project.findUnique({ where: { projectId }, include: { wbsElement: true } });
 
     if (!requestedProject) throw new NotFoundException('Project', projectId);
-    if (requestedProject.wbsElement.dateDeleted) throw new HttpException(400, 'This risks project has been deleted!');
+    if (requestedProject.wbsElement.dateDeleted) throw new DeletedException('Project', projectId);
 
     const createdRisk = await prisma.risk.create({
       data: {

--- a/src/backend/src/services/tasks.services.ts
+++ b/src/backend/src/services/tasks.services.ts
@@ -5,7 +5,7 @@ import taskQueryArgs from '../prisma-query-args/tasks.query-args';
 import teamQueryArgs from '../prisma-query-args/teams.query-args';
 import prisma from '../prisma/prisma';
 import taskTransformer from '../transformers/tasks.transformer';
-import { NotFoundException, AccessDeniedException, HttpException } from '../utils/errors.utils';
+import { NotFoundException, AccessDeniedException, HttpException, DeletedException } from '../utils/errors.utils';
 import { hasPermissionToEditTask } from '../utils/tasks.utils';
 import { allUsersOnTeam, isUserOnTeam } from '../utils/teams.utils';
 import { getUsers } from '../utils/users.utils';
@@ -39,7 +39,7 @@ export default class TasksService {
       include: { project: { include: { team: { ...teamQueryArgs }, wbsElement: true } } }
     });
     if (!requestedWbsElement) throw new NotFoundException('WBS Element', wbsPipe(wbsNum));
-    if (requestedWbsElement.dateDeleted) throw new HttpException(400, "This task's wbs element has been deleted!");
+    if (requestedWbsElement.dateDeleted) throw new DeletedException('WBS Element', wbsPipe(wbsNum));
     const { project } = requestedWbsElement;
     if (!project) throw new HttpException(400, "This task's wbs element is not linked to a project!");
 
@@ -95,7 +95,7 @@ export default class TasksService {
 
     const originalTask = await prisma.task.findUnique({ where: { taskId } });
     if (!originalTask) throw new NotFoundException('Task', taskId);
-    if (originalTask.dateDeleted) throw new HttpException(400, 'Cant edit a deleted Task!');
+    if (originalTask.dateDeleted) throw new DeletedException('Task', taskId);
 
     if (!isUnderWordCount(title, 15)) throw new HttpException(400, 'Title must be less than 15 words');
 
@@ -121,7 +121,7 @@ export default class TasksService {
     // Get the original task and check if it exists
     const originalTask = await prisma.task.findUnique({ where: { taskId } });
     if (!originalTask) throw new NotFoundException('Task', taskId);
-    if (originalTask.dateDeleted) throw new HttpException(400, 'Cant edit a deleted Task!');
+    if (originalTask.dateDeleted) throw new DeletedException('Task', taskId);
 
     const hasPermission = await hasPermissionToEditTask(user, taskId);
     if (!hasPermission)
@@ -150,7 +150,7 @@ export default class TasksService {
       }
     });
     if (!originalTask) throw new NotFoundException('Task', taskId);
-    if (originalTask.dateDeleted) throw new HttpException(400, 'Cant edit a deleted Task!');
+    if (originalTask.dateDeleted) throw new DeletedException('Task', taskId);
 
     const hasPermission = await hasPermissionToEditTask(user, taskId);
     if (!hasPermission)
@@ -197,11 +197,11 @@ export default class TasksService {
   static async deleteTask(currentUser: User, taskId: string): Promise<string> {
     const task = await prisma.task.findUnique({ where: { taskId }, ...taskQueryArgs });
     if (!task) throw new NotFoundException('Task', taskId);
-    if (task.dateDeleted) throw new HttpException(400, 'Cant delete a deleted Task!');
+    if (task.dateDeleted) throw new DeletedException('Task', taskId);
 
     const wbsElement = await prisma.wBS_Element.findUnique({ where: { wbsElementId: task.wbsElementId } });
     if (!wbsElement) throw new NotFoundException('WBS Element', task.wbsElementId);
-    if (wbsElement.dateDeleted) throw new HttpException(400, "This task's wbs element has been deleted!");
+    if (wbsElement.dateDeleted) throw new DeletedException('WBS Element', wbsElement.wbsElementId);
 
     // this checks the current users permissions
     const isAdmin = currentUser.role === Role.APP_ADMIN || currentUser.role === Role.ADMIN;

--- a/src/backend/src/services/tasks.services.ts
+++ b/src/backend/src/services/tasks.services.ts
@@ -9,6 +9,7 @@ import { NotFoundException, AccessDeniedException, HttpException, DeletedExcepti
 import { hasPermissionToEditTask } from '../utils/tasks.utils';
 import { allUsersOnTeam, isUserOnTeam } from '../utils/teams.utils';
 import { getUsers } from '../utils/users.utils';
+import { wbsNumOf } from '../utils/utils';
 
 export default class TasksService {
   /**
@@ -201,7 +202,10 @@ export default class TasksService {
 
     const wbsElement = await prisma.wBS_Element.findUnique({ where: { wbsElementId: task.wbsElementId } });
     if (!wbsElement) throw new NotFoundException('WBS Element', task.wbsElementId);
-    if (wbsElement.dateDeleted) throw new DeletedException('WBS Element', task.wbsElementId);
+    if (wbsElement.dateDeleted) {
+      const wbsNum = wbsNumOf(wbsElement);
+      throw new DeletedException('WBS Element', wbsPipe(wbsNum));
+    }
 
     // this checks the current users permissions
     const isAdmin = currentUser.role === Role.APP_ADMIN || currentUser.role === Role.ADMIN;

--- a/src/backend/src/services/tasks.services.ts
+++ b/src/backend/src/services/tasks.services.ts
@@ -201,7 +201,7 @@ export default class TasksService {
 
     const wbsElement = await prisma.wBS_Element.findUnique({ where: { wbsElementId: task.wbsElementId } });
     if (!wbsElement) throw new NotFoundException('WBS Element', task.wbsElementId);
-    if (wbsElement.dateDeleted) throw new DeletedException('WBS Element', wbsPipe(wbsElement));
+    if (wbsElement.dateDeleted) throw new DeletedException('WBS Element', task.wbsElementId);
 
     // this checks the current users permissions
     const isAdmin = currentUser.role === Role.APP_ADMIN || currentUser.role === Role.ADMIN;

--- a/src/backend/src/services/tasks.services.ts
+++ b/src/backend/src/services/tasks.services.ts
@@ -201,7 +201,7 @@ export default class TasksService {
 
     const wbsElement = await prisma.wBS_Element.findUnique({ where: { wbsElementId: task.wbsElementId } });
     if (!wbsElement) throw new NotFoundException('WBS Element', task.wbsElementId);
-    if (wbsElement.dateDeleted) throw new DeletedException('WBS Element', wbsElement.wbsElementId);
+    if (wbsElement.dateDeleted) throw new DeletedException('WBS Element', wbsPipe(wbsElement));
 
     // this checks the current users permissions
     const isAdmin = currentUser.role === Role.APP_ADMIN || currentUser.role === Role.ADMIN;

--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -511,7 +511,7 @@ export default class WorkPackagesService {
     });
 
     if (!workPackage) throw new NotFoundException('Work Package', wbsPipe(wbsNum));
-    if (workPackage.wbsElement.dateDeleted) throw new DeletedException('Work Package', workPackage.workPackageId);
+    if (workPackage.wbsElement.dateDeleted) throw new DeletedException('Work Package', wbsPipe(wbsNum));
 
     const { wbsElementId, workPackageId } = workPackage;
 

--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -11,7 +11,7 @@ import {
   WorkPackageStage
 } from 'shared';
 import prisma from '../prisma/prisma';
-import { NotFoundException, AccessDeniedException, HttpException } from '../utils/errors.utils';
+import { NotFoundException, AccessDeniedException, HttpException, DeletedException } from '../utils/errors.utils';
 import {
   createChangeJsonDates,
   createChangeJsonNonList,
@@ -161,7 +161,8 @@ export default class WorkPackagesService {
     });
 
     if (!wbsElem) throw new NotFoundException('WBS Element', `${carNumber}.${projectNumber}.${workPackageNumber}`);
-    if (wbsElem.dateDeleted) throw new HttpException(400, 'Cannot create a work package for a deleted project!');
+    if (wbsElem.dateDeleted)
+      throw new DeletedException('WBS Element', wbsPipe({ carNumber, projectNumber, workPackageNumber }));
 
     const { project } = wbsElem;
 
@@ -289,7 +290,7 @@ export default class WorkPackagesService {
     });
 
     if (!originalWorkPackage) throw new NotFoundException('Work Package', workPackageId);
-    if (originalWorkPackage.wbsElement.dateDeleted) throw new HttpException(400, 'Cannot edit a deleted work package!');
+    if (originalWorkPackage.wbsElement.dateDeleted) throw new DeletedException('Work Package', workPackageId);
 
     if (
       dependencies.find((dep: WbsNumber) =>
@@ -328,7 +329,7 @@ export default class WorkPackagesService {
         });
 
         if (!wbsElem) throw new NotFoundException('WBS Element', wbsPipe(wbsNum));
-        if (wbsElem.dateDeleted) throw new HttpException(400, `WBS ${wbsPipe(wbsNum)} has been deleted!`);
+        if (wbsElem.dateDeleted) throw new DeletedException('WBS Element', wbsPipe(wbsNum));
 
         return wbsElem.wbsElementId;
       })
@@ -510,7 +511,7 @@ export default class WorkPackagesService {
     });
 
     if (!workPackage) throw new NotFoundException('Work Package', wbsPipe(wbsNum));
-    if (workPackage.wbsElement.dateDeleted) throw new HttpException(400, 'This work package has already been deleted!');
+    if (workPackage.wbsElement.dateDeleted) throw new DeletedException('Work Package', workPackage.workPackageId);
 
     const { wbsElementId, workPackageId } = workPackage;
 

--- a/src/backend/src/utils/errors.utils.ts
+++ b/src/backend/src/utils/errors.utils.ts
@@ -23,8 +23,19 @@ export class NotFoundException extends HttpException {
    * @param name the name of the thing that can't be found
    * @param id the id of the thing that can't be found
    */
-  constructor(name: NotFoundObjectNames, id: number | string) {
+  constructor(name: ExceptionObjectNames, id: number | string) {
     super(404, `${name} with id: ${id} not found!`);
+  }
+}
+
+export class DeletedException extends HttpException {
+  /**
+   * Constructs a deleted error
+   * @param name the name of the thing that was deleted
+   * @param id the id of the thing that was deleted
+   */
+  constructor(name: ExceptionObjectNames, id: number | string) {
+    super(400, `${name} with id: ${id} has already been deleted!`);
   }
 }
 
@@ -55,7 +66,7 @@ export const errorHandler: ErrorRequestHandler = (error: unknown, _req: Request,
 };
 
 // type so that the not found error messages are consistent
-type NotFoundObjectNames =
+type ExceptionObjectNames =
   | 'User'
   | 'Risk'
   | 'Work Package'

--- a/src/backend/tests/change-requests.test.ts
+++ b/src/backend/tests/change-requests.test.ts
@@ -13,7 +13,7 @@ import { prismaWorkPackage1 } from './test-data/work-packages.test-data';
 import { prismaProject1 } from './test-data/projects.test-data';
 import { CR_Type } from '@prisma/client';
 import ChangeRequestsService from '../src/services/change-requests.services';
-import { AccessDeniedException, HttpException, NotFoundException } from '../src/utils/errors.utils';
+import { AccessDeniedException, HttpException, NotFoundException, DeletedException } from '../src/utils/errors.utils';
 import * as changeRequestTransformer from '../src/transformers/change-requests.transformer';
 import * as changeRequestUtils from '../src/utils/change-requests.utils';
 
@@ -327,7 +327,7 @@ describe('Change Requests', () => {
         .mockResolvedValue({ ...prismaChangeRequest1, dateDeleted: new Date('1/1/2023') });
       await expect(() =>
         ChangeRequestsService.addProposedSolution(greenlantern, crId, budgetImpact, description, timelineImpact, scopeImpact)
-      ).rejects.toThrow(new HttpException(400, 'This change request has been deleted!'));
+      ).rejects.toThrow(new DeletedException('Change Request', crId));
       expect(prisma.change_Request.findUnique).toHaveBeenCalledTimes(1);
     });
 
@@ -381,7 +381,7 @@ describe('Change Requests', () => {
         .spyOn(prisma.change_Request, 'findUnique')
         .mockResolvedValue({ ...prismaChangeRequest1, dateDeleted: new Date() });
       await expect(() => ChangeRequestsService.deleteChangeRequest(superman, 1)).rejects.toThrow(
-        new HttpException(400, 'This change request has already been deleted!')
+        new DeletedException('Change Request', 1)
       );
       expect(prisma.change_Request.findUnique).toHaveBeenCalledTimes(1);
     });

--- a/src/backend/tests/risks.test.ts
+++ b/src/backend/tests/risks.test.ts
@@ -6,7 +6,7 @@ import { prismaRisk1, prismaRisk1Deleted, prismaRisk1NoPerms, prismaRisk2, share
 import { batman, wonderwoman } from './test-data/users.test-data';
 import * as riskUtils from '../src/utils/risks.utils';
 import * as riskTransformer from '../src/transformers/risks.transformer';
-import { AccessDeniedException, HttpException, NotFoundException } from '../src/utils/errors.utils';
+import { AccessDeniedException, NotFoundException, DeletedException } from '../src/utils/errors.utils';
 
 describe('Risks', () => {
   const mockDate = new Date('2022-12-25T00:00:00.000Z');
@@ -193,9 +193,7 @@ describe('Risks', () => {
       jest.spyOn(prisma.risk, 'findUnique').mockResolvedValue(prismaRisk1Deleted);
       jest.spyOn(riskUtils, 'hasRiskPermissions').mockResolvedValue(true);
       const riskId = 'riskId';
-      await expect(() => RisksService.deleteRisk(batman, riskId)).rejects.toThrow(
-        new HttpException(400, 'This risk has already been deleted!')
-      );
+      await expect(() => RisksService.deleteRisk(batman, riskId)).rejects.toThrow(new DeletedException('Risk', riskId));
       expect(prisma.risk.findUnique).toHaveBeenCalledTimes(1);
       expect(prisma.risk.update).toHaveBeenCalledTimes(0);
     });

--- a/src/backend/tests/tasks.test.ts
+++ b/src/backend/tests/tasks.test.ts
@@ -4,7 +4,7 @@ import taskQueryArgs from '../src/prisma-query-args/tasks.query-args';
 import prisma from '../src/prisma/prisma';
 import TasksService from '../src/services/tasks.services';
 import * as taskTransformer from '../src/transformers/tasks.transformer';
-import { AccessDeniedException, HttpException, NotFoundException } from '../src/utils/errors.utils';
+import { AccessDeniedException, HttpException, NotFoundException, DeletedException } from '../src/utils/errors.utils';
 import * as userUtils from '../src/utils/users.utils';
 import * as taskUtils from '../src/utils/tasks.utils';
 import * as teamUtils from '../src/utils/teams.utils';
@@ -102,7 +102,7 @@ describe('Tasks', () => {
 
       await expect(() =>
         TasksService.createTask(batman, mockWBSNum, 'hellow world', '', mockDate, 'HIGH', 'DONE', [])
-      ).rejects.toThrow(new HttpException(400, "This task's wbs element has been deleted!"));
+      ).rejects.toThrow(new DeletedException('WBS Element', '1.2.0'));
 
       expect(prisma.wBS_Element.findUnique).toHaveBeenCalledTimes(1);
     });
@@ -222,7 +222,7 @@ describe('Tasks', () => {
       const taskId = '1';
       // Try updating from IN_PROGRESS to IN_BACKLOG
       await expect(() => TasksService.editTaskStatus(batman, taskId, Task_Status.IN_BACKLOG)).rejects.toThrow(
-        new HttpException(400, 'Cant edit a deleted Task!')
+        new DeletedException('Task', taskId)
       );
     });
   });
@@ -292,7 +292,7 @@ describe('Tasks', () => {
       const taskId = '1';
       await expect(() =>
         TasksService.editTaskAssignees(batman, taskId, [superman.userId, wonderwoman.userId])
-      ).rejects.toThrow(new HttpException(400, 'Cant edit a deleted Task!'));
+      ).rejects.toThrow(new DeletedException('Task', taskId));
     });
   });
 
@@ -313,7 +313,7 @@ describe('Tasks', () => {
       jest.spyOn(prisma.task, 'findUnique').mockResolvedValue(taskSaveTheDayDeletedPrisma);
 
       await expect(() => TasksService.deleteTask(batman, mockTaskId)).rejects.toThrow(
-        new HttpException(400, 'Cant delete a deleted Task!')
+        new DeletedException('Task', mockTaskId)
       );
 
       expect(prisma.task.findUnique).toHaveBeenCalledTimes(1);
@@ -336,7 +336,7 @@ describe('Tasks', () => {
       jest.spyOn(prisma.wBS_Element, 'findUnique').mockResolvedValue({ ...prismaWbsElement1, dateDeleted: new Date() });
 
       await expect(() => TasksService.deleteTask(batman, mockTaskId)).rejects.toThrow(
-        new HttpException(400, "This task's wbs element has been deleted!")
+        new DeletedException('WBS Element', '1.1.2')
       );
 
       expect(prisma.task.findUnique).toHaveBeenCalledTimes(1);
@@ -399,7 +399,7 @@ describe('Tasks', () => {
         .mockResolvedValue({ ...taskSaveTheDayPrisma, dateDeleted: new Date('1/1/2023') });
       await expect(() =>
         TasksService.editTask(superman, taskId, fakeTitle, fakeNotes, fakePriority, fakeDeadline)
-      ).rejects.toThrow(new HttpException(400, 'Cant edit a deleted Task!'));
+      ).rejects.toThrow(new DeletedException('Task', taskId));
       expect(prisma.task.findUnique).toHaveBeenCalledTimes(1);
     });
 

--- a/src/backend/tests/tasks.test.ts
+++ b/src/backend/tests/tasks.test.ts
@@ -336,7 +336,7 @@ describe('Tasks', () => {
       jest.spyOn(prisma.wBS_Element, 'findUnique').mockResolvedValue({ ...prismaWbsElement1, dateDeleted: new Date() });
 
       await expect(() => TasksService.deleteTask(batman, mockTaskId)).rejects.toThrow(
-        new DeletedException('WBS Element', '1.1.2')
+        new DeletedException('WBS Element', '1.2.0')
       );
 
       expect(prisma.task.findUnique).toHaveBeenCalledTimes(1);

--- a/src/backend/tests/work-packages.test.ts
+++ b/src/backend/tests/work-packages.test.ts
@@ -3,7 +3,7 @@ import { batman, wonderwoman } from './test-data/users.test-data';
 import { prismaWbsElement1 } from './test-data/wbs-element.test-data';
 import { prismaChangeRequest1 } from './test-data/change-requests.test-data';
 import { calculateWorkPackageProgress } from '../src/utils/work-packages.utils';
-import { AccessDeniedException, HttpException, NotFoundException } from '../src/utils/errors.utils';
+import { AccessDeniedException, HttpException, NotFoundException, DeletedException } from '../src/utils/errors.utils';
 import WorkPackageService from '../src/services/work-packages.services';
 import { WbsNumber } from 'shared';
 import { User } from '@prisma/client';
@@ -242,7 +242,7 @@ describe('Work Packages', () => {
       } as any);
 
       await expect(() => WorkPackageService.deleteWorkPackage(batman, wbsNum)).rejects.toThrow(
-        new HttpException(400, 'This work package has already been deleted!')
+        new DeletedException('Work Package', '1.2.3')
       );
 
       expect(prisma.work_Package.findFirst).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Changes

- Created a DeletedException in the errors.utils file 
- Updated all the services files + test files to use this exception when something was deleted

## Test Cases

- yarn test:frontend + yarn test:backend passed
- FinishLine works

## Checklist

- [X] All commits are tagged with the ticket number
- [X] No linting errors / newline at end of file warnings
- [X] All code follows repository-configured prettier formatting
- [X] No merge conflicts
- [X] All checks passing
- [X] Screenshots of UI changes (see Screenshots section)
- [X] Remove any non-applicable sections of this template
- [X] Assign the PR to yourself
- [X] No `yarn.lock` changes (unless dependencies have changed)
- [X] Request reviewers & ping on Slack
- [X] PR is linked to the ticket (fill in the closes line below)

Closes #962 
