### PR TITLE
fix upload receipt bug

### DIFF
--- a/src/backend/src/controllers/reimbursement-requests.controllers.ts
+++ b/src/backend/src/controllers/reimbursement-requests.controllers.ts
@@ -182,7 +182,10 @@ export default class ReimbursementRequestsController {
 
       const receipt = await ReimbursementRequestService.uploadReceipt(requestId, file, user);
 
-      res.header('Access-Control-Allow-Origin', 'true');
+      const isProd = process.env.NODE_ENV === 'production';
+      const origin = isProd ? 'https://finishlinebyner.com' : 'http://localhost:3000';
+
+      res.header('Access-Control-Allow-Origin', origin);
       res.status(200).json(receipt);
     } catch (error: unknown) {
       next(error);


### PR DESCRIPTION
## Changes

Ok so, I am stupid, the code I added did in fact make the upload receipt endpoint send an error no matter what on local and prod (LOL, basically true is not in our acceptable list of origins). The good news is, it appears the receipts do actually upload on prod on develop rn it just acts like it errored. I'm truely not sure what caused that error we were getting, but I think this code I added should explicitly prevent it from happening again

error on local an prod:
<img width="427" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/29521172/99edadab-c8b1-4d01-b9ae-17b01467239d">
old error:
![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/29521172/736a6e0d-6b5e-4613-9bb1-c6cde74201fa)


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #1298  (issue #)
