### PR TITLE
#1481: removed use of the any type

### DIFF
--- a/src/frontend/src/apis/finance.api.ts
+++ b/src/frontend/src/apis/finance.api.ts
@@ -84,8 +84,7 @@ export const deleteReimbursementRequest = (id: string) => {
 export const getAllExpenseTypes = () => {
   return axios.get(apiUrls.getAllExpenseTypes(), {
     transformResponse: (data) => {
-      const parsedData = JSON.parse(data) as ExpenseType[];
-      return parsedData.map((expenseType) => ({ ...expenseType, id: expenseType.expenseTypeId }));
+      return JSON.parse(data) as ExpenseType[];
     }
   });
 };

--- a/src/frontend/src/apis/finance.api.ts
+++ b/src/frontend/src/apis/finance.api.ts
@@ -16,6 +16,7 @@ import {
 } from './transformers/reimbursement-requests.transformer';
 import { saveAs } from 'file-saver';
 import { PDFDocument, PDFImage } from 'pdf-lib';
+import { ExpenseType } from 'shared';
 
 enum AllowedFileType {
   JPEG = 'image/jpeg',
@@ -82,8 +83,10 @@ export const deleteReimbursementRequest = (id: string) => {
  */
 export const getAllExpenseTypes = () => {
   return axios.get(apiUrls.getAllExpenseTypes(), {
-    transformResponse: (data) =>
-      JSON.parse(data).map((expenseType: any) => ({ ...expenseType, id: expenseType.expenseTypeId }))
+    transformResponse: (data) => {
+      const parsedData = JSON.parse(data) as ExpenseType[];
+      return parsedData.map((expenseType) => ({ ...expenseType, id: expenseType.expenseTypeId }));
+    }
   });
 };
 


### PR DESCRIPTION
## Changes

removed usage of `any` type in getAllExpenseTypes function

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1481
