### PR TITLE
#986 enforce monday start date

### DIFF
--- a/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageFormView.tsx
+++ b/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageFormView.tsx
@@ -85,6 +85,10 @@ const CreateWorkPackageFormView: React.FC<CreateWorkPackageFormViewProps> = ({ a
   } = useFieldArray({ control, name: 'deliverables' });
   const { fields: blockedBy, append: appendBlocker, remove: removeBlocker } = useFieldArray({ control, name: 'blockedBy' });
 
+  const validateStartDate = (startDate: Date) => {
+    return startDate.getDay() === 1;
+  };
+
   const blockedByFormControl = (
     <FormControl fullWidth>
       <FormLabel>Blocked By</FormLabel>
@@ -192,6 +196,7 @@ const CreateWorkPackageFormView: React.FC<CreateWorkPackageFormViewProps> = ({ a
                     onChange={onChange}
                     className={'padding: 10'}
                     value={value}
+                    //error={validateStartDate(value)}
                     renderInput={(params) => <TextField autoComplete="off" {...params} />}
                   />
                 )}

--- a/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageFormView.tsx
+++ b/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageFormView.tsx
@@ -21,7 +21,7 @@ import ReactHookTextField from '../../components/ReactHookTextField';
 import { FormControl, FormLabel, IconButton } from '@mui/material';
 import ReactHookEditableList from '../../components/ReactHookEditableList';
 import DeleteIcon from '@mui/icons-material/Delete';
-import { wbsTester } from '../../utils/form';
+import { wbsTester, startDateTester } from '../../utils/form';
 import NERFailButton from '../../components/NERFailButton';
 import NERSuccessButton from '../../components/NERSuccessButton';
 import { WorkPackageStage } from 'shared';
@@ -36,7 +36,10 @@ const schema = yup.object().shape({
     .integer('CR ID must be an integer')
     .min(1, 'CR ID must be greater than or equal to 1'),
   stage: yup.string(),
-  startDate: yup.date().required('Start Date is required'),
+  startDate: yup
+    .date()
+    .required('Start Date is required')
+    .test('start-date-valid', 'start date is not valid', startDateTester),
   duration: yup
     .number()
     .typeError('Duration must be a number')
@@ -85,7 +88,7 @@ const CreateWorkPackageFormView: React.FC<CreateWorkPackageFormViewProps> = ({ a
   } = useFieldArray({ control, name: 'deliverables' });
   const { fields: blockedBy, append: appendBlocker, remove: removeBlocker } = useFieldArray({ control, name: 'blockedBy' });
 
-  const validateStartDate = (startDate: Date) => {
+  const disableStartDate = (startDate: Date) => {
     return startDate.getDay() === 1;
   };
 
@@ -196,7 +199,7 @@ const CreateWorkPackageFormView: React.FC<CreateWorkPackageFormViewProps> = ({ a
                     onChange={onChange}
                     className={'padding: 10'}
                     value={value}
-                    //error={validateStartDate(value)}
+                    shouldDisableDate={disableStartDate}
                     renderInput={(params) => <TextField autoComplete="off" {...params} />}
                   />
                 )}

--- a/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageFormView.tsx
+++ b/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageFormView.tsx
@@ -55,6 +55,17 @@ interface CreateWorkPackageFormViewProps {
 }
 
 const CreateWorkPackageFormView: React.FC<CreateWorkPackageFormViewProps> = ({ allowSubmit, onSubmit, onCancel }) => {
+  const startDate = new Date();
+  const day = startDate.getDay();
+  if (day !== 1) {
+    //if(day == 0) {
+    //startDate.setDate(startDate.getDate() + 1);
+    //}
+    //else {
+    const daysUntilNextMon = (7 - day + 1) % 7;
+    startDate.setDate(startDate.getDate() + daysUntilNextMon);
+    //}
+  }
   const query = useQuery();
   const {
     handleSubmit,
@@ -68,7 +79,7 @@ const CreateWorkPackageFormView: React.FC<CreateWorkPackageFormViewProps> = ({ a
       wbsNum: query.get('wbs') || '',
       crId: Number(query.get('crId')),
       stage: 'NONE',
-      startDate: new Date(),
+      startDate: startDate,
       duration: null,
       blockedBy: [] as { wbsNum: string }[],
       expectedActivities: [] as { bulletId: number; detail: string }[],

--- a/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageFormView.tsx
+++ b/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageFormView.tsx
@@ -89,7 +89,7 @@ const CreateWorkPackageFormView: React.FC<CreateWorkPackageFormViewProps> = ({ a
   const { fields: blockedBy, append: appendBlocker, remove: removeBlocker } = useFieldArray({ control, name: 'blockedBy' });
 
   const disableStartDate = (startDate: Date) => {
-    return startDate.getDay() === 1;
+    return startDate.getDay() !== 1;
   };
 
   const blockedByFormControl = (

--- a/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageFormView.tsx
+++ b/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageFormView.tsx
@@ -58,13 +58,8 @@ const CreateWorkPackageFormView: React.FC<CreateWorkPackageFormViewProps> = ({ a
   const startDate = new Date();
   const day = startDate.getDay();
   if (day !== 1) {
-    //if(day == 0) {
-    //startDate.setDate(startDate.getDate() + 1);
-    //}
-    //else {
     const daysUntilNextMon = (7 - day + 1) % 7;
     startDate.setDate(startDate.getDate() + daysUntilNextMon);
-    //}
   }
   const query = useQuery();
   const {

--- a/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageFormView.tsx
+++ b/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageFormView.tsx
@@ -56,10 +56,10 @@ interface CreateWorkPackageFormViewProps {
 
 const CreateWorkPackageFormView: React.FC<CreateWorkPackageFormViewProps> = ({ allowSubmit, onSubmit, onCancel }) => {
   const startDate = new Date();
-  const day = startDate.getDay();
-  if (day !== 1) {
-    const daysUntilNextMon = (7 - day + 1) % 7;
-    startDate.setDate(startDate.getDate() + daysUntilNextMon);
+  const today = startDate.getDay();
+  if (today !== 1) {
+    const daysUntilNextMonday = (7 - today + 1) % 7;
+    startDate.setDate(startDate.getDate() + daysUntilNextMonday);
   }
   const query = useQuery();
   const {
@@ -74,7 +74,7 @@ const CreateWorkPackageFormView: React.FC<CreateWorkPackageFormViewProps> = ({ a
       wbsNum: query.get('wbs') || '',
       crId: Number(query.get('crId')),
       stage: 'NONE',
-      startDate: startDate,
+      startDate,
       duration: null,
       blockedBy: [] as { wbsNum: string }[],
       expectedActivities: [] as { bulletId: number; detail: string }[],

--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditContainer.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditContainer.tsx
@@ -22,14 +22,17 @@ import ReactHookTextField from '../../../components/ReactHookTextField';
 import ReactHookEditableList from '../../../components/ReactHookEditableList';
 import { useEditWorkPackage } from '../../../hooks/work-packages.hooks';
 import WorkPackageEditDetails from './WorkPackageEditDetails';
-import { bulletsToObject, mapBulletsToPayload } from '../../../utils/form';
+import { bulletsToObject, mapBulletsToPayload, startDateTester } from '../../../utils/form';
 import NERSuccessButton from '../../../components/NERSuccessButton';
 import NERFailButton from '../../../components/NERFailButton';
 import { useToast } from '../../../hooks/toasts.hooks';
 
 const schema = yup.object().shape({
   name: yup.string().required('Name is required!'),
-  startDate: yup.date().required('Start Date is required!'),
+  startDate: yup
+    .date()
+    .required('Start Date is required!')
+    .test('start-date-valid', 'start date is not valid', startDateTester),
   duration: yup.number().required()
 });
 

--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditDetails.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditDetails.tsx
@@ -18,6 +18,10 @@ interface Props {
 }
 
 const WorkPackageEditDetails: React.FC<Props> = ({ users, control, errors }) => {
+  const disableStartDate = (startDate: Date) => {
+    return startDate.getDay() === 1;
+  };
+
   const StageSelect = () => (
     <FormControl fullWidth>
       <FormLabel>Stage Select</FormLabel>
@@ -37,6 +41,7 @@ const WorkPackageEditDetails: React.FC<Props> = ({ users, control, errors }) => 
       />
     </FormControl>
   );
+
   return (
     <PageBlock title="Work Package Details">
       <Grid container xs={12}>
@@ -65,6 +70,7 @@ const WorkPackageEditDetails: React.FC<Props> = ({ users, control, errors }) => 
                     onChange={onChange}
                     className={'padding: 10'}
                     value={value}
+                    shouldDisableDate={disableStartDate}
                     renderInput={(params) => <TextField autoComplete="off" {...params} />}
                   />
                 </>

--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditDetails.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditDetails.tsx
@@ -19,7 +19,7 @@ interface Props {
 
 const WorkPackageEditDetails: React.FC<Props> = ({ users, control, errors }) => {
   const disableStartDate = (startDate: Date) => {
-    return startDate.getDay() === 1;
+    return startDate.getDay() !== 1;
   };
 
   const StageSelect = () => (

--- a/src/frontend/src/utils/form.ts
+++ b/src/frontend/src/utils/form.ts
@@ -42,7 +42,7 @@ export const wbsTester = (wbsNum: string | undefined) => {
  * @param startDate
  */
 export const startDateTester = (startDate: Date | undefined) => {
-  if (startDate === undefined || startDate.getDay() === 1) {
+  if (startDate === undefined || startDate.getDay() !== 1) {
     return false;
   }
   return true;

--- a/src/frontend/src/utils/form.ts
+++ b/src/frontend/src/utils/form.ts
@@ -36,3 +36,14 @@ export const wbsTester = (wbsNum: string | undefined) => {
   }
   return true;
 };
+
+/**
+ * Tests if a start date is valid
+ * @param startDate
+ */
+export const startDateTester = (startDate: Date | undefined) => {
+  if (startDate === undefined || startDate.getDay() === 1) {
+    return false;
+  }
+  return true;
+};


### PR DESCRIPTION
## Changes

In the CreateWorkPackageFormView file, I added the prop 'shouldDisableDate={disableStartDate}' to the <DatePicker> component. The 'disableStartDate' was a function that I created (in the same file) that disables choosing a date from the date picker if a given date was a Monday. I also updated the yup validator 'startDate: yup.date().required("Start Date is required")' by adding '.test("start-date-valid", "start-date-is-not-valid", startDateTester)' to it. In the form file, I made a StartDateTester function that returned false if the given startDate was undefined or if it was a Monday, and true otherwise. 

In the WorkPackageEditDetails file, I did the same as above in terms of adding the prop/creating the function for it. In the WorkPackageEditContainer file, I updated the yup validator as above in terms of adding a test using the same testing function as mentioned earlier. 

## Test Cases

- yarn test:frontend + backend pass
- manually tested on FinishLine (clicking on Mondays on date picker disabled + form does not submit when Monday date typed in)

## Screenshots

<img width="1338" alt="Screen Shot 2023-04-04 at 1 53 24 AM" src="https://user-images.githubusercontent.com/60333735/229700219-8897d090-c4d1-4fe1-9132-6f2de8e46fd0.png">

<img width="1389" alt="Screen Shot 2023-04-04 at 1 53 50 AM" src="https://user-images.githubusercontent.com/60333735/229700247-bfea4c6f-72b2-4e5d-941c-a32f9b65b6f2.png">

<img width="1355" alt="Screen Shot 2023-04-04 at 1 54 26 AM" src="https://user-images.githubusercontent.com/60333735/229700262-1403b716-2663-438a-8a2a-2954a81179ec.png">

<img width="1370" alt="Screen Shot 2023-04-04 at 1 54 44 AM" src="https://user-images.githubusercontent.com/60333735/229700280-bbd221a0-13c4-4c48-97b8-784a90e68737.png">

## Checklist

- [X] All commits are tagged with the ticket number
- [X] No linting errors / newline at end of file warnings
- [X] All code follows repository-configured prettier formatting
- [X] No merge conflicts
- [X] All checks passing
- [X] Screenshots of UI changes (see Screenshots section)
- [X] Remove any non-applicable sections of this template
- [X] Assign the PR to yourself
- [X] No `yarn.lock` changes (unless dependencies have changed)
- [X] Request reviewers & ping on Slack
- [X] PR is linked to the ticket (fill in the closes line below)

Closes #986 
