### PR TITLE
 Finance Fixes - Enforce Only Allowed Expense Types for RR edit #1281 

### DIFF
--- a/src/backend/src/services/reimbursement-requests.services.ts
+++ b/src/backend/src/services/reimbursement-requests.services.ts
@@ -258,6 +258,7 @@ export default class ReimbursementRequestService {
     });
 
     if (!expenseType) throw new NotFoundException('Expense Type', expenseTypeId);
+    if (!expenseType.allowed) throw new HttpException(400, 'Expense Type Not Allowed');
 
     await updateReimbursementProducts(
       oldReimbursementRequest.reimbursementProducts,


### PR DESCRIPTION
## Changes

Added a one-line check that throws 400 HTTP error if expenseType.allowed is false. 

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [X] All commits are tagged with the ticket number
- [X] No linting errors / newline at end of file warnings
- [X] All code follows repository-configured prettier formatting
- [X] No merge conflicts
- [X] All checks passing
- [X] Screenshots of UI changes (see Screenshots section)
- [X] Remove any non-applicable sections of this template
- [X] Assign the PR to yourself
- [X] No `yarn.lock` changes (unless dependencies have changed)
- [X] Request reviewers & ping on Slack
- [X] PR is linked to the ticket (fill in the closes line below)

Closes #1281
