### PR TITLE
#1035 Changed the project lead and manager selects to be autocomplete

### DIFF
--- a/src/frontend/src/components/NERAutocomplete.tsx
+++ b/src/frontend/src/components/NERAutocomplete.tsx
@@ -13,6 +13,7 @@ import {
   useTheme
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
+import { HTMLAttributes } from 'react';
 
 interface NERAutocompleteProps {
   id: string;
@@ -22,9 +23,10 @@ interface NERAutocompleteProps {
   placeholder: string;
   sx?: SxProps<Theme>;
   value?: { label: string; id: string } | null;
+  listboxProps?: HTMLAttributes<HTMLUListElement>;
 }
 
-const NERAutocomplete: React.FC<NERAutocompleteProps> = ({ id, onChange, options, size, placeholder, sx, value }) => {
+const NERAutocomplete: React.FC<NERAutocompleteProps> = ({ id, onChange, options, size, placeholder, sx, value, listboxProps }) => {
   const theme = useTheme();
 
   const autocompleteStyle = {
@@ -72,6 +74,7 @@ const NERAutocomplete: React.FC<NERAutocompleteProps> = ({ id, onChange, options
       size={size}
       renderInput={autocompleteRenderInput}
       value={value}
+      ListboxProps={listboxProps}
     />
   );
 };

--- a/src/frontend/src/components/NERAutocomplete.tsx
+++ b/src/frontend/src/components/NERAutocomplete.tsx
@@ -26,7 +26,16 @@ interface NERAutocompleteProps {
   listboxProps?: HTMLAttributes<HTMLUListElement>;
 }
 
-const NERAutocomplete: React.FC<NERAutocompleteProps> = ({ id, onChange, options, size, placeholder, sx, value, listboxProps }) => {
+const NERAutocomplete: React.FC<NERAutocompleteProps> = ({
+  id,
+  onChange,
+  options,
+  size,
+  placeholder,
+  sx,
+  value,
+  listboxProps
+}) => {
   const theme = useTheme();
 
   const autocompleteStyle = {

--- a/src/frontend/src/pages/WorkPackageDetailPage/ActivateWorkPackageModalContainer/ActivateWorkPackageModal.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/ActivateWorkPackageModalContainer/ActivateWorkPackageModal.tsx
@@ -17,7 +17,8 @@ import { Radio } from '@mui/material';
 import NERSuccessButton from '../../../components/NERSuccessButton';
 import NERFailButton from '../../../components/NERFailButton';
 import NERAutocomplete from '../../../components/NERAutocomplete';
-import { string } from 'yup/lib/locale';
+import { useState } from 'react';
+import { useToast } from '../../../hooks/toasts.hooks';
 
 interface ActivateWorkPackageModalProps {
   allUsers: User[];
@@ -28,15 +29,11 @@ interface ActivateWorkPackageModalProps {
 }
 
 const schema = yup.object().shape({
-  projectLeadId: yup.number().required().min(0),
-  projectManagerId: yup.number().required().min(0),
   startDate: yup.date().required(),
   confirmDetails: yup.boolean().required()
 });
 
 const defaultValues: FormInput = {
-  projectLeadId: {label: "", id: ""},
-  projectManagerId: {label: "", id: ""},
   startDate: new Date().toLocaleDateString(),
   confirmDetails: false
 };
@@ -53,11 +50,28 @@ const ActivateWorkPackageModal: React.FC<ActivateWorkPackageModalProps> = ({
     defaultValues
   });
 
+  const [projectLeadId, setProjectLeadId] = useState<string>();
+  const [projectManagerId, setProjectManagerId] = useState<string>();
+  const toast = useToast();
   /**
    * Wrapper function for onSubmit so that form data is reset after submit
    */
   const onSubmitWrapper = async (data: FormInput) => {
-    await onSubmit(data);
+    const { startDate, confirmDetails } = data;
+    if (!projectLeadId) {
+      toast.error('Please Set A Value For Project Lead');
+      return;
+    }
+    if (!projectManagerId) {
+      toast.error('Please Set A Value For Project Manager');
+      return;
+    }
+    await onSubmit({
+      startDate,
+      confirmDetails,
+      projectLeadId: parseInt(projectLeadId),
+      projectManagerId: parseInt(projectManagerId)
+    });
     reset(defaultValues);
   };
 
@@ -68,49 +82,29 @@ const ActivateWorkPackageModal: React.FC<ActivateWorkPackageModalProps> = ({
         <DialogContent>
           <Grid container spacing={2}>
             <Grid item xs={6}>
-              <Controller
-                name="projectLeadId"
-                control={control}
-                rules={{ required: true }}
-                render={({ field: { onChange, value } }) => (
-                  <>
-                    <Typography>Project Lead</Typography>
-                    <NERAutocomplete
-                      id="project-lead-autocomplete"
-                      onChange={onChange}
-                      options={allUsers.map((p) => ({
-                        label: fullNamePipe(p),
-                        id: p.userId.toString()
-                      }))}
-                      value={value}
-                      size="small"
-                      placeholder="Project Lead"
-                    />
-                  </>
-                )}
+              <Typography>Project Lead</Typography>
+              <NERAutocomplete
+                id="project-lead-autocomplete"
+                onChange={(_event, value) => setProjectLeadId(value?.id)}
+                options={allUsers.map((p) => ({
+                  label: fullNamePipe(p),
+                  id: p.userId.toString()
+                }))}
+                size="small"
+                placeholder="Project Lead"
               />
             </Grid>
             <Grid item xs={6}>
-              <Controller
-                name="projectManagerId"
-                control={control}
-                rules={{ required: true }}
-                render={({ field: { onChange, value } }) => (
-                  <>
-                    <Typography>Project Manager</Typography>
-                    <NERAutocomplete
-                      id="project-manager-autocomplete"
-                      onChange={onChange}
-                      value={value}
-                      options={allUsers.map((p) => ({
-                        label: fullNamePipe(p),
-                        id: p.userId.toString()
-                      }))}
-                      size="small"
-                      placeholder="Project Manager"
-                    />
-                  </>
-                )}
+              <Typography>Project Manager</Typography>
+              <NERAutocomplete
+                id="project-manager-autocomplete"
+                onChange={(_event, value) => setProjectManagerId(value?.id)}
+                options={allUsers.map((p) => ({
+                  label: fullNamePipe(p),
+                  id: p.userId.toString()
+                }))}
+                size="small"
+                placeholder="Project Manager"
               />
             </Grid>
             <Grid item xs={6}>

--- a/src/frontend/src/pages/WorkPackageDetailPage/ActivateWorkPackageModalContainer/ActivateWorkPackageModal.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/ActivateWorkPackageModalContainer/ActivateWorkPackageModal.tsx
@@ -18,6 +18,8 @@ import { FormControlLabel } from '@mui/material';
 import { Radio } from '@mui/material';
 import NERSuccessButton from '../../../components/NERSuccessButton';
 import NERFailButton from '../../../components/NERFailButton';
+import NERAutocomplete from '../../../components/NERAutocomplete';
+import { width } from '@mui/system';
 
 interface ActivateWorkPackageModalProps {
   allUsers: User[];
@@ -75,13 +77,17 @@ const ActivateWorkPackageModal: React.FC<ActivateWorkPackageModalProps> = ({
                 render={({ field: { onChange, value } }) => (
                   <>
                     <Typography>Project Lead</Typography>
-                    <Select onChange={onChange} value={value} variant="outlined" size="small" fullWidth>
-                      {allUsers.map((p) => (
-                        <MenuItem key={p.userId} value={p.userId}>
-                          {fullNamePipe(p)}
-                        </MenuItem>
-                      ))}
-                    </Select>
+                    <NERAutocomplete
+                      id="project-lead-autocomplete"
+                      onChange={onChange}
+                      options={allUsers.map((p) => ({
+                        label: fullNamePipe(p),
+                        id: p.userId.toString()
+                      }))}
+                      size="small"
+                      placeholder="Project Lead"
+                      sx={{ width: 2 / 2 }}
+                    />
                   </>
                 )}
               />
@@ -94,13 +100,17 @@ const ActivateWorkPackageModal: React.FC<ActivateWorkPackageModalProps> = ({
                 render={({ field: { onChange, value } }) => (
                   <>
                     <Typography>Project Manager</Typography>
-                    <Select onChange={onChange} value={value} variant="outlined" size="small" fullWidth>
-                      {allUsers.map((p) => (
-                        <MenuItem key={p.userId} value={p.userId}>
-                          {fullNamePipe(p)}
-                        </MenuItem>
-                      ))}
-                    </Select>
+                    <NERAutocomplete
+                      id="project-manager-autocomplete"
+                      onChange={onChange}
+                      options={allUsers.map((p) => ({
+                        label: fullNamePipe(p),
+                        id: p.userId.toString()
+                      }))}
+                      size="small"
+                      placeholder="Project Manager"
+                      sx={{ width: 2 / 2 }}
+                    />
                   </>
                 )}
               />

--- a/src/frontend/src/pages/WorkPackageDetailPage/ActivateWorkPackageModalContainer/ActivateWorkPackageModal.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/ActivateWorkPackageModalContainer/ActivateWorkPackageModal.tsx
@@ -17,6 +17,7 @@ import { Radio } from '@mui/material';
 import NERSuccessButton from '../../../components/NERSuccessButton';
 import NERFailButton from '../../../components/NERFailButton';
 import NERAutocomplete from '../../../components/NERAutocomplete';
+import { string } from 'yup/lib/locale';
 
 interface ActivateWorkPackageModalProps {
   allUsers: User[];
@@ -34,8 +35,8 @@ const schema = yup.object().shape({
 });
 
 const defaultValues: FormInput = {
-  projectLeadId: '',
-  projectManagerId: '',
+  projectLeadId: {label: "", id: ""},
+  projectManagerId: {label: "", id: ""},
   startDate: new Date().toLocaleDateString(),
   confirmDetails: false
 };
@@ -81,9 +82,9 @@ const ActivateWorkPackageModal: React.FC<ActivateWorkPackageModalProps> = ({
                         label: fullNamePipe(p),
                         id: p.userId.toString()
                       }))}
+                      value={value}
                       size="small"
                       placeholder="Project Lead"
-                      sx={{ width: 2 / 2 }}
                     />
                   </>
                 )}
@@ -100,13 +101,13 @@ const ActivateWorkPackageModal: React.FC<ActivateWorkPackageModalProps> = ({
                     <NERAutocomplete
                       id="project-manager-autocomplete"
                       onChange={onChange}
+                      value={value}
                       options={allUsers.map((p) => ({
                         label: fullNamePipe(p),
                         id: p.userId.toString()
                       }))}
                       size="small"
                       placeholder="Project Manager"
-                      sx={{ width: 2 / 2 }}
                     />
                   </>
                 )}

--- a/src/frontend/src/pages/WorkPackageDetailPage/ActivateWorkPackageModalContainer/ActivateWorkPackageModal.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/ActivateWorkPackageModalContainer/ActivateWorkPackageModal.tsx
@@ -87,7 +87,7 @@ const ActivateWorkPackageModal: React.FC<ActivateWorkPackageModalProps> = ({
 
   return (
     <form id={'activate-work-package-form'} onSubmit={handleSubmit(onSubmitWrapper)}>
-      <Dialog open={modalShow} onClose={onHide} sx={{ overflow: 'hidden', '&::-webkit-scrollbar': { display: 'none' } }}>
+      <Dialog open={modalShow} onClose={onHide}>
         <DialogTitle>{`Activate #${wbsPipe(wbsNum)}`}</DialogTitle>
         <DialogContent>
           <Grid container spacing={2}>
@@ -101,6 +101,7 @@ const ActivateWorkPackageModal: React.FC<ActivateWorkPackageModalProps> = ({
                 }))}
                 size="small"
                 placeholder="Project Lead"
+                listboxProps={{ style: { maxHeight: '199px' } }}
               />
             </Grid>
             <Grid item xs={6}>
@@ -113,6 +114,7 @@ const ActivateWorkPackageModal: React.FC<ActivateWorkPackageModalProps> = ({
                 }))}
                 size="small"
                 placeholder="Project Manager"
+                listboxProps={{ style: { maxHeight: '199px' } }}
               />
             </Grid>
             <Grid item xs={6}>

--- a/src/frontend/src/pages/WorkPackageDetailPage/ActivateWorkPackageModalContainer/ActivateWorkPackageModal.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/ActivateWorkPackageModalContainer/ActivateWorkPackageModal.tsx
@@ -11,15 +11,12 @@ import { User, WbsNumber } from 'shared';
 import { FormInput } from './ActivateWorkPackageModalContainer';
 import { fullNamePipe, wbsPipe } from '../../../utils/pipes';
 import { Box, Dialog, DialogActions, DialogContent, DialogTitle, TextField, Typography, Grid } from '@mui/material';
-import { Select } from '@mui/material';
-import { MenuItem } from '@mui/material';
 import { RadioGroup } from '@mui/material';
 import { FormControlLabel } from '@mui/material';
 import { Radio } from '@mui/material';
 import NERSuccessButton from '../../../components/NERSuccessButton';
 import NERFailButton from '../../../components/NERFailButton';
 import NERAutocomplete from '../../../components/NERAutocomplete';
-import { width } from '@mui/system';
 
 interface ActivateWorkPackageModalProps {
   allUsers: User[];

--- a/src/frontend/src/pages/WorkPackageDetailPage/ActivateWorkPackageModalContainer/ActivateWorkPackageModal.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/ActivateWorkPackageModalContainer/ActivateWorkPackageModal.tsx
@@ -10,7 +10,17 @@ import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { User, WbsNumber } from 'shared';
 import { FormInput } from './ActivateWorkPackageModalContainer';
 import { fullNamePipe, wbsPipe } from '../../../utils/pipes';
-import { Box, Dialog, DialogActions, DialogContent, DialogTitle, TextField, Typography, Grid } from '@mui/material';
+import {
+  Box,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+  Grid,
+  FormLabel,
+  FormControl
+} from '@mui/material';
 import { RadioGroup } from '@mui/material';
 import { FormControlLabel } from '@mui/material';
 import { Radio } from '@mui/material';
@@ -59,11 +69,11 @@ const ActivateWorkPackageModal: React.FC<ActivateWorkPackageModalProps> = ({
   const onSubmitWrapper = async (data: FormInput) => {
     const { startDate, confirmDetails } = data;
     if (!projectLeadId) {
-      toast.error('Please Set A Value For Project Lead');
+      toast.error('Please Select a Project Lead');
       return;
     }
     if (!projectManagerId) {
-      toast.error('Please Set A Value For Project Manager');
+      toast.error('Please Select a Project Manager');
       return;
     }
     await onSubmit({
@@ -77,12 +87,11 @@ const ActivateWorkPackageModal: React.FC<ActivateWorkPackageModalProps> = ({
 
   return (
     <form id={'activate-work-package-form'} onSubmit={handleSubmit(onSubmitWrapper)}>
-      <Dialog open={modalShow} onClose={onHide}>
+      <Dialog open={modalShow} onClose={onHide} sx={{ overflow: 'hidden', '&::-webkit-scrollbar': { display: 'none' } }}>
         <DialogTitle>{`Activate #${wbsPipe(wbsNum)}`}</DialogTitle>
         <DialogContent>
           <Grid container spacing={2}>
             <Grid item xs={6}>
-              <Typography>Project Lead</Typography>
               <NERAutocomplete
                 id="project-lead-autocomplete"
                 onChange={(_event, value) => setProjectLeadId(value?.id)}
@@ -95,7 +104,6 @@ const ActivateWorkPackageModal: React.FC<ActivateWorkPackageModalProps> = ({
               />
             </Grid>
             <Grid item xs={6}>
-              <Typography>Project Manager</Typography>
               <NERAutocomplete
                 id="project-manager-autocomplete"
                 onChange={(_event, value) => setProjectManagerId(value?.id)}
@@ -108,45 +116,49 @@ const ActivateWorkPackageModal: React.FC<ActivateWorkPackageModalProps> = ({
               />
             </Grid>
             <Grid item xs={6}>
-              <Controller
-                name="startDate"
-                control={control}
-                rules={{ required: true }}
-                render={({ field: { onChange, value } }) => (
-                  <>
-                    <Typography>Start Date (YYYY-MM-DD)</Typography>
-                    <DatePicker
-                      inputFormat="yyyy-MM-dd"
-                      onChange={onChange}
-                      className={'padding: 10'}
-                      value={value}
-                      renderInput={(params) => <TextField autoComplete="off" {...params} />}
-                    />
-                  </>
-                )}
-              />
+              <FormControl fullWidth>
+                <FormLabel>Start Date (YYYY-MM-DD)</FormLabel>
+                <Controller
+                  name="startDate"
+                  control={control}
+                  rules={{ required: true }}
+                  render={({ field: { onChange, value } }) => (
+                    <>
+                      <DatePicker
+                        inputFormat="yyyy-MM-dd"
+                        onChange={onChange}
+                        className={'padding: 10'}
+                        value={value}
+                        renderInput={(params) => <TextField autoComplete="off" {...params} />}
+                      />
+                    </>
+                  )}
+                />
+              </FormControl>
             </Grid>
             <Grid item xs={6}>
-              <Controller
-                name="confirmDetails"
-                control={control}
-                rules={{ required: true }}
-                render={({ field: { onChange, value } }) => (
-                  <>
-                    <Typography>Are the WP details correct?</Typography>
-                    <RadioGroup
-                      value={value}
-                      row
-                      aria-labelledby="demo-row-radio-buttons-group-label"
-                      name="row-radio-buttons-group"
-                      onChange={onChange}
-                    >
-                      <FormControlLabel value={1} control={<Radio />} label="Yes" />
-                      <FormControlLabel value={0} control={<Radio />} label="No" />
-                    </RadioGroup>
-                  </>
-                )}
-              />
+              <FormControl fullWidth>
+                <FormLabel>Are the WP details correct?</FormLabel>
+                <Controller
+                  name="confirmDetails"
+                  control={control}
+                  rules={{ required: true }}
+                  render={({ field: { onChange, value } }) => (
+                    <>
+                      <RadioGroup
+                        value={value}
+                        row
+                        aria-labelledby="demo-row-radio-buttons-group-label"
+                        name="row-radio-buttons-group"
+                        onChange={onChange}
+                      >
+                        <FormControlLabel value={1} control={<Radio />} label="Yes" />
+                        <FormControlLabel value={0} control={<Radio />} label="No" />
+                      </RadioGroup>
+                    </>
+                  )}
+                />
+              </FormControl>
             </Grid>
           </Grid>
         </DialogContent>

--- a/src/frontend/src/pages/WorkPackageDetailPage/ActivateWorkPackageModalContainer/ActivateWorkPackageModalContainer.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/ActivateWorkPackageModalContainer/ActivateWorkPackageModalContainer.tsx
@@ -20,8 +20,8 @@ interface ActivateWorkPackageModalContainerProps {
 }
 
 export interface FormInput {
-  projectLeadId?: {label: string, id: string};
-  projectManagerId?: {label: string, id: string};
+  projectLeadId?: number;
+  projectManagerId?: number;
   startDate: string;
   confirmDetails: boolean;
 }
@@ -39,14 +39,12 @@ const ActivateWorkPackageModalContainer: React.FC<ActivateWorkPackageModalContai
   const handleConfirm = async ({ projectLeadId, projectManagerId, startDate, confirmDetails }: FormInput) => {
     handleClose();
     if (auth.user?.userId === undefined) throw new Error('Cannot create activation change request without being logged in');
-    const { id } = projectLeadId!;
-    const { id: id2 } = projectManagerId!;
     await mutateAsync({
       submitterId: auth.user?.userId,
       wbsNum,
       type: ChangeRequestType.Activation,
-      id,
-      id2,
+      projectLeadId,
+      projectManagerId,
       startDate,
       confirmDetails
     });

--- a/src/frontend/src/pages/WorkPackageDetailPage/ActivateWorkPackageModalContainer/ActivateWorkPackageModalContainer.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/ActivateWorkPackageModalContainer/ActivateWorkPackageModalContainer.tsx
@@ -20,8 +20,8 @@ interface ActivateWorkPackageModalContainerProps {
 }
 
 export interface FormInput {
-  projectLeadId: number | '';
-  projectManagerId: number | '';
+  projectLeadId?: {label: string, id: string};
+  projectManagerId?: {label: string, id: string};
   startDate: string;
   confirmDetails: boolean;
 }
@@ -39,12 +39,14 @@ const ActivateWorkPackageModalContainer: React.FC<ActivateWorkPackageModalContai
   const handleConfirm = async ({ projectLeadId, projectManagerId, startDate, confirmDetails }: FormInput) => {
     handleClose();
     if (auth.user?.userId === undefined) throw new Error('Cannot create activation change request without being logged in');
+    const { id } = projectLeadId!;
+    const { id: id2 } = projectManagerId!;
     await mutateAsync({
       submitterId: auth.user?.userId,
       wbsNum,
       type: ChangeRequestType.Activation,
-      projectLeadId,
-      projectManagerId,
+      id,
+      id2,
       startDate,
       confirmDetails
     });

--- a/src/frontend/src/tests/pages/WorkPackageDetailPage/ActivateWorkPackageModalContainer/ActivateWorkPackageModal.test.tsx
+++ b/src/frontend/src/tests/pages/WorkPackageDetailPage/ActivateWorkPackageModalContainer/ActivateWorkPackageModal.test.tsx
@@ -9,6 +9,8 @@ import { exampleWbs1 } from '../../../test-support/test-data/wbs-numbers.stub';
 import ActivateWorkPackageModal from '../../../../pages/WorkPackageDetailPage/ActivateWorkPackageModalContainer/ActivateWorkPackageModal';
 import { wbsPipe } from '../../../../utils/pipes';
 
+jest.mock('../../../../hooks/toasts.hooks');
+
 /**
  * Mock function for submitting the form, use if there is additional functionality added while submitting
  */

--- a/src/frontend/src/tests/pages/WorkPackageDetailPage/ActivateWorkPackageModalContainer/ActivateWorkPackageModal.test.tsx
+++ b/src/frontend/src/tests/pages/WorkPackageDetailPage/ActivateWorkPackageModalContainer/ActivateWorkPackageModal.test.tsx
@@ -44,8 +44,6 @@ describe('activate work package modal test suite', () => {
 
     expect(screen.queryByText(`Activate #${wbsPipe(exampleWbs1)}`)).toBeInTheDocument();
     expect(screen.getByText(/Date/)).toBeInTheDocument();
-    expect(screen.getByText(/Lead/)).toBeInTheDocument();
-    expect(screen.getByText(/Manager/)).toBeInTheDocument();
     expect(screen.getByText(/WP details/)).toBeInTheDocument();
 
     expect(screen.getByText('Cancel')).toBeInTheDocument();

--- a/src/frontend/src/tests/pages/WorkPackageDetailPage/ActivateWorkPackageModalContainer/ActivateWorkPackageModalContainer.test.tsx
+++ b/src/frontend/src/tests/pages/WorkPackageDetailPage/ActivateWorkPackageModalContainer/ActivateWorkPackageModalContainer.test.tsx
@@ -21,6 +21,8 @@ import {
 
 jest.mock('../../../../hooks/change-requests.hooks');
 
+jest.mock('../../../../hooks/toasts.hooks');
+
 // random shit to make test happy by mocking out this hook
 const mockedUseCreateActivationCR = useCreateActivationChangeRequest as jest.Mock<UseMutationResult>;
 


### PR DESCRIPTION
Changed the project lead and manager selects to be NERAutocompletes
<img width="1214" alt="Screenshot 2023-04-05 at 8 23 31 PM" src="https://user-images.githubusercontent.com/76594216/230242324-f6d8193b-ff98-47dc-a610-e34dd1a4fcf1.png">
<img width="498" alt="Screenshot 2023-04-05 at 8 56 08 PM" src="https://user-images.githubusercontent.com/76594216/230246277-8427eb21-380e-4cfc-8577-3e8c5c110dae.png">
<img width="805" alt="Screenshot 2023-04-05 at 8 57 45 PM" src="https://user-images.githubusercontent.com/76594216/230246301-3dfdf71f-9121-49b3-b1d3-101202fdd021.png">


It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1035
