### PR TITLE
#1027 Create change request input component

### DIFF
--- a/src/frontend/src/components/ChangeRequestDropdown.tsx
+++ b/src/frontend/src/components/ChangeRequestDropdown.tsx
@@ -1,4 +1,4 @@
-import { MenuItem, Select, SelectChangeEvent, dividerClasses } from '@mui/material';
+import { MenuItem, Select, SelectChangeEvent } from '@mui/material';
 import { isWithinInterval, subDays } from 'date-fns';
 import { Control, Controller } from 'react-hook-form';
 import { wbsPipe } from 'shared';
@@ -12,6 +12,7 @@ interface ChangeRequestDropdownProps {
 }
 
 const ChangeRequestDropdown = ({ control, name }: ChangeRequestDropdownProps) => {
+  const user = useCurrentUser();
   const { isLoading, data: changeRequests } = useAllChangeRequests();
   if (isLoading || !changeRequests) return <LoadingIndicator />;
 
@@ -21,8 +22,8 @@ const ChangeRequestDropdown = ({ control, name }: ChangeRequestDropdownProps) =>
   const filteredRequests = changeRequests?.filter(
     (cr) => !!cr.dateReviewed && isWithinInterval(cr.dateReviewed, { start: fiveDaysAgo, end: today })
   );
+
   // The current user's CRs should be at the top
-  const user = useCurrentUser();
   filteredRequests.sort((a, b) => {
     const isSubmitterAUser = a.submitter.firstName === user.firstName && a.submitter.lastName === user.lastName;
     const isSubmitterBUser = b.submitter.firstName === user.firstName && b.submitter.lastName === user.lastName;

--- a/src/frontend/src/components/ChangeRequestDropdown.tsx
+++ b/src/frontend/src/components/ChangeRequestDropdown.tsx
@@ -1,4 +1,4 @@
-import { MenuItem, Select, SelectChangeEvent } from '@mui/material';
+import { MenuItem, Select, SelectChangeEvent, dividerClasses } from '@mui/material';
 import { isWithinInterval, subDays } from 'date-fns';
 import { Control, Controller } from 'react-hook-form';
 import { wbsPipe } from 'shared';
@@ -58,7 +58,7 @@ const ChangeRequestDropdown = ({ control, name }: ChangeRequestDropdownProps) =>
           }}
           size={'small'}
           placeholder={'Change Request Id'}
-          sx={{ width: 200 }}
+          sx={{ width: 200, textAlign: 'left' }}
         >
           {options.map((option) => (
             <MenuItem key={option.value} value={option.value}>

--- a/src/frontend/src/components/ChangeRequestDropdown.tsx
+++ b/src/frontend/src/components/ChangeRequestDropdown.tsx
@@ -1,10 +1,10 @@
-import { Box, FormLabel, MenuItem, Select, SelectChangeEvent } from '@mui/material';
+import { Box, FormControl, FormLabel, MenuItem, Select, SelectChangeEvent } from '@mui/material';
 import { isWithinInterval, subDays } from 'date-fns';
 import { Control, Controller } from 'react-hook-form';
 import { AuthenticatedUser, ChangeRequest, wbsPipe } from 'shared';
 import { useAllChangeRequests } from '../hooks/change-requests.hooks';
-import LoadingIndicator from './LoadingIndicator';
 import { useCurrentUser } from '../hooks/users.hooks';
+import LoadingIndicator from './LoadingIndicator';
 
 // Filter and sort change requests to display in the dropdown
 const getFilteredChangeRequests = (changeRequests: ChangeRequest[], user: AuthenticatedUser): ChangeRequest[] => {
@@ -64,6 +64,16 @@ const ChangeRequestDropdown = ({ control, name }: ChangeRequestDropdownProps) =>
               size={'small'}
               placeholder={'Change Request Id'}
               sx={{ width: 200, textAlign: 'left' }}
+              MenuProps={{
+                anchorOrigin: {
+                  vertical: 'bottom',
+                  horizontal: 'right'
+                },
+                transformOrigin: {
+                  vertical: 'top',
+                  horizontal: 'right'
+                }
+              }}
             >
               {approvedChangeRequestOptions.map((option) => (
                 <MenuItem key={option.value} value={option.value}>

--- a/src/frontend/src/components/ChangeRequestDropdown.tsx
+++ b/src/frontend/src/components/ChangeRequestDropdown.tsx
@@ -1,4 +1,4 @@
-import { FormLabel, MenuItem, Select, SelectChangeEvent } from '@mui/material';
+import { Box, FormLabel, MenuItem, Select, SelectChangeEvent } from '@mui/material';
 import { isWithinInterval, subDays } from 'date-fns';
 import { Control, Controller } from 'react-hook-form';
 import { AuthenticatedUser, ChangeRequest, wbsPipe } from 'shared';
@@ -48,31 +48,33 @@ const ChangeRequestDropdown = ({ control, name }: ChangeRequestDropdownProps) =>
   }));
 
   return (
-    <Controller
-      control={control}
-      name={name}
-      render={({ field: { onChange, value } }) => (
-        <>
-          <FormLabel>Change Request ID</FormLabel>
-          <Select
-            id="cr-autocomplete"
-            displayEmpty
-            renderValue={(value) => value}
-            value={value}
-            onChange={(event: SelectChangeEvent<number>) => onChange(event.target.value)}
-            size={'small'}
-            placeholder={'Change Request Id'}
-            sx={{ width: 200, textAlign: 'left' }}
-          >
-            {approvedChangeRequestOptions.map((option) => (
-              <MenuItem key={option.value} value={option.value}>
-                {option.label}
-              </MenuItem>
-            ))}
-          </Select>
-        </>
-      )}
-    />
+    <Box sx={{ display: 'flex', justifyContent: 'end' }}>
+      <Controller
+        control={control}
+        name={name}
+        render={({ field: { onChange, value } }) => (
+          <Box sx={{ width: 200, display: 'flex', flexDirection: 'column', justifyContent: 'start' }}>
+            <FormLabel sx={{ alignSelf: 'start' }}>Change Request ID</FormLabel>
+            <Select
+              id="cr-autocomplete"
+              displayEmpty
+              renderValue={(value) => value}
+              value={value}
+              onChange={(event: SelectChangeEvent<number>) => onChange(event.target.value)}
+              size={'small'}
+              placeholder={'Change Request Id'}
+              sx={{ width: '100%', textAlign: 'left' }}
+            >
+              {approvedChangeRequestOptions.map((option) => (
+                <MenuItem key={option.value} value={option.value}>
+                  {option.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </Box>
+        )}
+      />
+    </Box>
   );
 };
 

--- a/src/frontend/src/components/ChangeRequestDropdown.tsx
+++ b/src/frontend/src/components/ChangeRequestDropdown.tsx
@@ -1,4 +1,4 @@
-import { MenuItem, Select, SelectChangeEvent } from '@mui/material';
+import { FormLabel, MenuItem, Select, SelectChangeEvent } from '@mui/material';
 import { isWithinInterval, subDays } from 'date-fns';
 import { Control, Controller } from 'react-hook-form';
 import { AuthenticatedUser, ChangeRequest, wbsPipe } from 'shared';
@@ -52,22 +52,25 @@ const ChangeRequestDropdown = ({ control, name }: ChangeRequestDropdownProps) =>
       control={control}
       name={name}
       render={({ field: { onChange, value } }) => (
-        <Select
-          id="cr-autocomplete"
-          displayEmpty
-          renderValue={(value) => (value ? value : 'Change Request Id')}
-          value={value}
-          onChange={(event: SelectChangeEvent<number>) => onChange(event.target.value)}
-          size={'small'}
-          placeholder={'Change Request Id'}
-          sx={{ width: 200, textAlign: 'left' }}
-        >
-          {approvedChangeRequestOptions.map((option) => (
-            <MenuItem key={option.value} value={option.value}>
-              {option.label}
-            </MenuItem>
-          ))}
-        </Select>
+        <>
+          <FormLabel>Change Request ID</FormLabel>
+          <Select
+            id="cr-autocomplete"
+            displayEmpty
+            renderValue={(value) => value}
+            value={value}
+            onChange={(event: SelectChangeEvent<number>) => onChange(event.target.value)}
+            size={'small'}
+            placeholder={'Change Request Id'}
+            sx={{ width: 200, textAlign: 'left' }}
+          >
+            {approvedChangeRequestOptions.map((option) => (
+              <MenuItem key={option.value} value={option.value}>
+                {option.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </>
       )}
     />
   );

--- a/src/frontend/src/components/ChangeRequestDropdown.tsx
+++ b/src/frontend/src/components/ChangeRequestDropdown.tsx
@@ -20,7 +20,7 @@ const ChangeRequestDropdown = ({ control, name }: ChangeRequestDropdownProps) =>
   const fiveDaysAgo = subDays(today, 5);
 
   const filteredRequests = changeRequests?.filter(
-    (cr) => !!cr.dateReviewed && isWithinInterval(cr.dateReviewed, { start: fiveDaysAgo, end: today })
+    (cr) => cr.dateReviewed && cr.accepted && isWithinInterval(cr.dateReviewed, { start: fiveDaysAgo, end: today })
   );
 
   // The current user's CRs should be at the top
@@ -35,7 +35,7 @@ const ChangeRequestDropdown = ({ control, name }: ChangeRequestDropdownProps) =>
     return a.crId - b.crId;
   });
 
-  const options =
+  const approvedChangeRequestOptions =
     filteredRequests.map((cr) => ({
       label: `${cr.crId} - ${wbsPipe(cr.wbsNum)} - ${cr.submitter.firstName} ${cr.submitter.lastName} - ${cr.type}`,
       value: cr.crId
@@ -61,7 +61,7 @@ const ChangeRequestDropdown = ({ control, name }: ChangeRequestDropdownProps) =>
           placeholder={'Change Request Id'}
           sx={{ width: 200, textAlign: 'left' }}
         >
-          {options.map((option) => (
+          {approvedChangeRequestOptions.map((option) => (
             <MenuItem key={option.value} value={option.value}>
               {option.label}
             </MenuItem>

--- a/src/frontend/src/components/ChangeRequestDropdown.tsx
+++ b/src/frontend/src/components/ChangeRequestDropdown.tsx
@@ -49,12 +49,12 @@ const ChangeRequestDropdown = ({ control, name }: ChangeRequestDropdownProps) =>
 
   return (
     <Box sx={{ display: 'flex', justifyContent: 'end' }}>
-      <Controller
-        control={control}
-        name={name}
-        render={({ field: { onChange, value } }) => (
-          <Box sx={{ width: 200, display: 'flex', flexDirection: 'column', justifyContent: 'start' }}>
-            <FormLabel sx={{ alignSelf: 'start' }}>Change Request ID</FormLabel>
+      <FormControl>
+        <FormLabel sx={{ alignSelf: 'start' }}>Change Request ID</FormLabel>
+        <Controller
+          control={control}
+          name={name}
+          render={({ field: { onChange, value } }) => (
             <Select
               id="cr-autocomplete"
               displayEmpty
@@ -63,7 +63,7 @@ const ChangeRequestDropdown = ({ control, name }: ChangeRequestDropdownProps) =>
               onChange={(event: SelectChangeEvent<number>) => onChange(event.target.value)}
               size={'small'}
               placeholder={'Change Request Id'}
-              sx={{ width: '100%', textAlign: 'left' }}
+              sx={{ width: 200, textAlign: 'left' }}
             >
               {approvedChangeRequestOptions.map((option) => (
                 <MenuItem key={option.value} value={option.value}>
@@ -71,9 +71,9 @@ const ChangeRequestDropdown = ({ control, name }: ChangeRequestDropdownProps) =>
                 </MenuItem>
               ))}
             </Select>
-          </Box>
-        )}
-      />
+          )}
+        />
+      </FormControl>
     </Box>
   );
 };

--- a/src/frontend/src/components/ChangeRequestDropdown.tsx
+++ b/src/frontend/src/components/ChangeRequestDropdown.tsx
@@ -1,0 +1,41 @@
+import { Control, Controller } from 'react-hook-form';
+import { wbsPipe } from 'shared';
+import { useAllChangeRequests } from '../hooks/change-requests.hooks';
+import NERAutocomplete from './NERAutocomplete';
+
+interface ChangeRequestDropdownProps {
+  control: Control<any, any>;
+  name: string;
+}
+
+const ChangeRequestDropdown = ({ control, name }: ChangeRequestDropdownProps) => {
+  const { data: changeRequests } = useAllChangeRequests();
+  const options =
+    changeRequests
+      ?.filter((cr) => cr.accepted)
+      .map((cr) => ({
+        label: `${cr.crId} - ${wbsPipe(cr.wbsNum)} - ${cr.submitter.firstName} ${cr.submitter.lastName}`,
+        id: `${cr.crId}`
+      })) ?? [];
+
+  return (
+    <Controller
+      control={control}
+      name={name}
+      render={({ field: { onChange, value, name } }) => (
+        <NERAutocomplete
+          id="cr"
+          options={options}
+          value={options.find((option) => option.id === value)}
+          onChange={(event, value) => {
+            if (value) onChange(value.id);
+          }}
+          size={'small'}
+          placeholder={'Change Request Id'}
+        />
+      )}
+    />
+  );
+};
+
+export default ChangeRequestDropdown;

--- a/src/frontend/src/components/ChangeRequestDropdown.tsx
+++ b/src/frontend/src/components/ChangeRequestDropdown.tsx
@@ -1,7 +1,9 @@
 import { Control, Controller } from 'react-hook-form';
+import { subDays, isWithinInterval } from 'date-fns';
 import { wbsPipe } from 'shared';
 import { useAllChangeRequests } from '../hooks/change-requests.hooks';
 import NERAutocomplete from './NERAutocomplete';
+import LoadingIndicator from './LoadingIndicator';
 
 interface ChangeRequestDropdownProps {
   control: Control<any, any>;
@@ -9,10 +11,15 @@ interface ChangeRequestDropdownProps {
 }
 
 const ChangeRequestDropdown = ({ control, name }: ChangeRequestDropdownProps) => {
-  const { data: changeRequests } = useAllChangeRequests();
+  const { isLoading, data: changeRequests } = useAllChangeRequests();
+  if (isLoading || !changeRequests) return <LoadingIndicator />;
+
+  const today = new Date();
+  const fiveDaysAgo = subDays(today, 5);
+
   const options =
     changeRequests
-      ?.filter((cr) => cr.accepted)
+      ?.filter((cr) => !!cr.dateReviewed && isWithinInterval(cr.dateReviewed, { start: fiveDaysAgo, end: today }))
       .map((cr) => ({
         label: `${cr.crId} - ${wbsPipe(cr.wbsNum)} - ${cr.submitter.firstName} ${cr.submitter.lastName}`,
         id: `${cr.crId}`
@@ -22,12 +29,12 @@ const ChangeRequestDropdown = ({ control, name }: ChangeRequestDropdownProps) =>
     <Controller
       control={control}
       name={name}
-      render={({ field: { onChange, value, name } }) => (
+      render={({ field: { onChange, value } }) => (
         <NERAutocomplete
-          id="cr"
+          id="cr-autocomplete"
           options={options}
           value={options.find((option) => option.id === value)}
-          onChange={(event, value) => {
+          onChange={(_event, value) => {
             if (value) onChange(value.id);
           }}
           size={'small'}

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditContainer.tsx
@@ -156,12 +156,7 @@ const ProjectEditContainer: React.FC<ProjectEditContainerProps> = ({ project, ex
     <PageLayout
       title={`${wbsPipe(project.wbsNum)} - ${project.name}`}
       previousPages={[{ name: 'Projects', route: routes.PROJECTS }]}
-      headerRight={
-        <>
-          <ChangeRequestDropdown control={control} name="crId" />
-          {/* <ReactHookTextField name="crId" control={control} label="Change Request Id" type="number" size="small" /> */}
-        </>
-      }
+      headerRight={<ChangeRequestDropdown control={control} name="crId" />}
     >
       <form
         id="project-edit-form"

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditContainer.tsx
@@ -26,6 +26,7 @@ import NERFailButton from '../../../components/NERFailButton';
 import { useToast } from '../../../hooks/toasts.hooks';
 import { useState } from 'react';
 import PageLayout from '../../../components/PageLayout';
+import ChangeRequestDropdown from '../../../components/ChangeRequestDropdown';
 
 /* TODO: slide deck changed to confluence in frontend - needs to be updated in the backend */
 const schema = yup.object().shape({
@@ -155,7 +156,12 @@ const ProjectEditContainer: React.FC<ProjectEditContainerProps> = ({ project, ex
     <PageLayout
       title={`${wbsPipe(project.wbsNum)} - ${project.name}`}
       previousPages={[{ name: 'Projects', route: routes.PROJECTS }]}
-      headerRight={<ReactHookTextField name="crId" control={control} label="Change Request Id" type="number" size="small" />}
+      headerRight={
+        <>
+          <ChangeRequestDropdown control={control} name="crId" />
+          {/* <ReactHookTextField name="crId" control={control} label="Change Request Id" type="number" size="small" /> */}
+        </>
+      }
     >
       <form
         id="project-edit-form"

--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditContainer.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditContainer.tsx
@@ -15,7 +15,6 @@ import { Controller, useFieldArray, useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import * as yup from 'yup';
 import { Box, TextField, Autocomplete, FormControl } from '@mui/material';
-import ReactHookTextField from '../../../components/ReactHookTextField';
 import ReactHookEditableList from '../../../components/ReactHookEditableList';
 import { useEditWorkPackage } from '../../../hooks/work-packages.hooks';
 import WorkPackageEditDetails from './WorkPackageEditDetails';
@@ -26,6 +25,7 @@ import { useToast } from '../../../hooks/toasts.hooks';
 import { useState } from 'react';
 import { useSingleProject } from '../../../hooks/projects.hooks';
 import PageLayout from '../../../components/PageLayout';
+import ChangeRequestDropdown from '../../../components/ChangeRequestDropdown';
 
 const schema = yup.object().shape({
   name: yup.string().required('Name is required!'),
@@ -162,7 +162,6 @@ const WorkPackageEditContainer: React.FC<WorkPackageEditContainerProps> = ({ wor
       }
     }
   };
-
   const projectWbsString: string = projectWbsPipe(workPackage.wbsNum);
 
   return (
@@ -172,7 +171,7 @@ const WorkPackageEditContainer: React.FC<WorkPackageEditContainerProps> = ({ wor
         { name: 'Projects', route: routes.PROJECTS },
         { name: `${projectWbsString} - ${workPackage.projectName}`, route: `${routes.PROJECTS}/${projectWbsString}` }
       ]}
-      headerRight={<ReactHookTextField name="crId" control={control} label="Change Request Id" type="number" size="small" />}
+      headerRight={<ChangeRequestDropdown control={control} name="crId" />}
     >
       <form
         id="work-package-edit-form"


### PR DESCRIPTION
## Changes

Convert change request inputs to dropdowns/autocompletes so users don't have to remember CR IDs and manually type them out

## Screenshots

<img width="396" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/34677361/11d5d4e4-f217-4dde-89d2-4f48124b27c4">

<img width="488" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/34677361/e41139bd-7b58-42af-a576-a58deba6d1df">

<img width="500" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/34677361/49debe3c-d136-4984-8705-1dcd62a3d2ac">

New UI with label:

<img width="258" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/34677361/0e180d34-9247-4c07-a067-52f6208f9061">


## To Do

- [ ] autcomplete or dropdown?
- [ ] need to create an API for getting change requests? Or filter them client side?

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1027
