### PR TITLE
#1187: Heads can now edit project tasks

### DIFF
--- a/src/backend/src/services/tasks.services.ts
+++ b/src/backend/src/services/tasks.services.ts
@@ -94,7 +94,10 @@ export default class TasksService {
    */
   static async editTask(user: User, taskId: string, title: string, notes: string, priority: Task_Priority, deadline: Date) {
     const hasPermission = await hasPermissionToEditTask(user, taskId);
-    if (!hasPermission) throw new AccessDeniedException();
+    if (!hasPermission)
+      throw new AccessDeniedException(
+        'Only admins, app admins, heads, task creators, project leads, project managers, or project assignees can edit a task'
+      );
 
     const originalTask = await prisma.task.findUnique({ where: { taskId } });
     if (!originalTask) throw new NotFoundException('Task', taskId);
@@ -129,7 +132,7 @@ export default class TasksService {
     const hasPermission = await hasPermissionToEditTask(user, taskId);
     if (!hasPermission)
       throw new AccessDeniedException(
-        'Only admins, app admins, task creators, project leads, project managers, or project assignees can edit a task'
+        'Only admins, app admins, heads, task creators, project leads, project managers, or project assignees can edit a task'
       );
 
     const updatedTask = await prisma.task.update({ where: { taskId }, data: { status }, ...taskQueryArgs });

--- a/src/backend/src/services/tasks.services.ts
+++ b/src/backend/src/services/tasks.services.ts
@@ -158,7 +158,7 @@ export default class TasksService {
     const hasPermission = await hasPermissionToEditTask(user, taskId);
     if (!hasPermission)
       throw new AccessDeniedException(
-        'Only admins, app admins, task creators, project leads, project managers, or project assignees can edit a task'
+        'Only admins, app admins, heads, task creators, project leads, project managers, or project assignees can edit a task'
       );
 
     // this throws if any of the users aren't found

--- a/src/backend/tests/tasks.test.ts
+++ b/src/backend/tests/tasks.test.ts
@@ -288,7 +288,7 @@ describe('Tasks', () => {
         TasksService.editTaskAssignees(aquaman, taskId, [superman.userId, wonderwoman.userId])
       ).rejects.toThrow(
         new AccessDeniedException(
-          'Only admins, app admins, task creators, project leads, project managers, or project assignees can edit a task'
+          'Only admins, app admins, heads, task creators, project leads, project managers, or project assignees can edit a task'
         )
       );
     });

--- a/src/backend/tests/tasks.test.ts
+++ b/src/backend/tests/tasks.test.ts
@@ -201,7 +201,7 @@ describe('Tasks', () => {
       // Try updating from IN_PROGRESS to IN_BACKLOG
       await expect(() => TasksService.editTaskStatus(aquaman, taskId, Task_Status.IN_BACKLOG)).rejects.toThrow(
         new AccessDeniedException(
-          'Only admins, app admins, task creators, project leads, project managers, or project assignees can edit a task'
+          'Only admins, app admins, heads, task creators, project leads, project managers, or project assignees can edit a task'
         )
       );
     });
@@ -216,7 +216,7 @@ describe('Tasks', () => {
       // Aquaman is a leader, but did not create this task
       await expect(() => TasksService.editTaskStatus(aquaman, taskId, Task_Status.IN_BACKLOG)).rejects.toThrow(
         new AccessDeniedException(
-          'Only admins, app admins, task creators, project leads, project managers, or project assignees can edit a task'
+          'Only admins, app admins, heads, task creators, project leads, project managers, or project assignees can edit a task'
         )
       );
     });
@@ -391,7 +391,11 @@ describe('Tasks', () => {
       vi.spyOn(taskUtils, 'hasPermissionToEditTask').mockResolvedValue(false);
       await expect(() =>
         TasksService.editTask(wonderwoman, taskId, fakeTitle, fakeNotes, fakePriority, fakeDeadline)
-      ).rejects.toThrow(new AccessDeniedException());
+      ).rejects.toThrow(
+        new AccessDeniedException(
+          'Only admins, app admins, heads, task creators, project leads, project managers, or project assignees can edit a task'
+        )
+      );
     });
 
     test('Task not found', async () => {

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/TaskListTabPanel.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/TaskListTabPanel.tsx
@@ -123,6 +123,7 @@ const TaskListTabPanel = (props: TaskListTabPanelProps) => {
       (auth.user.role === 'APP_ADMIN' ||
         auth.user.role === 'ADMIN' ||
         auth.user.role === 'LEADERSHIP' ||
+        auth.user.role === 'HEAD' ||
         project.projectLead?.userId === auth.user.userId ||
         project.projectManager?.userId === auth.user.userId ||
         task.assignees.map((u) => u.userId).includes(auth.user.userId) ||


### PR DESCRIPTION
## Changes

**Frontend:** Went into `src\frontend\src\pages\ProjectDetailPage\ProjectViewContainer\TaskList\TaskListTabPanel.tsx` and add `auth.user.role == 'HEAD' ||` on line 126. 

**Backend:** Went into `src\backend\src\services\tasks.services.ts` and added "heads," to the AccessDeniedException message "'Only admins, app admins, heads, task creators, project leads, project managers, or project assignees can edit a task'"

**Test:** Went into `src\backend\tests\tasks.test.ts` and changed the test on line 291 so that the test for the backend AccessDeniedException message passes. 

## Screenshots

![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/119642092/45a0b1b2-d215-4992-a47f-c6ebdea2802f)

![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/119642092/ec7e8c1e-821f-4881-9cef-95f2154d6eb6)

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1187 (issue #)