### PR TITLE
#1330: mimicked the wp create endpoint as much as wp edit endpoint

### DIFF
--- a/src/backend/src/controllers/work-packages.controllers.ts
+++ b/src/backend/src/controllers/work-packages.controllers.ts
@@ -32,8 +32,7 @@ export default class WorkPackagesController {
   // Create a work package with the given details
   static async createWorkPackage(req: Request, res: Response, next: NextFunction) {
     try {
-      const { name, crId, startDate, duration, blockedBy, expectedActivities, deliverables, projectLead, projectManager } =
-        req.body;
+      const { name, crId, startDate, duration, blockedBy, expectedActivities, deliverables } = req.body;
 
       let { stage } = req.body;
       if (stage === 'NONE') {
@@ -51,9 +50,7 @@ export default class WorkPackagesController {
         duration,
         blockedBy,
         expectedActivities,
-        deliverables,
-        projectLead,
-        projectManager
+        deliverables
       );
 
       res.status(200).json(wbsString);

--- a/src/backend/src/controllers/work-packages.controllers.ts
+++ b/src/backend/src/controllers/work-packages.controllers.ts
@@ -32,7 +32,8 @@ export default class WorkPackagesController {
   // Create a work package with the given details
   static async createWorkPackage(req: Request, res: Response, next: NextFunction) {
     try {
-      const { projectWbsNum, name, crId, startDate, duration, blockedBy, expectedActivities, deliverables } = req.body;
+      const { name, crId, startDate, duration, blockedBy, expectedActivities, deliverables, projectLead, projectManager } =
+        req.body;
 
       let { stage } = req.body;
       if (stage === 'NONE') {
@@ -43,7 +44,6 @@ export default class WorkPackagesController {
 
       const wbsString: string = await WorkPackagesService.createWorkPackage(
         user,
-        projectWbsNum,
         name,
         crId,
         stage,
@@ -51,7 +51,9 @@ export default class WorkPackagesController {
         duration,
         blockedBy,
         expectedActivities,
-        deliverables
+        deliverables,
+        projectLead,
+        projectManager
       );
 
       res.status(200).json(wbsString);

--- a/src/backend/src/prisma/seed-data/work-packages.seed.ts
+++ b/src/backend/src/prisma/seed-data/work-packages.seed.ts
@@ -18,7 +18,6 @@ import { descBulletConverter } from '../../utils/description-bullets.utils';
  */
 export const seedWorkPackage = async (
   creator: User,
-  projectWbsNumber: WbsNumber,
   name: string,
   changeRequestId: number,
   stage: WorkPackageStage | null,
@@ -44,9 +43,7 @@ export const seedWorkPackage = async (
     duration,
     blockedBy,
     expectedActivities,
-    deliverables,
-    projectLead,
-    projectManager
+    deliverables
   );
 
   const workPackageWbsNumber = validateWBS(workPackage1WbsString);

--- a/src/backend/src/prisma/seed-data/work-packages.seed.ts
+++ b/src/backend/src/prisma/seed-data/work-packages.seed.ts
@@ -37,7 +37,6 @@ export const seedWorkPackage = async (
 }> => {
   const workPackage1WbsString = await WorkPackagesService.createWorkPackage(
     creator,
-    projectWbsNumber,
     name,
     changeRequestId,
     stage,
@@ -45,7 +44,9 @@ export const seedWorkPackage = async (
     duration,
     blockedBy,
     expectedActivities,
-    deliverables
+    deliverables,
+    projectLead,
+    projectManager
   );
 
   const workPackageWbsNumber = validateWBS(workPackage1WbsString);

--- a/src/backend/src/prisma/seed.ts
+++ b/src/backend/src/prisma/seed.ts
@@ -317,13 +317,59 @@ const performSeed: () => Promise<void> = async () => {
   );
 
   /**
+   * Make approved change requests that has project 1 and 5 as wbs element
+   */
+
+  const changeRequest2Id = await ChangeRequestsService.createStandardChangeRequest(
+    thomasEmrax,
+    project1WbsNumber.carNumber,
+    project1WbsNumber.projectNumber,
+    project1WbsNumber.workPackageNumber,
+    CR_Type.DEFINITION_CHANGE,
+    'Remove the uncessary rule',
+    [{ type: Scope_CR_Why_Type.DESIGN, explain: 'The rule has changed' }]
+  );
+
+  const proposedSolution2Id = await ChangeRequestsService.addProposedSolution(
+    thomasEmrax,
+    changeRequest2Id,
+    50,
+    'Remove the rule',
+    1,
+    'n/a'
+  );
+
+  await ChangeRequestsService.reviewChangeRequest(joeShmoe, changeRequest2Id, 'LGTM', true, proposedSolution2Id);
+
+  const changeRequest3Id = await ChangeRequestsService.createStandardChangeRequest(
+    thomasEmrax,
+    project5WbsNumber.carNumber,
+    project5WbsNumber.projectNumber,
+    project5WbsNumber.workPackageNumber,
+    CR_Type.ISSUE,
+    'Change the wire material',
+    [{ type: Scope_CR_Why_Type.MAINTENANCE, explain: 'It would be better to maintain' }]
+  );
+
+  const proposedSolution3Id = await ChangeRequestsService.addProposedSolution(
+    thomasEmrax,
+    changeRequest3Id,
+    50,
+    'Change to better wire material',
+    1,
+    'n/a'
+  );
+
+  await ChangeRequestsService.reviewChangeRequest(joeShmoe, changeRequest3Id, 'LGTM', true, proposedSolution3Id);
+
+  /**
    * Work Packages
    */
   /** Work Package 1 */
   const { workPackageWbsNumber: workPackage1WbsNumber, workPackage: workPackage1 } = await seedWorkPackage(
     joeShmoe,
     'Bodywork Concept of Design',
-    changeRequest1Id,
+    changeRequest2Id,
     WorkPackageStage.Design,
     '01/01/2023',
     3,
@@ -363,7 +409,7 @@ const performSeed: () => Promise<void> = async () => {
   const { workPackageWbsNumber: workPackage2WbsNumber, workPackage: workPackage2 } = await seedWorkPackage(
     thomasEmrax,
     'Adhesive Shear Strength Test',
-    changeRequest1Id,
+    changeRequest2Id,
     WorkPackageStage.Research,
     '01/22/2023',
     5,
@@ -386,7 +432,7 @@ const performSeed: () => Promise<void> = async () => {
   const workPackage3WbsString = await WorkPackagesService.createWorkPackage(
     thomasEmrax,
     'Manufacture Wiring Harness',
-    changeRequest1Id,
+    changeRequest3Id,
     WorkPackageStage.Manufacturing,
     '02/01/2023',
     3,
@@ -413,7 +459,7 @@ const performSeed: () => Promise<void> = async () => {
     true
   );
 
-  const changeRequest2Id = await ChangeRequestsService.createStandardChangeRequest(
+  const changeRequest4Id = await ChangeRequestsService.createStandardChangeRequest(
     thomasEmrax,
     project2WbsNumber.carNumber,
     project2WbsNumber.projectNumber,
@@ -425,16 +471,16 @@ const performSeed: () => Promise<void> = async () => {
       { type: Scope_CR_Why_Type.ESTIMATION, explain: 'I estimate that it would be really pretty' }
     ]
   );
-  await ChangeRequestsService.addProposedSolution(thomasEmrax, changeRequest2Id, 50, 'Buy hot pink paint', 1, 'n/a');
+  await ChangeRequestsService.addProposedSolution(thomasEmrax, changeRequest4Id, 50, 'Buy hot pink paint', 1, 'n/a');
   await ChangeRequestsService.addProposedSolution(
     thomasEmrax,
-    changeRequest2Id,
+    changeRequest4Id,
     40,
     'Buy slightly cheaper but lower quality hot pink paint',
     1,
     'n/a'
   );
-  await ChangeRequestsService.reviewChangeRequest(joeShmoe, changeRequest2Id, 'What the hell Thomas', false, null);
+  await ChangeRequestsService.reviewChangeRequest(joeShmoe, changeRequest4Id, 'What the hell Thomas', false, null);
 
   await ChangeRequestsService.createActivationChangeRequest(
     thomasEmrax,

--- a/src/backend/src/prisma/seed.ts
+++ b/src/backend/src/prisma/seed.ts
@@ -322,7 +322,6 @@ const performSeed: () => Promise<void> = async () => {
   /** Work Package 1 */
   const { workPackageWbsNumber: workPackage1WbsNumber, workPackage: workPackage1 } = await seedWorkPackage(
     joeShmoe,
-    project1WbsNumber,
     'Bodywork Concept of Design',
     changeRequest1Id,
     WorkPackageStage.Design,
@@ -363,7 +362,6 @@ const performSeed: () => Promise<void> = async () => {
   /** Work Package 2 */
   const { workPackageWbsNumber: workPackage2WbsNumber, workPackage: workPackage2 } = await seedWorkPackage(
     thomasEmrax,
-    project1WbsNumber,
     'Adhesive Shear Strength Test',
     changeRequest1Id,
     WorkPackageStage.Research,
@@ -399,9 +397,7 @@ const performSeed: () => Promise<void> = async () => {
       'Solder wiring segments together and heat shrink properly',
       'Cut all wires to length'
     ],
-    ['Completed wiring harness for the entire car'],
-    joeShmoe.userId,
-    thomasEmrax.userId
+    ['Completed wiring harness for the entire car']
   );
   const workPackage3WbsNumber = validateWBS(workPackage3WbsString);
 

--- a/src/backend/src/prisma/seed.ts
+++ b/src/backend/src/prisma/seed.ts
@@ -387,7 +387,6 @@ const performSeed: () => Promise<void> = async () => {
   /** Work Package 3 */
   const workPackage3WbsString = await WorkPackagesService.createWorkPackage(
     thomasEmrax,
-    project5WbsNumber,
     'Manufacture Wiring Harness',
     changeRequest1Id,
     WorkPackageStage.Manufacturing,
@@ -400,7 +399,9 @@ const performSeed: () => Promise<void> = async () => {
       'Solder wiring segments together and heat shrink properly',
       'Cut all wires to length'
     ],
-    ['Completed wiring harness for the entire car']
+    ['Completed wiring harness for the entire car'],
+    joeShmoe.userId,
+    thomasEmrax.userId
   );
   const workPackage3WbsNumber = validateWBS(workPackage3WbsString);
 

--- a/src/backend/src/routes/work-packages.routes.ts
+++ b/src/backend/src/routes/work-packages.routes.ts
@@ -11,9 +11,6 @@ workPackagesRouter.post(
   '/create',
   intMinZero(body('crId')),
   nonEmptyString(body('name')),
-  intMinZero(body('projectWbsNum.carNumber')),
-  intMinZero(body('projectWbsNum.projectNumber')),
-  intMinZero(body('projectWbsNum.workPackageNumber')),
   isWorkPackageStageOrNone(body('stage')),
   isDate(body('startDate')),
   intMinZero(body('duration')),
@@ -24,6 +21,8 @@ workPackagesRouter.post(
   nonEmptyString(body('expectedActivities.*')),
   body('deliverables').isArray(),
   nonEmptyString(body('deliverables.*')),
+  intMinZero(body('projectLead')),
+  intMinZero(body('projectManager')),
   validateInputs,
   WorkPackagesController.createWorkPackage
 );

--- a/src/backend/src/routes/work-packages.routes.ts
+++ b/src/backend/src/routes/work-packages.routes.ts
@@ -21,8 +21,6 @@ workPackagesRouter.post(
   nonEmptyString(body('expectedActivities.*')),
   body('deliverables').isArray(),
   nonEmptyString(body('deliverables.*')),
-  intMinZero(body('projectLead')),
-  intMinZero(body('projectManager')),
   validateInputs,
   WorkPackagesController.createWorkPackage
 );

--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -119,8 +119,6 @@ export default class WorkPackagesService {
    * @param blockedBy the WBS elements that need to be completed before this WP
    * @param expectedActivities the expected activities descriptions for this WP
    * @param deliverables the expected deliverables descriptions for this WP
-   * @param projectLead the new lead for this work package
-   * @param projectManager the new manager for this work package
    * @returns the WBS number of the successfully created work package
    * @throws if the work package could not be created
    */
@@ -133,9 +131,7 @@ export default class WorkPackagesService {
     duration: number,
     blockedBy: WbsNumber[],
     expectedActivities: string[],
-    deliverables: string[],
-    projectLead: number,
-    projectManager: number
+    deliverables: string[]
   ): Promise<string> {
     if (isGuest(user.role)) throw new AccessDeniedGuestException('create work packages');
 
@@ -174,14 +170,6 @@ export default class WorkPackagesService {
         400,
         `Given WBS Number ${carNumber}.${projectNumber}.${workPackageNumber} is not for a project.`
       );
-    }
-
-    if ((await getUserFullName(projectLead)) === 'no one') {
-      throw new NotFoundException('User', projectLead);
-    }
-
-    if ((await getUserFullName(projectManager)) === 'no one') {
-      throw new NotFoundException('User', projectManager);
     }
 
     if (blockedBy.find((dep: WbsNumber) => equalsWbsNumber(dep, projectWbsNum))) {
@@ -249,8 +237,6 @@ export default class WorkPackagesService {
             projectNumber,
             workPackageNumber: newWorkPackageNumber,
             name,
-            projectLeadId: projectLead,
-            projectManagerId: projectManager,
             changes: {
               create: {
                 changeRequestId: crId,

--- a/src/backend/tests/test-data/wbs-element.test-data.ts
+++ b/src/backend/tests/test-data/wbs-element.test-data.ts
@@ -13,3 +13,17 @@ export const prismaWbsElement1: PrismaWbsElement = {
   projectLeadId: 4,
   projectManagerId: 5
 };
+
+export const prismaWbsElement2: PrismaWbsElement = {
+  wbsElementId: 1,
+  status: PrismaWBSElementStatus.ACTIVE,
+  carNumber: 1,
+  projectNumber: 2,
+  workPackageNumber: 2,
+  dateCreated: new Date(),
+  dateDeleted: null,
+  name: 'car',
+  deletedByUserId: null,
+  projectLeadId: 4,
+  projectManagerId: 5
+};

--- a/src/backend/tests/work-packages.test.ts
+++ b/src/backend/tests/work-packages.test.ts
@@ -1,5 +1,5 @@
 import prisma from '../src/prisma/prisma';
-import { batman, flash, superman, wonderwoman } from './test-data/users.test-data';
+import { batman, wonderwoman } from './test-data/users.test-data';
 import { prismaWbsElement1, prismaWbsElement2 } from './test-data/wbs-element.test-data';
 import { prismaChangeRequest1 } from './test-data/change-requests.test-data';
 import { calculateWorkPackageProgress } from '../src/utils/work-packages.utils';
@@ -41,18 +41,17 @@ describe('Work Packages', () => {
   const expectedActivities = ['ayo'];
   const deliverables = ['ajdhjakfjafja'];
   const stage = WorkPackageStage.Design;
-  const createWorkPackageArgs: [
-    User,
-    WbsNumber,
-    string,
-    number,
-    WorkPackageStage,
-    string,
-    number,
-    WbsNumber[],
-    string[],
-    string[]
-  ] = [batman, projectWbsNum, name, crId, stage, startDate, duration, blockedBy, expectedActivities, deliverables];
+  const createWorkPackageArgs: [User, string, number, WorkPackageStage, string, number, WbsNumber[], string[], string[]] = [
+    batman,
+    name,
+    crId,
+    stage,
+    startDate,
+    duration,
+    blockedBy,
+    expectedActivities,
+    deliverables
+  ];
   /*********************************************************/
 
   afterEach(() => {
@@ -172,18 +171,17 @@ describe('Work Packages', () => {
 
     test("fails if the blocked by include the work package's own project", async () => {
       vi.spyOn(prisma.wBS_Element, 'findUnique').mockResolvedValueOnce(prismaWbsElement1);
-      const argsToTest: [
-        User,
-        WbsNumber,
-        string,
-        number,
-        WorkPackageStage,
-        string,
-        number,
-        WbsNumber[],
-        string[],
-        string[]
-      ] = [batman, projectWbsNum, name, crId, stage, startDate, duration, [projectWbsNum], expectedActivities, deliverables];
+      const argsToTest: [User, string, number, WorkPackageStage, string, number, WbsNumber[], string[], string[]] = [
+        batman,
+        name,
+        crId,
+        stage,
+        startDate,
+        duration,
+        [projectWbsNum],
+        expectedActivities,
+        deliverables
+      ];
 
       const callCreateWP = async () => {
         return await WorkPackageService.createWorkPackage.apply(null, argsToTest);

--- a/src/backend/tests/work-packages.test.ts
+++ b/src/backend/tests/work-packages.test.ts
@@ -41,8 +41,6 @@ describe('Work Packages', () => {
   const expectedActivities = ['ayo'];
   const deliverables = ['ajdhjakfjafja'];
   const stage = WorkPackageStage.Design;
-  const projectLead = flash.userId;
-  const projectManager = superman.userId;
   const createWorkPackageArgs: [
     User,
     WbsNumber,
@@ -53,23 +51,8 @@ describe('Work Packages', () => {
     number,
     WbsNumber[],
     string[],
-    string[],
-    number,
-    number
-  ] = [
-    batman,
-    projectWbsNum,
-    name,
-    crId,
-    stage,
-    startDate,
-    duration,
-    blockedBy,
-    expectedActivities,
-    deliverables,
-    projectLead,
-    projectManager
-  ];
+    string[]
+  ] = [batman, projectWbsNum, name, crId, stage, startDate, duration, blockedBy, expectedActivities, deliverables];
   /*********************************************************/
 
   afterEach(() => {
@@ -103,9 +86,7 @@ describe('Work Packages', () => {
           duration,
           blockedBy,
           expectedActivities,
-          deliverables,
-          projectLead,
-          projectManager
+          deliverables
         );
       };
 
@@ -115,7 +96,6 @@ describe('Work Packages', () => {
     });
 
     test('createWorkPackage fails if any elements in the blocked by are null', async () => {
-      vi.spyOn(prisma.user, 'findUnique').mockResolvedValue(flash);
       vi.spyOn(prisma.change_Request, 'findUnique').mockResolvedValue(prismaChangeRequest1);
       vi.spyOn(prisma.wBS_Element, 'findUnique').mockResolvedValueOnce(null);
       vi.spyOn(prisma.wBS_Element, 'findUnique').mockResolvedValueOnce({
@@ -144,9 +124,7 @@ describe('Work Packages', () => {
           duration,
           blockedBy,
           expectedActivities,
-          deliverables,
-          projectLead,
-          projectManager
+          deliverables
         );
       };
 
@@ -204,23 +182,8 @@ describe('Work Packages', () => {
         number,
         WbsNumber[],
         string[],
-        string[],
-        number,
-        number
-      ] = [
-        batman,
-        projectWbsNum,
-        name,
-        crId,
-        stage,
-        startDate,
-        duration,
-        [projectWbsNum],
-        expectedActivities,
-        deliverables,
-        projectLead,
-        projectManager
-      ];
+        string[]
+      ] = [batman, projectWbsNum, name, crId, stage, startDate, duration, [projectWbsNum], expectedActivities, deliverables];
 
       const callCreateWP = async () => {
         return await WorkPackageService.createWorkPackage.apply(null, argsToTest);


### PR DESCRIPTION
## Changes

- Added a backend function to add project lead and manager when creating a new work package. 
- Removed projectWbsNum as this could be retrieved from WP's change request.
- Updated the route, controller, service, and test accordingly. 
- Added two approved cr seed data that have 1.5.0 and 1.1.0 as WBS element.

## Notes
- I had to add two approved cr seed data after creating the CR endpoint redesign. To create original wp seed data: `1.1.1`, `1.1.2`, and `1.5.1`, we need an approved crs that has WBS element of 1.5.0 and 1.1.0. This is b/c instead of passing WBS num to create cr endpoint, we now automatically assign WBS element on new wp by retrieving the WBS element from approved cr.
<img width="960" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/91857946/bc8277aa-5492-4ad7-81f8-eaba8540a637">

## To Do

- [x] Fix tests for creating wp endpoint
- [x] Fix the seed data for wp create endpoint.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
