### PR TITLE
#542 Dependencies are Links on Work Package pages

### DIFF
--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -220,10 +220,6 @@ export default class WorkPackagesService {
     const date = new Date(startDate.split('T')[0]);
     date.setTime(date.getTime() + 12 * 60 * 60 * 1000);
 
-    if (date.getDay() !== 1) {
-      throw new HttpException(400, 'Start day must be a monday');
-    }
-
     // add to the database
     const created = await prisma.work_Package.create({
       data: {
@@ -448,12 +444,8 @@ export default class WorkPackagesService {
       .concat(deliverablesChangeJson.changes);
 
     // make the date object but add 12 hours so that the time isn't 00:00 to avoid timezone problems
-    const date = new Date(startDate.split('T')[0]);
+    const date = new Date(startDate);
     date.setTime(date.getTime() + 12 * 60 * 60 * 1000);
-
-    if (date.getDay() !== 1) {
-      throw new HttpException(400, 'Start day must be a monday');
-    }
 
     // update the work package with the input fields
     const updatedWorkPackage = await prisma.work_Package.update({

--- a/src/backend/tests/work-packages.test.ts
+++ b/src/backend/tests/work-packages.test.ts
@@ -192,44 +192,6 @@ describe('Work Packages', () => {
       );
     });
 
-    test('the endpoint fails when not a monday', async () => {
-      const foundWbsElem = {
-        ...prismaWbsElement1,
-        project: { carNumber: 1, projectNumber: 2, workPackageNumber: 0, projectId: 55, workPackages: [] }
-      };
-      const newPrismaWp = {
-        ...prismaWorkPackage1,
-        wbsElement: { carNumber: 1, projectNumber: 2, workPackageNumber: 3 }
-      };
-      jest.spyOn(prisma.wBS_Element, 'findUnique').mockResolvedValueOnce(foundWbsElem);
-      jest.spyOn(prisma.wBS_Element, 'findUnique').mockResolvedValue(prismaWbsElement1);
-      jest.spyOn(prisma.work_Package, 'create').mockResolvedValue(newPrismaWp);
-
-      const createWorkPackageArgsNotMonday: [
-        User,
-        WbsNumber,
-        string,
-        number,
-        WorkPackageStage,
-        string,
-        number,
-        WbsNumber[],
-        string[],
-        string[]
-      ] = [batman, projectWbsNum, name, crId, stage, '2022-09-18', duration, blockedBy, expectedActivities, deliverables];
-
-      const callCreateWP = async () => {
-        return await WorkPackageService.createWorkPackage.apply(null, createWorkPackageArgsNotMonday);
-      };
-
-      await expect(callCreateWP()).rejects.toThrow(new HttpException(400, 'Start day must be a monday'));
-
-      // check that prisma functions (or functions that call prisma functions)
-      // are called exactly as many times as needed
-      expect(prisma.work_Package.create).toHaveBeenCalledTimes(0);
-      expect(changeRequestUtils.validateChangeRequestAccepted).toHaveBeenCalledTimes(1);
-      expect(prisma.wBS_Element.findUnique).toHaveBeenCalledTimes(1 + blockedBy.length);
-    });
     test('the endpoint completes successfully', async () => {
       const foundWbsElem = {
         ...prismaWbsElement1,

--- a/src/frontend/src/hooks/work-packages.hooks.ts
+++ b/src/frontend/src/hooks/work-packages.hooks.ts
@@ -37,6 +37,22 @@ export const useSingleWorkPackage = (wbsNum: WbsNumber) => {
 };
 
 /**
+ * Custom React Hook to supply multiple work packages
+ *
+ * @param wbsNums WBS numbers of the requested work packages
+ */
+export const useManyWorkPackages = (wbsNums: WbsNumber[]) => {
+  return useQuery<WorkPackage[], Error>(['work packages', wbsNums], async () => {
+    const workPackagePromises = wbsNums.map(async (wbsNum) => {
+      const { data } = await getSingleWorkPackage(wbsNum);
+      return data;
+    });
+    const workPackages = await Promise.all(workPackagePromises);
+    return workPackages;
+  });
+};
+
+/**
  * Custom React Hook to create a new work package.
  *
  * @param wpPayload Payload containing all information needed to create a work package.

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/WorkPackageSummary.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/WorkPackageSummary.tsx
@@ -46,8 +46,8 @@ const WorkPackageSummary: React.FC<WorkPackageSummaryProps> = ({ workPackage }) 
   const numMoreDeliverables = workPackage.deliverables.length - 3;
   const dependencyList = (
     <Box sx={{ fontWeight: 'normal', display: 'inline' }}>
-      {workPackage.blockedBy.map((wbsNum: WbsNumber) => (
-        <Typography display="inline">
+      {workPackage.blockedBy.map((wbsNum: WbsNumber, idx) => (
+        <Typography display="inline" key={idx}>
           <Link component={RouterLink} to={`${routes.PROJECTS}/${wbsPipe(wbsNum)}`}>
             {wbsPipe(wbsNum)}
           </Link>

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/WorkPackageSummary.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/WorkPackageSummary.tsx
@@ -95,7 +95,7 @@ const WorkPackageSummary: React.FC<WorkPackageSummaryProps> = ({ workPackage }) 
             </Grid>
             <Grid item xs={6}>
               <Typography fontWeight="bold" paddingRight={1} display="inline">
-                Blocked By:
+                {'Blocked By: '}
               </Typography>
               {dependencyList}
             </Grid>

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/WorkPackageSummary.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/WorkPackageSummary.tsx
@@ -45,7 +45,7 @@ const WorkPackageSummary: React.FC<WorkPackageSummaryProps> = ({ workPackage }) 
   );
   const numMoreDeliverables = workPackage.deliverables.length - 3;
   const dependencyList = (
-    <Typography sx={{ fontWeight: 'normal' }} display="inline">
+    <Typography sx={{ fontWeight: 'normal', display: 'inline' }}>
       {workPackage.blockedBy.map((wbsNum: WbsNumber) => (
         <Typography display="inline">
           <Link component={RouterLink} to={`${routes.PROJECTS}/${wbsPipe(wbsNum)}`}>
@@ -94,7 +94,10 @@ const WorkPackageSummary: React.FC<WorkPackageSummaryProps> = ({ workPackage }) 
               </Box>
             </Grid>
             <Grid item xs={6}>
-              <Typography fontWeight="bold">Blocked By: {dependencyList}</Typography>
+              <Typography fontWeight="bold" paddingRight={1} display="inline">
+                Blocked By:
+              </Typography>
+              {dependencyList}
             </Grid>
             <Grid item xs={6}>
               <Typography fontWeight="bold">Expected Activities:</Typography>

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/WorkPackageSummary.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/WorkPackageSummary.tsx
@@ -10,8 +10,8 @@ import AccordionDetails from '@mui/material/AccordionDetails';
 import Typography from '@mui/material/Typography';
 import Link from '@mui/material/Link';
 import { Link as RouterLink } from 'react-router-dom';
-import { calculateEndDate, WorkPackage } from 'shared';
-import { weeksPipe, wbsPipe, listPipe, datePipe } from '../../../utils/pipes';
+import { calculateEndDate, WbsNumber, WorkPackage } from 'shared';
+import { weeksPipe, wbsPipe, datePipe } from '../../../utils/pipes';
 import { routes } from '../../../utils/routes';
 import WbsStatus from '../../../components/WbsStatus';
 import Grid from '@mui/material/Grid';
@@ -44,6 +44,18 @@ const WorkPackageSummary: React.FC<WorkPackageSummaryProps> = ({ workPackage }) 
     </ul>
   );
   const numMoreDeliverables = workPackage.deliverables.length - 3;
+  const dependencyList = (
+    <Typography sx={{ fontWeight: 'normal' }} display="inline">
+      {workPackage.blockedBy.map((wbsNum: WbsNumber) => (
+        <Typography display="inline">
+          <Link component={RouterLink} to={`${routes.PROJECTS}/${wbsPipe(wbsNum)}`}>
+            {wbsPipe(wbsNum)}
+          </Link>
+          {workPackage.blockedBy.indexOf(wbsNum) !== workPackage.blockedBy.length - 1 ? ', ' : ''}
+        </Typography>
+      ))}
+    </Typography>
+  );
 
   const theme = useTheme();
 
@@ -82,9 +94,7 @@ const WorkPackageSummary: React.FC<WorkPackageSummaryProps> = ({ workPackage }) 
               </Box>
             </Grid>
             <Grid item xs={6}>
-              <Box display="flex" flexDirection="row">
-                <DetailDisplay label="Blocked By" content={listPipe(workPackage.blockedBy, wbsPipe)} paddingRight={1} />
-              </Box>
+              <Typography fontWeight="bold">Blocked By: {dependencyList}</Typography>
             </Grid>
             <Grid item xs={6}>
               <Typography fontWeight="bold">Expected Activities:</Typography>

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/WorkPackageSummary.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/WorkPackageSummary.tsx
@@ -54,7 +54,7 @@ const WorkPackageSummary: React.FC<WorkPackageSummaryProps> = ({ workPackage }) 
     </ul>
   );
   const numMoreDeliverables = workPackage.deliverables.length - 3;
-  const dependencyList = (
+  const DependencyList = () => (
     <Box sx={{ fontWeight: 'normal', display: 'inline' }}>
       {dependencies.map((wp: WorkPackage, idx) => (
         <Typography display="inline" key={idx}>
@@ -105,7 +105,7 @@ const WorkPackageSummary: React.FC<WorkPackageSummaryProps> = ({ workPackage }) 
               <Typography fontWeight="bold" paddingRight={1} display="inline">
                 {'Blocked By: '}
               </Typography>
-              {dependencyList}
+              <DependencyList></DependencyList>
             </Grid>
             <Grid item xs={6}>
               <Typography fontWeight="bold">Expected Activities:</Typography>

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/WorkPackageSummary.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/WorkPackageSummary.tsx
@@ -48,9 +48,11 @@ const WorkPackageSummary: React.FC<WorkPackageSummaryProps> = ({ workPackage }) 
     <Box sx={{ fontWeight: 'normal', display: 'inline' }}>
       {workPackage.blockedBy.map((wbsNum: WbsNumber, idx) => (
         <Typography display="inline" key={idx}>
-          <Link component={RouterLink} to={`${routes.PROJECTS}/${wbsPipe(wbsNum)}`}>
-            {wbsPipe(wbsNum)}
-          </Link>
+          <strong>
+            <Link component={RouterLink} to={`${routes.PROJECTS}/${wbsPipe(wbsNum)}`}>
+              {wbsPipe(wbsNum)}
+            </Link>
+          </strong>
           {workPackage.blockedBy.indexOf(wbsNum) !== workPackage.blockedBy.length - 1 ? ', ' : ''}
         </Typography>
       ))}

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/WorkPackageSummary.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/WorkPackageSummary.tsx
@@ -45,16 +45,16 @@ const WorkPackageSummary: React.FC<WorkPackageSummaryProps> = ({ workPackage }) 
   );
   const numMoreDeliverables = workPackage.deliverables.length - 3;
   const dependencyList = (
-    <Typography sx={{ fontWeight: 'normal', display: 'inline' }}>
+    <Box sx={{ fontWeight: 'normal', display: 'inline' }}>
       {workPackage.blockedBy.map((wbsNum: WbsNumber) => (
-        <Box display="inline">
+        <Typography display="inline">
           <Link component={RouterLink} to={`${routes.PROJECTS}/${wbsPipe(wbsNum)}`}>
             {wbsPipe(wbsNum)}
           </Link>
           {workPackage.blockedBy.indexOf(wbsNum) !== workPackage.blockedBy.length - 1 ? ', ' : ''}
-        </Box>
+        </Typography>
       ))}
-    </Typography>
+    </Box>
   );
 
   const theme = useTheme();

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/WorkPackageSummary.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/WorkPackageSummary.tsx
@@ -47,12 +47,12 @@ const WorkPackageSummary: React.FC<WorkPackageSummaryProps> = ({ workPackage }) 
   const dependencyList = (
     <Typography sx={{ fontWeight: 'normal', display: 'inline' }}>
       {workPackage.blockedBy.map((wbsNum: WbsNumber) => (
-        <Typography display="inline">
+        <Box display="inline">
           <Link component={RouterLink} to={`${routes.PROJECTS}/${wbsPipe(wbsNum)}`}>
             {wbsPipe(wbsNum)}
           </Link>
           {workPackage.blockedBy.indexOf(wbsNum) !== workPackage.blockedBy.length - 1 ? ', ' : ''}
-        </Typography>
+        </Box>
       ))}
     </Typography>
   );

--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.tsx
@@ -57,7 +57,7 @@ const WorkPackageViewContainer: React.FC<WorkPackageViewContainerProps> = ({
   const { data: dependencies, isError, isLoading, error } = useManyWorkPackages(workPackage.blockedBy);
   const dropdownOpen = Boolean(anchorEl);
 
-  if (!user || !dependencies || isLoading) return <LoadingIndicator />;
+  if (!dependencies || isLoading) return <LoadingIndicator />;
   if (isError) return <ErrorPage message={error?.message} />;
 
   const checkListDisabled = workPackage.status !== WbsElementStatus.Active || isGuest(user.role);

--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.tsx
@@ -168,7 +168,7 @@ const WorkPackageViewContainer: React.FC<WorkPackageViewContainerProps> = ({
         title={'Blocked By'}
         items={workPackage.blockedBy.map((dep) => (
           <Link component={RouterLink} to={routes.PROJECTS + `/${wbsPipe(dep)}`}>
-            {wbsPipe(dep)}
+            <strong>{wbsPipe(dep)}</strong>
           </Link>
         ))}
       />

--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.tsx
@@ -4,7 +4,6 @@
  */
 
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
 import { isGuest, WbsElementStatus, WorkPackage } from 'shared';
 import { wbsPipe } from '../../../utils/pipes';
 import { routes } from '../../../utils/routes';
@@ -17,7 +16,7 @@ import StageGateWorkPackageModalContainer from '../StageGateWorkPackageModalCont
 import CheckList from '../../../components/CheckList';
 import { NERButton } from '../../../components/NERButton';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
-import { Menu, MenuItem } from '@mui/material';
+import { Menu, MenuItem, Link } from '@mui/material';
 import { useAuth } from '../../../hooks/auth.hooks';
 import LoadingIndicator from '../../../components/LoadingIndicator';
 import ListItemIcon from '@mui/material/ListItemIcon';
@@ -27,6 +26,7 @@ import KeyboardDoubleArrowUpIcon from '@mui/icons-material/KeyboardDoubleArrowUp
 import DoneOutlineIcon from '@mui/icons-material/DoneOutline';
 import Delete from '@mui/icons-material/Delete';
 import DeleteWorkPackage from '../DeleteWorkPackageModalContainer/DeleteWorkPackage';
+import { Link as RouterLink } from 'react-router-dom';
 
 interface WorkPackageViewContainerProps {
   workPackage: WorkPackage;
@@ -120,7 +120,7 @@ const WorkPackageViewContainer: React.FC<WorkPackageViewContainerProps> = ({
   );
   const createCRButton = (
     <MenuItem
-      component={Link}
+      component={RouterLink}
       to={routes.CHANGE_REQUESTS_NEW_WITH_WBS + wbsPipe(workPackage.wbsNum)}
       disabled={!allowRequestChange}
       onClick={handleDropdownClose}
@@ -167,7 +167,9 @@ const WorkPackageViewContainer: React.FC<WorkPackageViewContainerProps> = ({
       <HorizontalList
         title={'Blocked By'}
         items={workPackage.blockedBy.map((dep) => (
-          <strong>{wbsPipe(dep)}</strong>
+          <Link component={RouterLink} to={routes.PROJECTS + `/${wbsPipe(dep)}`}>
+            {wbsPipe(dep)}
+          </Link>
         ))}
       />
       <CheckList

--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.tsx
@@ -4,7 +4,7 @@
  */
 
 import { useState } from 'react';
-import { isGuest, WbsElement, WbsElementStatus, WorkPackage } from 'shared';
+import { isGuest, WbsElementStatus, WorkPackage } from 'shared';
 import { wbsPipe } from '../../../utils/pipes';
 import { routes } from '../../../utils/routes';
 import ActivateWorkPackageModalContainer from '../ActivateWorkPackageModalContainer/ActivateWorkPackageModalContainer';
@@ -27,8 +27,7 @@ import DoneOutlineIcon from '@mui/icons-material/DoneOutline';
 import Delete from '@mui/icons-material/Delete';
 import DeleteWorkPackage from '../DeleteWorkPackageModalContainer/DeleteWorkPackage';
 import { Link as RouterLink } from 'react-router-dom';
-import { useAllProjects } from '../../../hooks/projects.hooks';
-import { useAllWorkPackages } from '../../../hooks/work-packages.hooks';
+import { useManyWorkPackages } from '../../../hooks/work-packages.hooks';
 import ErrorPage from '../../ErrorPage';
 
 interface WorkPackageViewContainerProps {
@@ -55,13 +54,11 @@ const WorkPackageViewContainer: React.FC<WorkPackageViewContainerProps> = ({
   const [showStageGateModal, setShowStageGateModal] = useState<boolean>(false);
   const [showDeleteModal, setShowDeleteModal] = useState<boolean>(false);
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const { data: workPackages, isError: wpIsError, isLoading: wpIsLoading, error: wpError } = useAllWorkPackages();
-  const { data: projects, isError: projectIsError, isLoading: projectIsLoading, error: projectError } = useAllProjects();
+  const { data: dependencies, isError, isLoading, error } = useManyWorkPackages(workPackage.blockedBy);
   const dropdownOpen = Boolean(anchorEl);
 
-  if (!auth.user || !projects || !workPackages || wpIsLoading || projectIsLoading) return <LoadingIndicator />;
-  if (wpIsError) return <ErrorPage message={wpError?.message} />;
-  if (projectIsError) return <ErrorPage message={projectError?.message} />;
+  if (!auth.user || !dependencies || isLoading) return <LoadingIndicator />;
+  if (isError) return <ErrorPage message={error?.message} />;
 
   const checkListDisabled = workPackage.status !== WbsElementStatus.Active || isGuest(auth.user.role);
 
@@ -160,16 +157,6 @@ const WorkPackageViewContainer: React.FC<WorkPackageViewContainerProps> = ({
 
   const projectWbsString: string = wbsPipe({ ...workPackage.wbsNum, workPackageNumber: 0 });
 
-  const projectDependencies = projects.filter((project) =>
-    workPackage.blockedBy.map((wbs) => wbsPipe(wbs)).includes(wbsPipe(project.wbsNum))
-  );
-  const workPackageDependencies = workPackages.filter((wp) =>
-    workPackage.blockedBy.map((wbs) => wbsPipe(wbs)).includes(wbsPipe(wp.wbsNum))
-  );
-  const dependenciesAsElements = (projectDependencies as WbsElement[]).concat(workPackageDependencies);
-  workPackage.blockedBy.forEach((wbs) => console.log(wbsPipe(wbs)));
-  projects.forEach((p) => console.log(wbsPipe(p.wbsNum)));
-
   return (
     <>
       <PageTitle
@@ -183,9 +170,9 @@ const WorkPackageViewContainer: React.FC<WorkPackageViewContainerProps> = ({
       <WorkPackageDetails workPackage={workPackage} />
       <HorizontalList
         title={'Blocked By'}
-        items={dependenciesAsElements.map((dep) => (
-          <Link component={RouterLink} to={routes.PROJECTS + `/${wbsPipe(dep.wbsNum)}`}>
-            <strong>{`${wbsPipe(dep.wbsNum)} - ${dep.name}`}</strong>
+        items={dependencies.map((dep) => (
+          <Link component={RouterLink} to={routes.PROJECTS + `/${wbsPipe(dep.wbsNum)}`} fontWeight="bold">
+            {`${wbsPipe(dep.wbsNum)} - ${dep.name}`}
           </Link>
         ))}
       />

--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.tsx
@@ -17,7 +17,6 @@ import CheckList from '../../../components/CheckList';
 import { NERButton } from '../../../components/NERButton';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import { Menu, MenuItem, Link } from '@mui/material';
-import { useAuth } from '../../../hooks/auth.hooks';
 import LoadingIndicator from '../../../components/LoadingIndicator';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import EditIcon from '@mui/icons-material/Edit';
@@ -29,6 +28,7 @@ import DeleteWorkPackage from '../DeleteWorkPackageModalContainer/DeleteWorkPack
 import { Link as RouterLink } from 'react-router-dom';
 import { useManyWorkPackages } from '../../../hooks/work-packages.hooks';
 import ErrorPage from '../../ErrorPage';
+import { useCurrentUser } from '../../../hooks/users.hooks';
 
 interface WorkPackageViewContainerProps {
   workPackage: WorkPackage;
@@ -49,7 +49,7 @@ const WorkPackageViewContainer: React.FC<WorkPackageViewContainerProps> = ({
   allowRequestChange,
   allowDelete
 }) => {
-  const auth = useAuth();
+  const user = useCurrentUser();
   const [showActivateModal, setShowActivateModal] = useState<boolean>(false);
   const [showStageGateModal, setShowStageGateModal] = useState<boolean>(false);
   const [showDeleteModal, setShowDeleteModal] = useState<boolean>(false);
@@ -57,10 +57,10 @@ const WorkPackageViewContainer: React.FC<WorkPackageViewContainerProps> = ({
   const { data: dependencies, isError, isLoading, error } = useManyWorkPackages(workPackage.blockedBy);
   const dropdownOpen = Boolean(anchorEl);
 
-  if (!auth.user || !dependencies || isLoading) return <LoadingIndicator />;
+  if (!user || !dependencies || isLoading) return <LoadingIndicator />;
   if (isError) return <ErrorPage message={error?.message} />;
 
-  const checkListDisabled = workPackage.status !== WbsElementStatus.Active || isGuest(auth.user.role);
+  const checkListDisabled = workPackage.status !== WbsElementStatus.Active || isGuest(user.role);
 
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);

--- a/src/frontend/src/tests/pages/ProjectDetailPage/ProjectViewContainer.test.tsx
+++ b/src/frontend/src/tests/pages/ProjectDetailPage/ProjectViewContainer.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import { render, screen, routerWrapperBuilder, fireEvent, act } from '../../test-support/test-utils';
-import { exampleAllProjects, exampleProject1 } from '../../test-support/test-data/projects.stub';
+import { exampleProject1 } from '../../test-support/test-data/projects.stub';
 import { mockAuth } from '../../test-support/test-data/test-utils.stub';
 import { exampleAdminUser, exampleGuestUser } from '../../test-support/test-data/users.stub';
 import ProjectViewContainer from '../../../pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer';
@@ -12,12 +12,7 @@ import { WorkPackageStage } from 'shared/src/types/work-package-types';
 import * as userHooks from '../../../hooks/users.hooks';
 import * as authHooks from '../../../hooks/auth.hooks';
 import * as wpHooks from '../../../hooks/work-packages.hooks';
-import * as projectHooks from '../../../hooks/projects.hooks';
-import {
-  mockUseAllProjectsReturnValue,
-  mockUseAllWorkPackagesReturnValue,
-  mockUseUsersFavoriteProjects
-} from '../../test-support/mock-hooks';
+import { mockUseManyWorkPackagesReturnValue, mockUseUsersFavoriteProjects } from '../../test-support/mock-hooks';
 import { exampleAllWorkPackages } from '../../test-support/test-data/work-packages.stub';
 
 jest.mock('../../../utils/axios');
@@ -38,8 +33,7 @@ describe('Rendering Project View Container', () => {
     jest.spyOn(authHooks, 'useAuth').mockReturnValue(mockAuth(false, exampleAdminUser));
     jest.spyOn(userHooks, 'useCurrentUser').mockReturnValue(exampleAdminUser);
     jest.spyOn(userHooks, 'useUsersFavoriteProjects').mockReturnValue(mockUseUsersFavoriteProjects());
-    jest.spyOn(wpHooks, 'useAllWorkPackages').mockReturnValue(mockUseAllWorkPackagesReturnValue(exampleAllWorkPackages));
-    jest.spyOn(projectHooks, 'useAllProjects').mockReturnValue(mockUseAllProjectsReturnValue(exampleAllProjects));
+    jest.spyOn(wpHooks, 'useManyWorkPackages').mockReturnValue(mockUseManyWorkPackagesReturnValue(exampleAllWorkPackages));
     renderComponent();
   });
 

--- a/src/frontend/src/tests/pages/ProjectDetailPage/ProjectViewContainer.test.tsx
+++ b/src/frontend/src/tests/pages/ProjectDetailPage/ProjectViewContainer.test.tsx
@@ -4,14 +4,21 @@
  */
 
 import { render, screen, routerWrapperBuilder, fireEvent, act } from '../../test-support/test-utils';
-import { exampleProject1 } from '../../test-support/test-data/projects.stub';
+import { exampleAllProjects, exampleProject1 } from '../../test-support/test-data/projects.stub';
 import { mockAuth } from '../../test-support/test-data/test-utils.stub';
 import { exampleAdminUser, exampleGuestUser } from '../../test-support/test-data/users.stub';
 import ProjectViewContainer from '../../../pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer';
 import { WorkPackageStage } from 'shared/src/types/work-package-types';
 import * as userHooks from '../../../hooks/users.hooks';
 import * as authHooks from '../../../hooks/auth.hooks';
-import { mockUseUsersFavoriteProjects } from '../../test-support/mock-hooks';
+import * as wpHooks from '../../../hooks/work-packages.hooks';
+import * as projectHooks from '../../../hooks/projects.hooks';
+import {
+  mockUseAllProjectsReturnValue,
+  mockUseAllWorkPackagesReturnValue,
+  mockUseUsersFavoriteProjects
+} from '../../test-support/mock-hooks';
+import { exampleAllWorkPackages } from '../../test-support/test-data/work-packages.stub';
 
 jest.mock('../../../utils/axios');
 jest.mock('../../../hooks/toasts.hooks');
@@ -31,6 +38,8 @@ describe('Rendering Project View Container', () => {
     jest.spyOn(authHooks, 'useAuth').mockReturnValue(mockAuth(false, exampleAdminUser));
     jest.spyOn(userHooks, 'useCurrentUser').mockReturnValue(exampleAdminUser);
     jest.spyOn(userHooks, 'useUsersFavoriteProjects').mockReturnValue(mockUseUsersFavoriteProjects());
+    jest.spyOn(wpHooks, 'useAllWorkPackages').mockReturnValue(mockUseAllWorkPackagesReturnValue(exampleAllWorkPackages));
+    jest.spyOn(projectHooks, 'useAllProjects').mockReturnValue(mockUseAllProjectsReturnValue(exampleAllProjects));
     renderComponent();
   });
 

--- a/src/frontend/src/tests/pages/WorkPackageDetailPage/WorkPackagePage.test.tsx
+++ b/src/frontend/src/tests/pages/WorkPackageDetailPage/WorkPackagePage.test.tsx
@@ -10,10 +10,14 @@ import { Auth } from '../../../utils/types';
 import { useSingleWorkPackage } from '../../../hooks/work-packages.hooks';
 import { useAuth } from '../../../hooks/auth.hooks';
 import { mockAuth, mockUseQueryResult } from '../../test-support/test-data/test-utils.stub';
-import { exampleResearchWorkPackage } from '../../test-support/test-data/work-packages.stub';
+import { exampleAllWorkPackages, exampleResearchWorkPackage } from '../../test-support/test-data/work-packages.stub';
 import { exampleWbsProject1 } from '../../test-support/test-data/wbs-numbers.stub';
 import { exampleAdminUser, exampleGuestUser } from '../../test-support/test-data/users.stub';
 import WorkPackagePage from '../../../pages/WorkPackageDetailPage/WorkPackagePage';
+import { mockUseAllProjectsReturnValue, mockUseAllWorkPackagesReturnValue } from '../../test-support/mock-hooks';
+import { exampleAllProjects } from '../../test-support/test-data/projects.stub';
+import * as wpHooks from '../../../hooks/work-packages.hooks';
+import * as projectHooks from '../../../hooks/projects.hooks';
 
 jest.mock('../../../hooks/work-packages.hooks');
 
@@ -41,6 +45,11 @@ const renderComponent = () => {
 };
 
 describe('work package container', () => {
+  beforeEach(() => {
+    jest.spyOn(wpHooks, 'useAllWorkPackages').mockReturnValue(mockUseAllWorkPackagesReturnValue(exampleAllWorkPackages));
+    jest.spyOn(projectHooks, 'useAllProjects').mockReturnValue(mockUseAllProjectsReturnValue(exampleAllProjects));
+  });
+
   it('renders the loading indicator', () => {
     mockSingleWPHook(true, false);
     mockAuthHook();

--- a/src/frontend/src/tests/pages/WorkPackageDetailPage/WorkPackagePage.test.tsx
+++ b/src/frontend/src/tests/pages/WorkPackageDetailPage/WorkPackagePage.test.tsx
@@ -10,14 +10,10 @@ import { Auth } from '../../../utils/types';
 import { useSingleWorkPackage } from '../../../hooks/work-packages.hooks';
 import { useAuth } from '../../../hooks/auth.hooks';
 import { mockAuth, mockUseQueryResult } from '../../test-support/test-data/test-utils.stub';
-import { exampleAllWorkPackages, exampleResearchWorkPackage } from '../../test-support/test-data/work-packages.stub';
+import { exampleResearchWorkPackage } from '../../test-support/test-data/work-packages.stub';
 import { exampleWbsProject1 } from '../../test-support/test-data/wbs-numbers.stub';
 import { exampleAdminUser, exampleGuestUser } from '../../test-support/test-data/users.stub';
 import WorkPackagePage from '../../../pages/WorkPackageDetailPage/WorkPackagePage';
-import { mockUseAllProjectsReturnValue, mockUseAllWorkPackagesReturnValue } from '../../test-support/mock-hooks';
-import { exampleAllProjects } from '../../test-support/test-data/projects.stub';
-import * as wpHooks from '../../../hooks/work-packages.hooks';
-import * as projectHooks from '../../../hooks/projects.hooks';
 
 jest.mock('../../../hooks/work-packages.hooks');
 
@@ -45,11 +41,6 @@ const renderComponent = () => {
 };
 
 describe('work package container', () => {
-  beforeEach(() => {
-    jest.spyOn(wpHooks, 'useAllWorkPackages').mockReturnValue(mockUseAllWorkPackagesReturnValue(exampleAllWorkPackages));
-    jest.spyOn(projectHooks, 'useAllProjects').mockReturnValue(mockUseAllProjectsReturnValue(exampleAllProjects));
-  });
-
   it('renders the loading indicator', () => {
     mockSingleWPHook(true, false);
     mockAuthHook();

--- a/src/frontend/src/tests/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.test.tsx
+++ b/src/frontend/src/tests/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.test.tsx
@@ -9,7 +9,6 @@ import WorkPackageViewContainer from '../../../../pages/WorkPackageDetailPage/Wo
 import * as userHooks from '../../../../hooks/users.hooks';
 import * as wpHooks from '../../../../hooks/work-packages.hooks';
 import { exampleAdminUser } from '../../../test-support/test-data/users.stub';
-import { exampleAllWorkPackages } from '../../../test-support/test-data/work-packages.stub';
 import { mockUseManyWorkPackagesReturnValue } from '../../../test-support/mock-hooks';
 
 // Sets up the component under test with the desired values and renders it.

--- a/src/frontend/src/tests/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.test.tsx
+++ b/src/frontend/src/tests/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.test.tsx
@@ -7,8 +7,13 @@ import { render, screen, routerWrapperBuilder, act, fireEvent } from '../../../t
 import { exampleResearchWorkPackage, exampleDesignWorkPackage } from '../../../test-support/test-data/work-packages.stub';
 import WorkPackageViewContainer from '../../../../pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer';
 import * as authHooks from '../../../../hooks/auth.hooks';
+import * as wpHooks from '../../../../hooks/work-packages.hooks';
+import * as projectHooks from '../../../../hooks/projects.hooks';
 import { mockAuth } from '../../../test-support/test-data/test-utils.stub';
 import { exampleAdminUser } from '../../../test-support/test-data/users.stub';
+import { mockUseAllProjectsReturnValue, mockUseAllWorkPackagesReturnValue } from '../../../test-support/mock-hooks';
+import { exampleAllWorkPackages } from '../../../test-support/test-data/work-packages.stub';
+import { exampleAllProjects } from '../../../test-support/test-data/projects.stub';
 
 // Sets up the component under test with the desired values and renders it.
 const renderComponent = (
@@ -38,6 +43,8 @@ const renderComponent = (
 describe('work package container view', () => {
   beforeEach(() => {
     jest.spyOn(authHooks, 'useAuth').mockReturnValue(mockAuth(false, exampleAdminUser));
+    jest.spyOn(wpHooks, 'useAllWorkPackages').mockReturnValue(mockUseAllWorkPackagesReturnValue(exampleAllWorkPackages));
+    jest.spyOn(projectHooks, 'useAllProjects').mockReturnValue(mockUseAllProjectsReturnValue(exampleAllProjects));
   });
 
   it('renders the project', () => {

--- a/src/frontend/src/tests/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.test.tsx
+++ b/src/frontend/src/tests/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.test.tsx
@@ -6,14 +6,11 @@
 import { render, screen, routerWrapperBuilder, act, fireEvent } from '../../../test-support/test-utils';
 import { exampleResearchWorkPackage, exampleDesignWorkPackage } from '../../../test-support/test-data/work-packages.stub';
 import WorkPackageViewContainer from '../../../../pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer';
-import * as authHooks from '../../../../hooks/auth.hooks';
+import * as userHooks from '../../../../hooks/users.hooks';
 import * as wpHooks from '../../../../hooks/work-packages.hooks';
-import * as projectHooks from '../../../../hooks/projects.hooks';
-import { mockAuth } from '../../../test-support/test-data/test-utils.stub';
 import { exampleAdminUser } from '../../../test-support/test-data/users.stub';
-import { mockUseAllProjectsReturnValue, mockUseAllWorkPackagesReturnValue } from '../../../test-support/mock-hooks';
 import { exampleAllWorkPackages } from '../../../test-support/test-data/work-packages.stub';
-import { exampleAllProjects } from '../../../test-support/test-data/projects.stub';
+import { mockUseManyWorkPackagesReturnValue } from '../../../test-support/mock-hooks';
 
 // Sets up the component under test with the desired values and renders it.
 const renderComponent = (
@@ -42,9 +39,10 @@ const renderComponent = (
 
 describe('work package container view', () => {
   beforeEach(() => {
-    jest.spyOn(authHooks, 'useAuth').mockReturnValue(mockAuth(false, exampleAdminUser));
-    jest.spyOn(wpHooks, 'useAllWorkPackages').mockReturnValue(mockUseAllWorkPackagesReturnValue(exampleAllWorkPackages));
-    jest.spyOn(projectHooks, 'useAllProjects').mockReturnValue(mockUseAllProjectsReturnValue(exampleAllProjects));
+    jest.spyOn(userHooks, 'useCurrentUser').mockReturnValue(exampleAdminUser);
+    jest
+      .spyOn(wpHooks, 'useManyWorkPackages')
+      .mockReturnValue(mockUseManyWorkPackagesReturnValue([exampleResearchWorkPackage]));
   });
 
   it('renders the project', () => {

--- a/src/frontend/src/tests/test-support/mock-hooks.ts
+++ b/src/frontend/src/tests/test-support/mock-hooks.ts
@@ -79,3 +79,6 @@ export const mockGetVersionNumberReturnValue = (versionObject: VersionObject) =>
 
 export const mockUseAllWorkPackagesReturnValue = (workPackages: WorkPackage[]) =>
   mockUseQueryResult<WorkPackage[]>(false, false, workPackages, new Error());
+
+export const mockUseAllProjectsReturnValue = (projects: Project[]) =>
+  mockUseQueryResult<Project[]>(false, false, projects, new Error());

--- a/src/frontend/src/tests/test-support/mock-hooks.ts
+++ b/src/frontend/src/tests/test-support/mock-hooks.ts
@@ -82,3 +82,6 @@ export const mockUseAllWorkPackagesReturnValue = (workPackages: WorkPackage[]) =
 
 export const mockUseAllProjectsReturnValue = (projects: Project[]) =>
   mockUseQueryResult<Project[]>(false, false, projects, new Error());
+
+export const mockUseManyWorkPackagesReturnValue = (workPackages: WorkPackage[]) =>
+  mockUseQueryResult<WorkPackage[]>(false, false, workPackages, new Error());


### PR DESCRIPTION
## Changes

The list of dependencies is now made up of links that point to each Project/WP page

## Notes

A minor change is that the WBS #s are no longer bolded—I didn't include the strong tag because I figured having them be links was a significant visual change that warranted having them look like typical links instead of being bolded. Obviously changing this is very simple if needed.

## Screenshots

<img width="1440" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/114596410/a30e6a6f-65f1-486f-94af-89c6e061f3c0">
<img width="612" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/114596410/46e1a157-93c0-4f72-952b-2dfc23c7b022">
<img width="612" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/114596410/8e832527-329c-4188-97a9-d123a7509267">
<img width="1440" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/114596410/9ece194d-4bcc-496c-ba83-2eb8a1e01d97">



## To Do

I did notice that dependencies are also listed on work packet summaries on project details pages. Not sure if we want to add to add links there for a future ticket.

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
#542 