### PR TITLE
#1143: added getAllVendors endpoint with unit test and vendor transformation

### DIFF
--- a/src/backend/src/controllers/reimbursement-requests.controllers.ts
+++ b/src/backend/src/controllers/reimbursement-requests.controllers.ts
@@ -6,8 +6,18 @@
 import { NextFunction, Request, Response } from 'express';
 import { getCurrentUser } from '../utils/auth.utils';
 import ReimbursementRequestService from '../services/reimbursement-requests.services';
+import { Vendor } from 'shared';
 
 export default class ReimbursementRequestsController {
+  static async getAllVendors(_req: Request, res: Response, next: NextFunction) {
+    try {
+      const vendors: Vendor[] = await ReimbursementRequestService.getAllVendors();
+      return res.status(200).json(vendors);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
   static async createReimbursementRequest(req: Request, res: Response, next: NextFunction) {
     try {
       const { dateOfExpense, vendorId, account, receiptPictures, reimbursementProducts, expenseTypeId, totalCost } =

--- a/src/backend/src/routes/reimbursement-requests.routes.ts
+++ b/src/backend/src/routes/reimbursement-requests.routes.ts
@@ -11,6 +11,8 @@ import ReimbursementRequestController from '../controllers/reimbursement-request
 
 const reimbursementRequestsRouter = express.Router();
 
+reimbursementRequestsRouter.get('/vendors', ReimbursementRequestController.getAllVendors);
+
 reimbursementRequestsRouter.post(
   '/create',
   isDate(body('dateOfExpense')),

--- a/src/backend/src/services/reimbursement-requests.services.ts
+++ b/src/backend/src/services/reimbursement-requests.services.ts
@@ -4,12 +4,22 @@
  */
 
 import { Reimbursement_Request, User } from '@prisma/client';
-import { Club_Account, isAdmin, isGuest } from 'shared';
+import { Club_Account, isAdmin, isGuest, Vendor } from 'shared';
 import prisma from '../prisma/prisma';
 import { ReimbursementProductCreateArgs, validateReimbursementProducts } from '../utils/reimbursement-requests.utils';
 import { AccessDeniedAdminOnlyException, AccessDeniedGuestException, NotFoundException } from '../utils/errors.utils';
+import vendorTransformer from '../transformers/vendor.transformer';
 
 export default class ReimbursementRequestService {
+  /**
+   * Get all the vendors in the database.
+   * @returns all the vendors
+   */
+  static async getAllVendors(): Promise<Vendor[]> {
+    const vendors = await prisma.vendor.findMany();
+    return vendors.map(vendorTransformer);
+  }
+
   /**
    * Creates a reimbursement request in the database
    * @param recipient the user who is creating the reimbursement request

--- a/src/backend/src/transformers/vendor.transformer.ts
+++ b/src/backend/src/transformers/vendor.transformer.ts
@@ -1,0 +1,12 @@
+import { Prisma } from '@prisma/client';
+import { Vendor } from 'shared';
+
+const vendorTransformer = (vendor: Prisma.VendorGetPayload<null>): Vendor => {
+  return {
+    vendorId: vendor.vendorId,
+    dateCreated: vendor.dateCreated,
+    name: vendor.name
+  };
+};
+
+export default vendorTransformer;

--- a/src/backend/tests/reimbursement-requests.test.ts
+++ b/src/backend/tests/reimbursement-requests.test.ts
@@ -12,6 +12,15 @@ describe('Reimbursement Requests', () => {
   });
 
   describe('Vendor Tests', () => {
+    test('Get all vendors works', async () => {
+      jest.spyOn(prisma.vendor, 'findMany').mockResolvedValue([]);
+
+      const res = await ReimbursementRequestService.getAllVendors();
+
+      expect(prisma.vendor.findMany).toHaveBeenCalledTimes(1);
+      expect(res).toStrictEqual([]);
+    });
+
     test('Create Vendor throws error if user is not admin', async () => {
       await expect(ReimbursementRequestService.createVendor(wonderwoman, 'HOLA BUDDY')).rejects.toThrow(
         new AccessDeniedAdminOnlyException('create vendors')
@@ -37,12 +46,7 @@ describe('Reimbursement Requests', () => {
     test('Create Expense Type Successfully returns expense type Id', async () => {
       jest.spyOn(prisma.expense_Type, 'create').mockResolvedValue(Parts);
 
-      const expenseType = await ReimbursementRequestService.createExpenseType(
-        batman,
-        Parts.name,
-        Parts.code,
-        Parts.allowed
-      );
+      const expenseType = await ReimbursementRequestService.createExpenseType(batman, Parts.name, Parts.code, Parts.allowed);
 
       expect(expenseType.expenseTypeId).toBe(Parts.expenseTypeId);
     });

--- a/src/shared/src/types/reimbursement-requests-types.ts
+++ b/src/shared/src/types/reimbursement-requests-types.ts
@@ -7,3 +7,9 @@ export enum Club_Account {
   CASH = 'CASH',
   BUDGET = 'BUDGET'
 }
+
+export interface Vendor {
+  vendorId: string;
+  dateCreated: Date;
+  name: string;
+}


### PR DESCRIPTION


## Changes
- Added getAllVendors endpoint in the backend router with functions in reimbursement-requests controller and service
- Added vendor shared type in the backend directory
- Added vendor transformation to make the endpoint return all vendors in shared instead of prisma type
- Added a unit test for getAllVendors endpoint

## Notes

Need confirmation from others with vendor shared type definition

## Screenshots

Our initial data seed for vendor in db was empty. Thus, getAllVendors returns empty array.
<img width="741" alt="#1143-Get-Test-SS1" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/91857946/fbee0c5f-08b0-4ba3-b4c7-46736fa3fd9c">

Added a vendor data manually in PgAdmin4
<img width="960" alt="#1143-Mock-Data-DB" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/91857946/5e878d79-c1d7-4a39-96cb-c380c759c2ed">

Confirmed our getAllVendors returns all added vendor data
<img width="743" alt="#1143-Get-Test2-SS2" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/91857946/1154eb53-f919-4b30-943b-8a2edd947b16">


## To Do

- [ ] Confirm the vendor shared type definition

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
