### PR TITLE
#1049 wp create make blocked by autocomplete

### DIFF
--- a/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageForm.tsx
+++ b/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageForm.tsx
@@ -21,13 +21,11 @@ export interface CreateWorkPackageFormInputs {
   duration: number | null;
   crId: number;
   stage: WorkPackageStage | 'None';
-  wbsNum: string;
-  blockedBy: { wbsNum: string }[];
+  wbsNum: string | null;
+  blockedBy: string[];
   expectedActivities: { bulletId: number; detail: string }[];
   deliverables: { bulletId: number; detail: string }[];
 }
-
-// Stuff from Mihir's PR goes in this file and only this file
 
 const CreateWorkPackageForm: React.FC = () => {
   const history = useHistory();
@@ -36,8 +34,8 @@ const CreateWorkPackageForm: React.FC = () => {
   const query = useQuery();
 
   const { isLoading, mutateAsync } = useCreateSingleWorkPackage();
-  if (isLoading || auth.user === undefined) return <LoadingIndicator />;
   const [wbsNum, setWbsNum] = useState(query.get('wbsNum') || '');
+  if (isLoading || auth.user === undefined) return <LoadingIndicator />;
   if (isLoading) return <LoadingIndicator />;
   const handleSubmit = async (data: CreateWorkPackageFormInputs) => {
     const { name, startDate, duration, crId, blockedBy, stage } = data;
@@ -57,8 +55,8 @@ const CreateWorkPackageForm: React.FC = () => {
         return;
       }
 
-      const blockedByWbsNums = blockedBy.map((blocker: { wbsNum: string }) => {
-        const blockedWbsNum = validateWBS(blocker.wbsNum);
+      const blockedByWbsNums = blockedBy.map((blocker: string) => {
+        const blockedWbsNum = validateWBS(blocker);
         return {
           carNumber: blockedWbsNum.carNumber,
           projectNumber: blockedWbsNum.projectNumber,

--- a/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageForm.tsx
+++ b/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageForm.tsx
@@ -34,7 +34,7 @@ const CreateWorkPackageForm: React.FC = () => {
   const query = useQuery();
 
   const { isLoading, mutateAsync } = useCreateSingleWorkPackage();
-  const [wbsNum, setWbsNum] = useState(query.get('wbsNum') || '');
+  const [wbsNum, setWbsNum] = useState(query.get('wbs') || '');
   if (isLoading || auth.user === undefined) return <LoadingIndicator />;
   if (isLoading) return <LoadingIndicator />;
   const handleSubmit = async (data: CreateWorkPackageFormInputs) => {

--- a/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageForm.tsx
+++ b/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageForm.tsx
@@ -12,6 +12,7 @@ import { routes } from '../../utils/routes';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import CreateWorkPackageFormView from './CreateWorkPackageFormView';
 import { CreateWorkPackageApiInputs } from '../../apis/work-packages.api';
+import { useQuery } from '../../hooks/utils.hooks';
 
 export interface CreateWorkPackageFormInputs {
   name: string;
@@ -29,6 +30,7 @@ const CreateWorkPackageForm: React.FC = () => {
   const history = useHistory();
   const auth = useAuth();
   const toast = useToast();
+  const query = useQuery();
 
   const { isLoading, mutateAsync } = useCreateSingleWorkPackage();
 

--- a/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageForm.tsx
+++ b/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageForm.tsx
@@ -12,7 +12,6 @@ import { routes } from '../../utils/routes';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import CreateWorkPackageFormView from './CreateWorkPackageFormView';
 import { CreateWorkPackageApiInputs } from '../../apis/work-packages.api';
-import { useQuery } from '../../hooks/utils.hooks';
 
 export interface CreateWorkPackageFormInputs {
   name: string;
@@ -26,11 +25,12 @@ export interface CreateWorkPackageFormInputs {
   deliverables: { bulletId: number; detail: string }[];
 }
 
+// Stuff from Mihir's PR goes in this file and only this file
+
 const CreateWorkPackageForm: React.FC = () => {
   const history = useHistory();
   const auth = useAuth();
   const toast = useToast();
-  const query = useQuery();
 
   const { isLoading, mutateAsync } = useCreateSingleWorkPackage();
 

--- a/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageFormView.tsx
+++ b/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageFormView.tsx
@@ -18,14 +18,14 @@ import { Controller, useFieldArray, useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useQuery } from '../../hooks/utils.hooks';
 import ReactHookTextField from '../../components/ReactHookTextField';
-import { FormControl, FormLabel, IconButton } from '@mui/material';
+import { Autocomplete, FormControl, FormLabel } from '@mui/material';
 import ReactHookEditableList from '../../components/ReactHookEditableList';
-import DeleteIcon from '@mui/icons-material/Delete';
 import { wbsTester, startDateTester } from '../../utils/form';
 import NERFailButton from '../../components/NERFailButton';
 import NERSuccessButton from '../../components/NERSuccessButton';
-import { WorkPackageStage } from 'shared';
+import { Project, WorkPackage, WorkPackageStage } from 'shared';
 import { CreateWorkPackageFormInputs } from './CreateWorkPackageForm';
+import ProjectsService from '../../../../backend/src/services/projects.services';
 
 const schema = yup.object().shape({
   name: yup.string().required('Name is required'),
@@ -93,25 +93,31 @@ const CreateWorkPackageFormView: React.FC<CreateWorkPackageFormViewProps> = ({ a
     append: appendDeliverable,
     remove: removeDeliverable
   } = useFieldArray({ control, name: 'deliverables' });
-  const { fields: blockedBy, append: appendBlocker, remove: removeBlocker } = useFieldArray({ control, name: 'blockedBy' });
+  const { append: appendBlocker } = useFieldArray({ control, name: 'blockedBy' });
 
   const disableStartDate = (startDate: Date) => {
     return startDate.getDay() !== 1;
   };
 
+  const project: Project = await ProjectsService.getSingleProject(handleSubmit.wbsNum);
+  const workPackages: WorkPackage[] = project.workPackages;
+
   const blockedByFormControl = (
     <FormControl fullWidth>
       <FormLabel>Blocked By</FormLabel>
-      {blockedBy.map((_element, i) => {
-        return (
-          <Grid item sx={{ display: 'flex', alignItems: 'center' }}>
-            <TextField required autoComplete="off" {...register(`blockedBy.${i}.wbsNum`)} sx={{ width: 9 / 10 }} />
-            <IconButton type="button" onClick={() => removeBlocker(i)} sx={{ mx: 1, my: 0 }}>
-              <DeleteIcon />
-            </IconButton>
-          </Grid>
-        );
-      })}
+      <Autocomplete
+        //isOptionEqualToValue={(option, value) => option.id === value.id}
+        filterSelectedOptions
+        multiple
+        id="tags-standard"
+        options={workPackages}
+        //value={members}
+        //onChange={(_event, newValue) => setMembers(newValue)}
+        getOptionLabel={(option) => option.name}
+        renderInput={(params) => (
+          <TextField {...params} variant="standard" label="Work Packages" placeholder="Select A Work Package" />
+        )}
+      />
       <Button
         variant="contained"
         color="success"

--- a/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageFormView.tsx
+++ b/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageFormView.tsx
@@ -110,36 +110,38 @@ const CreateWorkPackageFormView: React.FC<CreateWorkPackageFormViewProps> = ({ a
     return startDate.getDay() !== 1;
   };
 
-  const options = workPackages
-    .filter((workPackage) => workPackage.userId !== team.leader.userId)
-    .sort((a, b) => (a.firstName > b.firstName ? 1 : -1))
-    .map(workPackageToAutocompleteOption);
+  const blockedByOptions = workPackages.map(workPackageToAutocompleteOption);
 
   const blockedByFormControl = (
-    // replace with lines 202 - 227 from Peyton's PR
     <FormControl fullWidth>
-      <FormLabel>Blocked By</FormLabel>
-      <Autocomplete
-        isOptionEqualToValue={(option, value) => option.id === value.id}
-        filterSelectedOptions
-        multiple
-        id="tags-standard"
-        options={options}
-        value={workPackages}
-        onChange={(_event, newValue) => setWorkPackages(newValue)}
-        getOptionLabel={(option) => option.label}
-        renderInput={(params) => (
-          <TextField {...params} variant="standard" label="Work Packages" placeholder="Select A Work Package" />
+      <Controller
+        name="blockedBy"
+        control={control}
+        render={({ field: { onChange, value: formValue } }) => (
+          <Autocomplete
+            isOptionEqualToValue={(option, value) => {
+              console.log(option, value);
+              return option.id === value.id;
+            }}
+            filterSelectedOptions
+            multiple
+            // id not here
+            options={blockedByOptions}
+            getOptionLabel={(option) => option.label}
+            // how does this onChange work
+            onChange={(_, value) => onChange(value.map((v) => v.id))}
+            // how does this value thing work
+            value={formValue.map((v: string) => {
+              let change = blockedByOptions.find((o) => o.id === v);
+              return change!;
+            })}
+            renderInput={(params) => (
+              // label not here
+              <TextField {...params} variant="standard" placeholder="Select Blockers" error={!!errors.blockedBy} />
+            )}
+          />
         )}
       />
-      <Button
-        variant="contained"
-        color="success"
-        onClick={() => appendBlocker({ wbsNum: '' })}
-        sx={{ my: 2, width: 'max-content' }}
-      >
-        + ADD NEW BLOCKER
-      </Button>
     </FormControl>
   );
 

--- a/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageFormView.tsx
+++ b/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageFormView.tsx
@@ -24,7 +24,6 @@ import NERFailButton from '../../components/NERFailButton';
 import NERSuccessButton from '../../components/NERSuccessButton';
 import { WorkPackage, WorkPackageStage, validateWBS, wbsPipe } from 'shared';
 import { CreateWorkPackageFormInputs } from './CreateWorkPackageForm';
-import { useState } from 'react';
 import { useSingleProject } from '../../hooks/projects.hooks';
 
 const schema = yup.object().shape({

--- a/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageFormView.tsx
+++ b/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageFormView.tsx
@@ -57,7 +57,7 @@ interface CreateWorkPackageFormViewProps {
 }
 
 const workPackageToAutocompleteOption = (workPackage: WorkPackage): { label: string; id: number } => {
-  return { label: `${fullNamePipe(workPackage)} (${workPackage.name})`, id: number(workPackage.wbsNum) };
+  return { label: `(${workPackage.wbsNum}) (${workPackage.name})`, id: workPackage.id };
 };
 
 const CreateWorkPackageFormView: React.FC<CreateWorkPackageFormViewProps> = ({ allowSubmit, onSubmit, onCancel }) => {
@@ -122,7 +122,7 @@ const CreateWorkPackageFormView: React.FC<CreateWorkPackageFormViewProps> = ({ a
         options={options}
         value={workPackages}
         onChange={(_event, newValue) => setWorkPackages(newValue)}
-        getOptionLabel={(option) => option.name}
+        getOptionLabel={(option) => option.label}
         renderInput={(params) => (
           <TextField {...params} variant="standard" label="Work Packages" placeholder="Select A Work Package" />
         )}

--- a/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageFormView.tsx
+++ b/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageFormView.tsx
@@ -62,7 +62,6 @@ const blockedByToAutocompleteOption = (workPackage: WorkPackage) => {
 
 const CreateWorkPackageFormView: React.FC<CreateWorkPackageFormViewProps> = ({
   wbsNum,
-  setWbsNum,
   allowSubmit,
   onSubmit,
   onCancel
@@ -75,7 +74,7 @@ const CreateWorkPackageFormView: React.FC<CreateWorkPackageFormViewProps> = ({
   }
   const query = useQuery();
 
-  const { data: project } = useSingleProject(validateWBS(query.get('wbsNum') || ''));
+  const { data: project } = useSingleProject(validateWBS(query.get('wbs') || ''));
   const workPackages = project ? project.workPackages : [];
 
   const {
@@ -90,7 +89,7 @@ const CreateWorkPackageFormView: React.FC<CreateWorkPackageFormViewProps> = ({
       crId: Number(query.get('crId')),
       stage: 'NONE' as WorkPackageStage | 'None',
       startDate,
-      wbsNum: null,
+      wbsNum: wbsNum,
       duration: null,
       blockedBy: [] as string[],
       expectedActivities: [] as { bulletId: number; detail: string }[],
@@ -128,18 +127,14 @@ const CreateWorkPackageFormView: React.FC<CreateWorkPackageFormViewProps> = ({
             }}
             filterSelectedOptions
             multiple
-            // id not here
             options={blockedByOptions}
             getOptionLabel={(option) => option.label}
-            // how does this onChange work
             onChange={(_, values) => onChange(values.map((v) => v.id))}
-            // how does this value thing work
             value={formValue.map((v: string) => {
               let change = blockedByOptions.find((o) => o.id === v);
               return change!;
             })}
             renderInput={(params) => (
-              // label not here
               <TextField {...params} variant="standard" placeholder="Select Blockers" error={!!errors.blockedBy} />
             )}
           />

--- a/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageFormView.tsx
+++ b/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageFormView.tsx
@@ -74,7 +74,7 @@ const CreateWorkPackageFormView: React.FC<CreateWorkPackageFormViewProps> = ({
   }
   const query = useQuery();
 
-  const { data: project } = useSingleProject(validateWBS(query.get('wbs') || ''));
+  const { data: project } = useSingleProject(validateWBS(wbsNum));
   const workPackages = project ? project.workPackages : [];
 
   const {

--- a/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageFormView.tsx
+++ b/src/frontend/src/pages/CreateWorkPackagePage/CreateWorkPackageFormView.tsx
@@ -69,12 +69,11 @@ const CreateWorkPackageFormView: React.FC<CreateWorkPackageFormViewProps> = ({ a
   }
   const query = useQuery();
 
-  const [wbsNum, setWbsNum] = useState(query.get('wbsNum') || '');
-
-  const { data: project } = useSingleProject(validateWBS(wbsNum || ''));
-  const workPacks = project ? project.workPackages : undefined;
+  const { data: project } = useSingleProject(validateWBS(query.get('wbsNum') || ''));
+  const workPacks = project ? project.workPackages : [];
 
   const [workPackages, setWorkPackages] = useState(workPacks.map(workPackageToAutocompleteOption));
+  // useState for project wbsNum, don't need one for workPackages
   const {
     handleSubmit,
     control,
@@ -111,7 +110,13 @@ const CreateWorkPackageFormView: React.FC<CreateWorkPackageFormViewProps> = ({ a
     return startDate.getDay() !== 1;
   };
 
+  const options = workPackages
+    .filter((workPackage) => workPackage.userId !== team.leader.userId)
+    .sort((a, b) => (a.firstName > b.firstName ? 1 : -1))
+    .map(workPackageToAutocompleteOption);
+
   const blockedByFormControl = (
+    // replace with lines 202 - 227 from Peyton's PR
     <FormControl fullWidth>
       <FormLabel>Blocked By</FormLabel>
       <Autocomplete


### PR DESCRIPTION
## Changes

In the CreateWorkPackageForm file:
- Copy pasted code relating to the wbsNum from Mihir's PR

In the CreateWorkPackageFormView file:
- Updated code to account for the wbsNum passed in from the CreateWorkPackageForm file 
- Copy pasted FormControl section from Peyton's PR 
- Obtained the project with given wbsNum and then obtained the work packages for the project
- Made function blockedByToAutocompleteOption which shows how each work package option should be displayed in the autocomplete

## To Do

- Fix error (it doesn't seem to be occurring anymore, not sure why)
- yarn test:backend + frontend
- manually test on FinishLine
- Get rid of any comments
- Abstract common features between multiple autocompletes into an NERMultipleAutocomplete

## Checklist

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
