### PR TITLE
#1412 - Blocked By Bug

### DIFF
--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -154,6 +154,12 @@ export default class WorkPackagesService {
       throw new HttpException(400, 'A Work Package cannot have its own project as a blocker');
     }
 
+    blockedBy.forEach((dep: WbsNumber) => {
+      if (dep.workPackageNumber === 0) {
+        throw new HttpException(400, 'A Project cannot be a Blocker');
+      }
+    });
+
     const wbsElem = await prisma.wBS_Element.findUnique({
       where: {
         wbsNumber: {
@@ -286,6 +292,12 @@ export default class WorkPackagesService {
   ): Promise<void> {
     // verify user is allowed to edit work packages
     if (isGuest(user.role)) throw new AccessDeniedGuestException('edit work packages');
+
+    blockedBy.forEach((dep: WbsNumber) => {
+      if (dep.workPackageNumber === 0) {
+        throw new HttpException(400, 'A Project cannot be a Blocker');
+      }
+    });
 
     const { userId } = user;
 

--- a/src/frontend/src/hooks/work-packages.hooks.ts
+++ b/src/frontend/src/hooks/work-packages.hooks.ts
@@ -38,22 +38,6 @@ export const useSingleWorkPackage = (wbsNum: WbsNumber) => {
 };
 
 /**
- * Custom React Hook to supply multiple work packages
- *
- * @param wbsNums WBS numbers of the requested work packages
- */
-export const useManyWorkPackages = (wbsNums: WbsNumber[]) => {
-  return useQuery<WorkPackage[], Error>(['work packages', wbsNums], async () => {
-    const workPackagePromises = wbsNums.map(async (wbsNum) => {
-      const { data } = await getSingleWorkPackage(wbsNum);
-      return data;
-    });
-    const workPackages = await Promise.all(workPackagePromises);
-    return workPackages;
-  });
-};
-
-/**
  * Custom React Hook to create a new work package.
  *
  * @param wpPayload Payload containing all information needed to create a work package.

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/WorkPackageSummary.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/WorkPackageSummary.tsx
@@ -18,7 +18,7 @@ import Grid from '@mui/material/Grid';
 import { useTheme } from '@mui/material';
 import DetailDisplay from '../../../components/DetailDisplay';
 import WorkPackageStageChip from '../../../components/WorkPackageStageChip';
-import { useManyWorkPackages } from '../../../hooks/work-packages.hooks';
+import { useGetBlockingWorkPackages } from '../../../hooks/work-packages.hooks';
 import LoadingIndicator from '../../../components/LoadingIndicator';
 import ErrorPage from '../../ErrorPage';
 
@@ -37,7 +37,7 @@ const WorkPackageSummary: React.FC<WorkPackageSummaryProps> = ({ workPackage }) 
     </ul>
   );
 
-  const { data: dependencies, isError, isLoading, error } = useManyWorkPackages(workPackage.blockedBy);
+  const { data: dependencies, isError, isLoading, error } = useGetBlockingWorkPackages(workPackage.wbsNum);
   const theme = useTheme();
 
   if (!dependencies || isLoading) return <LoadingIndicator />;

--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.tsx
@@ -22,7 +22,7 @@ import KeyboardDoubleArrowUpIcon from '@mui/icons-material/KeyboardDoubleArrowUp
 import DoneOutlineIcon from '@mui/icons-material/DoneOutline';
 import Delete from '@mui/icons-material/Delete';
 import DeleteWorkPackage from '../DeleteWorkPackageModalContainer/DeleteWorkPackage';
-import { useManyWorkPackages } from '../../../hooks/work-packages.hooks';
+import { useGetBlockingWorkPackages } from '../../../hooks/work-packages.hooks';
 import PageLayout from '../../../components/PageLayout';
 import LoadingIndicator from '../../../components/LoadingIndicator';
 import ErrorPage from '../../ErrorPage';
@@ -52,7 +52,7 @@ const WorkPackageViewContainer: React.FC<WorkPackageViewContainerProps> = ({
   const [showStageGateModal, setShowStageGateModal] = useState<boolean>(false);
   const [showDeleteModal, setShowDeleteModal] = useState<boolean>(false);
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const { data: dependencies, isError, isLoading, error } = useManyWorkPackages(workPackage.blockedBy);
+  const { data: dependencies, isError, isLoading, error } = useGetBlockingWorkPackages(workPackage.wbsNum);
   const dropdownOpen = Boolean(anchorEl);
   const wbsNum = wbsPipe(workPackage.wbsNum);
 

--- a/src/frontend/src/tests/pages/ProjectDetailPage/ProjectViewContainer.test.tsx
+++ b/src/frontend/src/tests/pages/ProjectDetailPage/ProjectViewContainer.test.tsx
@@ -12,7 +12,7 @@ import { WorkPackageStage } from 'shared/src/types/work-package-types';
 import * as userHooks from '../../../hooks/users.hooks';
 import * as authHooks from '../../../hooks/auth.hooks';
 import * as wpHooks from '../../../hooks/work-packages.hooks';
-import { mockUseManyWorkPackagesReturnValue, mockUseUsersFavoriteProjects } from '../../test-support/mock-hooks';
+import { mockUseGetBlockingWorkPackagesReturnValue, mockUseUsersFavoriteProjects } from '../../test-support/mock-hooks';
 import { exampleAllWorkPackages } from '../../test-support/test-data/work-packages.stub';
 
 vi.mock('../../../utils/axios');
@@ -33,7 +33,9 @@ describe('Rendering Project View Container', () => {
     vi.spyOn(authHooks, 'useAuth').mockReturnValue(mockAuth(false, exampleAdminUser));
     vi.spyOn(userHooks, 'useCurrentUser').mockReturnValue(exampleAdminUser);
     vi.spyOn(userHooks, 'useUsersFavoriteProjects').mockReturnValue(mockUseUsersFavoriteProjects());
-    vi.spyOn(wpHooks, 'useManyWorkPackages').mockReturnValue(mockUseManyWorkPackagesReturnValue(exampleAllWorkPackages));
+    vi.spyOn(wpHooks, 'useGetBlockingWorkPackages').mockReturnValue(
+      mockUseGetBlockingWorkPackagesReturnValue(exampleAllWorkPackages)
+    );
     renderComponent();
   });
 

--- a/src/frontend/src/tests/pages/WorkPackageDetailPage/WorkPackagePage.test.tsx
+++ b/src/frontend/src/tests/pages/WorkPackageDetailPage/WorkPackagePage.test.tsx
@@ -7,7 +7,7 @@ import { UseQueryResult } from 'react-query';
 import { AuthenticatedUser, WorkPackage } from 'shared';
 import { render, screen, routerWrapperBuilder, act, fireEvent } from '../../test-support/test-utils';
 import { Auth } from '../../../utils/types';
-import { useManyWorkPackages, useSingleWorkPackage } from '../../../hooks/work-packages.hooks';
+import { useGetBlockingWorkPackages, useSingleWorkPackage } from '../../../hooks/work-packages.hooks';
 import { useAuth } from '../../../hooks/auth.hooks';
 import { mockAuth, mockUseQueryResult } from '../../test-support/test-data/test-utils.stub';
 import { exampleDesignWorkPackage, exampleResearchWorkPackage } from '../../test-support/test-data/work-packages.stub';
@@ -25,10 +25,10 @@ const mockSingleWPHook = (isLoading: boolean, isError: boolean, data?: WorkPacka
   mockedUseSingleWorkPackage.mockReturnValue(mockUseQueryResult<WorkPackage>(isLoading, isError, data, error));
 };
 
-const mockedUseManyWorkPackages = useManyWorkPackages as jest.Mock<UseQueryResult<WorkPackage[]>>;
+const mockedGetBlockingWorkPackages = useGetBlockingWorkPackages as jest.Mock<UseQueryResult<WorkPackage[]>>;
 
-const mockManyWorkPackagesHook = (isLoading: boolean, isError: boolean, data?: WorkPackage[], error?: Error) => {
-  mockedUseManyWorkPackages.mockReturnValue(mockUseQueryResult<WorkPackage[]>(isLoading, isError, data, error));
+const mockGetBlockingWorkPackagesHook = (isLoading: boolean, isError: boolean, data?: WorkPackage[], error?: Error) => {
+  mockedGetBlockingWorkPackages.mockReturnValue(mockUseQueryResult<WorkPackage[]>(isLoading, isError, data, error));
 };
 
 vi.mock('../../../hooks/auth.hooks');
@@ -63,7 +63,7 @@ describe('work package container', () => {
     mockSingleWPHook(true, false);
     mockAuthHook();
     mockCurrentUserHook();
-    mockManyWorkPackagesHook(true, false);
+    mockGetBlockingWorkPackagesHook(true, false);
     renderComponent();
 
     expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
@@ -74,7 +74,7 @@ describe('work package container', () => {
     mockSingleWPHook(false, false, exampleResearchWorkPackage);
     mockAuthHook();
     mockCurrentUserHook();
-    mockManyWorkPackagesHook(false, false, [exampleDesignWorkPackage]);
+    mockGetBlockingWorkPackagesHook(false, false, [exampleDesignWorkPackage]);
     renderComponent();
 
     expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
@@ -87,7 +87,7 @@ describe('work package container', () => {
     mockSingleWPHook(false, true, undefined, new Error('404 could not find the requested work package'));
     mockAuthHook();
     mockCurrentUserHook();
-    mockManyWorkPackagesHook(false, false);
+    mockGetBlockingWorkPackagesHook(false, false);
     renderComponent();
 
     expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
@@ -99,7 +99,7 @@ describe('work package container', () => {
     mockSingleWPHook(false, true);
     mockAuthHook();
     mockCurrentUserHook();
-    mockManyWorkPackagesHook(false, false);
+    mockGetBlockingWorkPackagesHook(false, false);
     renderComponent();
 
     expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
@@ -111,7 +111,7 @@ describe('work package container', () => {
     mockSingleWPHook(false, false, exampleResearchWorkPackage);
     mockAuthHook(exampleAdminUser);
     mockCurrentUserHook();
-    mockManyWorkPackagesHook(false, false, [exampleDesignWorkPackage]);
+    mockGetBlockingWorkPackagesHook(false, false, [exampleDesignWorkPackage]);
     renderComponent();
 
     act(() => {
@@ -124,7 +124,7 @@ describe('work package container', () => {
     mockSingleWPHook(false, false, exampleResearchWorkPackage);
     mockAuthHook(exampleGuestUser);
     mockCurrentUserHook(exampleGuestUser);
-    mockManyWorkPackagesHook(false, false, [exampleDesignWorkPackage]);
+    mockGetBlockingWorkPackagesHook(false, false, [exampleDesignWorkPackage]);
     renderComponent();
 
     act(() => {

--- a/src/frontend/src/tests/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.test.tsx
+++ b/src/frontend/src/tests/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.test.tsx
@@ -10,7 +10,7 @@ import * as wpHooks from '../../../../hooks/work-packages.hooks';
 import { exampleAdminUser } from '../../../test-support/test-data/users.stub';
 import AppContextUser from '../../../../app/AppContextUser';
 import * as userHooks from '../../../../hooks/users.hooks';
-import { mockUseManyWorkPackagesReturnValue } from '../../../test-support/mock-hooks';
+import { mockUseGetBlockingWorkPackagesReturnValue } from '../../../test-support/mock-hooks';
 
 // Sets up the component under test with the desired values and renders it.
 const renderComponent = (
@@ -42,8 +42,8 @@ const renderComponent = (
 describe.skip('work package container view', () => {
   beforeEach(() => {
     vi.spyOn(userHooks, 'useCurrentUser').mockReturnValue(exampleAdminUser);
-    vi.spyOn(wpHooks, 'useManyWorkPackages').mockReturnValue(
-      mockUseManyWorkPackagesReturnValue([exampleResearchWorkPackage])
+    vi.spyOn(wpHooks, 'useGetBlockingWorkPackages').mockReturnValue(
+      mockUseGetBlockingWorkPackagesReturnValue([exampleResearchWorkPackage])
     );
   });
 

--- a/src/frontend/src/tests/test-support/mock-hooks.ts
+++ b/src/frontend/src/tests/test-support/mock-hooks.ts
@@ -83,5 +83,5 @@ export const mockUseAllWorkPackagesReturnValue = (workPackages: WorkPackage[]) =
 export const mockUseAllProjectsReturnValue = (projects: Project[]) =>
   mockUseQueryResult<Project[]>(false, false, projects, new Error());
 
-export const mockUseManyWorkPackagesReturnValue = (workPackages: WorkPackage[]) =>
+export const mockUseGetBlockingWorkPackagesReturnValue = (workPackages: WorkPackage[]) =>
   mockUseQueryResult<WorkPackage[]>(false, false, workPackages, new Error());


### PR DESCRIPTION
## Changes

This is bc of that weird forever loading bug that got reported today.

Read the ticket, but tl;dr: when blockedBy wasn't an autocomplete you could set a project as a blocker (which causes issues for our getter methods) because we weren't enforcing blockers not being projects even though every time we fetch a blocker we expect it to be a WP only (in the front and backend), so I enforced that. Also we had two hooks being used to get blockedBy WPs and now we should only have one that will hopefully give better error messages

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #1412  (issue #)
