### PR TITLE
#1315 Add date received field to report refund form

### DIFF
--- a/src/backend/src/controllers/reimbursement-requests.controllers.ts
+++ b/src/backend/src/controllers/reimbursement-requests.controllers.ts
@@ -72,9 +72,9 @@ export default class ReimbursementRequestsController {
   static async reimburseUser(req: Request, res: Response, next: NextFunction) {
     try {
       const user = await getCurrentUser(res);
-      const { amount } = req.body;
+      const { amount, dateReceived } = req.body;
 
-      const reimbursement = await ReimbursementRequestService.reimburseUser(amount, user);
+      const reimbursement = await ReimbursementRequestService.reimburseUser(amount, dateReceived, user);
       res.status(200).json(reimbursement);
     } catch (error: unknown) {
       next(error);

--- a/src/backend/src/routes/reimbursement-requests.routes.ts
+++ b/src/backend/src/routes/reimbursement-requests.routes.ts
@@ -111,6 +111,7 @@ reimbursementRequestsRouter.post(
 reimbursementRequestsRouter.post(
   '/reimburse',
   intMinZero(body('amount')),
+  isDate(body('dateReceived')),
   validateInputs,
   ReimbursementRequestController.reimburseUser
 );

--- a/src/backend/src/services/reimbursement-requests.services.ts
+++ b/src/backend/src/services/reimbursement-requests.services.ts
@@ -167,10 +167,11 @@ export default class ReimbursementRequestService {
    * Function to reimburse a user for their expenses.
    *
    * @param amount the amount to be reimbursed
+   * @param dateReceived the date the amount was received
    * @param submitter the person performing the reimbursement
    * @returns the created reimbursement
    */
-  static async reimburseUser(amount: number, submitter: User): Promise<Reimbursement> {
+  static async reimburseUser(amount: number, dateReceived: Date, submitter: User): Promise<Reimbursement> {
     if (isGuest(submitter.role)) {
       throw new AccessDeniedException('Guests cannot reimburse a user for their expenses.');
     }
@@ -199,7 +200,7 @@ export default class ReimbursementRequestService {
       data: {
         purchaserId: submitter.userId,
         amount,
-        dateCreated: new Date(),
+        dateCreated: dateReceived,
         userSubmittedId: submitter.userId
       },
       ...reimbursementQueryArgs

--- a/src/backend/src/services/reimbursement-requests.services.ts
+++ b/src/backend/src/services/reimbursement-requests.services.ts
@@ -171,7 +171,7 @@ export default class ReimbursementRequestService {
    * @param submitter the person performing the reimbursement
    * @returns the created reimbursement
    */
-  static async reimburseUser(amount: number, dateReceived: Date, submitter: User): Promise<Reimbursement> {
+  static async reimburseUser(amount: number, dateReceived: string, submitter: User): Promise<Reimbursement> {
     if (isGuest(submitter.role)) {
       throw new AccessDeniedException('Guests cannot reimburse a user for their expenses.');
     }
@@ -196,6 +196,11 @@ export default class ReimbursementRequestService {
     if (amount > totalOwed - totalReimbursed) {
       throw new HttpException(400, 'Reimbursement is greater than the total amount owed to the user');
     }
+
+    // make the date object but add 12 hours so that the time isn't 00:00 to avoid timezone problems
+    const dateCreated = new Date(dateReceived.split('T')[0]);
+    dateCreated.setTime(dateCreated.getTime() + 12 * 60 * 60 * 1000);
+
     const newReimbursement = await prisma.reimbursement.create({
       data: {
         purchaserId: submitter.userId,

--- a/src/backend/tests/reimbursement-requests.test.ts
+++ b/src/backend/tests/reimbursement-requests.test.ts
@@ -573,7 +573,7 @@ describe('Reimbursement Requests', () => {
 
   describe('Reimbursement User Tests', () => {
     test('Throws an error if user is a guest', async () => {
-      await expect(ReimbursementRequestService.reimburseUser(100, theVisitor)).rejects.toThrow(
+      await expect(ReimbursementRequestService.reimburseUser(100, new Date('2023-01-01'), theVisitor)).rejects.toThrow(
         new AccessDeniedException('Guests cannot reimburse a user for their expenses.')
       );
     });
@@ -590,7 +590,7 @@ describe('Reimbursement Requests', () => {
         }
       ]);
 
-      await expect(ReimbursementRequestService.reimburseUser(200, batman)).rejects.toThrow(
+      await expect(ReimbursementRequestService.reimburseUser(200, new Date('2023-01-01'), batman)).rejects.toThrow(
         new HttpException(400, 'Reimbursement is greater than the total amount owed to the user')
       );
     });
@@ -602,7 +602,7 @@ describe('Reimbursement Requests', () => {
         reimbursementId: 'reimbursementMockId',
         purchaserId: batman.userId,
         amount: reimbursementAmount,
-        dateCreated: new Date(),
+        dateCreated: new Date('2023-01-01'),
         userSubmitted: batman,
         userSubmittedId: batman.userId
       };
@@ -619,7 +619,11 @@ describe('Reimbursement Requests', () => {
       ]);
       vi.spyOn(prisma.reimbursement, 'create').mockResolvedValue(reimbursementMock);
 
-      const newReimbursement = await ReimbursementRequestService.reimburseUser(reimbursementAmount, batman);
+      const newReimbursement = await ReimbursementRequestService.reimburseUser(
+        reimbursementAmount,
+        new Date('2023-01-01'),
+        batman
+      );
 
       expect(newReimbursement).toStrictEqual(reimbursementTransformer(reimbursementMock));
     });

--- a/src/backend/tests/reimbursement-requests.test.ts
+++ b/src/backend/tests/reimbursement-requests.test.ts
@@ -573,7 +573,7 @@ describe('Reimbursement Requests', () => {
 
   describe('Reimbursement User Tests', () => {
     test('Throws an error if user is a guest', async () => {
-      await expect(ReimbursementRequestService.reimburseUser(100, new Date('2023-01-01'), theVisitor)).rejects.toThrow(
+      await expect(ReimbursementRequestService.reimburseUser(100, '2023-01-11T11:12:33.409Z', theVisitor)).rejects.toThrow(
         new AccessDeniedException('Guests cannot reimburse a user for their expenses.')
       );
     });
@@ -590,7 +590,7 @@ describe('Reimbursement Requests', () => {
         }
       ]);
 
-      await expect(ReimbursementRequestService.reimburseUser(200, new Date('2023-01-01'), batman)).rejects.toThrow(
+      await expect(ReimbursementRequestService.reimburseUser(200, '2023-01-01T09:12:33.409Z', batman)).rejects.toThrow(
         new HttpException(400, 'Reimbursement is greater than the total amount owed to the user')
       );
     });
@@ -621,7 +621,7 @@ describe('Reimbursement Requests', () => {
 
       const newReimbursement = await ReimbursementRequestService.reimburseUser(
         reimbursementAmount,
-        new Date('2023-01-01'),
+        '2023-01-01T19:12:33.409Z',
         batman
       );
 

--- a/src/frontend/src/apis/finance.api.ts
+++ b/src/frontend/src/apis/finance.api.ts
@@ -271,10 +271,11 @@ export const sendPendingAdvisorList = (saboNumbers: number[]) => {
  * Reports a given dollar amount representing a new account credit
  *
  * @param amount the dollar amount being reimbursed
+ * @param dateReceived the date the refund was received
  * @returns a reimbursement with the given dollar amount
  */
-export const reportRefund = (amount: number) => {
-  return axios.post(apiUrls.financeReportRefund(), { amount });
+export const reportRefund = (amount: number, dateReceived: string) => {
+  return axios.post(apiUrls.financeReportRefund(), { amount, dateReceived });
 };
 
 /**

--- a/src/frontend/src/hooks/finance.hooks.ts
+++ b/src/frontend/src/hooks/finance.hooks.ts
@@ -306,10 +306,10 @@ export const useSendPendingAdvisorList = () => {
  */
 export const useReportRefund = () => {
   const queryClient = useQueryClient();
-  return useMutation<Reimbursement, Error, { refundAmount: number }>(
+  return useMutation<Reimbursement, Error, { refundAmount: number; dateReceived: string }>(
     ['reimbursement'],
-    async (formData: { refundAmount: number }) => {
-      const { data } = await reportRefund(formData.refundAmount);
+    async (formData: { refundAmount: number; dateReceived: string }) => {
+      const { data } = await reportRefund(formData.refundAmount, formData.dateReceived);
       queryClient.invalidateQueries(['reimbursement']);
       return data;
     }

--- a/src/frontend/src/pages/FinancePage/FinanceComponents/ReportRefundModal.tsx
+++ b/src/frontend/src/pages/FinancePage/FinanceComponents/ReportRefundModal.tsx
@@ -1,6 +1,6 @@
-import { FormControl } from '@mui/material';
+import { FormControl, TextField } from '@mui/material';
 import NERFormModal from '../../../components/NERFormModal';
-import { useForm } from 'react-hook-form';
+import { Controller, useForm } from 'react-hook-form';
 import AttachMoneyIcon from '@mui/icons-material/AttachMoney';
 import ReactHookTextField from '../../../components/ReactHookTextField';
 import LoadingIndicator from '../../../components/LoadingIndicator';
@@ -8,6 +8,8 @@ import { useToast } from '../../../hooks/toasts.hooks';
 import { useReportRefund } from '../../../hooks/finance.hooks';
 import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
+import { DatePicker } from '@mui/x-date-pickers';
+import { useState } from 'react';
 
 const schema = yup.object().shape({
   refundAmount: yup
@@ -17,7 +19,8 @@ const schema = yup.object().shape({
       if (!value) return false;
       return Math.floor(value * 100) === value * 100;
     })
-    .typeError('The refund amount should be a valid number')
+    .typeError('The refund amount should be a valid number'),
+  dateReceived: yup.date().required()
 });
 
 interface ReportRefundProps {
@@ -41,12 +44,13 @@ const ReportRefundModal: React.FC<ReportRefundProps> = ({ modalShow, handleClose
   } = useForm({
     resolver: yupResolver(schema),
     defaultValues: {
-      refundAmount: ''
+      refundAmount: '',
+      dateReceived: new Date()
     },
     mode: 'onChange'
   });
 
-  const handleConfirm = async (data: { refundAmount: number }) => {
+  const handleConfirm = async (data: { refundAmount: number; dateReceived: Date }) => {
     handleClose();
     try {
       await mutateAsync({ refundAmount: data.refundAmount * 100 });
@@ -78,6 +82,26 @@ const ReportRefundModal: React.FC<ReportRefundProps> = ({ modalShow, handleClose
             sx={{ width: 1 }}
             startAdornment={<AttachMoneyIcon />}
             errorMessage={errors.refundAmount}
+          />
+          {/* <DatePicker
+            inputFormat="yyyy-MM-dd"
+            onChange={datePickerOnChange}
+            value={dateReceived}
+            renderInput={(params) => <TextField autoComplete="off" {...params} />}
+          /> */}
+          <Controller
+            name="dateReceived"
+            control={control}
+            rules={{ required: true }}
+            render={({ field: { onChange, value } }) => (
+              <DatePicker
+                inputFormat="yyyy-MM-dd"
+                onChange={(e) => onChange(e ?? new Date())}
+                className={'padding: 10'}
+                value={value}
+                renderInput={(params) => <TextField autoComplete="off" {...params} />}
+              />
+            )}
           />
         </FormControl>
       )}

--- a/src/frontend/src/pages/FinancePage/FinanceComponents/ReportRefundModal.tsx
+++ b/src/frontend/src/pages/FinancePage/FinanceComponents/ReportRefundModal.tsx
@@ -54,8 +54,11 @@ const ReportRefundModal: React.FC<ReportRefundProps> = ({ modalShow, handleClose
   const handleConfirm = async (data: { refundAmount: number; dateReceived: Date }) => {
     handleClose();
     try {
-      await mutateAsync({ refundAmount: data.refundAmount * 100, dateReceived: data.dateReceived.toISOString() });
-      toast.success(`New Account Credit Amount #${data.refundAmount} Reported Successfully`);
+      await mutateAsync({
+        refundAmount: Math.round(data.refundAmount * 100),
+        dateReceived: data.dateReceived.toISOString()
+      });
+      toast.success('New Account Credit Reported Successfully');
     } catch (error: unknown) {
       if (error instanceof Error) {
         toast.error(error.message);

--- a/src/frontend/src/pages/FinancePage/FinanceComponents/ReportRefundModal.tsx
+++ b/src/frontend/src/pages/FinancePage/FinanceComponents/ReportRefundModal.tsx
@@ -1,15 +1,14 @@
-import { FormControl, TextField } from '@mui/material';
-import NERFormModal from '../../../components/NERFormModal';
-import { Controller, useForm } from 'react-hook-form';
-import AttachMoneyIcon from '@mui/icons-material/AttachMoney';
-import ReactHookTextField from '../../../components/ReactHookTextField';
-import LoadingIndicator from '../../../components/LoadingIndicator';
-import { useToast } from '../../../hooks/toasts.hooks';
-import { useReportRefund } from '../../../hooks/finance.hooks';
-import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
+import AttachMoneyIcon from '@mui/icons-material/AttachMoney';
+import { FormControl, TextField } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers';
-import { useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import * as yup from 'yup';
+import LoadingIndicator from '../../../components/LoadingIndicator';
+import NERFormModal from '../../../components/NERFormModal';
+import ReactHookTextField from '../../../components/ReactHookTextField';
+import { useReportRefund } from '../../../hooks/finance.hooks';
+import { useToast } from '../../../hooks/toasts.hooks';
 
 const schema = yup.object().shape({
   refundAmount: yup
@@ -53,7 +52,7 @@ const ReportRefundModal: React.FC<ReportRefundProps> = ({ modalShow, handleClose
   const handleConfirm = async (data: { refundAmount: number; dateReceived: Date }) => {
     handleClose();
     try {
-      await mutateAsync({ refundAmount: data.refundAmount * 100 });
+      await mutateAsync({ refundAmount: data.refundAmount * 100, dateReceived: data.dateReceived.toISOString() });
       toast.success(`New Account Credit Amount #${data.refundAmount} Reported Successfully`);
     } catch (error: unknown) {
       if (error instanceof Error) {

--- a/src/frontend/src/pages/FinancePage/FinanceComponents/ReportRefundModal.tsx
+++ b/src/frontend/src/pages/FinancePage/FinanceComponents/ReportRefundModal.tsx
@@ -1,6 +1,6 @@
 import { yupResolver } from '@hookform/resolvers/yup';
 import AttachMoneyIcon from '@mui/icons-material/AttachMoney';
-import { FormControl, TextField } from '@mui/material';
+import { FormControl, FormLabel, TextField } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers';
 import { Controller, useForm } from 'react-hook-form';
 import * as yup from 'yup';
@@ -75,6 +75,7 @@ const ReportRefundModal: React.FC<ReportRefundProps> = ({ modalShow, handleClose
         <LoadingIndicator />
       ) : (
         <FormControl>
+          <FormLabel>Amount</FormLabel>
           <ReactHookTextField
             name="refundAmount"
             control={control}
@@ -82,12 +83,8 @@ const ReportRefundModal: React.FC<ReportRefundProps> = ({ modalShow, handleClose
             startAdornment={<AttachMoneyIcon />}
             errorMessage={errors.refundAmount}
           />
-          {/* <DatePicker
-            inputFormat="yyyy-MM-dd"
-            onChange={datePickerOnChange}
-            value={dateReceived}
-            renderInput={(params) => <TextField autoComplete="off" {...params} />}
-          /> */}
+
+          <FormLabel sx={{ paddingTop: 2 }}>Date Received</FormLabel>
           <Controller
             name="dateReceived"
             control={control}

--- a/src/frontend/src/pages/FinancePage/FinanceComponents/ReportRefundModal.tsx
+++ b/src/frontend/src/pages/FinancePage/FinanceComponents/ReportRefundModal.tsx
@@ -16,7 +16,9 @@ const schema = yup.object().shape({
     .required()
     .test('two decimals', 'Refund must be formatted as a dollar amount with at most two decimals', (value) => {
       if (!value) return false;
-      return Math.floor(value * 100) === value * 100;
+      const roundedValue = Math.round(value * 100) / 100; // 2 decimal places
+      const threshold = 0.001;
+      return Math.abs(roundedValue - value) <= threshold;
     })
     .typeError('The refund amount should be a valid number'),
   dateReceived: yup.date().required()

--- a/src/frontend/src/pages/FinancePage/RefundsSection.tsx
+++ b/src/frontend/src/pages/FinancePage/RefundsSection.tsx
@@ -105,7 +105,7 @@ const Refunds = ({ userReimbursementRequests, allReimbursementRequests }: Refund
           <Table aria-label="simple table">
             <TableHead>
               <TableRow>
-                <ColumnHeader title="Date" />
+                <ColumnHeader title="Date Received" />
                 <ColumnHeader title="Amount ($)" />
                 {tabValue === 1 && <ColumnHeader title="Recipient" />}
               </TableRow>


### PR DESCRIPTION
## Changes

Add date received field to report refund form so that it does not have to default to the current date.



## Screenshots

<img width="403" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/34677361/26ec9bbd-bcbd-4d92-bd28-8c916d450d9c">

<img width="512" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/34677361/e00ea28f-4668-4fc9-b632-4b5dd81092ff">


## To Do

- [x] Update tests
- [x] Add field to modal

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1315
