### PR TITLE
#481 - Add Stale Issue Workflow

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,42 @@
+name: Label Stale Issues
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  add_stale_label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Set "stale" label on update
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const needsStale = (issue) =>  {
+              const labels = issue.labels.map(labelObj => labelObj.name);
+
+              return (issue.assignees !== undefined
+              && issue.assignees.length > 0
+              && !labels.includes('epic')
+              && !labels.includes('stale')
+              && issue.state === 'open' 
+              && new Date(issue.updated_at) <= new Date() - 14 * 24 * 60 * 60 * 1000);
+            }
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open'
+            });
+            for (const issue of issues) {
+              if (!issue.pull_request && await needsStale(issue)) {
+                console.log(`Adding STALE to issue #${issue.number}: ${issue.title}`);
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  labels: ['stale']
+                });
+              }
+            }


### PR DESCRIPTION
## Changes

Add workflow that marks stale issues, using [@actions/github-script](https://github.com/actions/github-script).

## Notes

This workflow suffers from the **same major flaws** as a [solution](https://github.com/jonathan-chen10/react-stale-workflow-test/blob/main/proposed-workflows/update-state/stale-action.yml) using [@actions/stale](https://github.com/actions/stale) does: it depends on the issue's `updated_at` time, which changes with unimportant things like adding labels and moving milestones, yet doesn't update with important things like linking a commit or a PR. Feel free to look around the [Github issues object](https://api.github.com/repos/Northeastern-Electric-Racing/FinishLine/issues/481) to see if there are any better data to use.

This workflow does *not* automatically remove stale label on updating: the label must be removed automatically. (It is easy to modify to do so, though.)

Currently, stale is hard-coded to 14 days. It may be helpful to [move the script to a separate file](https://github.com/actions/github-script#run-a-separate-file) to improve readability.

Ignores `epic` labels. console.logs the newly stale issues.

`!issue.pull_request` is needed because in Github, issues work like WBS numbers: every taggable number has an issue object in `api.github.com/repos/<org>/<repo>/issues/:id`, but only PRs have non-trivial `/pulls/:id`. `pull_request` is a field that only PRs have (I think?), so that's how I'm filtering out the PRs. It also looks like the prefix of `node_id` can be used for that too.

There may also be performance issues (cannot process all the issues at once and get stuck only working on the first X issues -- a complaint I've seen in @actions/stale) and other miscellaneous bugs.

## Test Cases

Try it and see what breaks (;;o_o)

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #481 
