### PR TITLE
#1289 change expense type to autocomplete

### DIFF
--- a/src/frontend/src/components/NERAutocomplete.tsx
+++ b/src/frontend/src/components/NERAutocomplete.tsx
@@ -44,11 +44,8 @@ const NERAutocomplete: React.FC<NERAutocompleteProps> = ({
     height: '40px',
     backgroundColor: theme.palette.background.default,
     width: '100%',
-    border: '2px black',
-    borderRadius: '25px',
-    '&.Mui-focused': {
-      borderColor: 'red'
-    },
+    border: 0,
+    borderColor: 'black',
     ...sx
   };
 

--- a/src/frontend/src/components/NERAutocomplete.tsx
+++ b/src/frontend/src/components/NERAutocomplete.tsx
@@ -3,16 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import {
-  Autocomplete,
-  AutocompleteRenderInputParams,
-  InputAdornment,
-  SxProps,
-  TextField,
-  Theme,
-  useTheme
-} from '@mui/material';
-import SearchIcon from '@mui/icons-material/Search';
+import { Autocomplete, AutocompleteRenderInputParams, SxProps, TextField, Theme, useTheme } from '@mui/material';
 import { HTMLAttributes } from 'react';
 
 interface NERAutocompleteProps {

--- a/src/frontend/src/components/NERAutocomplete.tsx
+++ b/src/frontend/src/components/NERAutocomplete.tsx
@@ -44,13 +44,9 @@ const NERAutocomplete: React.FC<NERAutocompleteProps> = ({
     height: '40px',
     backgroundColor: theme.palette.background.default,
     width: '100%',
+    border: '2px black',
     borderRadius: '25px',
-    border: 0,
-    '.MuiOutlinedInput-notchedOutline': {
-      borderColor: 'black',
-      borderRadius: '25px'
-    },
-    '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+    '&.Mui-focused': {
       borderColor: 'red'
     },
     ...sx
@@ -61,12 +57,7 @@ const NERAutocomplete: React.FC<NERAutocompleteProps> = ({
       <TextField
         {...params}
         InputProps={{
-          ...params.InputProps,
-          startAdornment: (
-            <InputAdornment position="start">
-              <SearchIcon />
-            </InputAdornment>
-          )
+          ...params.InputProps
         }}
         placeholder={placeholder}
         required

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
@@ -1,5 +1,6 @@
 import { Delete } from '@mui/icons-material';
 import {
+  Autocomplete,
   FormControl,
   FormHelperText,
   FormLabel,
@@ -188,17 +189,17 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
                   name="expenseTypeId"
                   control={control}
                   render={({ field: { onChange, value } }) => (
-                    <Select
-                      onChange={(newValue) => onChange(newValue.target.value)}
-                      value={value}
-                      error={!!errors.expenseTypeId}
-                    >
-                      {allExpenseTypes.map((expenseType) => (
-                        <MenuItem key={expenseType.expenseTypeId} value={expenseType.expenseTypeId}>
-                          {expenseType.name}
-                        </MenuItem>
-                      ))}
-                    </Select>
+                    <Autocomplete
+                      options={allExpenseTypes}
+                      getOptionLabel={(expenseType) => expenseType.name}
+                      value={allExpenseTypes.find((expenseType) => expenseType.expenseTypeId === value) || null}
+                      onChange={(_event, newValue) => {
+                        if (newValue) {
+                          onChange(newValue.expenseTypeId);
+                        }
+                      }}
+                      renderInput={(params) => <TextField {...params} label="Expense Type" error={!!errors.expenseTypeId} />}
+                    />
                   )}
                 />
                 <FormHelperText error>{errors.expenseTypeId?.message}</FormHelperText>

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
@@ -1,6 +1,5 @@
 import { Delete } from '@mui/icons-material';
 import {
-  Autocomplete,
   FormControl,
   FormHelperText,
   FormLabel,
@@ -34,7 +33,6 @@ import { ReimbursementRequestFormInput } from './ReimbursementRequestForm';
 import { useState } from 'react';
 import { useToast } from '../../../hooks/toasts.hooks';
 import NERAutocomplete from '../../../components/NERAutocomplete';
-import { fullNamePipe } from '../../../utils/pipes';
 import { Link as RouterLink } from 'react-router-dom';
 import { routes } from '../../../utils/routes';
 import { codeAndRefundSourceName, expenseTypePipe } from '../../../utils/pipes';

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
@@ -199,7 +199,7 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
                     return (
                       <NERAutocomplete
                         id={'expenseType'}
-                        size="small"
+                        size="medium"
                         options={mappedExpenseTypes}
                         value={mappedExpenseTypes.find((expenseType) => expenseType.id === value) || null}
                         placeholder="Expense Type"

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
@@ -194,7 +194,6 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
                   name="expenseTypeId"
                   control={control}
                   render={({ field: { onChange, value } }) => {
-                    const selectedExpenseType = allExpenseTypes.find((expenseType) => expenseType.expenseTypeId === value);
                     return (
                       <NERAutocomplete
                         options={allExpenseTypes.map(expenseTypesToAutocomplete)}
@@ -207,6 +206,8 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
                         onChange={(_event, newValue) => {
                           if (newValue) {
                             onChange(newValue.label);
+                          } else {
+                            onChange('');
                           }
                         }}
                         id={'expenseType'}

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
@@ -1,5 +1,6 @@
 import { Delete } from '@mui/icons-material';
 import {
+  Autocomplete,
   FormControl,
   FormHelperText,
   FormLabel,
@@ -197,14 +198,14 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
                     const mappedExpenseTypes = allExpenseTypes.map(expenseTypesToAutocomplete);
                     return (
                       <NERAutocomplete
+                        id={'expenseType'}
+                        size="small"
                         options={mappedExpenseTypes}
                         value={mappedExpenseTypes.find((expenseType) => expenseType.id === value) || null}
                         placeholder="Expense Type"
                         onChange={(_event, newValue) => {
                           newValue ? onChange(newValue.id) : onChange('');
                         }}
-                        id={'expenseType'}
-                        size="small"
                       />
                     );
                   }}

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
@@ -198,7 +198,9 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
                           onChange(newValue.expenseTypeId);
                         }
                       }}
-                      renderInput={(params) => <TextField {...params} label="Expense Type" error={!!errors.expenseTypeId} />}
+                      renderInput={(params) => (
+                        <TextField {...params} placeholder="Expense Type" error={!!errors.expenseTypeId} />
+                      )}
                     />
                   )}
                 />

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
@@ -192,15 +192,13 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
                     <Autocomplete
                       options={allExpenseTypes}
                       getOptionLabel={(expenseType) => expenseType.name}
-                      value={allExpenseTypes.find((expenseType) => expenseType.expenseTypeId === value) || null}
+                      value={allExpenseTypes.find((expenseType) => expenseType.expenseTypeId === value)}
                       onChange={(_event, newValue) => {
                         if (newValue) {
                           onChange(newValue.expenseTypeId);
                         }
                       }}
-                      renderInput={(params) => (
-                        <TextField {...params} placeholder="Expense Type" error={!!errors.expenseTypeId} />
-                      )}
+                      renderInput={(params) => <TextField {...params} placeholder="Expense Type" />}
                     />
                   )}
                 />

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
@@ -102,8 +102,8 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
     </FormControl>
   );
 
-  const expenseTypesToAutocomplete = (expense: ExpenseType): { label: string; id: string } => {
-    return { label: expense.name, id: expense.toString() };
+  const expenseTypesToAutocomplete = (expenseType: ExpenseType): { label: string; id: string } => {
+    return { label: expenseType.name, id: expenseType.expenseTypeId };
   };
 
   return (
@@ -194,24 +194,17 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
                   name="expenseTypeId"
                   control={control}
                   render={({ field: { onChange, value } }) => {
+                    const mappedExpenseTypes = allExpenseTypes.map(expenseTypesToAutocomplete);
                     return (
                       <NERAutocomplete
-                        options={allExpenseTypes.map(expenseTypesToAutocomplete)}
-                        value={
-                          allExpenseTypes
-                            .map(expenseTypesToAutocomplete)
-                            .find((expenseType) => expenseType.label === value) || null
-                        }
+                        options={mappedExpenseTypes}
+                        value={mappedExpenseTypes.find((expenseType) => expenseType.id === value) || null}
                         placeholder="Expense Type"
                         onChange={(_event, newValue) => {
-                          if (newValue) {
-                            onChange(newValue.label);
-                          } else {
-                            onChange('');
-                          }
+                          newValue ? onChange(newValue.id) : onChange('');
                         }}
                         id={'expenseType'}
-                        size={undefined}
+                        size="small"
                       />
                     );
                   }}

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
@@ -1,6 +1,5 @@
 import { Delete } from '@mui/icons-material';
 import {
-  Autocomplete,
   FormControl,
   FormHelperText,
   FormLabel,
@@ -30,6 +29,8 @@ import NERSuccessButton from '../../../components/NERSuccessButton';
 import { ReimbursementRequestFormInput } from './ReimbursementRequestForm';
 import { useState } from 'react';
 import { useToast } from '../../../hooks/toasts.hooks';
+import NERAutocomplete from '../../../components/NERAutocomplete';
+import { fullNamePipe } from '../../../utils/pipes';
 
 interface ReimbursementRequestFormViewProps {
   allVendors: Vendor[];
@@ -100,6 +101,10 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
       </ul>
     </FormControl>
   );
+
+  const expenseTypesToAutocomplete = (expense: ExpenseType): { label: string; id: string } => {
+    return { label: expense.name, id: expense.toString() };
+  };
 
   return (
     <form
@@ -188,19 +193,27 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
                 <Controller
                   name="expenseTypeId"
                   control={control}
-                  render={({ field: { onChange, value } }) => (
-                    <Autocomplete
-                      options={allExpenseTypes}
-                      getOptionLabel={(expenseType) => expenseType.name}
-                      value={allExpenseTypes.find((expenseType) => expenseType.expenseTypeId === value)}
-                      onChange={(_event, newValue) => {
-                        if (newValue) {
-                          onChange(newValue.expenseTypeId);
+                  render={({ field: { onChange, value } }) => {
+                    const selectedExpenseType = allExpenseTypes.find((expenseType) => expenseType.expenseTypeId === value);
+                    return (
+                      <NERAutocomplete
+                        options={allExpenseTypes.map(expenseTypesToAutocomplete)}
+                        value={
+                          allExpenseTypes
+                            .map(expenseTypesToAutocomplete)
+                            .find((expenseType) => expenseType.label === value) || null
                         }
-                      }}
-                      renderInput={(params) => <TextField {...params} placeholder="Expense Type" />}
-                    />
-                  )}
+                        placeholder="Expense Type"
+                        onChange={(_event, newValue) => {
+                          if (newValue) {
+                            onChange(newValue.label);
+                          }
+                        }}
+                        id={'expenseType'}
+                        size={undefined}
+                      />
+                    );
+                  }}
                 />
                 <FormHelperText error>{errors.expenseTypeId?.message}</FormHelperText>
               </FormControl>


### PR DESCRIPTION
## Changes

the create/edit reimbursement request form is now an autocomplete select
The create and edit forms functionality should be unaffected
NERAutocomplete now looks like NativeSelect
## Notes

_Any other notes go here_

## Test Cases

- Case A
- Edge case
- ...

## Screenshots

<img width="519" alt="expenseTypeSmall" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/126923741/b683b11b-e239-401d-b09a-3ff35a9b548b">
<img width="1440" alt="expenseTypeLarge" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/126923741/643aa262-4b4b-4a4a-8b87-974aaff6e1ac">


_Any remaining things that need to get done_

- [ ] item 1
- [ ] ...

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #1289 
