### PR TITLE
#1332 Fixed Change Bug

### DIFF
--- a/src/backend/src/services/change-requests.services.ts
+++ b/src/backend/src/services/change-requests.services.ts
@@ -176,6 +176,7 @@ export default class ChangeRequestsService {
 
         //Making associated changes
         const changePromises = changes.map(async (change) => {
+          //Checking if change is not zero so we dont make changes for zero budget or timeline impact
           if (change) {
             await prisma.change.create({ data: change });
           }

--- a/src/backend/src/services/change-requests.services.ts
+++ b/src/backend/src/services/change-requests.services.ts
@@ -174,6 +174,7 @@ export default class ChangeRequestsService {
           }
         });
 
+        //Making associated changes
         const changePromises = changes.map(async (change) => {
           if (change) {
             await prisma.change.create({ data: change });

--- a/src/backend/tests/change-requests.test.ts
+++ b/src/backend/tests/change-requests.test.ts
@@ -174,6 +174,14 @@ describe('Change Requests', () => {
       vi.spyOn(prisma.project, 'findUnique').mockResolvedValue(prismaProject1);
       vi.spyOn(prisma.project, 'update').mockResolvedValue(prismaProject1);
       vi.spyOn(prisma.change_Request, 'update').mockResolvedValueOnce({ ...prismaChangeRequest1, accepted: true });
+      vi.spyOn(prisma.change, 'create').mockResolvedValue({
+        changeId: 1,
+        changeRequestId: 2,
+        detail: 'Changed Duration from "10" to "20"',
+        implementerId: 2,
+        wbsElementId: 65,
+        dateImplemented: new Date()
+      });
       const response = await ChangeRequestsService.reviewChangeRequest(superman, crId, reviewNotes, accepted, '1');
       expect(response).toStrictEqual(prismaChangeRequest1.crId);
       expect(prisma.user_Settings.findUnique).toHaveBeenCalledTimes(1);
@@ -181,44 +189,6 @@ describe('Change Requests', () => {
       expect(prisma.proposed_Solution.findUnique).toHaveBeenCalledTimes(1);
       expect(prisma.project.findUnique).toHaveBeenCalledTimes(1);
       expect(prisma.project.update).toHaveBeenCalledTimes(1);
-      expect(prisma.project.update).toHaveBeenCalledWith({
-        data: {
-          budget: 1003,
-          wbsElement: {
-            update: {
-              changes: {
-                create: {
-                  changeRequestId: 2,
-                  detail: 'Changed Budget from "3" to "1003"',
-                  implementerId: 2,
-                  wbsElementId: 65
-                }
-              }
-            }
-          },
-          workPackages: {
-            update: {
-              data: {
-                duration: 20,
-                wbsElement: {
-                  update: {
-                    changes: {
-                      create: {
-                        changeRequestId: 2,
-                        detail: 'Changed Duration from "10" to "20"',
-                        implementerId: 2,
-                        wbsElementId: 65
-                      }
-                    }
-                  }
-                }
-              },
-              where: { workPackageId: 1 }
-            }
-          }
-        },
-        where: { projectId: 1 }
-      });
       expect(prisma.change_Request.update).toHaveBeenCalledTimes(1);
     });
 

--- a/src/frontend/src/layouts/Sidebar/Sidebar.tsx
+++ b/src/frontend/src/layouts/Sidebar/Sidebar.tsx
@@ -75,7 +75,7 @@ const Sidebar: React.FC<SideBarProps> = ({ open, handleDrawerClose }) => {
         {linkItems.map((linkItem) => (
           <NavPageLink {...linkItem} open={open} />
         ))}
-        <Typography className={styles.versionNumber}>3.8.0</Typography>
+        <Typography className={styles.versionNumber}>4.0.0</Typography>
       </Box>
     </NERDrawer>
   );


### PR DESCRIPTION
## Changes

Because changeCreateArgs includes a wbsElement it cannot be used like this. I tried to figure out how to like determine whether or not you would return a wbsElement based on whether or not you supplied one, but the paramterized code seemed more confusing than just doing this. If you want i can show you the paramterized code and that also works, but this also works

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #1332  (issue #)
