### PR TITLE
#677 remove any type from project edit container project edit details

### DIFF
--- a/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditContainer.tsx
@@ -43,12 +43,12 @@ interface ProjectEditContainerProps {
 
 export interface ProjectEditFormInput {
   name: string;
-  budget: string;
+  budget: number;
   summary: string;
-  bomLink: string;
-  googleDriveFolderLink: string;
-  taskListLink: string;
-  slideDeckLink: string;
+  bomLink: string | undefined;
+  googleDriveFolderLink: string | undefined;
+  taskListLink: string | undefined;
+  slideDeckLink: string | undefined;
   // projectId: number;
   crId: string;
   goals: {
@@ -123,21 +123,21 @@ const ProjectEditContainer: React.FC<ProjectEditContainerProps> = ({ project, ex
       name,
       budget,
       summary,
-      bomLink,
-      googleDriveFolderLink,
-      taskListLink,
-      slideDeckLink,
-      projectLeadId,
-      projectManagerId
+      bomLink = '',
+      googleDriveFolderLink = '',
+      taskListLink = '',
+      slideDeckLink = '',
+      projectLeadId = 0,
+      projectManagerId = 0
     } = data;
-    const rules = data.rules.map((rule) => rule.rule || rule);
+    const rules = data.rules.map((rule) => rule.rule);
     const goals = mapBulletsToPayload(data.goals);
     const features = mapBulletsToPayload(data.features);
     const otherConstraints = mapBulletsToPayload(data.constraints);
 
     const payload = {
       name,
-      budget: parseInt(budget),
+      budget,
       summary,
       bomLink,
       googleDriveFolderLink,

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditContainer.tsx
@@ -41,6 +41,33 @@ interface ProjectEditContainerProps {
   exitEditMode: () => void;
 }
 
+export interface dataPayload {
+  name: string;
+  budget: number;
+  summary: string;
+  bomLink: string | undefined;
+  googleDriveFolderLink: string | undefined;
+  taskListLink: string | undefined;
+  slideDeckLink: string | undefined;
+  // projectId: number;
+  crId: string;
+  goals: {
+    bulletId: number;
+    detail: string;
+  }[];
+  features: {
+    bulletId: number;
+    detail: string;
+  }[];
+  constraints: {
+    bulletId: number;
+    detail: string;
+  }[];
+  projectLeadId: number | undefined;
+  projectManagerId: number | undefined;
+  rules: { rule: string }[];
+}
+
 const ProjectEditContainer: React.FC<ProjectEditContainerProps> = ({ project, exitEditMode }) => {
   const query = useQuery();
   const allUsers = useAllUsers();
@@ -89,7 +116,7 @@ const ProjectEditContainer: React.FC<ProjectEditContainerProps> = ({ project, ex
 
   const users = allUsers.data.filter((u) => u.role !== 'GUEST');
 
-  const onSubmit = async (data: any) => {
+  const onSubmit = async (data: dataPayload) => {
     const {
       name,
       budget,
@@ -101,14 +128,14 @@ const ProjectEditContainer: React.FC<ProjectEditContainerProps> = ({ project, ex
       projectLeadId,
       projectManagerId
     } = data;
-    const rules = data.rules.map((rule: any) => rule.rule || rule);
+    const rules = data.rules.map((rule) => rule.rule || rule);
     const goals = mapBulletsToPayload(data.goals);
     const features = mapBulletsToPayload(data.features);
     const otherConstraints = mapBulletsToPayload(data.constraints);
 
     const payload = {
       name,
-      budget: parseInt(budget),
+      budget,
       summary,
       bomLink,
       googleDriveFolderLink,

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditContainer.tsx
@@ -41,14 +41,14 @@ interface ProjectEditContainerProps {
   exitEditMode: () => void;
 }
 
-export interface dataPayload {
+export interface ProjectEditFormInput {
   name: string;
-  budget: number;
+  budget: string;
   summary: string;
-  bomLink: string | undefined;
-  googleDriveFolderLink: string | undefined;
-  taskListLink: string | undefined;
-  slideDeckLink: string | undefined;
+  bomLink: string;
+  googleDriveFolderLink: string;
+  taskListLink: string;
+  slideDeckLink: string;
   // projectId: number;
   crId: string;
   goals: {
@@ -65,7 +65,9 @@ export interface dataPayload {
   }[];
   projectLeadId: number | undefined;
   projectManagerId: number | undefined;
-  rules: { rule: string }[];
+  rules: {
+    rule: string;
+  }[];
 }
 
 const ProjectEditContainer: React.FC<ProjectEditContainerProps> = ({ project, exitEditMode }) => {
@@ -116,7 +118,7 @@ const ProjectEditContainer: React.FC<ProjectEditContainerProps> = ({ project, ex
 
   const users = allUsers.data.filter((u) => u.role !== 'GUEST');
 
-  const onSubmit = async (data: dataPayload) => {
+  const onSubmit = async (data: ProjectEditFormInput) => {
     const {
       name,
       budget,
@@ -135,7 +137,7 @@ const ProjectEditContainer: React.FC<ProjectEditContainerProps> = ({ project, ex
 
     const payload = {
       name,
-      budget,
+      budget: parseInt(budget),
       summary,
       bomLink,
       googleDriveFolderLink,

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditDetails.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditDetails.tsx
@@ -1,15 +1,16 @@
 import { User } from 'shared';
-import { Controller } from 'react-hook-form';
+import { Controller, Control, FieldErrorsImpl } from 'react-hook-form';
 import { FormControl, FormLabel, Grid, MenuItem, TextField } from '@mui/material';
 import PageBlock from '../../../layouts/PageBlock';
 import ReactHookTextField from '../../../components/ReactHookTextField';
 import AttachMoneyIcon from '@mui/icons-material/AttachMoney';
 import { fullNamePipe } from '../../../utils/pipes';
+import { dataPayload } from './ProjectEditContainer';
 
 interface ProjectEditDetailsProps {
   users: User[];
-  control: any;
-  errors: any;
+  control: Control<dataPayload>;
+  errors: FieldErrorsImpl<dataPayload>;
 }
 
 const ProjectEditDetails: React.FC<ProjectEditDetailsProps> = ({ users, control, errors }) => {

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditDetails.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditDetails.tsx
@@ -5,12 +5,12 @@ import PageBlock from '../../../layouts/PageBlock';
 import ReactHookTextField from '../../../components/ReactHookTextField';
 import AttachMoneyIcon from '@mui/icons-material/AttachMoney';
 import { fullNamePipe } from '../../../utils/pipes';
-import { dataPayload } from './ProjectEditContainer';
+import { ProjectEditFormInput } from './ProjectEditContainer';
 
 interface ProjectEditDetailsProps {
   users: User[];
-  control: Control<dataPayload>;
-  errors: FieldErrorsImpl<dataPayload>;
+  control: Control<ProjectEditFormInput>;
+  errors: FieldErrorsImpl<ProjectEditFormInput>;
 }
 
 const ProjectEditDetails: React.FC<ProjectEditDetailsProps> = ({ users, control, errors }) => {


### PR DESCRIPTION
## Changes

Do not merge yet!! 

Removed `any` types from the `ProjectEditDetails.tsx` file with no problems.

Removed `any` type from `ProjectEditContainer.tsx` however ran into a singular problem ( see todo )

## Notes

Just seeking some guidance. 

If I change type rules to `string[]` I get a whole new set of errors which I am trying to work around if possible.

## To Do

- [ ] Fix error on line 155

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [ x] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #677)
