### PR TITLE
#1176: Added Set Team Head Endpoint with the unit test

### DIFF
--- a/src/backend/src/controllers/teams.controllers.ts
+++ b/src/backend/src/controllers/teams.controllers.ts
@@ -55,8 +55,8 @@ export default class TeamsController {
     try {
       const { userId } = req.body;
       const { teamId } = req.params;
-      const user = await getCurrentUser(res);
-      const team = await TeamsService.setTeamHead(user, teamId, userId);
+      const submitter = await getCurrentUser(res);
+      const team = await TeamsService.setTeamHead(submitter, teamId, userId);
       return res.status(200).json(team);
     } catch (error: unknown) {
       next(error);

--- a/src/backend/src/controllers/teams.controllers.ts
+++ b/src/backend/src/controllers/teams.controllers.ts
@@ -50,4 +50,15 @@ export default class TeamsController {
       next(error);
     }
   }
+
+  static async setTeamHead(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { userId } = req.body;
+      const user = await getCurrentUser(res);
+      const team = await TeamsService.setTeamHead(user, req.params.teamId, userId);
+      return res.status(200).json(team);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
 }

--- a/src/backend/src/controllers/teams.controllers.ts
+++ b/src/backend/src/controllers/teams.controllers.ts
@@ -54,8 +54,9 @@ export default class TeamsController {
   static async setTeamHead(req: Request, res: Response, next: NextFunction) {
     try {
       const { userId } = req.body;
+      const { teamId } = req.params;
       const user = await getCurrentUser(res);
-      const team = await TeamsService.setTeamHead(user, req.params.teamId, userId);
+      const team = await TeamsService.setTeamHead(user, teamId, userId);
       return res.status(200).json(team);
     } catch (error: unknown) {
       next(error);

--- a/src/backend/src/routes/teams.routes.ts
+++ b/src/backend/src/routes/teams.routes.ts
@@ -21,5 +21,6 @@ teamsRouter.post(
   validateInputs,
   TeamsController.editDescription
 );
+teamsRouter.post('/:teamId/set-head', intMinZero(body('userId')), validateInputs, TeamsController.setTeamHead);
 
 export default teamsRouter;

--- a/src/backend/src/services/teams.services.ts
+++ b/src/backend/src/services/teams.services.ts
@@ -137,6 +137,12 @@ export default class TeamsService {
     if (!newHead) throw new NotFoundException('User', userId);
     if (!isHead(newHead.role)) throw new AccessDeniedException('The team head must be at least an head');
 
+    const newHeadTeam = await prisma.team.findFirst({
+      where: { leaderId: userId }
+    });
+
+    if (newHeadTeam) throw new AccessDeniedException('The new team head must not be a leader of another team');
+
     const updateTeam = await prisma.team.update({
       where: { teamId },
       data: {

--- a/src/backend/src/services/teams.services.ts
+++ b/src/backend/src/services/teams.services.ts
@@ -1,4 +1,4 @@
-import { isAdmin, Team } from 'shared';
+import { isAdmin, isHead, Team } from 'shared';
 import { User } from '@prisma/client';
 import teamQueryArgs from '../prisma-query-args/teams.query-args';
 import prisma from '../prisma/prisma';
@@ -135,17 +135,13 @@ export default class TeamsService {
     });
 
     if (!newHead) throw new NotFoundException('User', userId);
-
-    // retrieve userId for the head to update team's head in the database
-    const transformedHead = {
-      userId: newHead.userId
-    };
+    if (!isHead(newHead.role)) throw new AccessDeniedException('the team head must be at least an head');
 
     const updateTeam = await prisma.team.update({
       where: { teamId },
       data: {
         leader: {
-          connect: transformedHead
+          connect: { userId }
         }
       },
       ...teamQueryArgs

--- a/src/backend/src/services/teams.services.ts
+++ b/src/backend/src/services/teams.services.ts
@@ -115,27 +115,27 @@ export default class TeamsService {
 
   /**
    * Update the team's head of the given team to the given user
-   * @param user The submitter of this request
+   * @param submitter The submitter of this request
    * @param teamId The id for the team that is being edited
    * @param userId The user to be the new team's head
    * @returns The team with the new head
    */
-  static async setTeamHead(user: User, teamId: string, userId: number): Promise<Team> {
+  static async setTeamHead(submitter: User, teamId: string, userId: number): Promise<Team> {
     const team = await prisma.team.findUnique({
       where: { teamId },
       ...teamQueryArgs
     });
 
     if (!team) throw new NotFoundException('Team', teamId);
-    if (!isAdmin(user.role) && user.userId !== team.leaderId)
-      throw new AccessDeniedException('you must be an admin or the team lead to update the leader!');
+    if (!isAdmin(submitter.role) && submitter.userId !== team.leaderId)
+      throw new AccessDeniedException('You must be an admin or the team lead to update the leader!');
 
     const newHead = await prisma.user.findUnique({
       where: { userId }
     });
 
     if (!newHead) throw new NotFoundException('User', userId);
-    if (!isHead(newHead.role)) throw new AccessDeniedException('the team head must be at least an head');
+    if (!isHead(newHead.role)) throw new AccessDeniedException('The team head must be at least an head');
 
     const updateTeam = await prisma.team.update({
       where: { teamId },

--- a/src/backend/tests/teams.test.ts
+++ b/src/backend/tests/teams.test.ts
@@ -117,4 +117,40 @@ describe('Teams', () => {
       expect(prisma.team.findUnique).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('setTeamHead', () => {
+    test('setTeamHead head not found', async () => {
+      jest.spyOn(prisma.team, 'findUnique').mockResolvedValue(prismaTeam1);
+
+      const callSetTeamHead = async () => await TeamsService.setTeamHead(flash, sharedTeam1.teamId, 122);
+
+      const expectedException = new HttpException(404, 'User with id: 122 not found!');
+
+      await expect(callSetTeamHead).rejects.toThrow(expectedException);
+    });
+
+    test('setTeamHead works', async () => {
+      jest.spyOn(prisma.team, 'findUnique').mockResolvedValue(prismaTeam1);
+      jest.spyOn(prisma.team, 'update').mockResolvedValue(prismaTeam1);
+      jest.spyOn(prisma.user, 'findUnique').mockResolvedValue(superman);
+
+      const teamId = 'id1';
+      const res = await TeamsService.setTeamHead(flash, sharedTeam1.teamId, 2);
+
+      expect(prisma.team.findUnique).toHaveBeenCalledTimes(1);
+      expect(prisma.team.update).toHaveBeenCalledTimes(1);
+      expect(prisma.team.update).toHaveBeenCalledWith({
+        where: { teamId },
+        data: {
+          leader: {
+            connect: {
+              userId: 2
+            }
+          }
+        },
+        ...teamQueryArgs
+      });
+      expect(res).toStrictEqual(sharedTeam1);
+    });
+  });
 });

--- a/src/backend/tests/teams.test.ts
+++ b/src/backend/tests/teams.test.ts
@@ -152,10 +152,26 @@ describe('Teams', () => {
       await expect(callSetTeamHead).rejects.toThrow(expectedException);
     });
 
+    test('setTeamHead new head is already a lead of another team', async () => {
+      jest.spyOn(prisma.team, 'findUnique').mockResolvedValue(prismaTeam1);
+      jest.spyOn(prisma.team, 'findFirst').mockResolvedValue(justiceLeague);
+      jest.spyOn(prisma.user, 'findUnique').mockResolvedValue(superman);
+
+      const callSetTeamHead = async () => await TeamsService.setTeamHead(flash, sharedTeam1.teamId, 1);
+
+      const expectedException = new HttpException(
+        403,
+        'Access Denied: The new team head must not be a leader of another team'
+      );
+
+      await expect(callSetTeamHead).rejects.toThrow(expectedException);
+    });
+
     test('setTeamHead works', async () => {
       jest.spyOn(prisma.team, 'findUnique').mockResolvedValue(prismaTeam1);
       jest.spyOn(prisma.team, 'update').mockResolvedValue(prismaTeam1);
       jest.spyOn(prisma.user, 'findUnique').mockResolvedValue(superman);
+      jest.spyOn(prisma.team, 'findFirst').mockResolvedValue(null);
 
       const teamId = 'id1';
       const res = await TeamsService.setTeamHead(flash, sharedTeam1.teamId, 2);

--- a/src/backend/tests/teams.test.ts
+++ b/src/backend/tests/teams.test.ts
@@ -120,11 +120,34 @@ describe('Teams', () => {
 
   describe('setTeamHead', () => {
     test('setTeamHead head not found', async () => {
+      jest.spyOn(prisma.user, 'findUnique').mockResolvedValue(null);
       jest.spyOn(prisma.team, 'findUnique').mockResolvedValue(prismaTeam1);
 
       const callSetTeamHead = async () => await TeamsService.setTeamHead(flash, sharedTeam1.teamId, 122);
 
       const expectedException = new HttpException(404, 'User with id: 122 not found!');
+
+      await expect(callSetTeamHead).rejects.toThrow(expectedException);
+    });
+
+    test('setTeamHead team not found', async () => {
+      jest.spyOn(prisma.user, 'findUnique').mockResolvedValue(superman);
+      jest.spyOn(prisma.team, 'findUnique').mockResolvedValue(null);
+
+      const callSetTeamHead = async () => await TeamsService.setTeamHead(flash, 'randomId', 2);
+
+      const expectedException = new HttpException(404, 'Team with id: randomId not found!');
+
+      await expect(callSetTeamHead).rejects.toThrow(expectedException);
+    });
+
+    test(`setTeamHead head's role is not at least head role`, async () => {
+      jest.spyOn(prisma.team, 'findUnique').mockResolvedValue(prismaTeam1);
+      jest.spyOn(prisma.user, 'findUnique').mockResolvedValue(wonderwoman);
+
+      const callSetTeamHead = async () => await TeamsService.setTeamHead(flash, sharedTeam1.teamId, 3);
+
+      const expectedException = new HttpException(403, 'Access Denied: the team head must be at least an head');
 
       await expect(callSetTeamHead).rejects.toThrow(expectedException);
     });

--- a/src/backend/tests/teams.test.ts
+++ b/src/backend/tests/teams.test.ts
@@ -147,7 +147,7 @@ describe('Teams', () => {
 
       const callSetTeamHead = async () => await TeamsService.setTeamHead(flash, sharedTeam1.teamId, 3);
 
-      const expectedException = new HttpException(403, 'Access Denied: the team head must be at least an head');
+      const expectedException = new HttpException(403, 'Access Denied: The team head must be at least an head');
 
       await expect(callSetTeamHead).rejects.toThrow(expectedException);
     });


### PR DESCRIPTION
## Changes

- Added set team head endpoint in the teams.routes.ts
- Added set team head controller in the teams.controllers.ts
- Added set team head service function in the teams.services.ts 
- Added unit test for set team head endpoint in teams.test.ts

## Test Cases

- **Case A**
- Check the endpoint throws error when given new head's userId is not found
- **Case B**
- Check the endpoint successfully updates the given team's leader to a given user

## Screenshots
**A team before the head update:**
<img width="957" alt="#1176-test-ss1" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/91857946/e30b573f-35ef-41c2-bd27-98a983913513">
**A team after the head update (new Head with userId: 9):**
<img width="960" alt="#1176-test-ss2" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/91857946/ca26ad20-4ba0-4f42-b39a-ef5257ccf35c">
**Retrieve the updated team after the update**
<img width="960" alt="#1176-test-ss3" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/91857946/61aade01-87d7-4ad5-a46e-e544671745f4">

**A test that checks if the new head is already a leader of another team:
Note that Thomas with userId, 1 is already a leader of a certain team.**
<img width="960" alt="#1176-test-ss4" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/91857946/1083f2f7-e0fa-465a-a609-0301db6f0e4f">
**Rejects setting Thomas as a new leader to a certain team**
<img width="958" alt="#1176-test-ss5" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/91857946/feb43c8a-e092-414a-b7d2-3e50c0f70b4d">



## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
