### PR TITLE
1292 finance fixes expense types should be displayed with their code

### DIFF
--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
@@ -118,7 +118,10 @@ const ReimbursementRequestDetailsView: React.FC<ReimbursementRequestDetailsViewP
             <VerticalDetailDisplay label="Refund Source" content={`${reimbursementRequest.account}`} />
           </Grid>
           <Grid item sm={6} xs={12}>
-            <VerticalDetailDisplay label="Expense Type" content={`${reimbursementRequest.expenseType.name}`} />
+            <VerticalDetailDisplay
+              label="Expense Type"
+              content={`${reimbursementRequest.expenseType.code} - ${reimbursementRequest.expenseType.name}`}
+            />
           </Grid>
           <Grid item sm={6} xs={12}>
             <VerticalDetailDisplay label="Date Delivered" content={dateUndefinedPipe(reimbursementRequest.dateDelivered)} />

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
@@ -29,6 +29,7 @@ import NERSuccessButton from '../../../components/NERSuccessButton';
 import { ReimbursementRequestFormInput } from './ReimbursementRequestForm';
 import { useState } from 'react';
 import { useToast } from '../../../hooks/toasts.hooks';
+import { expenseTypePipe } from '../../../utils/pipes';
 
 interface ReimbursementRequestFormViewProps {
   allVendors: Vendor[];
@@ -195,7 +196,7 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
                     >
                       {allExpenseTypes.map((expenseType) => (
                         <MenuItem key={expenseType.expenseTypeId} value={expenseType.expenseTypeId}>
-                          {expenseType.name}
+                          {expenseTypePipe(expenseType)}
                         </MenuItem>
                       ))}
                     </Select>

--- a/src/frontend/src/utils/pipes.ts
+++ b/src/frontend/src/utils/pipes.ts
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { WbsNumber, User, wbsPipe, WbsElement } from 'shared';
+import { WbsNumber, User, wbsPipe, WbsElement, ExpenseType } from 'shared';
 
 /**
  * Pipes:
@@ -83,6 +83,10 @@ export const numberParamPipe = (param: string | null) => {
   } catch (err) {
     return null;
   }
+};
+
+export const expenseTypePipe = (expenseType: ExpenseType) => {
+  return `${expenseType.code} - ${expenseType.name}`;
 };
 
 /** Display timeline status in readable form


### PR DESCRIPTION
## Changes

Everything in frontend involving expense type has "Code - Name" format.

## Screenshots
<img width="421" alt="Screen Shot 2023-09-11 at 11 05 47 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/56454934/842afe22-8588-474d-999d-f7a8bd14fcdd">

<img width="689" alt="Screen Shot 2023-09-11 at 11 00 59 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/56454934/8ad46c23-15bf-4cb9-b40c-f254ad9dc608">
-ad49-d00920e980b7">
<img width="695" alt="Screen Shot 2023-09-11 at 11 01 25 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/56454934/094a26bd-1394-4023-b5c4-92dabf6875b6">

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #1292 )
