### PR TITLE
#1287: Vender and Account Code Forms Enabled Submit Buttons

### DIFF
--- a/src/frontend/src/components/NERFormModal.tsx
+++ b/src/frontend/src/components/NERFormModal.tsx
@@ -28,7 +28,6 @@ const NERFormModal = ({
    */
   const onSubmitWrapper = async (data: any) => {
     await onFormSubmit(data);
-    console.log('reset');
     reset();
   };
 

--- a/src/frontend/src/components/NERFormModal.tsx
+++ b/src/frontend/src/components/NERFormModal.tsx
@@ -28,13 +28,17 @@ const NERFormModal = ({
    */
   const onSubmitWrapper = async (data: any) => {
     await onFormSubmit(data);
-    reset({ confirmDone: false });
+    console.log('reset');
+    reset();
   };
 
   return (
     <NERModal
       open={open}
-      onHide={onHide}
+      onHide={() => {
+        onHide();
+        reset();
+      }}
       formId={formId}
       title={title}
       cancelText={cancelText ? cancelText : 'Cancel'}

--- a/src/frontend/src/components/NERFormModal.tsx
+++ b/src/frontend/src/components/NERFormModal.tsx
@@ -45,7 +45,7 @@ const NERFormModal = ({
       disabled={disabled}
       showCloseButton={showCloseButton}
     >
-      <form id={formId} onSubmit={handleUseFormSubmit(onSubmitWrapper)}>
+      <form id={formId} onSubmit={handleUseFormSubmit(onSubmitWrapper)} noValidate>
         {children}
       </form>
     </NERModal>

--- a/src/frontend/src/pages/AdminToolsPage/FinanceConfig/AccountCodeFormModal.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/FinanceConfig/AccountCodeFormModal.tsx
@@ -49,7 +49,7 @@ const AccountCodeFormModal = ({ showModal, handleClose, defaultValues, onSubmit 
       open={showModal}
       onHide={handleClose}
       title={!!defaultValues ? 'Edit Account Code' : 'Create Account Code'}
-      reset={reset}
+      reset={() => reset({ name: '', code: undefined, allowed: false })}
       handleUseFormSubmit={handleSubmit}
       onFormSubmit={onFormSubmit}
       formId={!!defaultValues ? 'edit-vendor-form' : 'create-vendor-form'}

--- a/src/frontend/src/pages/AdminToolsPage/FinanceConfig/AccountCodeFormModal.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/FinanceConfig/AccountCodeFormModal.tsx
@@ -26,7 +26,6 @@ const AccountCodeFormModal = ({ showModal, handleClose, defaultValues, onSubmit 
   const {
     handleSubmit,
     control,
-    formState: { isValid },
     reset
   } = useForm({
     mode: 'onChange',
@@ -58,7 +57,6 @@ const AccountCodeFormModal = ({ showModal, handleClose, defaultValues, onSubmit 
       handleUseFormSubmit={handleSubmit}
       onFormSubmit={onFormSubmit}
       formId={!!defaultValues ? 'edit-vendor-form' : 'create-vendor-form'}
-      disabled={!isValid}
       showCloseButton
     >
       <FormControl fullWidth>

--- a/src/frontend/src/pages/AdminToolsPage/FinanceConfig/AccountCodeFormModal.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/FinanceConfig/AccountCodeFormModal.tsx
@@ -23,11 +23,7 @@ interface AccountCodeFormModalProps {
 
 const AccountCodeFormModal = ({ showModal, handleClose, defaultValues, onSubmit }: AccountCodeFormModalProps) => {
   const toast = useToast();
-  const {
-    handleSubmit,
-    control,
-    reset
-  } = useForm({
+  const { handleSubmit, control, reset } = useForm({
     mode: 'onChange',
     resolver: yupResolver(schema),
     defaultValues: {

--- a/src/frontend/src/pages/AdminToolsPage/FinanceConfig/AccountCodeFormModal.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/FinanceConfig/AccountCodeFormModal.tsx
@@ -2,14 +2,14 @@ import { ExpenseType } from 'shared';
 import { ExpenseTypePayload } from '../../../hooks/finance.hooks';
 import { Controller, useForm } from 'react-hook-form';
 import NERFormModal from '../../../components/NERFormModal';
-import { Checkbox, FormControl, FormLabel } from '@mui/material';
+import { Checkbox, FormControl, FormLabel, FormHelperText } from '@mui/material';
 import ReactHookTextField from '../../../components/ReactHookTextField';
 import { useToast } from '../../../hooks/toasts.hooks';
 import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
 
 const schema = yup.object().shape({
-  code: yup.number().required('Account Code is Required'),
+  code: yup.number().typeError('Account Code must be a number').required('Account Code is Required'),
   name: yup.string().required('Account Name is Required'),
   allowed: yup.boolean().required('Allowed is Required')
 });
@@ -23,8 +23,12 @@ interface AccountCodeFormModalProps {
 
 const AccountCodeFormModal = ({ showModal, handleClose, defaultValues, onSubmit }: AccountCodeFormModalProps) => {
   const toast = useToast();
-  const { handleSubmit, control, reset } = useForm({
-    mode: 'onChange',
+  const {
+    handleSubmit,
+    control,
+    reset,
+    formState: { errors }
+  } = useForm({
     resolver: yupResolver(schema),
     defaultValues: {
       code: defaultValues?.code,
@@ -58,10 +62,12 @@ const AccountCodeFormModal = ({ showModal, handleClose, defaultValues, onSubmit 
       <FormControl fullWidth>
         <FormLabel>Account Name</FormLabel>
         <ReactHookTextField name="name" control={control} fullWidth />
+        <FormHelperText error>{errors.name?.message}</FormHelperText>
       </FormControl>
       <FormControl fullWidth>
         <FormLabel>Account Code</FormLabel>
         <ReactHookTextField name="code" control={control} fullWidth />
+        <FormHelperText error>{errors.code?.message}</FormHelperText>
       </FormControl>
       <FormControl>
         <FormLabel>Allowed?</FormLabel>

--- a/src/frontend/src/pages/AdminToolsPage/FinanceConfig/AccountCodesTable.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/FinanceConfig/AccountCodesTable.tsx
@@ -49,7 +49,10 @@ const AccountCodesTable = () => {
       {clickedAccountCode && (
         <EditAccountCodeModal
           showModal={showEditModal}
-          handleClose={() => setShowEditModal(false)}
+          handleClose={() => {
+            setShowEditModal(false);
+            setClickedAccountCode(undefined);
+          }}
           accountCode={clickedAccountCode}
         />
       )}

--- a/src/frontend/src/pages/AdminToolsPage/FinanceConfig/CreateVendorModal.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/FinanceConfig/CreateVendorModal.tsx
@@ -49,7 +49,7 @@ const CreateVendorModal = ({ showModal, handleClose }: NewVendorProps) => {
       open={showModal}
       onHide={handleClose}
       title="New Vendor"
-      reset={reset}
+      reset={() => reset({ name: '' })}
       handleUseFormSubmit={handleSubmit}
       onFormSubmit={onSubmit}
       formId="new-vendor-form"

--- a/src/frontend/src/pages/AdminToolsPage/FinanceConfig/CreateVendorModal.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/FinanceConfig/CreateVendorModal.tsx
@@ -10,7 +10,7 @@ import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
 
 const schema = yup.object().shape({
-  name: yup.string().required('Account Name is Required')
+  name: yup.string().required('Vendor Name is Required')
 });
 
 interface NewVendorProps {

--- a/src/frontend/src/pages/AdminToolsPage/FinanceConfig/CreateVendorModal.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/FinanceConfig/CreateVendorModal.tsx
@@ -36,7 +36,6 @@ const CreateVendorModal = ({ showModal, handleClose }: NewVendorProps) => {
   const {
     handleSubmit,
     control,
-    formState: { isValid },
     reset
   } = useForm({
     mode: 'onChange',
@@ -58,7 +57,6 @@ const CreateVendorModal = ({ showModal, handleClose }: NewVendorProps) => {
       handleUseFormSubmit={handleSubmit}
       onFormSubmit={onSubmit}
       formId="new-vendor-form"
-      disabled={!isValid}
       showCloseButton
     >
       <FormControl>

--- a/src/frontend/src/pages/AdminToolsPage/FinanceConfig/CreateVendorModal.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/FinanceConfig/CreateVendorModal.tsx
@@ -1,6 +1,6 @@
 import { useForm } from 'react-hook-form';
 import NERFormModal from '../../../components/NERFormModal';
-import { FormControl, FormLabel } from '@mui/material';
+import { FormControl, FormLabel, FormHelperText } from '@mui/material';
 import ReactHookTextField from '../../../components/ReactHookTextField';
 import { useCreateVendor } from '../../../hooks/finance.hooks';
 import { useToast } from '../../../hooks/toasts.hooks';
@@ -33,8 +33,12 @@ const CreateVendorModal = ({ showModal, handleClose }: NewVendorProps) => {
     handleClose();
   };
 
-  const { handleSubmit, control, reset } = useForm({
-    mode: 'onChange',
+  const {
+    handleSubmit,
+    control,
+    reset,
+    formState: { errors }
+  } = useForm({
     resolver: yupResolver(schema),
     defaultValues: {
       name: ''
@@ -58,6 +62,7 @@ const CreateVendorModal = ({ showModal, handleClose }: NewVendorProps) => {
       <FormControl>
         <FormLabel>Vendor Name</FormLabel>
         <ReactHookTextField name="name" control={control} sx={{ width: 1 }} />
+        <FormHelperText error>{errors.name?.message}</FormHelperText>
       </FormControl>
     </NERFormModal>
   );

--- a/src/frontend/src/pages/AdminToolsPage/FinanceConfig/CreateVendorModal.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/FinanceConfig/CreateVendorModal.tsx
@@ -33,11 +33,7 @@ const CreateVendorModal = ({ showModal, handleClose }: NewVendorProps) => {
     handleClose();
   };
 
-  const {
-    handleSubmit,
-    control,
-    reset
-  } = useForm({
+  const { handleSubmit, control, reset } = useForm({
     mode: 'onChange',
     resolver: yupResolver(schema),
     defaultValues: {


### PR DESCRIPTION
## Changes

Removed "disabled" props for the elements being returned in AccountCodeFormModal.tsx and CreateVendorModal.tsx and removed unnecessary variable (isValid) in both files.

## Notes

- Error pop ups and "if there's a problem with any for the form fields, the modal doesn't close" seems to be already implemented; once I deleted the disabled props and tried submitting an invalid form, they seemed to work as intended without any further implementation. 
- New Change Request form had it so the error would only pop up on the first field that was invalid (i.e. there is only one error that pops up even if there's multiple sections that aren't filled out) and it is the same case with the Create and Edit Account Code Forms. I left it as is so there's consistency, but if there should be an error under every invalid field, I can look into that.
- While testing the Edit Account Code Form, I noticed a bug; if the Edit Account Code Form is successfully submitted, when you click on it again, the form is autofilled with the old Account Code information (ex: if Account Code information X is what is currently there and you change successfully change it to Account Code information Y, when you click on it again, the Edit Account Code Form fields are auto-populated with information X instead of Y. Let me know if this was intended, if we should open a new ticket for this, etc.

## Screenshots
Screenshots of the enabled submit buttons even when there's invalid fields and tested the ways an error popup can be produced for each of the changed forms.

Create Vendor Form:
<img width="280" alt="New Vendor Submit Enabled" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/92332953/1004ecf2-dcaf-4c20-8fb7-8f358fae381c">
<img width="280" alt="New Vendor Error Popup" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/92332953/c2067b03-d3a9-4195-a384-46929df1b632">

Create Account Code Form:
<img width="540" alt="Create Account Code Submit Enabled" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/92332953/0ad9d295-99e5-46e6-8162-1a5fc08d88a3">
<img width="540" alt="Create Account Code Error 1" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/92332953/2fd85a05-b916-4412-b248-bd1fdb092c27">
<img width="540" alt="Create Account Code Error 2" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/92332953/a15f4157-f3af-4114-866a-6bd2944876c3">
<img width="540" alt="Create Account Code Error Popup 3" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/92332953/dd906de8-9d4c-4289-be62-2034d9553e02">

Edit Account Code Form:
<img width="540" alt="Edit Account Code Submit Enabled" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/92332953/7b04ec42-11ab-481e-b72c-373e77ad05ce">
<img width="540" alt="Edit Account Code Error Popup 1" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/92332953/b88a343a-46d6-4512-9ff7-a2337a3bbce3">
<img width="540" alt="Edit Account Code Error Popup 2" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/92332953/e754495e-0fb2-41e7-86ab-0e96f09ddf8d">
<img width="540" alt="Edit Account Code Error Popup 3" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/92332953/35514add-9548-4bad-83e2-3a397f23405e">


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1287
