### PR TITLE
#1166 Change Slide Deck Link to say Confluence Link

### DIFF
--- a/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditContainer.tsx
@@ -29,7 +29,7 @@ import { useToast } from '../../../hooks/toasts.hooks';
 const schema = yup.object().shape({
   name: yup.string().required('Name is required!'),
   budget: yup.number().required('Budget is required!').min(0).integer('Budget must be an even dollar amount!'),
-  slideDeckLink: yup.string().required('Slide deck link is required!').url('Invalid URL'),
+  slideDeckLink: yup.string().required('Confluence link is required!').url('Invalid URL'),
   googleDriveFolderLink: yup.string().required('Google Drive folder link is required!').url('Invalid URL'),
   bomLink: yup.string().url('Invalid URL').required('Bom link is required!'),
   taskListLink: yup.string().required('Task list link is required!').url('Invalid URL'),

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditContainer.tsx
@@ -26,6 +26,7 @@ import NERSuccessButton from '../../../components/NERSuccessButton';
 import NERFailButton from '../../../components/NERFailButton';
 import { useToast } from '../../../hooks/toasts.hooks';
 
+/* TODO: slide deck changed to confluence in frontend - needs to be updated in the backend */
 const schema = yup.object().shape({
   name: yup.string().required('Name is required!'),
   budget: yup.number().required('Budget is required!').min(0).integer('Budget must be an even dollar amount!'),

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditDetails.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditDetails.tsx
@@ -84,6 +84,7 @@ const ProjectEditDetails: React.FC<ProjectEditDetailsProps> = ({ users, control,
         </Grid>
         <Grid item xs={12} sx={{ my: 1 }}>
           <FormControl sx={{ width: '80%' }}>
+            {/* TODO: slide deck changed to confluence in frontend - needs to be updated in the backend */} 
             <FormLabel>Confluence Link</FormLabel>
             <ReactHookTextField
               name="slideDeckLink"

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditDetails.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditDetails.tsx
@@ -84,7 +84,7 @@ const ProjectEditDetails: React.FC<ProjectEditDetailsProps> = ({ users, control,
         </Grid>
         <Grid item xs={12} sx={{ my: 1 }}>
           <FormControl sx={{ width: '80%' }}>
-            {/* TODO: slide deck changed to confluence in frontend - needs to be updated in the backend */} 
+            {/* TODO: slide deck changed to confluence in frontend - needs to be updated in the backend */}
             <FormLabel>Confluence Link</FormLabel>
             <ReactHookTextField
               name="slideDeckLink"

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditDetails.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditDetails.tsx
@@ -84,11 +84,11 @@ const ProjectEditDetails: React.FC<ProjectEditDetailsProps> = ({ users, control,
         </Grid>
         <Grid item xs={12} sx={{ my: 1 }}>
           <FormControl sx={{ width: '80%' }}>
-            <FormLabel>Slide Deck Link</FormLabel>
+            <FormLabel>Confluence Link</FormLabel>
             <ReactHookTextField
               name="slideDeckLink"
               control={control}
-              placeholder="Enter slide deck link..."
+              placeholder="Enter confluence link..."
               errorMessage={errors.slideDeckLink}
             />
           </FormControl>

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectDetails.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectDetails.tsx
@@ -109,6 +109,7 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ project }) => {
           </Grid>
           <Grid item xs={6} display="flex" alignItems="center">
             <CoPresent sx={{ fontSize: 22, color: theme.palette.text.primary }} />
+            {/* TODO: slide deck changed to confluence in frontend - needs to be updated in the backend */} 
             <Link href={project.slideDeckLink!} target="_blank" underline="always" fontSize={19} sx={{ pl: 1 }}>
               Confluence
             </Link>

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectDetails.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectDetails.tsx
@@ -110,7 +110,7 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ project }) => {
           <Grid item xs={6} display="flex" alignItems="center">
             <CoPresent sx={{ fontSize: 22, color: theme.palette.text.primary }} />
             <Link href={project.slideDeckLink!} target="_blank" underline="always" fontSize={19} sx={{ pl: 1 }}>
-              Slide Deck
+              Confluence
             </Link>
           </Grid>
           <Grid item xs={6} display="flex" alignItems="center">

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectDetails.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectDetails.tsx
@@ -109,7 +109,7 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ project }) => {
           </Grid>
           <Grid item xs={6} display="flex" alignItems="center">
             <CoPresent sx={{ fontSize: 22, color: theme.palette.text.primary }} />
-            {/* TODO: slide deck changed to confluence in frontend - needs to be updated in the backend */} 
+            {/* TODO: slide deck changed to confluence in frontend - needs to be updated in the backend */}
             <Link href={project.slideDeckLink!} target="_blank" underline="always" fontSize={19} sx={{ pl: 1 }}>
               Confluence
             </Link>

--- a/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModal.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModal.tsx
@@ -58,7 +58,7 @@ const StageGateWorkPackageModal: React.FC<StageGateWorkPackageModalProps> = ({ w
               rules={{ required: true }}
               render={({ field: { onChange, value } }) => (
                 <>
-                  {/* TODO: slide deck changed to confluence in frontend - needs to be updated in the backend */} 
+                  {/* TODO: slide deck changed to confluence in frontend - needs to be updated in the backend */}
                   <Typography sx={{ paddingTop: 1 }}>Is everything done?</Typography>
                   <ul style={{ marginTop: 0, marginBottom: 2 }}>
                     <li>Updated confluence & documentation</li>

--- a/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModal.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModal.tsx
@@ -58,9 +58,10 @@ const StageGateWorkPackageModal: React.FC<StageGateWorkPackageModalProps> = ({ w
               rules={{ required: true }}
               render={({ field: { onChange, value } }) => (
                 <>
+                  {/* TODO: slide deck changed to confluence in frontend - needs to be updated in the backend */} 
                   <Typography sx={{ paddingTop: 1 }}>Is everything done?</Typography>
                   <ul style={{ marginTop: 0, marginBottom: 2 }}>
-                    <li>Updated slide deck & documentation</li>
+                    <li>Updated confluence & documentation</li>
                     <li>Creating any outstanding change requests</li>
                     <li>Submitted all receipts to the procurement form</li>
                     <li>Completed all Work Package expected activities</li>


### PR DESCRIPTION
## Changes

1. Changed front-facing text to say Confluence instead of Slide Deck

## Notes

We decided to leave this ticket to just be front-end changes due to an eventual rework

Also I did this ticket because I'm bored in OOD rn

## Screenshots

![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/120137306/4047552c-4a6d-46e8-919f-5ab5e7792503)

![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/120137306/280aac5b-2051-4edf-bbf1-43ec03653e1c)

![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/120137306/918757d6-95a3-43c8-907a-cf1a38e662a0)

![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/120137306/7e7a869a-70a4-42d1-95de-3fe9ed641247)


Closes #1166
