### PR TITLE
#1139 Delete Reimbursement Request Endpoint

### DIFF
--- a/src/backend/src/controllers/reimbursement-requests.controllers.ts
+++ b/src/backend/src/controllers/reimbursement-requests.controllers.ts
@@ -66,8 +66,8 @@ export default class ReimbursementRequestsController {
     try {
       const { requestId } = req.params;
       const user = await getCurrentUser(res);
-      const deletedRequest = await ReimbursementRequestService.deleteReimbursementRequest(requestId, user);
-      res.status(200).json(deletedRequest);
+      const deletedReimbursementRequest = await ReimbursementRequestService.deleteReimbursementRequest(requestId, user);
+      res.status(200).json(deletedReimbursementRequest);
     } catch (error: unknown) {
       next(error);
     }

--- a/src/backend/src/controllers/reimbursement-requests.controllers.ts
+++ b/src/backend/src/controllers/reimbursement-requests.controllers.ts
@@ -64,9 +64,9 @@ export default class ReimbursementRequestsController {
 
   static async deleteReimbursementRequest(req: Request, res: Response, next: NextFunction) {
     try {
-      const { id } = req.params;
+      const { requestId } = req.params;
       const user = await getCurrentUser(res);
-      const deletedRequest = await ReimbursementRequestService.deleteReimbursementRequest(id, user);
+      const deletedRequest = await ReimbursementRequestService.deleteReimbursementRequest(requestId, user);
       res.status(200).json(deletedRequest);
     } catch (error: unknown) {
       next(error);

--- a/src/backend/src/controllers/reimbursement-requests.controllers.ts
+++ b/src/backend/src/controllers/reimbursement-requests.controllers.ts
@@ -66,8 +66,8 @@ export default class ReimbursementRequestsController {
     try {
       const { id } = req.params;
       const user = await getCurrentUser(res);
-      await ReimbursementRequestService.deleteReimbursementRequest(id, user);
-      res.status(200).json({ message: 'Successfully deleted reimbursement request' });
+      const deletedRequest = await ReimbursementRequestService.deleteReimbursementRequest(id, user);
+      res.status(200).json(deletedRequest);
     } catch (error: unknown) {
       next(error);
     }

--- a/src/backend/src/controllers/reimbursement-requests.controllers.ts
+++ b/src/backend/src/controllers/reimbursement-requests.controllers.ts
@@ -62,6 +62,16 @@ export default class ReimbursementRequestsController {
     }
   }
 
+  static async deleteReimbursementRequest(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { requestId } = req.params;
+      const user = await getCurrentUser(res);
+      const deletedReimbursementRequest = await ReimbursementRequestService.deleteReimbursementRequest(requestId, user);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
   static async sendPendingAdvisorList(req: Request, res: Response, next: NextFunction) {
     try {
       const { saboNumbers } = req.body;

--- a/src/backend/src/controllers/reimbursement-requests.controllers.ts
+++ b/src/backend/src/controllers/reimbursement-requests.controllers.ts
@@ -64,10 +64,10 @@ export default class ReimbursementRequestsController {
 
   static async deleteReimbursementRequest(req: Request, res: Response, next: NextFunction) {
     try {
-      const { requestId } = req.params;
+      const { id } = req.params;
       const user = await getCurrentUser(res);
-      const deletedReimbursementRequest = await ReimbursementRequestService.deleteReimbursementRequest(requestId, user);
-      res.status(200).json(deletedReimbursementRequest);
+      await ReimbursementRequestService.deleteReimbursementRequest(id, user);
+      res.status(200).json({ message: 'Successfully deleted reimbursement request' });
     } catch (error: unknown) {
       next(error);
     }

--- a/src/backend/src/controllers/reimbursement-requests.controllers.ts
+++ b/src/backend/src/controllers/reimbursement-requests.controllers.ts
@@ -67,6 +67,7 @@ export default class ReimbursementRequestsController {
       const { requestId } = req.params;
       const user = await getCurrentUser(res);
       const deletedReimbursementRequest = await ReimbursementRequestService.deleteReimbursementRequest(requestId, user);
+      res.status(200).json(deletedReimbursementRequest);
     } catch (error: unknown) {
       next(error);
     }

--- a/src/backend/src/routes/reimbursement-requests.routes.ts
+++ b/src/backend/src/routes/reimbursement-requests.routes.ts
@@ -13,8 +13,6 @@ const reimbursementRequestsRouter = express.Router();
 
 reimbursementRequestsRouter.get('/vendors', ReimbursementRequestController.getAllVendors);
 
-reimbursementRequestsRouter.get('/current-user', ReimbursementRequestController.getCurrentUserReimbursementRequests);
-
 reimbursementRequestsRouter.post(
   '/create',
   isDate(body('dateOfExpense')),
@@ -31,8 +29,6 @@ reimbursementRequestsRouter.post(
   validateInputs,
   ReimbursementRequestController.createReimbursementRequest
 );
-
-reimbursementRequestsRouter.get('/', ReimbursementRequestController.getAllReimbursementRequests);
 
 reimbursementRequestsRouter.post(
   '/:requestId/edit',
@@ -83,10 +79,6 @@ reimbursementRequestsRouter.post(
   ReimbursementRequestController.createExpenseType
 );
 
-reimbursementRequestsRouter.delete(
-  '/:requestId/delete',
-  validateInputs,
-  ReimbursementRequestController.deleteReimbursementRequest
-);
+reimbursementRequestsRouter.delete('/:requestId/delete', ReimbursementRequestController.deleteReimbursementRequest);
 
 export default reimbursementRequestsRouter;

--- a/src/backend/src/routes/reimbursement-requests.routes.ts
+++ b/src/backend/src/routes/reimbursement-requests.routes.ts
@@ -79,6 +79,6 @@ reimbursementRequestsRouter.post(
   ReimbursementRequestController.createExpenseType
 );
 
-reimbursementRequestsRouter.post('/:id/delete', validateInputs, ReimbursementRequestController.deleteReimbursementRequest);
+reimbursementRequestsRouter.delete('/:id/delete', validateInputs, ReimbursementRequestController.deleteReimbursementRequest);
 
 export default reimbursementRequestsRouter;

--- a/src/backend/src/routes/reimbursement-requests.routes.ts
+++ b/src/backend/src/routes/reimbursement-requests.routes.ts
@@ -79,9 +79,6 @@ reimbursementRequestsRouter.post(
   ReimbursementRequestController.createExpenseType
 );
 
-reimbursementRequestsRouter.post(
-  '/reimbursement-requests/:id/delete',
-  ReimbursementRequestController.deleteReimbursementRequest
-);
+reimbursementRequestsRouter.post('/:id/delete', validateInputs, ReimbursementRequestController.deleteReimbursementRequest);
 
 export default reimbursementRequestsRouter;

--- a/src/backend/src/routes/reimbursement-requests.routes.ts
+++ b/src/backend/src/routes/reimbursement-requests.routes.ts
@@ -79,4 +79,6 @@ reimbursementRequestsRouter.post(
   ReimbursementRequestController.createExpenseType
 );
 
+reimbursementRequestsRouter.post('/reimbursement-requests/:id/delete');
+
 export default reimbursementRequestsRouter;

--- a/src/backend/src/routes/reimbursement-requests.routes.ts
+++ b/src/backend/src/routes/reimbursement-requests.routes.ts
@@ -79,6 +79,10 @@ reimbursementRequestsRouter.post(
   ReimbursementRequestController.createExpenseType
 );
 
-reimbursementRequestsRouter.delete('/:id/delete', validateInputs, ReimbursementRequestController.deleteReimbursementRequest);
+reimbursementRequestsRouter.delete(
+  '/:requestId/delete',
+  validateInputs,
+  ReimbursementRequestController.deleteReimbursementRequest
+);
 
 export default reimbursementRequestsRouter;

--- a/src/backend/src/routes/reimbursement-requests.routes.ts
+++ b/src/backend/src/routes/reimbursement-requests.routes.ts
@@ -13,6 +13,8 @@ const reimbursementRequestsRouter = express.Router();
 
 reimbursementRequestsRouter.get('/vendors', ReimbursementRequestController.getAllVendors);
 
+reimbursementRequestsRouter.get('/current-user', ReimbursementRequestController.getCurrentUserReimbursementRequests);
+
 reimbursementRequestsRouter.post(
   '/create',
   isDate(body('dateOfExpense')),
@@ -29,6 +31,8 @@ reimbursementRequestsRouter.post(
   validateInputs,
   ReimbursementRequestController.createReimbursementRequest
 );
+
+reimbursementRequestsRouter.get('/', ReimbursementRequestController.getAllReimbursementRequests);
 
 reimbursementRequestsRouter.post(
   '/:requestId/edit',

--- a/src/backend/src/routes/reimbursement-requests.routes.ts
+++ b/src/backend/src/routes/reimbursement-requests.routes.ts
@@ -79,6 +79,9 @@ reimbursementRequestsRouter.post(
   ReimbursementRequestController.createExpenseType
 );
 
-reimbursementRequestsRouter.post('/reimbursement-requests/:id/delete');
+reimbursementRequestsRouter.post(
+  '/reimbursement-requests/:id/delete',
+  ReimbursementRequestController.deleteReimbursementRequest
+);
 
 export default reimbursementRequestsRouter;

--- a/src/backend/src/services/reimbursement-requests.services.ts
+++ b/src/backend/src/services/reimbursement-requests.services.ts
@@ -180,20 +180,30 @@ export default class ReimbursementRequestService {
   /**
    * Soft-deletes the given reimbursement request
    *
-   * @param requestId the request to be deleted
-   * @param deleter the user deleting the request
+   * @param requestId the reimbursement request to be deleted
+   * @param submitter the user deleting the reimbursement request
    */
-  static async deleteReimbursementRequest(requestId: string, deleter: User): Promise<Reimbursement_Request> {
+  static async deleteReimbursementRequest(requestId: string, submitter: User): Promise<Reimbursement_Request> {
     const request = await prisma.reimbursement_Request.findUnique({
-      where: { reimbursementRequestId: requestId }
+      where: { reimbursementRequestId: requestId },
+      include: {
+        reimbursementsStatuses: true
+      }
     });
 
     if (!request) throw new NotFoundException('Reimbursement Request', requestId);
-    if (request.recipientId !== deleter.userId)
+    if (request.recipientId !== submitter.userId)
       throw new AccessDeniedException(
         'You do not have access to delete this reimbursement request, only the creator can delete a reimbursement request'
       );
     if (request.dateDeleted) throw new DeletedException('Reimbursement Request', requestId);
+    if (
+      request.reimbursementsStatuses &&
+      request.reimbursementsStatuses.some(
+        (reimbursementStatus) => reimbursementStatus.type === Reimbursement_Status_Type.SABO_SUBMITTED
+      )
+    )
+      throw new AccessDeniedException('You cannot delete this reimbursement request. It has already been approved');
 
     const deletedRequest = await prisma.reimbursement_Request.update({
       where: { reimbursementRequestId: requestId },

--- a/src/backend/src/services/reimbursement-requests.services.ts
+++ b/src/backend/src/services/reimbursement-requests.services.ts
@@ -183,12 +183,9 @@ export default class ReimbursementRequestService {
    * @param requestId the request to be deleted
    * @param deleter the user deleting the request
    */
-  static async deleteReimbursementRequest(requestId: string, deleter: User): Promise<void> {
+  static async deleteReimbursementRequest(requestId: string, deleter: User): Promise<Reimbursement_Request> {
     const request = await prisma.reimbursement_Request.findUnique({
-      where: { reimbursementRequestId: requestId },
-      include: {
-        reimbursementProducts: true
-      }
+      where: { reimbursementRequestId: requestId }
     });
 
     if (!request) throw new NotFoundException('Reimbursement Request', requestId);
@@ -196,12 +193,14 @@ export default class ReimbursementRequestService {
       throw new AccessDeniedException(
         'You do not have access to delete this reimbursement request, only the creator can delete a reimbursement request'
       );
-    if (request.dateDeleted) throw new DeletedException('Reimbursement Request', request.reimbursementRequestId);
+    if (request.dateDeleted) throw new DeletedException('Reimbursement Request', requestId);
 
-    await prisma.reimbursement_Request.update({
+    const deletedRequest = await prisma.reimbursement_Request.update({
       where: { reimbursementRequestId: requestId },
       data: { dateDeleted: new Date() }
     });
+
+    return deletedRequest;
   }
 
   /**

--- a/src/backend/src/services/reimbursement-requests.services.ts
+++ b/src/backend/src/services/reimbursement-requests.services.ts
@@ -177,6 +177,24 @@ export default class ReimbursementRequestService {
     return updatedReimbursementRequest;
   }
 
+  static async deleteReimbursementRequest(requestId: string, deleter: User) {
+    const request = await prisma.reimbursement_Request.findUnique({
+      where: { reimbursementRequestId: requestId },
+      include: {
+        reimbursementProducts: true
+      }
+    });
+
+    if (!request) throw new NotFoundException('Reimbursement Request', requestId);
+    if (request.recepientId !== deleter.userId)
+      throw new AccessDeniedException(
+        'You do not have access to delete this reimbursement request, only the creator can delete a reimbursement request'
+      );
+    if (request.dateDeleted) throw new DeletedException('Reimbursement Request', requestId);
+
+    request.dateDeleted = new Date();
+  }
+
   /**
    * sends the pending advisor reimbursements to the advisor
    * @param sender the person sending the pending advisor list

--- a/src/backend/src/services/reimbursement-requests.services.ts
+++ b/src/backend/src/services/reimbursement-requests.services.ts
@@ -212,7 +212,6 @@ export default class ReimbursementRequestService {
       );
     if (request.dateDeleted) throw new DeletedException('Reimbursement Request', requestId);
     if (
-      request.reimbursementsStatuses &&
       request.reimbursementsStatuses.some(
         (reimbursementStatus) => reimbursementStatus.type === Reimbursement_Status_Type.SABO_SUBMITTED
       )

--- a/src/backend/src/utils/errors.utils.ts
+++ b/src/backend/src/utils/errors.utils.ts
@@ -24,7 +24,7 @@ export class DeletedException extends HttpException {
    * @param id the id of the thing that is deleted
    */
   constructor(name: ExceptionObjectNames, id: number | string) {
-    super(404, `${name} with id: ${id} has been deleted!`);
+    super(404, `${name} with id: ${id} has been deleted already!`);
   }
 }
 

--- a/src/backend/tests/reimbursement-requests.test.ts
+++ b/src/backend/tests/reimbursement-requests.test.ts
@@ -255,7 +255,7 @@ describe('Reimbursement Requests', () => {
 
     test('Request succeeds', async () => {
       jest.spyOn(prisma.reimbursement_Request, 'findUnique').mockResolvedValue(GiveMeMyMoney);
-      jest.spyOn(prisma.reimbursement_Request, 'update').mockResolvedValue(GiveMeMyMoney);
+      jest.spyOn(prisma.reimbursement_Request, 'update').mockResolvedValue({ ...GiveMeMyMoney, dateDeleted: new Date() });
 
       await ReimbursementRequestService.deleteReimbursementRequest(GiveMeMyMoney.reimbursementRequestId, batman);
 

--- a/src/backend/tests/reimbursement-requests.test.ts
+++ b/src/backend/tests/reimbursement-requests.test.ts
@@ -292,7 +292,8 @@ describe('Reimbursement Requests', () => {
     });
 
     test('Delete Reimbursement Request succeeds', async () => {
-      jest.spyOn(prisma.reimbursement_Request, 'findUnique').mockResolvedValue(GiveMeMyMoney);
+      const GiveMeMyMoneyWithStatus = { ...GiveMeMyMoney, reimbursementsStatuses: [] };
+      jest.spyOn(prisma.reimbursement_Request, 'findUnique').mockResolvedValue(GiveMeMyMoneyWithStatus);
       jest.spyOn(prisma.reimbursement_Request, 'update').mockResolvedValue({ ...GiveMeMyMoney, dateDeleted: new Date() });
 
       await ReimbursementRequestService.deleteReimbursementRequest(GiveMeMyMoney.reimbursementRequestId, batman);

--- a/src/backend/tests/test-data/reimbursement-requests.test-data.ts
+++ b/src/backend/tests/test-data/reimbursement-requests.test-data.ts
@@ -2,7 +2,9 @@ import {
   Vendor as PrismaVendor,
   Reimbursement_Request as PrismaReimbursementRequest,
   Expense_Type as PrismaExpenseType,
-  Reimbursement_Product as PrismaReimbursementProduct
+  Reimbursement_Product as PrismaReimbursementProduct,
+  Reimbursement_Status as PrismaReimbursementStatus,
+  Reimbursement_Status_Type
 } from '@prisma/client';
 import { Club_Account } from 'shared';
 export const PopEyes: PrismaVendor = {
@@ -40,4 +42,12 @@ export const GiveMeMoneyProduct: PrismaReimbursementProduct = {
   cost: 0,
   dateDeleted: null,
   wbsElementId: 1
+};
+
+export const Status: PrismaReimbursementStatus = {
+  reimbursementStatusId: 1,
+  type: Reimbursement_Status_Type.SABO_SUBMITTED,
+  userId: 2,
+  dateCreated: new Date(),
+  reimbursementRequestId: 'id'
 };


### PR DESCRIPTION
## Changes

Endpoint made for deleting reimbursement requests

## Notes

Sorry this took a while, first backend ticket and had to learn postman lol

## Test Cases

- Request cannot be deleted by a user that did not create it
<img width="844" alt="Screenshot 2023-06-07 at 4 09 07 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/114596410/05e11903-56a4-4131-937d-c567ede58481">

- Request cannot be deleted if it has been already
<img width="897" alt="Screenshot 2023-06-07 at 4 15 00 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/114596410/8d8f7fc6-347a-4fbc-9505-679184bf206c">

- Request cannot be deleted if an invalid id is given
<img width="855" alt="Screenshot 2023-06-07 at 4 09 28 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/114596410/7411de47-90d2-47ba-b339-c11fca65bc7d">

- Success
<img width="856" alt="Screenshot 2023-06-07 at 4 26 03 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/114596410/f1036af8-7fd5-4930-9ecd-faf2a8064f3c">

## Checklist
- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1139