### PR TITLE
#1314 Version number overlaping sidebar

### DIFF
--- a/src/frontend/src/layouts/Sidebar/Sidebar.tsx
+++ b/src/frontend/src/layouts/Sidebar/Sidebar.tsx
@@ -79,11 +79,13 @@ const Sidebar: React.FC<SideBarProps> = ({ open, handleDrawerClose }) => {
         flex={1}
         justifyContent={'space-between'}
       >
-        {linkItems.map((linkItem) => (
-          <NavPageLink {...linkItem} open={open} />
-        ))}
+        <Box>
+          {linkItems.map((linkItem) => (
+            <NavPageLink {...linkItem} open={open} />
+          ))}
+        </Box>
+        <Typography className={styles.versionNumber}>4.0.0</Typography>
       </Box>
-      <Typography className={styles.versionNumber}>4.0.0</Typography>
     </NERDrawer>
   );
 };

--- a/src/frontend/src/layouts/Sidebar/Sidebar.tsx
+++ b/src/frontend/src/layouts/Sidebar/Sidebar.tsx
@@ -75,8 +75,8 @@ const Sidebar: React.FC<SideBarProps> = ({ open, handleDrawerClose }) => {
         {linkItems.map((linkItem) => (
           <NavPageLink {...linkItem} open={open} />
         ))}
-        <Typography className={styles.versionNumber}>4.0.0</Typography>
       </Box>
+      <Typography className={styles.versionNumber}>4.0.0</Typography>
     </NERDrawer>
   );
 };

--- a/src/frontend/src/layouts/Sidebar/Sidebar.tsx
+++ b/src/frontend/src/layouts/Sidebar/Sidebar.tsx
@@ -71,7 +71,14 @@ const Sidebar: React.FC<SideBarProps> = ({ open, handleDrawerClose }) => {
         <IconButton onClick={handleDrawerClose}>{theme.direction === 'rtl' ? <ChevronRight /> : <ChevronLeft />}</IconButton>
       </DrawerHeader>
       <Divider />
-      <Box overflow={'auto'} sx={{ overflowX: 'hidden' }}>
+      <Box
+        overflow={'auto'}
+        sx={{ overflowX: 'hidden' }}
+        display="flex"
+        flexDirection={'column'}
+        flex={1}
+        justifyContent={'space-between'}
+      >
         {linkItems.map((linkItem) => (
           <NavPageLink {...linkItem} open={open} />
         ))}

--- a/src/frontend/src/stylesheets/layouts/sidebar/sidebar.module.css
+++ b/src/frontend/src/stylesheets/layouts/sidebar/sidebar.module.css
@@ -14,10 +14,11 @@
 }
 
 .versionNumber {
-  position: absolute;
+  position: relative;
   text-align: center;
   color: #ffffff;
-  width: 100%;
   bottom: 0;
+  width: 100%;
   height: 6em;
+  padding-top: 4em;
 }

--- a/src/frontend/src/stylesheets/layouts/sidebar/sidebar.module.css
+++ b/src/frontend/src/stylesheets/layouts/sidebar/sidebar.module.css
@@ -17,8 +17,6 @@
   position: relative;
   text-align: center;
   color: #ffffff;
-  bottom: 0;
   width: 100%;
-  height: 6em;
-  padding-top: 4em;
+  padding-bottom: 3em;
 }

--- a/src/frontend/src/stylesheets/layouts/sidebar/sidebar.module.css
+++ b/src/frontend/src/stylesheets/layouts/sidebar/sidebar.module.css
@@ -18,5 +18,5 @@
   text-align: center;
   color: #ffffff;
   width: 100%;
-  padding-bottom: 3em;
+  padding-bottom: 2em;
 }


### PR DESCRIPTION
## Changes

I fixed the issue where the version number overlaps the sidebar when the window gets to small. I did this by changing the position of the version number from "absolute" to "relative" in the css file. I then moved it outside of the sidebar box so it stays visible as the window gets smaller. I also added some padding on top of the version number to keep the spacing.

## Test Cases

1) Screen is really small vertically
 - The side links turn into a scrollbar, so that the version number doesn't overlap the links.

## Screenshots

Focusing on the appearance of the navigation bar and version number on the left

![1314_1](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/41128621/6938ff71-d441-41e0-8af9-998a2531d1f3)
![1314_2](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/41128621/48ec5074-917f-44af-b4eb-9f92a8b94da0)
![1314_3](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/41128621/5fac5e7b-0899-419e-8e31-b88b1eddb877)

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1314
