### PR TITLE
#1358 Reimbursement page now sorts wbs elements by number

### DIFF
--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
@@ -35,6 +35,7 @@ import { useToast } from '../../../hooks/toasts.hooks';
 import { Link as RouterLink } from 'react-router-dom';
 import { routes } from '../../../utils/routes';
 import { codeAndRefundSourceName, expenseTypePipe } from '../../../utils/pipes';
+import { wbsNumComparator } from 'shared/src/validate-wbs';
 
 interface ReimbursementRequestFormViewProps {
   allVendors: Vendor[];
@@ -89,6 +90,8 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
     label: wbsPipe(wbsElement.wbsNum) + ' - ' + wbsElement.wbsName,
     id: wbsPipe(wbsElement.wbsNum)
   }));
+
+  wbsElementAutocompleteOptions.sort((wbsNum1, wbsNum2) => wbsNumComparator(wbsNum1.id, wbsNum2.id));
 
   const ReceiptFileInput = () => (
     <FormControl>


### PR DESCRIPTION
## Changes

Wbs dropdown on reimbursement creation and edit page now sorts the elements by number.

## Screenshots

![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/128248843/2656ff29-ac71-47a8-8440-b6fed692220e)

![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/128248843/57a09f24-0533-4bc8-8373-80c21a4432e7)

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1358
