### PR TITLE
#1278 added a xs sizing to Grid components for the Admin Tools Financ…

### DIFF
--- a/src/frontend/src/pages/AdminToolsPage/AdminToolsFinanceConfig.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/AdminToolsFinanceConfig.tsx
@@ -7,10 +7,10 @@ const AdminToolsFinanceConfig: React.FC = () => {
   return (
     <PageBlock title="Finance Config">
       <Grid container spacing="3%">
-        <Grid item direction="column" xs={6}>
+        <Grid item direction="column" xs={12} md={6}>
           <VendorsTable />
         </Grid>
-        <Grid item direction="column" alignSelf="right" xs={6}>
+        <Grid item direction="column" alignSelf="right" xs={12} md={6}>
           <AccountCodesTable />
         </Grid>
       </Grid>


### PR DESCRIPTION
## Changes

Defined a width of 12 for grid components for sizes xs and above, and a width of 6 for grid components for sizes md and above. This forces the account code and vendor tables to be on separate lines for screen sizes below md.

## Screenshots

<img width="1440" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/44937958/d9ed6eb3-521d-4e22-b15f-444d84487e10">

<img width="579" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/44937958/1cfdb017-4b82-432e-8615-d53d2fdc6fa4">

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1278 
