### PR TITLE
#1280 Throws Error if expense type assigned to rr is not allowed

### DIFF
--- a/src/backend/src/services/reimbursement-requests.services.ts
+++ b/src/backend/src/services/reimbursement-requests.services.ts
@@ -130,7 +130,7 @@ export default class ReimbursementRequestService {
 
     if (!expenseType) throw new NotFoundException('Expense Type', expenseTypeId);
 
-    if (!expenseType.allowed) throw new HttpException(400, `The expense type ${expenseType} is not allowed!`);
+    if (!expenseType.allowed) throw new HttpException(400, `The expense type ${expenseType.name} is not allowed!`);
 
     const validatedReimbursementProudcts = await validateReimbursementProducts(reimbursementProducts);
 

--- a/src/backend/src/services/reimbursement-requests.services.ts
+++ b/src/backend/src/services/reimbursement-requests.services.ts
@@ -130,6 +130,8 @@ export default class ReimbursementRequestService {
 
     if (!expenseType) throw new NotFoundException('Expense Type', expenseTypeId);
 
+    if (!expenseType.allowed) throw new HttpException(400, `The expense type ${expenseType} is not allowed!`);
+
     const validatedReimbursementProudcts = await validateReimbursementProducts(reimbursementProducts);
 
     const createdReimbursementRequest = await prisma.reimbursement_Request.create({


### PR DESCRIPTION
## Changes

Added a check in  the createReimbursementRequest function in services to throw an http exception if the expenseType assigned to the RR is not allowed

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1280 
