### PR TITLE
#1248 - NERFormModal

### DIFF
--- a/src/frontend/src/components/CheckList.tsx
+++ b/src/frontend/src/components/CheckList.tsx
@@ -13,10 +13,7 @@ import { useCheckDescriptionBullet } from '../hooks/description-bullets.hooks';
 import { useAuth } from '../hooks/auth.hooks';
 import { Tooltip } from '@mui/material';
 import { User } from 'shared';
-import Dialog from '@mui/material/Dialog';
-import DialogActions from '@mui/material/DialogActions';
-import DialogTitle from '@mui/material/DialogTitle';
-import Button from '@mui/material/Button';
+import NERModal from './NERModal';
 
 export type CheckListItem = {
   id: number;
@@ -99,24 +96,16 @@ const CheckList: React.FC<CheckListProps> = ({ title, headerRight, items, isDisa
           />
         ))}
       </FormControl>
-      <Dialog open={showConfirm} onClose={() => setShowConfirm(false)}>
-        <DialogTitle>Are you sure you want to mark this completed task as NOT completed?</DialogTitle>
-        <DialogActions className="justify-content-around">
-          <Button
-            onClick={() => handleUncheck(currIdx)}
-            type="submit"
-            className="mb-3"
-            autoFocus
-            variant="contained"
-            color="success"
-          >
-            Yes
-          </Button>
-          <Button onClick={() => setShowConfirm(false)} className="mb-3" variant="contained" color="error">
-            No
-          </Button>
-        </DialogActions>
-      </Dialog>
+      <NERModal
+        open={showConfirm}
+        onHide={() => setShowConfirm(false)}
+        title="Warning!"
+        cancelText="No"
+        submitText="Yes"
+        onSubmit={() => handleUncheck(currIdx)}
+      >
+        <Typography>Are you sure you want to mark this completed task as NOT completed?</Typography>
+      </NERModal>
     </PageBlock>
   );
 };

--- a/src/frontend/src/components/NERFormModal.tsx
+++ b/src/frontend/src/components/NERFormModal.tsx
@@ -1,20 +1,12 @@
 import { ReactNode } from 'react';
-import { UseFormHandleSubmit, UseFormReset } from 'react-hook-form';
-import NERModal from './NERModal';
+import { FieldValues, UseFormHandleSubmit, UseFormReset } from 'react-hook-form';
+import NERModal, { NERModalProps } from './NERModal';
 
-interface NERFormModalProps {
-  open: boolean;
-  formId: string;
-  title: string;
-  reset: UseFormReset<any>;
-  handleUseFormSubmit: UseFormHandleSubmit<any, undefined>;
-  onFormSubmit: (data: any) => void;
-  onHide: () => void;
-  disabled?: boolean;
-  submitText?: string;
-  cancelText?: string;
+interface NERFormModalProps<T extends FieldValues> extends NERModalProps {
+  reset: UseFormReset<T>;
+  handleUseFormSubmit: UseFormHandleSubmit<T, undefined>;
+  onFormSubmit: (data: T) => void;
   children?: ReactNode;
-  showCloseButton?: boolean;
 }
 
 const NERFormModal = ({
@@ -30,7 +22,7 @@ const NERFormModal = ({
   disabled,
   children,
   showCloseButton
-}: NERFormModalProps) => {
+}: NERFormModalProps<any>) => {
   /**
    * Wrapper function for onSubmit so that form data is reset after submit
    */

--- a/src/frontend/src/components/NERFormModal.tsx
+++ b/src/frontend/src/components/NERFormModal.tsx
@@ -1,0 +1,60 @@
+import { ReactNode } from 'react';
+import { UseFormHandleSubmit, UseFormReset } from 'react-hook-form';
+import NERModal from './NERModal';
+
+interface NERFormModalProps {
+  open: boolean;
+  formId: string;
+  title: string;
+  reset: UseFormReset<any>;
+  handleUseFormSubmit: UseFormHandleSubmit<any, undefined>;
+  onFormSubmit: (data: any) => void;
+  onHide: () => void;
+  disabled?: boolean;
+  submitText?: string;
+  cancelText?: string;
+  children?: ReactNode;
+  showCloseButton?: boolean;
+}
+
+const NERFormModal = ({
+  open,
+  onHide,
+  formId,
+  title,
+  reset,
+  handleUseFormSubmit,
+  onFormSubmit,
+  cancelText,
+  submitText,
+  disabled,
+  children,
+  showCloseButton
+}: NERFormModalProps) => {
+  /**
+   * Wrapper function for onSubmit so that form data is reset after submit
+   */
+  const onSubmitWrapper = async (data: any) => {
+    await onFormSubmit(data);
+    reset({ confirmDone: false });
+  };
+
+  return (
+    <NERModal
+      open={open}
+      onHide={onHide}
+      formId={formId}
+      title={title}
+      cancelText={cancelText ? cancelText : 'Cancel'}
+      submitText={submitText ? submitText : 'Submit'}
+      disabled={disabled}
+      showCloseButton={showCloseButton}
+    >
+      <form id={formId} onSubmit={handleUseFormSubmit(onSubmitWrapper)}>
+        {children}
+      </form>
+    </NERModal>
+  );
+};
+
+export default NERFormModal;

--- a/src/frontend/src/components/NERModal.tsx
+++ b/src/frontend/src/components/NERModal.tsx
@@ -1,0 +1,51 @@
+import { Box, Dialog, DialogActions, DialogContent, DialogTitle } from '@mui/material';
+import NERFailButton from './NERFailButton';
+import NERSuccessButton from './NERSuccessButton';
+import { UseFormHandleSubmit, UseFormReset } from 'react-hook-form/dist/types';
+import { ReactNode } from 'react';
+
+const background = '#ef4345';
+
+interface NERModalProps {
+  open: boolean;
+  formId: string;
+  title: string;
+  reset: UseFormReset<any>;
+  handleUseFormSubmit: UseFormHandleSubmit<any, undefined>;
+  onFormSubmit: (data: any) => void;
+  onHide: () => void;
+  children?: ReactNode;
+}
+
+const NERModal = ({ open, onHide, formId, title, reset, handleUseFormSubmit, onFormSubmit, children }: NERModalProps) => {
+  /**
+   * Wrapper function for onSubmit so that form data is reset after submit
+   */
+  const onSubmitWrapper = async (data: any) => {
+    await onFormSubmit(data);
+    reset({ confirmDone: false });
+  };
+
+  return (
+    <Dialog open={open} onClose={onHide} PaperProps={{ style: { borderRadius: '10px' } }}>
+      <DialogTitle sx={{ backgroundColor: background }}>{title}</DialogTitle>
+      <DialogContent sx={{ '&.MuiDialogContent-root': { paddingTop: '20px' } }}>
+        <form id={formId} onSubmit={handleUseFormSubmit(onSubmitWrapper)}>
+          {children}
+        </form>
+      </DialogContent>
+      <DialogActions>
+        <Box sx={{ display: 'flex', flexDirection: 'row' }}>
+          <NERFailButton sx={{ mx: 1, mb: 1 }} form={formId} onClick={onHide}>
+            Cancel
+          </NERFailButton>
+          <NERSuccessButton sx={{ mx: 1, mb: 1 }} type="submit" form={formId}>
+            Submit
+          </NERSuccessButton>
+        </Box>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default NERModal;

--- a/src/frontend/src/components/NERModal.tsx
+++ b/src/frontend/src/components/NERModal.tsx
@@ -50,11 +50,11 @@ const NERModal = ({
       )}
       <DialogContent sx={{ '&.MuiDialogContent-root': { paddingTop: '20px' } }}>{children}</DialogContent>
       <DialogActions>
-        <Box sx={{ display: 'flex', flexDirection: 'row' }}>
-          <NERFailButton sx={{ mx: 1, mb: 1 }} form={formId} onClick={onHide}>
+        <Box sx={{ display: 'flex', flexDirection: 'row', mb: 1 }}>
+          <NERFailButton sx={{ mx: 1 }} form={formId} onClick={onHide}>
             {cancelText || 'Cancel'}
           </NERFailButton>
-          <NERSuccessButton sx={{ mx: 1, mb: 1 }} type="submit" form={formId} onClick={onSubmit} disabled={disabled}>
+          <NERSuccessButton sx={{ mx: 1 }} type="submit" form={formId} onClick={onSubmit} disabled={disabled}>
             {submitText || 'Submit'}
           </NERSuccessButton>
         </Box>

--- a/src/frontend/src/components/NERModal.tsx
+++ b/src/frontend/src/components/NERModal.tsx
@@ -6,15 +6,15 @@ import CloseIcon from '@mui/icons-material/Close';
 
 const background = '#ef4345';
 
-interface NERModalProps {
+export interface NERModalProps {
   open: boolean;
   formId?: string;
   title: string;
-  onSubmit?: (data: any) => void;
+  onSubmit?: () => void;
   onHide: () => void;
   children?: ReactNode;
-  cancelText: string;
-  submitText: string;
+  cancelText?: string;
+  submitText?: string;
   disabled?: boolean;
   showCloseButton?: boolean;
 }
@@ -52,10 +52,10 @@ const NERModal = ({
       <DialogActions>
         <Box sx={{ display: 'flex', flexDirection: 'row' }}>
           <NERFailButton sx={{ mx: 1, mb: 1 }} form={formId} onClick={onHide}>
-            {cancelText}
+            {cancelText || 'Cancel'}
           </NERFailButton>
           <NERSuccessButton sx={{ mx: 1, mb: 1 }} type="submit" form={formId} onClick={onSubmit} disabled={disabled}>
-            {submitText}
+            {submitText || 'Submit'}
           </NERSuccessButton>
         </Box>
       </DialogActions>

--- a/src/frontend/src/components/NERModal.tsx
+++ b/src/frontend/src/components/NERModal.tsx
@@ -1,46 +1,61 @@
-import { Box, Dialog, DialogActions, DialogContent, DialogTitle } from '@mui/material';
+import { Box, Dialog, DialogActions, DialogContent, DialogTitle, IconButton } from '@mui/material';
 import NERFailButton from './NERFailButton';
 import NERSuccessButton from './NERSuccessButton';
-import { UseFormHandleSubmit, UseFormReset } from 'react-hook-form/dist/types';
 import { ReactNode } from 'react';
+import CloseIcon from '@mui/icons-material/Close';
 
 const background = '#ef4345';
 
 interface NERModalProps {
   open: boolean;
-  formId: string;
+  formId?: string;
   title: string;
-  reset: UseFormReset<any>;
-  handleUseFormSubmit: UseFormHandleSubmit<any, undefined>;
-  onFormSubmit: (data: any) => void;
+  onSubmit?: (data: any) => void;
   onHide: () => void;
   children?: ReactNode;
+  cancelText: string;
+  submitText: string;
+  disabled?: boolean;
+  showCloseButton?: boolean;
 }
 
-const NERModal = ({ open, onHide, formId, title, reset, handleUseFormSubmit, onFormSubmit, children }: NERModalProps) => {
-  /**
-   * Wrapper function for onSubmit so that form data is reset after submit
-   */
-  const onSubmitWrapper = async (data: any) => {
-    await onFormSubmit(data);
-    reset({ confirmDone: false });
-  };
-
+const NERModal = ({
+  open,
+  onHide,
+  formId,
+  title,
+  onSubmit,
+  children,
+  cancelText,
+  submitText,
+  disabled = false,
+  showCloseButton = false
+}: NERModalProps) => {
   return (
     <Dialog open={open} onClose={onHide} PaperProps={{ style: { borderRadius: '10px' } }}>
       <DialogTitle sx={{ backgroundColor: background }}>{title}</DialogTitle>
-      <DialogContent sx={{ '&.MuiDialogContent-root': { paddingTop: '20px' } }}>
-        <form id={formId} onSubmit={handleUseFormSubmit(onSubmitWrapper)}>
-          {children}
-        </form>
-      </DialogContent>
+      {showCloseButton && (
+        <IconButton
+          aria-label="close"
+          onClick={onHide}
+          sx={{
+            position: 'absolute',
+            right: 16,
+            top: 12,
+            color: (theme) => theme.palette.text.primary
+          }}
+        >
+          <CloseIcon />
+        </IconButton>
+      )}
+      <DialogContent sx={{ '&.MuiDialogContent-root': { paddingTop: '20px' } }}>{children}</DialogContent>
       <DialogActions>
         <Box sx={{ display: 'flex', flexDirection: 'row' }}>
           <NERFailButton sx={{ mx: 1, mb: 1 }} form={formId} onClick={onHide}>
-            Cancel
+            {cancelText}
           </NERFailButton>
-          <NERSuccessButton sx={{ mx: 1, mb: 1 }} type="submit" form={formId}>
-            Submit
+          <NERSuccessButton sx={{ mx: 1, mb: 1 }} type="submit" form={formId} onClick={onSubmit} disabled={disabled}>
+            {submitText}
           </NERSuccessButton>
         </Box>
       </DialogActions>

--- a/src/frontend/src/pages/ChangeRequestDetailPage/DeleteChangeRequestView.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/DeleteChangeRequestView.tsx
@@ -4,24 +4,13 @@
  */
 
 import { ChangeRequest } from 'shared';
-import {
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  FormControl,
-  FormLabel,
-  IconButton,
-  Typography
-} from '@mui/material';
+import { FormControl, FormLabel, Typography } from '@mui/material';
 import { useForm } from 'react-hook-form';
-import NERSuccessButton from '../../components/NERSuccessButton';
 import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
-import NERFailButton from '../../components/NERFailButton';
 import { DeleteChangeRequestInputs } from './DeleteChangeRequest';
 import ReactHookTextField from '../../components/ReactHookTextField';
-import CloseIcon from '@mui/icons-material/Close';
+import NERFormModal from '../../components/NERFormModal';
 
 interface DeleteChangeRequestViewProps {
   changeRequest: ChangeRequest;
@@ -40,7 +29,8 @@ const DeleteChangeRequestView: React.FC<DeleteChangeRequestViewProps> = ({ chang
   const {
     handleSubmit,
     control,
-    formState: { errors, isValid }
+    formState: { errors, isValid },
+    reset
   } = useForm({
     resolver: yupResolver(schema),
     defaultValues: {
@@ -49,75 +39,36 @@ const DeleteChangeRequestView: React.FC<DeleteChangeRequestViewProps> = ({ chang
     mode: 'onChange'
   });
 
-  const onSubmitWrapper = async (data: DeleteChangeRequestInputs) => {
-    await onSubmit(data);
-  };
-
   return (
-    <Dialog open={modalShow} onClose={onHide}>
-      <DialogTitle
-        className="font-weight-bold"
-        sx={{
-          '&.MuiDialogTitle-root': {
-            padding: '1rem 1.5rem 0'
-          }
-        }}
-      >{`Delete Change Request #${changeRequest.crId}`}</DialogTitle>
-      <IconButton
-        aria-label="close"
-        onClick={onHide}
-        sx={{
-          position: 'absolute',
-          right: 8,
-          top: 8,
-          color: (theme) => theme.palette.grey[500]
-        }}
-      >
-        <CloseIcon />
-      </IconButton>
-      <DialogContent
-        sx={{
-          '&.MuiDialogContent-root': {
-            padding: '1rem 1.5rem'
-          }
-        }}
-      >
-        <Typography sx={{ marginBottom: '1rem' }}>
-          Are you sure you want to delete Change Request #{changeRequest.crId}?
-        </Typography>
-        <Typography sx={{ fontWeight: 'bold' }}>This action cannot be undone!</Typography>
-        <form
-          id="delete-cr-form"
-          onSubmit={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            handleSubmit(onSubmitWrapper)(e);
-          }}
-        >
-          <FormControl>
-            <FormLabel sx={{ marginTop: '1rem', marginBottom: '1rem' }}>
-              To confirm deletion, please type in the ID number of this Change Request.
-            </FormLabel>
-            <ReactHookTextField
-              control={control}
-              name="crId"
-              errorMessage={errors.crId}
-              placeholder="Enter Change Request ID here"
-              sx={{ width: 1 }}
-              type="number"
-            />
-          </FormControl>
-        </form>
-      </DialogContent>
-      <DialogActions>
-        <NERSuccessButton variant="contained" sx={{ mx: 1 }} onClick={onHide}>
-          Cancel
-        </NERSuccessButton>
-        <NERFailButton variant="contained" type="submit" form="delete-cr-form" sx={{ mx: 1 }} disabled={!isValid}>
-          Delete
-        </NERFailButton>
-      </DialogActions>
-    </Dialog>
+    <NERFormModal
+      open={modalShow}
+      onHide={onHide}
+      title={`Delete Change Request #${changeRequest.crId}`}
+      reset={reset}
+      handleUseFormSubmit={handleSubmit}
+      onFormSubmit={onSubmit}
+      formId="delete-cr-form"
+      disabled={!isValid}
+      showCloseButton
+    >
+      <Typography sx={{ marginBottom: '1rem' }}>
+        Are you sure you want to delete Change Request #{changeRequest.crId}?
+      </Typography>
+      <Typography sx={{ fontWeight: 'bold' }}>This action cannot be undone!</Typography>
+      <FormControl>
+        <FormLabel sx={{ marginTop: '1rem', marginBottom: '1rem' }}>
+          To confirm deletion, please type in the ID number of this Change Request.
+        </FormLabel>
+        <ReactHookTextField
+          control={control}
+          name="crId"
+          errorMessage={errors.crId}
+          placeholder="Enter Change Request ID here"
+          sx={{ width: 1 }}
+          type="number"
+        />
+      </FormControl>
+    </NERFormModal>
   );
 };
 

--- a/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModal.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModal.tsx
@@ -21,6 +21,7 @@ import {
 } from '@mui/material';
 import NERSuccessButton from '../../../components/NERSuccessButton';
 import NERFailButton from '../../../components/NERFailButton';
+import NERModal from '../../../components/NERModal';
 
 interface StageGateWorkPackageModalProps {
   wbsNum: WbsNumber;
@@ -38,67 +39,54 @@ const StageGateWorkPackageModal: React.FC<StageGateWorkPackageModalProps> = ({ w
     resolver: yupResolver(schema)
   });
 
-  /**
-   * Wrapper function for onSubmit so that form data is reset after submit
-   */
-  const onSubmitWrapper = async (data: FormInput) => {
-    await onSubmit(data);
-    reset({ confirmDone: false });
-  };
-
   return (
-    <Dialog open={modalShow} onClose={onHide}>
-      <DialogTitle>{`Stage Gate #${wbsPipe(wbsNum)}`}</DialogTitle>
-      <DialogContent>
-        <form id={'stage-gate-work-package-form'} onSubmit={handleSubmit(onSubmitWrapper)}>
-          <div className={'px-4'}>
-            <Controller
-              name="confirmDone"
-              control={control}
-              rules={{ required: true }}
-              render={({ field: { onChange, value } }) => (
-                <>
-                  {/* TODO: slide deck changed to confluence in frontend - needs to be updated in the backend */}
-                  <Typography sx={{ paddingTop: 1 }}>Is everything done?</Typography>
-                  <ul style={{ marginTop: 0, marginBottom: 2 }}>
-                    <li>Updated confluence & documentation</li>
-                    <li>Creating any outstanding change requests</li>
-                    <li>Submitted all receipts to the procurement form</li>
-                    <li>Completed all Work Package expected activities</li>
-                    <li>Completed all Work Package deliverables</li>
-                    <li>Ensure rules compliance</li>
-                  </ul>
-                  <RadioGroup value={value} row onChange={onChange}>
-                    <FormControlLabel
-                      value={1}
-                      control={<Radio />}
-                      label="Yes"
-                      id={`stageGateWPForm-ConfirmDone-checkbox-yes`}
-                      aria-labelledby={`stageGateWPForm-ConfirmDone`}
-                    />
-                    <FormControlLabel
-                      value={0}
-                      control={<Radio />}
-                      label="No"
-                      id={`stageGateWPForm-ConfirmDone-checkbox-no`}
-                      aria-labelledby={`stageGateWPForm-ConfirmDone`}
-                    />
-                  </RadioGroup>
-                </>
-              )}
-            />
-          </div>
-        </form>
-      </DialogContent>
-      <DialogActions>
-        <NERFailButton form="stage-gate-work-package-form" sx={{ mx: 1, mb: 1 }} onClick={onHide}>
-          Cancel
-        </NERFailButton>
-        <NERSuccessButton type="submit" sx={{ mx: 1, mb: 1 }} form="stage-gate-work-package-form">
-          Submit
-        </NERSuccessButton>
-      </DialogActions>
-    </Dialog>
+    <NERModal
+      open={modalShow}
+      onHide={onHide}
+      title={`Stage Gate #${wbsPipe(wbsNum)}`}
+      reset={reset}
+      handleUseFormSubmit={handleSubmit}
+      onFormSubmit={onSubmit}
+      form="stage-gate-work-package-form"
+    >
+      <div className={'px-4'}>
+        <Controller
+          name="confirmDone"
+          control={control}
+          rules={{ required: true }}
+          render={({ field: { onChange, value } }) => (
+            <>
+              {/* TODO: slide deck changed to confluence in frontend - needs to be updated in the backend */}
+              <Typography sx={{ paddingTop: 1 }}>Is everything done?</Typography>
+              <ul style={{ marginTop: 0, marginBottom: 2 }}>
+                <li>Updated confluence & documentation</li>
+                <li>Creating any outstanding change requests</li>
+                <li>Submitted all receipts to the procurement form</li>
+                <li>Completed all Work Package expected activities</li>
+                <li>Completed all Work Package deliverables</li>
+                <li>Ensure rules compliance</li>
+              </ul>
+              <RadioGroup value={value} row onChange={onChange}>
+                <FormControlLabel
+                  value={1}
+                  control={<Radio />}
+                  label="Yes"
+                  id={`stageGateWPForm-ConfirmDone-checkbox-yes`}
+                  aria-labelledby={`stageGateWPForm-ConfirmDone`}
+                />
+                <FormControlLabel
+                  value={0}
+                  control={<Radio />}
+                  label="No"
+                  id={`stageGateWPForm-ConfirmDone-checkbox-no`}
+                  aria-labelledby={`stageGateWPForm-ConfirmDone`}
+                />
+              </RadioGroup>
+            </>
+          )}
+        />
+      </div>
+    </NERModal>
   );
 };
 

--- a/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModal.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModal.tsx
@@ -38,43 +38,41 @@ const StageGateWorkPackageModal: React.FC<StageGateWorkPackageModalProps> = ({ w
       onFormSubmit={onSubmit}
       formId="stage-gate-work-package-form"
     >
-      <div className={'px-4'}>
-        <Controller
-          name="confirmDone"
-          control={control}
-          rules={{ required: true }}
-          render={({ field: { onChange, value } }) => (
-            <>
-              {/* TODO: slide deck changed to confluence in frontend - needs to be updated in the backend */}
-              <Typography sx={{ paddingTop: 1 }}>Is everything done?</Typography>
-              <ul style={{ marginTop: 0, marginBottom: 2 }}>
-                <li>Updated confluence & documentation</li>
-                <li>Creating any outstanding change requests</li>
-                <li>Submitted all receipts to the procurement form</li>
-                <li>Completed all Work Package expected activities</li>
-                <li>Completed all Work Package deliverables</li>
-                <li>Ensure rules compliance</li>
-              </ul>
-              <RadioGroup value={value} row onChange={onChange}>
-                <FormControlLabel
-                  value={1}
-                  control={<Radio />}
-                  label="Yes"
-                  id={`stageGateWPForm-ConfirmDone-checkbox-yes`}
-                  aria-labelledby={`stageGateWPForm-ConfirmDone`}
-                />
-                <FormControlLabel
-                  value={0}
-                  control={<Radio />}
-                  label="No"
-                  id={`stageGateWPForm-ConfirmDone-checkbox-no`}
-                  aria-labelledby={`stageGateWPForm-ConfirmDone`}
-                />
-              </RadioGroup>
-            </>
-          )}
-        />
-      </div>
+      <Controller
+        name="confirmDone"
+        control={control}
+        rules={{ required: true }}
+        render={({ field: { onChange, value } }) => (
+          <>
+            {/* TODO: slide deck changed to confluence in frontend - needs to be updated in the backend */}
+            <Typography sx={{ paddingTop: 1 }}>Is everything done?</Typography>
+            <ul style={{ marginTop: 0, marginBottom: 2 }}>
+              <li>Updated confluence & documentation</li>
+              <li>Creating any outstanding change requests</li>
+              <li>Submitted all receipts to the procurement form</li>
+              <li>Completed all Work Package expected activities</li>
+              <li>Completed all Work Package deliverables</li>
+              <li>Ensure rules compliance</li>
+            </ul>
+            <RadioGroup value={value} row onChange={onChange}>
+              <FormControlLabel
+                value={1}
+                control={<Radio />}
+                label="Yes"
+                id={`stageGateWPForm-ConfirmDone-checkbox-yes`}
+                aria-labelledby={`stageGateWPForm-ConfirmDone`}
+              />
+              <FormControlLabel
+                value={0}
+                control={<Radio />}
+                label="No"
+                id={`stageGateWPForm-ConfirmDone-checkbox-no`}
+                aria-labelledby={`stageGateWPForm-ConfirmDone`}
+              />
+            </RadioGroup>
+          </>
+        )}
+      />
     </NERFormModal>
   );
 };

--- a/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModal.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModal.tsx
@@ -9,19 +9,8 @@ import { Controller, useForm } from 'react-hook-form';
 import { WbsNumber } from 'shared';
 import { FormInput } from './StageGateWorkPackageModalContainer';
 import { wbsPipe } from '../../../utils/pipes';
-import {
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  FormControlLabel,
-  Radio,
-  RadioGroup,
-  Typography
-} from '@mui/material';
-import NERSuccessButton from '../../../components/NERSuccessButton';
-import NERFailButton from '../../../components/NERFailButton';
-import NERModal from '../../../components/NERModal';
+import { FormControlLabel, Radio, RadioGroup, Typography } from '@mui/material';
+import NERFormModal from '../../../components/NERFormModal';
 
 interface StageGateWorkPackageModalProps {
   wbsNum: WbsNumber;
@@ -40,14 +29,14 @@ const StageGateWorkPackageModal: React.FC<StageGateWorkPackageModalProps> = ({ w
   });
 
   return (
-    <NERModal
+    <NERFormModal
       open={modalShow}
       onHide={onHide}
       title={`Stage Gate #${wbsPipe(wbsNum)}`}
       reset={reset}
       handleUseFormSubmit={handleSubmit}
       onFormSubmit={onSubmit}
-      form="stage-gate-work-package-form"
+      formId="stage-gate-work-package-form"
     >
       <div className={'px-4'}>
         <Controller
@@ -86,7 +75,7 @@ const StageGateWorkPackageModal: React.FC<StageGateWorkPackageModalProps> = ({ w
           )}
         />
       </div>
-    </NERModal>
+    </NERFormModal>
   );
 };
 


### PR DESCRIPTION
## Changes

I'm trying to make a component for an NERModal, so we can use it for all these finance modals. Lmk if you think the NERFormModal is overkill, I made it cause a lot of our modals that have forms have that bit of code that's the same every time.

I only migrated 3 of the modals to show how we can use this component. I think migrating the rest of the modals would be good tickets for the fall.

## Screenshots

<img width="476" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/29521172/fd3fdff2-9586-4c98-8f1d-4d6b6a04a885">


## To Do

- [ ] Make a generic NERModal and more specific NERFormModal
- [ ] Migrate rest of modals (maybe, unless we wanna make them into easy tickets)

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #1258  (issue #)
