### PR TITLE
#685 change user settings edit to use ner buttons

### DIFF
--- a/src/frontend/src/pages/SettingsPage/UserSettings/UserSettings.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserSettings/UserSettings.tsx
@@ -13,7 +13,8 @@ import PageBlock from '../../../layouts/PageBlock';
 import ErrorPage from '../../ErrorPage';
 import UserSettingsEdit from './UserSettingsEdit';
 import UserSettingsView from './UserSettingsView';
-import { NERButton } from '../../../components/NERButton';
+import NERSuccessButton from '../../../components/NERSuccessButton';
+import NERFailButton from '../../../components/NERFailButton';
 import { Grid, IconButton } from '@mui/material';
 
 interface UserSettingsProps {
@@ -49,10 +50,10 @@ const UserSettings: React.FC<UserSettingsProps> = ({ userId }) => {
           </IconButton>
         ) : (
           <div className="d-flex flex-row">
-            <NERButton onClick={() => setEdit(false)}>Cancel</NERButton>
-            <NERButton type="submit" form="update-user-settings">
+            <NERFailButton onClick={() => setEdit(false)}>Cancel</NERFailButton>
+            <NERSuccessButton type="submit" form="update-user-settings">
               Save
-            </NERButton>
+            </NERSuccessButton>
           </div>
         )
       }

--- a/src/frontend/src/pages/SettingsPage/UserSettings/UserSettings.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserSettings/UserSettings.tsx
@@ -51,7 +51,7 @@ const UserSettings: React.FC<UserSettingsProps> = ({ userId }) => {
         ) : (
           <div className="d-flex flex-row">
             <NERFailButton onClick={() => setEdit(false)}>Cancel</NERFailButton>
-            <NERSuccessButton type="submit" form="update-user-settings">
+            <NERSuccessButton sx={{ ml: 2 }} type="submit" form="update-user-settings">
               Save
             </NERSuccessButton>
           </div>


### PR DESCRIPTION
## Changes

changed Cancel and Save buttons on  the UserSettings page so that they use NERFaillButton/NERSuccessButton instead of NERButton

## Notes

Meets all Acceptance Criteria:
- The save/cancel buttons on UserSettingsEdit use NERSuccessButton/NERFailButton and not Button
- The save/cancel buttons on that page looks like the new success/cancel buttons (green and red contained, see the edit members section on a teams specific page to see a good example of how it looks).
- Verify nothing looks weird/ everything works as it did before.

Q - Should I delete the NERButton.tsx file since it's being replaced by NERSuccessButton/NERFailButton?

## Screenshots

normal sized window:
![image](https://user-images.githubusercontent.com/119455146/230242827-b868fccb-842f-4596-90a4-8e2cb70ff923.png)

smallest possible window:
![image](https://user-images.githubusercontent.com/119455146/230242906-4d00e0b4-2573-4dd7-93de-9556b514e9ce.png)

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #685 
