### PR TITLE
#1300 Added error text to start date in work package edit

### DIFF
--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditDetails.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditDetails.tsx
@@ -83,16 +83,28 @@ const WorkPackageEditDetails: React.FC<Props> = ({
             <Controller
               name="startDate"
               control={control}
-              rules={{ required: true }}
+              rules={{ required: 'Start date is required' }}
               render={({ field: { onChange, value } }) => (
                 <>
                   <DatePicker
                     inputFormat="yyyy-MM-dd"
                     onChange={(date) => onChange(date ?? new Date())}
-                    className={'padding: 10'}
                     value={value}
                     shouldDisableDate={disableStartDate}
-                    renderInput={(params) => <TextField autoComplete="off" {...params} />}
+                    renderInput={(params) => (
+                      <TextField
+                        autoComplete="off"
+                        {...params}
+                        error={!!errors.startDate}
+                        helperText={
+                          errors.startDate?.type === 'required'
+                            ? 'Start date is required'
+                            : errors.startDate
+                            ? 'Please enter a valid date (YYYY-MM-DD)'
+                            : null
+                        }
+                      />
+                    )}
                   />
                 </>
               )}

--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditDetails.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditDetails.tsx
@@ -117,13 +117,13 @@ const WorkPackageEditDetails: React.FC<Props> = ({
                         {...params}
                         error={!!error && error.type !== 'clear'}
                         helperText={
-                          error?.type === 'required'
+                          error && error.type === 'required'
                             ? 'Start date is required'
-                            : error?.type === 'notMonday'
+                            : error && error.type === 'notMonday'
                             ? 'Work Packages should always start on Mondays'
-                            : error?.type === 'invalidDate'
+                            : error && error.type === 'invalidDate'
                             ? 'Please enter a valid date (YYYY-MM-DD)'
-                            : ''
+                            : undefined
                         }
                       />
                     )}

--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditDetails.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditDetails.tsx
@@ -83,25 +83,47 @@ const WorkPackageEditDetails: React.FC<Props> = ({
             <Controller
               name="startDate"
               control={control}
-              rules={{ required: 'Start date is required' }}
-              render={({ field: { onChange, value } }) => (
+              rules={{ required: true }}
+              render={({ field: { onChange, value }, fieldState: { error } }) => (
                 <>
                   <DatePicker
                     inputFormat="yyyy-MM-dd"
-                    onChange={(date) => onChange(date ?? new Date())}
+                    onChange={(date) => {
+                      // Check if the date is a valid date
+                      if (date && isNaN(date.getTime())) {
+                        control.setError('startDate', {
+                          type: 'invalidDate',
+                          message: 'Please enter a valid date (YYYY-MM-DD)'
+                        });
+                      }
+                      // Check if the date is a Monday
+                      else if (date && date.getDay() !== 1) {
+                        control.setError('startDate', {
+                          type: 'notMonday',
+                          message: 'Work Packages should always start on Mondays'
+                        });
+                      } else {
+                        // If it's a valid date and a Monday, clear any existing errors and update the date
+                        control.setError('startDate', { type: 'clear', message: '' }); // clear the error
+                        onChange(date ?? new Date());
+                      }
+                    }}
+                    className={'padding: 10'}
                     value={value}
                     shouldDisableDate={disableStartDate}
                     renderInput={(params) => (
                       <TextField
                         autoComplete="off"
                         {...params}
-                        error={!!errors.startDate}
+                        error={!!error && error.type !== 'clear'}
                         helperText={
-                          errors.startDate?.type === 'required'
+                          error?.type === 'required'
                             ? 'Start date is required'
-                            : errors.startDate
+                            : error?.type === 'notMonday'
+                            ? 'Work Packages should always start on Mondays'
+                            : error?.type === 'invalidDate'
                             ? 'Please enter a valid date (YYYY-MM-DD)'
-                            : null
+                            : ''
                         }
                       />
                     )}


### PR DESCRIPTION
## Changes

Added a user-friendly error message which pops up when a non-valid date is entered into the start date field of work package edit.

## Screenshots

![Uploading Screen Shot 2023-09-21 at 9.37.07 PM.png…]()
<img width="1728" alt="Screen Shot 2023-09-21 at 9 36 22 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/120525697/61c016f0-8d8b-42ca-b88b-1cfd9c26cb2c">
<img width="265" alt="Screen Shot 2023-09-21 at 9 27 27 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/120525697/a55b4549-acd8-4b5f-a1c5-55c7ef07b8b9">


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #1300 (issue #)
