### PR TITLE
#1128 - My Reimbursement Requests Endpoint

### DIFF
--- a/src/backend/src/controllers/reimbursement-requests.controllers.ts
+++ b/src/backend/src/controllers/reimbursement-requests.controllers.ts
@@ -9,10 +9,10 @@ import ReimbursementRequestService from '../services/reimbursement-requests.serv
 import { Vendor } from 'shared';
 
 export default class ReimbursementRequestsController {
-  static async getUserReimbursementRequests(_req: Request, res: Response, next: NextFunction) {
+  static async getCurrentUserReimbursementRequests(_req: Request, res: Response, next: NextFunction) {
     try {
       const user = await getCurrentUser(res);
-      const userReimbursementRequests = await ReimbursementRequestService.getUserReimbursementRequests(user);
+      const userReimbursementRequests = await ReimbursementRequestService.getCurrentUserReimbursementRequests(user);
       res.status(200).json(userReimbursementRequests);
     } catch (error: unknown) {
       next(error);

--- a/src/backend/src/controllers/reimbursement-requests.controllers.ts
+++ b/src/backend/src/controllers/reimbursement-requests.controllers.ts
@@ -13,7 +13,7 @@ export default class ReimbursementRequestsController {
   static async getCurrentUserReimbursementRequests(_req: Request, res: Response, next: NextFunction) {
     try {
       const user = await getCurrentUser(res);
-      const userReimbursementRequests = await ReimbursementRequestService.getCurrentUserReimbursementRequests(user);
+      const userReimbursementRequests = await ReimbursementRequestService.getUserReimbursementRequests(user);
       res.status(200).json(userReimbursementRequests);
     } catch (error: unknown) {
       next(error);

--- a/src/backend/src/controllers/reimbursement-requests.controllers.ts
+++ b/src/backend/src/controllers/reimbursement-requests.controllers.ts
@@ -3,6 +3,16 @@ import { getCurrentUser } from '../utils/auth.utils';
 import ReimbursementRequestService from '../services/reimbursement-requests.services';
 
 export default class ReimbursementRequestsController {
+  static async getUserReimbursementRequests(req: Request, res: Response, next: NextFunction) {
+    try {
+      const user = await getCurrentUser(res);
+      const userReimbursementRequests = await ReimbursementRequestService.getUserReimbursementRequests(user);
+      res.status(200).json(userReimbursementRequests);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
   static async createReimbursementRequest(req: Request, res: Response, next: NextFunction) {
     try {
       const { dateOfExpense, vendorId, account, receiptPictures, reimbursementProducts, expenseTypeId, totalCost } =

--- a/src/backend/src/routes/reimbursement-requests.routes.ts
+++ b/src/backend/src/routes/reimbursement-requests.routes.ts
@@ -6,6 +6,8 @@ import ReimbursementRequestController from '../controllers/reimbursement-request
 
 const reimbursementRequestsRouter = express.Router();
 
+reimbursementRequestsRouter.get('/me', ReimbursementRequestController.getUserReimbursementRequests);
+
 reimbursementRequestsRouter.post(
   '/create',
   isDate(body('dateOfExpense')),

--- a/src/backend/src/routes/reimbursement-requests.routes.ts
+++ b/src/backend/src/routes/reimbursement-requests.routes.ts
@@ -13,7 +13,7 @@ const reimbursementRequestsRouter = express.Router();
 
 reimbursementRequestsRouter.get('/vendors', ReimbursementRequestController.getAllVendors);
 
-reimbursementRequestsRouter.get('/me', ReimbursementRequestController.getUserReimbursementRequests);
+reimbursementRequestsRouter.get('/current-user', ReimbursementRequestController.getCurrentUserReimbursementRequests);
 
 reimbursementRequestsRouter.post(
   '/create',

--- a/src/backend/src/services/reimbursement-requests.services.ts
+++ b/src/backend/src/services/reimbursement-requests.services.ts
@@ -31,7 +31,7 @@ export default class ReimbursementRequestService {
    * Returns all reimbursement requests in the database that are created by the given user.
    * @param recipient the user retrieving their reimbursement requests
    */
-  static async getCurrentUserReimbursementRequests(recipient: User): Promise<ReimbursementRequest[]> {
+  static async getUserReimbursementRequests(recipient: User): Promise<ReimbursementRequest[]> {
     const userReimbursementRequests = await prisma.reimbursement_Request.findMany({
       where: { dateDeleted: null, recipientId: recipient.userId },
       ...reimbursementRequestQueryArgs

--- a/src/backend/src/services/reimbursement-requests.services.ts
+++ b/src/backend/src/services/reimbursement-requests.services.ts
@@ -26,10 +26,10 @@ import sendMailToAdvisor from '../utils/transporter.utils';
 
 export default class ReimbursementRequestService {
   /**
-   * Returns all reimbursement requests in the database that are created by a user.
+   * Returns all reimbursement requests in the database that are created by the given user.
    * @param recipient the user retrieving their reimbursement requests
    */
-  static async getUserReimbursementRequests(recipient: User): Promise<Reimbursement_Request[]> {
+  static async getCurrentUserReimbursementRequests(recipient: User): Promise<Reimbursement_Request[]> {
     const userReimbursementRequests = await prisma.reimbursement_Request.findMany({
       where: { dateDeleted: null, recipientId: recipient.userId }
     });

--- a/src/backend/src/services/reimbursement-requests.services.ts
+++ b/src/backend/src/services/reimbursement-requests.services.ts
@@ -30,10 +30,10 @@ export default class ReimbursementRequestService {
    * @param recipient the user retrieving their reimbursement requests
    */
   static async getUserReimbursementRequests(recipient: User): Promise<Reimbursement_Request[]> {
-    const prismaQueryResult = await prisma.reimbursement_Request.findMany({
-      where: { dateDeleted: null, recepientId: recipient.userId }
+    const userReimbursementRequests = await prisma.reimbursement_Request.findMany({
+      where: { dateDeleted: null, recipientId: recipient.userId }
     });
-    return prismaQueryResult;
+    return userReimbursementRequests;
   }
 
   /**

--- a/src/backend/src/services/reimbursement-requests.services.ts
+++ b/src/backend/src/services/reimbursement-requests.services.ts
@@ -6,6 +6,17 @@ import { AccessDeniedGuestException, NotFoundException } from '../utils/errors.u
 
 export default class ReimbursementRequestService {
   /**
+   * Returns all reimbursement requests in the database that are created by a user.
+   * @param recipient the user retrieving their reimbursement requests
+   */
+  static async getUserReimbursementRequests(recipient: User): Promise<Reimbursement_Request[]> {
+    const prismaQueryResult = await prisma.reimbursement_Request.findMany({
+      where: { dateDeleted: null, recepientId: recipient.userId }
+    });
+    return prismaQueryResult;
+  }
+
+  /**
    * Creates a reimbursement request in the database
    * @param recipient the user who is creating the reimbursement request
    * @param dateOfExpense the date that the expense occured

--- a/src/backend/src/services/reimbursement-requests.services.ts
+++ b/src/backend/src/services/reimbursement-requests.services.ts
@@ -31,11 +31,12 @@ export default class ReimbursementRequestService {
    * Returns all reimbursement requests in the database that are created by the given user.
    * @param recipient the user retrieving their reimbursement requests
    */
-  static async getCurrentUserReimbursementRequests(recipient: User): Promise<Reimbursement_Request[]> {
+  static async getCurrentUserReimbursementRequests(recipient: User): Promise<ReimbursementRequest[]> {
     const userReimbursementRequests = await prisma.reimbursement_Request.findMany({
-      where: { dateDeleted: null, recipientId: recipient.userId }
+      where: { dateDeleted: null, recipientId: recipient.userId },
+      ...reimbursementRequestQueryArgs
     });
-    return userReimbursementRequests;
+    return userReimbursementRequests.map(reimbursementRequestTransformer);
   }
 
   /**

--- a/src/backend/tests/reimbursement-requests.test.ts
+++ b/src/backend/tests/reimbursement-requests.test.ts
@@ -70,7 +70,7 @@ describe('Reimbursement Requests', () => {
       // assert
       expect(prismaGetManySpy).toBeCalledTimes(1);
       expect(prismaGetManySpy).toBeCalledWith({ where: { dateDeleted: null, recipientId: batman.userId } });
-      expect(matches).toEqual([GiveMeMyMoney]);
+      expect(matches).toHaveLength(1);
     });
   });
 

--- a/src/backend/tests/reimbursement-requests.test.ts
+++ b/src/backend/tests/reimbursement-requests.test.ts
@@ -65,7 +65,7 @@ describe('Reimbursement Requests', () => {
       prismaGetManySpy.mockResolvedValue([GiveMeMyMoney]);
 
       // act
-      const matches = await ReimbursementRequestService.getUserReimbursementRequests(batman);
+      const matches = await ReimbursementRequestService.getCurrentUserReimbursementRequests(batman);
 
       // assert
       expect(prismaGetManySpy).toBeCalledTimes(1);

--- a/src/backend/tests/reimbursement-requests.test.ts
+++ b/src/backend/tests/reimbursement-requests.test.ts
@@ -73,7 +73,7 @@ describe('Reimbursement Requests', () => {
       prismaGetManySpy.mockResolvedValue([prismaGiveMeMyMoney]);
 
       // act
-      const matches = await ReimbursementRequestService.getCurrentUserReimbursementRequests(batman);
+      const matches = await ReimbursementRequestService.getUserReimbursementRequests(batman);
 
       // assert
       expect(prismaGetManySpy).toBeCalledTimes(1);

--- a/src/backend/tests/reimbursement-requests.test.ts
+++ b/src/backend/tests/reimbursement-requests.test.ts
@@ -1,3 +1,4 @@
+import { ClubAccount } from 'shared';
 import prisma from '../src/prisma/prisma';
 import ReimbursementRequestService from '../src/services/reimbursement-requests.services';
 import {
@@ -7,8 +8,15 @@ import {
   HttpException,
   NotFoundException
 } from '../src/utils/errors.utils';
-import { GiveMeMoneyProduct, GiveMeMyMoney, Parts, PopEyes } from './test-data/reimbursement-requests.test-data';
+import {
+  GiveMeMoneyProduct,
+  GiveMeMyMoney,
+  Parts,
+  PopEyes,
+  prismaGiveMeMyMoney
+} from './test-data/reimbursement-requests.test-data';
 import { batman, superman, wonderwoman } from './test-data/users.test-data';
+import reimbursementRequestQueryArgs from '../src/prisma-query-args/reimbursement-requests.query-args';
 
 describe('Reimbursement Requests', () => {
   beforeEach(() => {});
@@ -62,14 +70,17 @@ describe('Reimbursement Requests', () => {
     test('successfully calls the Prisma function', async () => {
       // mock prisma calls
       const prismaGetManySpy = jest.spyOn(prisma.reimbursement_Request, 'findMany');
-      prismaGetManySpy.mockResolvedValue([GiveMeMyMoney]);
+      prismaGetManySpy.mockResolvedValue([prismaGiveMeMyMoney]);
 
       // act
       const matches = await ReimbursementRequestService.getCurrentUserReimbursementRequests(batman);
 
       // assert
       expect(prismaGetManySpy).toBeCalledTimes(1);
-      expect(prismaGetManySpy).toBeCalledWith({ where: { dateDeleted: null, recipientId: batman.userId } });
+      expect(prismaGetManySpy).toBeCalledWith({
+        where: { dateDeleted: null, recipientId: batman.userId },
+        ...reimbursementRequestQueryArgs
+      });
       expect(matches).toHaveLength(1);
     });
   });
@@ -83,7 +94,7 @@ describe('Reimbursement Requests', () => {
           GiveMeMyMoney.reimbursementRequestId,
           GiveMeMyMoney.dateOfExpense,
           GiveMeMyMoney.vendorId,
-          GiveMeMyMoney.account,
+          GiveMeMyMoney.account as ClubAccount,
           GiveMeMyMoney.expenseTypeId,
           GiveMeMyMoney.totalCost,
           [],
@@ -104,7 +115,7 @@ describe('Reimbursement Requests', () => {
           GiveMeMyMoney.reimbursementRequestId,
           GiveMeMyMoney.dateOfExpense,
           GiveMeMyMoney.vendorId,
-          GiveMeMyMoney.account,
+          GiveMeMyMoney.account as ClubAccount,
           GiveMeMyMoney.expenseTypeId,
           GiveMeMyMoney.totalCost,
           [],
@@ -116,13 +127,12 @@ describe('Reimbursement Requests', () => {
 
     test('Edit Reimbursement Request Fails When User is not the recipient', async () => {
       jest.spyOn(prisma.reimbursement_Request, 'findUnique').mockResolvedValue(GiveMeMyMoney);
-
       await expect(() =>
         ReimbursementRequestService.editReimbursementRequest(
           GiveMeMyMoney.reimbursementRequestId,
           GiveMeMyMoney.dateOfExpense,
           GiveMeMyMoney.vendorId,
-          GiveMeMyMoney.account,
+          GiveMeMyMoney.account as ClubAccount,
           GiveMeMyMoney.expenseTypeId,
           GiveMeMyMoney.totalCost,
           [],
@@ -145,7 +155,7 @@ describe('Reimbursement Requests', () => {
           GiveMeMyMoney.reimbursementRequestId,
           GiveMeMyMoney.dateOfExpense,
           GiveMeMyMoney.vendorId,
-          GiveMeMyMoney.account,
+          GiveMeMyMoney.account as ClubAccount,
           GiveMeMyMoney.expenseTypeId,
           GiveMeMyMoney.totalCost,
           [],
@@ -165,7 +175,7 @@ describe('Reimbursement Requests', () => {
           GiveMeMyMoney.reimbursementRequestId,
           GiveMeMyMoney.dateOfExpense,
           GiveMeMyMoney.vendorId,
-          GiveMeMyMoney.account,
+          GiveMeMyMoney.account as ClubAccount,
           GiveMeMyMoney.expenseTypeId,
           GiveMeMyMoney.totalCost,
           [],
@@ -189,7 +199,7 @@ describe('Reimbursement Requests', () => {
           GiveMeMyMoney.reimbursementRequestId,
           GiveMeMyMoney.dateOfExpense,
           GiveMeMyMoney.vendorId,
-          GiveMeMyMoney.account,
+          GiveMeMyMoney.account as ClubAccount,
           GiveMeMyMoney.expenseTypeId,
           GiveMeMyMoney.totalCost,
           [
@@ -219,7 +229,7 @@ describe('Reimbursement Requests', () => {
         GiveMeMyMoney.reimbursementRequestId,
         GiveMeMyMoney.dateOfExpense,
         GiveMeMyMoney.vendorId,
-        GiveMeMyMoney.account,
+        GiveMeMyMoney.account as ClubAccount,
         GiveMeMyMoney.expenseTypeId,
         GiveMeMyMoney.totalCost,
         [

--- a/src/backend/tests/reimbursement-requests.test.ts
+++ b/src/backend/tests/reimbursement-requests.test.ts
@@ -58,6 +58,22 @@ describe('Reimbursement Requests', () => {
     });
   });
 
+  describe('Get User Reimbursement Request Tests', () => {
+    it('successfully calls the Prisma function', async () => {
+      // mock prisma calls
+      const prismaGetManySpy = jest.spyOn(prisma.reimbursement_Request, 'findMany');
+      prismaGetManySpy.mockResolvedValue([GiveMeMyMoney]);
+
+      // act
+      const matches = await ReimbursementRequestService.getUserReimbursementRequests(batman);
+
+      // assert
+      expect(prismaGetManySpy).toBeCalledTimes(1);
+      expect(prismaGetManySpy).toBeCalledWith({ where: { dateDeleted: null, recipientId: batman.userId } });
+      expect(matches).toEqual([GiveMeMyMoney]);
+    });
+  });
+
   describe('Edit Reimbursement Request Tests', () => {
     test('Request Fails When Id does not exist', async () => {
       jest.spyOn(prisma.reimbursement_Request, 'findUnique').mockResolvedValue(null);

--- a/src/backend/tests/reimbursement-requests.test.ts
+++ b/src/backend/tests/reimbursement-requests.test.ts
@@ -59,7 +59,7 @@ describe('Reimbursement Requests', () => {
   });
 
   describe('Get User Reimbursement Request Tests', () => {
-    it('successfully calls the Prisma function', async () => {
+    test('successfully calls the Prisma function', async () => {
       // mock prisma calls
       const prismaGetManySpy = jest.spyOn(prisma.reimbursement_Request, 'findMany');
       prismaGetManySpy.mockResolvedValue([GiveMeMyMoney]);

--- a/src/backend/tests/test-data/reimbursement-requests.test-data.ts
+++ b/src/backend/tests/test-data/reimbursement-requests.test-data.ts
@@ -2,9 +2,13 @@ import {
   Vendor as PrismaVendor,
   Reimbursement_Request as PrismaReimbursementRequest,
   Expense_Type as PrismaExpenseType,
-  Reimbursement_Product as PrismaReimbursementProduct
+  Reimbursement_Product as PrismaReimbursementProduct,
+  Club_Accounts,
+  Prisma
 } from '@prisma/client';
-import { ClubAccount } from 'shared';
+import reimbursementRequestQueryArgs from '../../src/prisma-query-args/reimbursement-requests.query-args';
+import { batman } from './users.test-data';
+import { prismaWbsElement1 } from './wbs-element.test-data';
 export const PopEyes: PrismaVendor = {
   vendorId: 'CHICKEN',
   dateCreated: new Date('12/22/203'),
@@ -26,7 +30,7 @@ export const GiveMeMyMoney: PrismaReimbursementRequest = {
   dateOfExpense: new Date('18/8/2023'),
   recipientId: 1,
   vendorId: '',
-  account: ClubAccount.CASH,
+  account: Club_Accounts.CASH,
   totalCost: 0,
   receiptPictures: [],
   dateDelivered: null,
@@ -40,4 +44,13 @@ export const GiveMeMoneyProduct: PrismaReimbursementProduct = {
   cost: 0,
   dateDeleted: null,
   wbsElementId: 1
+};
+
+export const prismaGiveMeMyMoney: Prisma.Reimbursement_RequestGetPayload<typeof reimbursementRequestQueryArgs> = {
+  ...GiveMeMyMoney,
+  reimbursementsStatuses: [],
+  recipient: batman,
+  vendor: PopEyes,
+  reimbursementProducts: [{ ...GiveMeMoneyProduct, wbsElement: prismaWbsElement1 }],
+  expenseType: Parts
 };


### PR DESCRIPTION
## Changes

Add endpoint `/reimbursement-requests/current-user` to fetch all reimbursement requests whose recipientId matches the current user's.

## Test Cases

### Jest tests

- Test that the appropriate Prisma function has been called with the desired inputs.

### Postman tests

Did not write seed data, instead I manually made the reimbursement requests like so.
![Screen Shot 2023-06-04 at 1 47 31 PM](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/59806366/23add209-d716-4ce3-899a-82db07eb8ee3)
![Screen Shot 2023-06-04 at 1 50 45 PM](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/59806366/45a3a704-9556-406b-8aca-6940dd0c1731)
![Screen Shot 2023-06-04 at 1 52 47 PM](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/59806366/d5805e60-1eab-4f3d-ae0f-8863c4d10288)

Database after inserting new reimbursement:
![Screen Shot 2023-06-04 at 2 03 14 PM](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/59806366/b5b62b16-9fbd-4edc-9092-faaa01ffc307)

- TEST CASE 1: Calling endpoint when Authorization = 1 (match found)
![Screen Shot 2023-06-09 at 12 19 30 AM](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/59806366/dd804090-0b3e-4f62-95b8-4e8995df8be9)

- TEST CASE 2: Calling endpoint when Authorization = 2 (match not found)
![Screen Shot 2023-06-09 at 12 19 51 AM](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/59806366/23d352c5-3da5-4d07-9f35-9021f3d44338)


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1128 
