### PR TITLE
#1513: added team description to user settings

### DIFF
--- a/src/frontend/src/pages/SettingsPage/Settings.tsx
+++ b/src/frontend/src/pages/SettingsPage/Settings.tsx
@@ -139,22 +139,22 @@ const Settings: React.FC = () => {
       </PageBlock>
       <PageBlock title="User Details">
         <Grid container spacing={2}>
-          <Grid item md={4} lg={2}>
+          <Grid item xs={12} sm={6} md={4} lg>
             <DetailDisplay label="First Name" content={user.firstName} />
           </Grid>
-          <Grid item md={4} lg={2}>
+          <Grid item xs={12} sm={6} md={4} lg>
             <DetailDisplay label="Last Name" content={user.lastName} />
           </Grid>
-          <Grid item md={4} lg={3}>
+          <Grid item xs={12} sm={6} md={4} lg={3}>
             <DetailDisplay label="Email" content={user.email} />
           </Grid>
-          <Grid item md={4} lg={2}>
+          <Grid item xs={12} sm={6} md={4} lg>
             <DetailDisplay label="Email ID" content={String(user.emailId)} />
           </Grid>
-          <Grid item md={4} lg={2}>
+          <Grid item xs={12} sm={6} md={4} lg>
             <DetailDisplay label="Role" content={user.role} />
           </Grid>
-          <Grid item md={4} lg={3}>
+          <Grid item xs={12} sm={6} md={4} lg>
             <DetailDisplay
               label="Teams"
               content={userTeams.length === 0 ? 'None' : userTeams.map((team) => team.teamName).join(', ')}

--- a/src/frontend/src/pages/SettingsPage/Settings.tsx
+++ b/src/frontend/src/pages/SettingsPage/Settings.tsx
@@ -15,6 +15,7 @@ import PageLayout from '../../components/PageLayout';
 import { useCurrentUser, useCurrentUserSecureSettings, useSingleUserSettings } from '../../hooks/users.hooks';
 import ErrorPage from '../ErrorPage';
 import UserSecureSettings from './UserSecureSettings/UserSecureSettings';
+import { useAllTeams } from '../../hooks/teams.hooks';
 
 const NERSwitch = styled((props: SwitchProps) => (
   <Switch focusVisibleClassName=".Mui-focusVisible" disableRipple {...props} />
@@ -80,16 +81,20 @@ const Settings: React.FC = () => {
     error: secureSettingsError,
     data: userSecureSettings
   } = useCurrentUserSecureSettings();
+  const { isLoading: allTeamsIsLoading, isError: allTeamsIsError, data: teams, error: allTeamsError } = useAllTeams();
 
   if (secureSettingsIsError) return <ErrorPage error={secureSettingsError} message={secureSettingsError.message} />;
   if (settingsIsError) return <ErrorPage error={settingsError} message={settingsError.message} />;
+  if (allTeamsIsError) return <ErrorPage error={allTeamsError} message={allTeamsError.message} />;
   if (
     auth.isLoading ||
     !auth.user ||
     settingsIsLoading ||
     !userSettingsData ||
     secureSettingsIsLoading ||
-    !userSecureSettings
+    !userSecureSettings ||
+    allTeamsIsLoading ||
+    !teams
   )
     return <LoadingIndicator />;
 
@@ -99,6 +104,10 @@ const Settings: React.FC = () => {
       auth.signout();
     }, 2000);
   };
+
+  const userTeams = teams.filter((team) =>
+    team.members.some((member) => member.userId === user.userId || team.head.userId === user.userId)
+  );
 
   return (
     <PageLayout title="Settings">
@@ -144,6 +153,12 @@ const Settings: React.FC = () => {
           </Grid>
           <Grid item md={4} lg={2}>
             <DetailDisplay label="Role" content={user.role} />
+          </Grid>
+          <Grid item md={4} lg={3}>
+            <DetailDisplay
+              label="Teams"
+              content={userTeams.length === 0 ? 'None' : userTeams.map((team) => team.teamName).join(', ')}
+            />
           </Grid>
         </Grid>
       </PageBlock>


### PR DESCRIPTION
## Changes

On the user settings page, if the user is part of a Team or Teams, then it is displayed as "Teams: " and a list separated by commas, and if they are part are no team, "Teams: None" is displayed.

## Screenshots

![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/78322291/378ac2c2-5eea-43b6-b554-ce85a4b2d6eb)
![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/78322291/ee8f9b61-54a9-4ef9-a788-fc631b84cbed)
![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/78322291/a41a830c-bca8-48b2-8f2f-13ad0b85220f)
![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/78322291/42e815b5-acb0-4b89-827d-5d6fe8a110a3)

## To Do

- [ ] Maybe move frontend logic of figuring out which teams the user is on to the backend

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #1513
