### PR TITLE
#1167 persistent filters for projects table

### DIFF
--- a/src/frontend/src/pages/ProjectsPage/ProjectsTable.tsx
+++ b/src/frontend/src/pages/ProjectsPage/ProjectsTable.tsx
@@ -114,11 +114,10 @@ const ProjectsTable: React.FC = () => {
     }
   ];
 
-  const defaultFilterValues = {
-    field: 'carNumber',
-    operator: '=',
-    value: undefined
-  };
+  const filterValues = JSON.parse(
+    // sets filter to a default value if no filter is stored in local storage
+    localStorage.getItem('projectsTableFilters') ?? '{"columnField": "carNumber", "operatorValue": "=", "value": ""}'
+  );
 
   const theme = useTheme();
   return (
@@ -169,20 +168,16 @@ const ProjectsTable: React.FC = () => {
           }
         }}
         onFilterModelChange={(filterModel: GridFilterModel) => {
-          const filterProps = filterModel.items[0];
-
-          localStorage.setItem('projectsTableFilterColumnName', filterProps.columnField);
-          localStorage.setItem('projectsTableFilterOperator', filterProps.operatorValue ?? defaultFilterValues.operator);
-          localStorage.setItem('projectsTableFilterValue', filterProps.value);
+          localStorage.setItem('projectsTableFilters', JSON.stringify(filterModel.items[0]));
         }}
         initialState={{
           filter: {
             filterModel: {
               items: [
                 {
-                  columnField: localStorage.getItem('projectsTableFilterColumnName') ?? defaultFilterValues.field,
-                  operatorValue: localStorage.getItem('projectsTableFilterOperator') ?? defaultFilterValues.operator,
-                  value: localStorage.getItem('projectsTableFilterValue') ?? defaultFilterValues.value
+                  columnField: filterValues.columnField,
+                  operatorValue: filterValues.operatorValue,
+                  value: filterValues.value
                 }
               ]
             }

--- a/src/frontend/src/pages/ProjectsPage/ProjectsTable.tsx
+++ b/src/frontend/src/pages/ProjectsPage/ProjectsTable.tsx
@@ -116,7 +116,7 @@ const ProjectsTable: React.FC = () => {
 
   const filterValues = JSON.parse(
     // sets filter to a default value if no filter is stored in local storage
-    localStorage.getItem('projectsTableFilters') ?? '{"columnField": "carNumber", "operatorValue": "=", "value": ""}'
+    localStorage.getItem('projectsTableFilter') ?? '{"columnField": "carNumber", "operatorValue": "=", "value": ""}'
   );
 
   const theme = useTheme();
@@ -168,7 +168,7 @@ const ProjectsTable: React.FC = () => {
           }
         }}
         onFilterModelChange={(filterModel: GridFilterModel) => {
-          localStorage.setItem('projectsTableFilters', JSON.stringify(filterModel.items[0]));
+          localStorage.setItem('projectsTableFilter', JSON.stringify(filterModel.items[0]));
         }}
         initialState={{
           filter: {

--- a/src/frontend/src/pages/ProjectsPage/ProjectsTable.tsx
+++ b/src/frontend/src/pages/ProjectsPage/ProjectsTable.tsx
@@ -2,6 +2,7 @@
  * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
  * See the LICENSE file in the repository root folder for details.
  */
+
 import { Grid, Link, useTheme } from '@mui/material';
 import { DataGrid, GridColDef, GridFilterModel, GridRow, GridRowProps, GridToolbar } from '@mui/x-data-grid';
 import { useState } from 'react';

--- a/src/frontend/src/pages/ProjectsPage/ProjectsTable.tsx
+++ b/src/frontend/src/pages/ProjectsPage/ProjectsTable.tsx
@@ -2,7 +2,6 @@
  * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
  * See the LICENSE file in the repository root folder for details.
  */
-import React from 'react';
 import { Grid, Link, useTheme } from '@mui/material';
 import { DataGrid, GridColDef, GridFilterModel, GridRow, GridRowProps, GridToolbar } from '@mui/x-data-grid';
 import { useState } from 'react';

--- a/src/frontend/src/pages/ProjectsPage/ProjectsTable.tsx
+++ b/src/frontend/src/pages/ProjectsPage/ProjectsTable.tsx
@@ -2,9 +2,9 @@
  * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
  * See the LICENSE file in the repository root folder for details.
  */
-
+import React from 'react';
 import { Grid, Link, useTheme } from '@mui/material';
-import { DataGrid, GridColDef, GridRow, GridRowProps, GridToolbar } from '@mui/x-data-grid';
+import { DataGrid, GridColDef, GridFilterModel, GridRow, GridRowProps, GridToolbar } from '@mui/x-data-grid';
 import { useState } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import { Project, WbsElementStatus } from 'shared';
@@ -114,6 +114,12 @@ const ProjectsTable: React.FC = () => {
     }
   ];
 
+  const defaultFilterValues = {
+    field: 'carNumber',
+    operator: '=',
+    value: undefined
+  };
+
   const theme = useTheme();
   return (
     <Grid container xs={12}>
@@ -162,7 +168,25 @@ const ProjectsTable: React.FC = () => {
             quickFilterProps: { debounceMs: 500 }
           }
         }}
+        onFilterModelChange={(filterModel: GridFilterModel) => {
+          const filterProps = filterModel.items[0];
+
+          localStorage.setItem('projectsTableFilterColumnName', filterProps.columnField);
+          localStorage.setItem('projectsTableFilterOperator', filterProps.operatorValue ?? defaultFilterValues.operator);
+          localStorage.setItem('projectsTableFilterValue', filterProps.value);
+        }}
         initialState={{
+          filter: {
+            filterModel: {
+              items: [
+                {
+                  columnField: localStorage.getItem('projectsTableFilterColumnName') ?? defaultFilterValues.field,
+                  operatorValue: localStorage.getItem('projectsTableFilterOperator') ?? defaultFilterValues.operator,
+                  value: localStorage.getItem('projectsTableFilterValue') ?? defaultFilterValues.value
+                }
+              ]
+            }
+          },
           sorting: {
             sortModel: [{ field: 'wbsNum', sort: 'asc' }]
           },


### PR DESCRIPTION
## Changes

Added onFilterModelChange listener for DataGrid that stores the changed fields as a JSON string in local storage. Added filter for the initialState of DataGrid that grabs the saved fields from local storage (after parsing JSON string back into an object) and defaults to a set of default values if filter does not exist in local storage.

## Test Cases

- Tested reloading page
- Tested going to another page on the site and going back
- Tested closing and opening in a new tab

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1167
