### PR TITLE
#1124-wp-detail-revamp-changes-tab

### DIFF
--- a/src/frontend/src/components/BulletList.tsx
+++ b/src/frontend/src/components/BulletList.tsx
@@ -5,6 +5,8 @@
 
 import { ReactNode } from 'react';
 import PageBlock from '../layouts/PageBlock';
+import { fontFamily } from '@mui/system';
+import { Typography } from '@mui/material';
 
 interface BulletListProps {
   title: string;
@@ -30,9 +32,12 @@ const BulletList: React.FC<BulletListProps> = ({ title, headerRight, list, order
     builtList = <ol style={styles.bulletList}>{listPrepared}</ol>;
   }
   return (
-    <PageBlock title={title} headerRight={headerRight} defaultClosed={defaultClosed}>
+    <>
+      <Typography variant="h3" sx={{ fontFamily: 'Oswald,sans-serif' }}>
+        {title}
+      </Typography>
       {builtList}
-    </PageBlock>
+    </>
   );
 };
 

--- a/src/frontend/src/components/ChangesList.tsx
+++ b/src/frontend/src/components/ChangesList.tsx
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { Link } from '@mui/material';
+import { Link, Box } from '@mui/material';
 import Typography from '@mui/material/Typography';
 import { ImplementedChange } from 'shared';
 import { fullNamePipe, datePipe } from '../utils/pipes';
@@ -18,23 +18,26 @@ interface ChangesListProps {
 
 const ChangesList: React.FC<ChangesListProps> = ({ changes }) => {
   return (
-    <BulletList
-      title={'Changes'}
-      list={changes.map((ic) => (
-        <>
-          [
-          <Link component={RouterLink} to={`${routes.CHANGE_REQUESTS}/${ic.changeRequestId}`}>
-            #{ic.changeRequestId}
-          </Link>
-          ]
-          <DynamicTooltip title={`${fullNamePipe(ic.implementer)} - ${datePipe(ic.dateImplemented)}`}>
-            <Typography component="span">{ic.detail}</Typography>
-          </DynamicTooltip>
-        </>
-      ))}
-      readOnly={true}
-      defaultClosed
-    />
+    <Box>
+      <ul>
+        {changes.map((ic, idx) => (
+          <li key={idx}>
+            <div style={{ display: 'flex', flexDirection: 'row' }}>
+              <div style={{ marginRight: '4px' }}>
+                [
+                <Link component={RouterLink} to={`${routes.CHANGE_REQUESTS}/${ic.changeRequestId}`}>
+                  #{ic.changeRequestId}
+                </Link>
+                ]
+              </div>
+              <DynamicTooltip title={`${fullNamePipe(ic.implementer)} - ${datePipe(ic.dateImplemented)}`}>
+                <Typography component="span">{ic.detail}</Typography>
+              </DynamicTooltip>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </Box>
   );
 };
 

--- a/src/frontend/src/components/ChangesList.tsx
+++ b/src/frontend/src/components/ChangesList.tsx
@@ -18,26 +18,23 @@ interface ChangesListProps {
 
 const ChangesList: React.FC<ChangesListProps> = ({ changes }) => {
   return (
-    <Box>
-      <ul>
-        {changes.map((ic, idx) => (
-          <li key={idx}>
-            <div style={{ display: 'flex', flexDirection: 'row' }}>
-              <div style={{ marginRight: '4px' }}>
-                [
-                <Link component={RouterLink} to={`${routes.CHANGE_REQUESTS}/${ic.changeRequestId}`}>
-                  #{ic.changeRequestId}
-                </Link>
-                ]
-              </div>
-              <DynamicTooltip title={`${fullNamePipe(ic.implementer)} - ${datePipe(ic.dateImplemented)}`}>
-                <Typography component="span">{ic.detail}</Typography>
-              </DynamicTooltip>
-            </div>
-          </li>
-        ))}
-      </ul>
-    </Box>
+    <BulletList
+      title={'Changes'}
+      list={changes.map((ic) => (
+        <>
+          [
+          <Link component={RouterLink} to={`${routes.CHANGE_REQUESTS}/${ic.changeRequestId}`}>
+            #{ic.changeRequestId}
+          </Link>
+          ]{' '}
+          <DynamicTooltip title={`${fullNamePipe(ic.implementer)} - ${datePipe(ic.dateImplemented)}`}>
+            <Typography component="span">{ic.detail}</Typography>
+          </DynamicTooltip>
+        </>
+      ))}
+      readOnly={true}
+      defaultClosed
+    />
   );
 };
 

--- a/src/frontend/src/components/ChangesList.tsx
+++ b/src/frontend/src/components/ChangesList.tsx
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { Link, Box } from '@mui/material';
+import { Link } from '@mui/material';
 import Typography from '@mui/material/Typography';
 import { ImplementedChange } from 'shared';
 import { fullNamePipe, datePipe } from '../utils/pipes';

--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.tsx
@@ -8,13 +8,8 @@ import { Link } from 'react-router-dom';
 import { isGuest, WbsElementStatus, WorkPackage } from 'shared';
 import { wbsPipe } from '../../../utils/pipes';
 import { routes } from '../../../utils/routes';
-import ActivateWorkPackageModalContainer from '../ActivateWorkPackageModalContainer/ActivateWorkPackageModalContainer';
-import HorizontalList from '../../../components/HorizontalList';
-import WorkPackageDetails from './WorkPackageDetails';
 import ChangesList from '../../../components/ChangesList';
 import PageTitle from '../../../layouts/PageTitle/PageTitle';
-import StageGateWorkPackageModalContainer from '../StageGateWorkPackageModalContainer/StageGateWorkPackageModalContainer';
-import CheckList from '../../../components/CheckList';
 import { NERButton } from '../../../components/NERButton';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import { Menu, MenuItem } from '@mui/material';
@@ -26,7 +21,6 @@ import SyncAltIcon from '@mui/icons-material/SyncAlt';
 import KeyboardDoubleArrowUpIcon from '@mui/icons-material/KeyboardDoubleArrowUp';
 import DoneOutlineIcon from '@mui/icons-material/DoneOutline';
 import Delete from '@mui/icons-material/Delete';
-import DeleteWorkPackage from '../DeleteWorkPackageModalContainer/DeleteWorkPackage';
 
 interface WorkPackageViewContainerProps {
   workPackage: WorkPackage;
@@ -55,8 +49,6 @@ const WorkPackageViewContainer: React.FC<WorkPackageViewContainerProps> = ({
   const dropdownOpen = Boolean(anchorEl);
 
   if (!auth.user) return <LoadingIndicator />;
-
-  const checkListDisabled = workPackage.status !== WbsElementStatus.Active || isGuest(auth.user.role);
 
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);

--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.tsx
@@ -163,53 +163,7 @@ const WorkPackageViewContainer: React.FC<WorkPackageViewContainerProps> = ({
         ]}
         actionButton={projectActionsDropdown}
       />
-      <WorkPackageDetails workPackage={workPackage} />
-      <HorizontalList
-        title={'Blocked By'}
-        items={workPackage.blockedBy.map((dep) => (
-          <strong>{wbsPipe(dep)}</strong>
-        ))}
-      />
-      <CheckList
-        title={'Expected Activities'}
-        items={workPackage.expectedActivities
-          .filter((ea) => !ea.dateDeleted)
-          .map((ea) => {
-            return { ...ea, resolved: !!ea.userChecked, user: ea.userChecked, dateAdded: ea.dateAdded };
-          })}
-        isDisabled={checkListDisabled}
-      />
-      <CheckList
-        title={'Deliverables'}
-        items={workPackage.deliverables
-          .filter((del) => !del.dateDeleted)
-          .map((del) => {
-            return { ...del, resolved: !!del.userChecked, user: del.userChecked, dateAdded: del.dateAdded };
-          })}
-        isDisabled={checkListDisabled}
-      />
       <ChangesList changes={workPackage.changes} />
-      {showActivateModal && (
-        <ActivateWorkPackageModalContainer
-          wbsNum={workPackage.wbsNum}
-          modalShow={showActivateModal}
-          handleClose={() => setShowActivateModal(false)}
-        />
-      )}
-      {showStageGateModal && (
-        <StageGateWorkPackageModalContainer
-          wbsNum={workPackage.wbsNum}
-          modalShow={showStageGateModal}
-          handleClose={() => setShowStageGateModal(false)}
-        />
-      )}
-      {showDeleteModal && (
-        <DeleteWorkPackage
-          wbsNum={workPackage.wbsNum}
-          modalShow={showDeleteModal}
-          handleClose={() => setShowDeleteModal(false)}
-        />
-      )}
     </>
   );
 };


### PR DESCRIPTION
## Changes

Added the (soon to come) changes tab's content

## Notes

Removed everything else from the wp detail page. The content will just be put into the Changes tab

I did edit `ChangesList.tsx`, I do not think that should cause any problems though.

## Screenshots

![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/86690869/8b11db03-4012-43e9-8312-e4566ee0d09a)

![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/86690869/a8b20afb-175d-4732-9e60-505bccd30cdd)

## To Do

- [ ] Implement the tab content onto the actual tab once it's created

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #1124)
