### PR TITLE
#955: right-aligned actions menu on workpackages and change requests,…

### DIFF
--- a/src/frontend/src/components/ActionsMenu.tsx
+++ b/src/frontend/src/components/ActionsMenu.tsx
@@ -19,7 +19,6 @@ interface ActionsMenuProps {
 
 const ActionsMenu: React.FC<ActionsMenuProps> = ({ buttons, title = 'Actions' }) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
   };
@@ -40,7 +39,19 @@ const ActionsMenu: React.FC<ActionsMenuProps> = ({ buttons, title = 'Actions' })
       >
         {title}
       </NERButton>
-      <Menu open={dropdownOpen} anchorEl={anchorEl} onClose={handleDropdownClose}>
+      <Menu
+        open={dropdownOpen}
+        anchorEl={anchorEl}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'right'
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'right'
+        }}
+        onClose={handleDropdownClose}
+      >
         {buttons.flatMap((button, index) => {
           return [
             button.dividerTop && <Divider key={`${index}-divider`} />,

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
@@ -111,7 +111,7 @@ const ProjectViewContainer: React.FC<ProjectViewContainerProps> = ({ project, en
       : 'Assign to My Team';
 
     return (
-      <MenuItem onClick={handleAssignToMyTeam}>
+      <MenuItem onClick={handleAssignToMyTeam} divider={true}>
         <ListItemIcon>
           <GroupIcon fontSize="small" />
         </ListItemIcon>

--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.tsx
@@ -127,6 +127,7 @@ const WorkPackageViewContainer: React.FC<WorkPackageViewContainerProps> = ({
       to={routes.CHANGE_REQUESTS_NEW_WITH_WBS + wbsPipe(workPackage.wbsNum)}
       disabled={!allowRequestChange}
       onClick={handleDropdownClose}
+      divider={true}
     >
       <ListItemIcon>
         <SyncAltIcon fontSize="small" />
@@ -144,7 +145,19 @@ const WorkPackageViewContainer: React.FC<WorkPackageViewContainerProps> = ({
       >
         Actions
       </NERButton>
-      <Menu open={dropdownOpen} anchorEl={anchorEl} onClose={handleDropdownClose}>
+      <Menu
+        open={dropdownOpen}
+        anchorEl={anchorEl}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'right'
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'right'
+        }}
+        onClose={handleDropdownClose}
+      >
         {editButton}
         {workPackage.status === WbsElementStatus.Inactive ? activateButton : ''}
         {workPackage.status === WbsElementStatus.Active ? stageGateButton : ''}


### PR DESCRIPTION
## Changes

Trash icon added to change requests page, added line between delete and other buttons in actions dropdown menus (on project page and workpackages page) and rightaligned dropdown menus for work packages and change requests page.

## Notes
Changed actions menu, which is also used by reimbursment request actions. Screenshots attached for new behavior of its dropdown menu (only change is right-alignment of actions menu).

## Screenshots
<img width="1280" alt="Screenshot 2023-09-27 at 8 41 40 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/76175287/000f0298-a2d3-459a-b5ed-693aff0f260b">
<img width="447" alt="Screenshot 2023-09-27 at 8 42 03 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/76175287/941be3b4-0288-47f2-bf6b-28d8f94dea50">
<img width="1280" alt="Screenshot 2023-09-27 at 8 42 23 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/76175287/3a0183aa-15ff-49db-a721-d997bfe29b59">
<img width="444" alt="Screenshot 2023-09-27 at 8 42 45 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/76175287/cda316d6-5434-42ee-b706-500d59253b98">
<img width="1280" alt="Screenshot 2023-09-27 at 8 43 34 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/76175287/072c5777-a1cd-497f-ba06-a260173bfdb1">
<img width="450" alt="Screenshot 2023-09-27 at 8 43 50 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/76175287/47b367e2-d191-42d2-babb-3419e2d5f093">
Reimbursement request details:
<img width="1280" alt="Screenshot 2023-09-27 at 9 06 59 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/76175287/ec21ddfc-ecc7-4162-960e-1f80e5b65f68">
<img width="449" alt="Screenshot 2023-09-27 at 9 07 29 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/76175287/df602f0d-dd3c-4575-a7a3-78a0ae5a4304">

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #955 
