### PR TITLE
#676 refactoring remove any type from login logindev and loginpage

### DIFF
--- a/src/frontend/src/pages/LoginPage/Login.tsx
+++ b/src/frontend/src/pages/LoginPage/Login.tsx
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { useState } from 'react';
+import { FormEvent, useState } from 'react';
 import { useHistory } from 'react-router';
 import { useToggleTheme } from '../../hooks/theme.hooks';
 import { useAuth } from '../../hooks/auth.hooks';
@@ -11,6 +11,7 @@ import { routes } from '../../utils/routes';
 import LoginPage from './LoginPage';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import { useQuery } from '../../hooks/utils.hooks';
+import { GoogleLoginResponse, GoogleLoginResponseOffline } from 'react-google-login';
 
 /**
  * Page for unauthenticated users to do login.
@@ -52,7 +53,7 @@ const Login = () => {
     }
   };
 
-  const devFormSubmit = async (e: Event) => {
+  const devFormSubmit = async (e: FormEvent) => {
     e.preventDefault();
     const authedUser = await auth.devSignin(devUserId);
     if (authedUser.defaultTheme && authedUser.defaultTheme.toLocaleLowerCase() !== theme.activeTheme) {
@@ -61,8 +62,11 @@ const Login = () => {
     redirectAfterLogin();
   };
 
-  const verifyLogin = async (response: any) => {
-    const { id_token } = response.getAuthResponse();
+  const verifyLogin = async (response: GoogleLoginResponse | GoogleLoginResponseOffline) => {
+    if (response.code) {
+      throw new Error('Invalid login object');
+    }
+    const { id_token } = (response as GoogleLoginResponse).getAuthResponse();
     if (!id_token) throw new Error('Invalid login object');
     const authedUser = await auth.signin(id_token);
     if (authedUser.defaultTheme && authedUser.defaultTheme !== theme.activeTheme.toUpperCase()) {

--- a/src/frontend/src/pages/LoginPage/Login.tsx
+++ b/src/frontend/src/pages/LoginPage/Login.tsx
@@ -52,7 +52,7 @@ const Login = () => {
     }
   };
 
-  const devFormSubmit = async (e: any) => {
+  const devFormSubmit = async (e: Event) => {
     e.preventDefault();
     const authedUser = await auth.devSignin(devUserId);
     if (authedUser.defaultTheme && authedUser.defaultTheme.toLocaleLowerCase() !== theme.activeTheme) {

--- a/src/frontend/src/pages/LoginPage/LoginDev.tsx
+++ b/src/frontend/src/pages/LoginPage/LoginDev.tsx
@@ -13,9 +13,10 @@ import LoadingIndicator from '../../components/LoadingIndicator';
 import { useAllUsers } from '../../hooks/users.hooks';
 import { fullNamePipe } from '../../utils/pipes';
 import { rankUserRole } from 'shared';
+import { FormEvent } from 'react';
 interface LoginDevProps {
   devSetUser: (userId: number) => void;
-  devFormSubmit: (e: any) => any;
+  devFormSubmit: (e: FormEvent) => void;
 }
 
 /**

--- a/src/frontend/src/pages/LoginPage/LoginPage.tsx
+++ b/src/frontend/src/pages/LoginPage/LoginPage.tsx
@@ -7,14 +7,15 @@ import Card from '@mui/material/Card';
 import CardActions from '@mui/material/CardActions';
 import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
-import GoogleLogin from 'react-google-login';
+import GoogleLogin, { GoogleLoginResponse, GoogleLoginResponseOffline } from 'react-google-login';
 import LoginDev from './LoginDev';
+import { FormEvent } from 'react';
 
 interface LoginPageProps {
   devSetUser: (userId: number) => void;
-  devFormSubmit: (e: any) => any;
-  prodSuccess: (res: any) => any;
-  prodFailure: (res: any) => any;
+  devFormSubmit: (e: FormEvent) => void;
+  prodSuccess: (res: GoogleLoginResponse | GoogleLoginResponseOffline) => void;
+  prodFailure: (res: any) => void;
 }
 
 /**


### PR DESCRIPTION
## Changes

Removed `any` from `Login.tsx` `LoginDev.tsx` and `LoginPage.tsx`. I left `any` for `onFailure` because it needs to take in different errors and in the `GoogleLoginProps` interface in `index.d.ts`, `onFailure` takes in any.

## Notes

Removing `any` from `verifyLogin` required adding a tiny bit of extra code to the function. The only way to replace any was to also include `GoogleResponseOffline` but `getAuthResponse` doesn't take in Offline therefore we needed to confirm that Offline would not be fed to `getAuthResponse`. I worked on this solution with Nezam.

Closes #676 
