### PR TITLE
709-RemoveAnyTypeFromchange-requeststransforms

### DIFF
--- a/src/frontend/src/apis/transformers/change-requests.transformers.ts
+++ b/src/frontend/src/apis/transformers/change-requests.transformers.ts
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { ChangeRequest, ChangeRequestType, ImplementedChange } from 'shared';
+import { ChangeRequest, ImplementedChange } from 'shared';
 
 /**
  * Transforms a change request to ensure deep field transformation of date objects.

--- a/src/frontend/src/apis/transformers/change-requests.transformers.ts
+++ b/src/frontend/src/apis/transformers/change-requests.transformers.ts
@@ -12,7 +12,10 @@ import { ChangeRequest, ChangeRequestType, ImplementedChange } from 'shared';
  * @returns Properly transformed change request object.
  */
 export const changeRequestTransformer = (changeRequest: ChangeRequest) => {
-  const data: any = {
+  interface MaybeActiveChangeRequest extends ChangeRequest {
+    startDate?: Date;
+  }
+  const data: MaybeActiveChangeRequest = {
     ...changeRequest,
     implementedChanges: changeRequest.implementedChanges?.map(implementedChangeTransformer),
     dateSubmitted: new Date(changeRequest.dateSubmitted),
@@ -20,7 +23,7 @@ export const changeRequestTransformer = (changeRequest: ChangeRequest) => {
     dateImplemented: changeRequest.dateImplemented ? new Date(changeRequest.dateImplemented) : changeRequest.dateImplemented
   };
   if (changeRequest.type === ChangeRequestType.Activation) {
-    data.startDate = new Date(data.startDate);
+    if (data.startDate) data.startDate = new Date(data.startDate);
   }
   const output: ChangeRequest = data;
   return output;

--- a/src/frontend/src/apis/transformers/change-requests.transformers.ts
+++ b/src/frontend/src/apis/transformers/change-requests.transformers.ts
@@ -11,10 +11,12 @@ import { ChangeRequest, ChangeRequestType, ImplementedChange } from 'shared';
  * @param changeRequest Incoming change request object supplied by the HTTP response.
  * @returns Properly transformed change request object.
  */
+
+interface MaybeActiveChangeRequest extends ChangeRequest {
+  startDate?: Date;
+}
+
 export const changeRequestTransformer = (changeRequest: ChangeRequest) => {
-  interface MaybeActiveChangeRequest extends ChangeRequest {
-    startDate?: Date;
-  }
   const data: MaybeActiveChangeRequest = {
     ...changeRequest,
     implementedChanges: changeRequest.implementedChanges?.map(implementedChangeTransformer),
@@ -22,8 +24,8 @@ export const changeRequestTransformer = (changeRequest: ChangeRequest) => {
     dateReviewed: changeRequest.dateReviewed ? new Date(changeRequest.dateReviewed) : changeRequest.dateReviewed,
     dateImplemented: changeRequest.dateImplemented ? new Date(changeRequest.dateImplemented) : changeRequest.dateImplemented
   };
-  if (changeRequest.type === ChangeRequestType.Activation) {
-    if (data.startDate) data.startDate = new Date(data.startDate);
+  if (data.startDate) {
+    data.startDate = new Date(data.startDate);
   }
   const output: ChangeRequest = data;
   return output;


### PR DESCRIPTION
## Changes

Made a new interface to change the any type of the data to MaybeActiveChangeRequest. Had to make this new interface to extend the ChangeRequest interface because sometimes the method gets and ActivationChangeRequest which has additional properties. 

## Notes

The code was complicated to decipher because the method could not discern between an ActivationChangeRequest or not, so sometimes a non-ActivationChangeRequest would be passed through and the conditional that only accepted ActivationChangeRequests would blow up. 

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ X] All commits are tagged with the ticket number
- [ X] No linting errors / newline at end of file warnings
- [ X] All code follows repository-configured prettier formatting
- [ X] No merge conflicts
- [ X] All checks passing
- [ X] Screenshots of UI changes (see Screenshots section)
- [ X] Remove any non-applicable sections of this template
- [ X] Assign the PR to yourself
- [ X] No `yarn.lock` changes (unless dependencies have changed)
- [ X] Request reviewers & ping on Slack
- [ X] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
