### PR TITLE
#1293: Added the code of the refund sources to prefix their names

### DIFF
--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
@@ -29,6 +29,7 @@ import NERSuccessButton from '../../../components/NERSuccessButton';
 import { ReimbursementRequestFormInput } from './ReimbursementRequestForm';
 import { useState } from 'react';
 import { useToast } from '../../../hooks/toasts.hooks';
+import { refundSourceToCodeName } from '../../../utils/pipes';
 
 interface ReimbursementRequestFormViewProps {
   allVendors: Vendor[];
@@ -142,7 +143,7 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
                   >
                     {Object.values(ClubAccount).map((account) => (
                       <MenuItem key={account} value={account}>
-                        {account}
+                        {refundSourceToCodeName(account, account === ClubAccount.CASH ? 830667 : 800462)}
                       </MenuItem>
                     ))}
                   </Select>

--- a/src/frontend/src/utils/pipes.ts
+++ b/src/frontend/src/utils/pipes.ts
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { WbsNumber, User, wbsPipe, WbsElement } from 'shared';
+import { WbsNumber, User, wbsPipe, WbsElement, ClubAccount } from 'shared';
 
 /**
  * Pipes:
@@ -123,4 +123,9 @@ export const dateUndefinedPipe = (date?: Date): string => {
 
 export const centsToDollar = (cents: number) => {
   return (cents / 100.0).toFixed(2);
+};
+
+/** Displays a refund source as a string "Code - Name" */
+export const refundSourceToCodeName = (refundSource: ClubAccount, refundCode: number) => {
+  return `${refundCode}-${refundSource}`;
 };


### PR DESCRIPTION
## Changes

Created a new pipe in order to prefix the name of the refund sources with their assigned codes and replaced the call to ClubAccount's properties(CASH, BUDGET) to the call of the pipe which took in arguments of the ClubAccount's properties and their assigned code to display them in the manner of 'CODE-NAME'.

## Screenshots

<img width="343" alt="Screenshot 2023-09-15 at 4 04 10 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/23368417/c1f29a14-0113-4247-8b5b-a69a236f1f38">

<img width="1508" alt="Screenshot 2023-09-15 at 4 02 00 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/23368417/5f8c3987-4cec-4766-9937-d418c784bce3">

<img width="1506" alt="Screenshot 2023-09-15 at 4 01 37 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/23368417/1b567a59-ddc6-48d5-9e7a-342c0acad660">

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
closes #1293 