### PR TITLE
#987 wp creation and editing backend logic enforces monday start

### DIFF
--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -220,6 +220,10 @@ export default class WorkPackagesService {
     const date = new Date(startDate.split('T')[0]);
     date.setTime(date.getTime() + 12 * 60 * 60 * 1000);
 
+    if (date.getDay() !== 1) {
+      throw new HttpException(400, 'Start day must be a monday');
+    }
+
     // add to the database
     const created = await prisma.work_Package.create({
       data: {
@@ -444,8 +448,12 @@ export default class WorkPackagesService {
       .concat(deliverablesChangeJson.changes);
 
     // make the date object but add 12 hours so that the time isn't 00:00 to avoid timezone problems
-    const date = new Date(startDate);
+    const date = new Date(startDate.split('T')[0]);
     date.setTime(date.getTime() + 12 * 60 * 60 * 1000);
+
+    if (date.getDay() !== 1) {
+      throw new HttpException(400, 'Start day must be a monday');
+    }
 
     // update the work package with the input fields
     const updatedWorkPackage = await prisma.work_Package.update({

--- a/src/backend/tests/work-packages.test.ts
+++ b/src/backend/tests/work-packages.test.ts
@@ -29,7 +29,7 @@ describe('Work Packages', () => {
   };
   const name = 'Pack your bags';
   const crId = 1;
-  const startDate = '2022-09-18';
+  const startDate = '2023-04-24';
   const duration = 5;
   const blockedBy: WbsNumber[] = [
     {
@@ -192,6 +192,44 @@ describe('Work Packages', () => {
       );
     });
 
+    test('the endpoint fails when not a monday', async () => {
+      const foundWbsElem = {
+        ...prismaWbsElement1,
+        project: { carNumber: 1, projectNumber: 2, workPackageNumber: 0, projectId: 55, workPackages: [] }
+      };
+      const newPrismaWp = {
+        ...prismaWorkPackage1,
+        wbsElement: { carNumber: 1, projectNumber: 2, workPackageNumber: 3 }
+      };
+      jest.spyOn(prisma.wBS_Element, 'findUnique').mockResolvedValueOnce(foundWbsElem);
+      jest.spyOn(prisma.wBS_Element, 'findUnique').mockResolvedValue(prismaWbsElement1);
+      jest.spyOn(prisma.work_Package, 'create').mockResolvedValue(newPrismaWp);
+
+      const createWorkPackageArgsNotMonday: [
+        User,
+        WbsNumber,
+        string,
+        number,
+        WorkPackageStage,
+        string,
+        number,
+        WbsNumber[],
+        string[],
+        string[]
+      ] = [batman, projectWbsNum, name, crId, stage, '2022-09-18', duration, blockedBy, expectedActivities, deliverables];
+
+      const callCreateWP = async () => {
+        return await WorkPackageService.createWorkPackage.apply(null, createWorkPackageArgsNotMonday);
+      };
+
+      await expect(callCreateWP()).rejects.toThrow(new HttpException(400, 'Start day must be a monday'));
+
+      // check that prisma functions (or functions that call prisma functions)
+      // are called exactly as many times as needed
+      expect(prisma.work_Package.create).toHaveBeenCalledTimes(0);
+      expect(changeRequestUtils.validateChangeRequestAccepted).toHaveBeenCalledTimes(1);
+      expect(prisma.wBS_Element.findUnique).toHaveBeenCalledTimes(1 + blockedBy.length);
+    });
     test('the endpoint completes successfully', async () => {
       const foundWbsElem = {
         ...prismaWbsElement1,
@@ -199,6 +237,7 @@ describe('Work Packages', () => {
       };
       const newPrismaWp = {
         ...prismaWorkPackage1,
+        startDate: new Date('04/24/2023'),
         wbsElement: { carNumber: 1, projectNumber: 2, workPackageNumber: 3 }
       };
       jest.spyOn(prisma.wBS_Element, 'findUnique').mockResolvedValueOnce(foundWbsElem);


### PR DESCRIPTION
## Changes

enforced monday in backend and adjusted tests

## Test Cases

-  added case where WP creation fails if not a monday

_If you did any manual testing (e.g., with Postman), put screenshots of the http request and before and after of the db_

i would but the body was so odee

_If none of this applies, you can delete this section_


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #987
