### PR TITLE
#745 used projectManagerID and projectLeadId to store numbers

### DIFF
--- a/src/backend/src/controllers/work-packages.controllers.ts
+++ b/src/backend/src/controllers/work-packages.controllers.ts
@@ -72,7 +72,7 @@ export default class WorkPackagesController {
         blockedBy,
         expectedActivities,
         deliverables,
-        projectLead,
+        projectLeadId,
         projectManagerId
       } = req.body;
 
@@ -94,7 +94,7 @@ export default class WorkPackagesController {
         blockedBy,
         expectedActivities,
         deliverables,
-        projectLead,
+        projectLeadId,
         projectManagerId
       );
       return res.status(200).json({ message: 'Work package updated successfully' });

--- a/src/backend/src/controllers/work-packages.controllers.ts
+++ b/src/backend/src/controllers/work-packages.controllers.ts
@@ -73,7 +73,7 @@ export default class WorkPackagesController {
         expectedActivities,
         deliverables,
         projectLead,
-        projectManager
+        projectManagerId
       } = req.body;
 
       let { stage } = req.body;
@@ -95,7 +95,7 @@ export default class WorkPackagesController {
         expectedActivities,
         deliverables,
         projectLead,
-        projectManager
+        projectManagerId
       );
       return res.status(200).json({ message: 'Work package updated successfully' });
     } catch (error: unknown) {

--- a/src/backend/src/routes/work-packages.routes.ts
+++ b/src/backend/src/routes/work-packages.routes.ts
@@ -44,8 +44,8 @@ workPackagesRouter.post(
   body('deliverables').isArray(),
   body('deliverables.*.id').isInt({ min: -1 }).not().isString(),
   nonEmptyString(body('deliverables.*.detail')),
-  intMinZero(body('projectLead').optional()),
-  intMinZero(body('projectManager').optional()),
+  intMinZero(body('projectLeadId').optional()),
+  intMinZero(body('projectManagerId').optional()),
   validateInputs,
   WorkPackagesController.editWorkPackage
 );

--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -281,8 +281,8 @@ export default class WorkPackagesService {
     blockedBy: WbsNumber[],
     expectedActivities: DescriptionBullet[],
     deliverables: DescriptionBullet[],
-    projectLead: number,
-    projectManager: number
+    projectLeadId: number,
+    projectManagerId: number
   ): Promise<void> {
     // verify user is allowed to edit work packages
     if (isGuest(user.role)) throw new AccessDeniedGuestException('edit work packages');
@@ -407,7 +407,7 @@ export default class WorkPackagesService {
     const projectManagerChangeJson = createChange(
       'project manager',
       await getUserFullName(originalWorkPackage.wbsElement.projectManagerId),
-      await getUserFullName(projectManager),
+      await getUserFullName(projectManagerId),
       crId,
       userId,
       wbsElementId!
@@ -419,7 +419,7 @@ export default class WorkPackagesService {
     const projectLeadChangeJson = createChange(
       'project lead',
       await getUserFullName(originalWorkPackage.wbsElement.projectLeadId),
-      await getUserFullName(projectLead),
+      await getUserFullName(projectLeadId),
       crId,
       userId,
       wbsElementId!
@@ -447,8 +447,8 @@ export default class WorkPackagesService {
         wbsElement: {
           update: {
             name,
-            projectLeadId: projectLead,
-            projectManagerId: projectManager
+            projectLeadId: projectLeadId,
+            projectManagerId: projectManagerId
           }
         },
         stage,

--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -447,8 +447,8 @@ export default class WorkPackagesService {
         wbsElement: {
           update: {
             name,
-            projectLeadId: projectLeadId,
-            projectManagerId: projectManagerId
+            projectLeadId,
+            projectManagerId
           }
         },
         stage,

--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -267,8 +267,8 @@ export default class WorkPackagesService {
    * @param blockedBy the new WBS elements to be completed before this WP
    * @param expectedActivities the new expected activities descriptions for this WP
    * @param deliverables the new expected deliverables descriptions for this WP
-   * @param projectLead the new lead for this work package
-   * @param projectManager the new manager for this work package
+   * @param projectLeadId the new lead for this work package
+   * @param projectManagerId the new manager for this work package
    */
   static async editWorkPackage(
     user: User,

--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditContainer.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditContainer.tsx
@@ -140,8 +140,8 @@ const WorkPackageEditContainer: React.FC<WorkPackageEditContainerProps> = ({ wor
     const blockedByWbsNums = blockedBy.map((blocker) => validateWBS(blocker));
     try {
       const payload = {
-        projectLead: leadId ? parseInt(leadId) : undefined,
-        projectManager: managerId ? parseInt(managerId) : undefined,
+        projectLeadId: leadId ? parseInt(leadId) : undefined,
+        projectManagerId: managerId ? parseInt(managerId) : undefined,
         workPackageId: workPackage.id,
         userId,
         name,


### PR DESCRIPTION
## Changes

Changed WorkPackageEditContainer.tsx and work-packages.routes.ts to incorporate projectManagerId and projectLeadId instead of projectManager and projectLead

## Notes

The instructions said to change work-packages.controller.tsx as well but I'm not sure if it should be changed. Please let me know!


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ x] All commits are tagged with the ticket number
- [ x] No linting errors / newline at end of file warnings
- [ x] All code follows repository-configured prettier formatting
- [ x] No merge conflicts
- [x ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [x ] Remove any non-applicable sections of this template
- [ x] Assign the PR to yourself
- [x ] No `yarn.lock` changes (unless dependencies have changed)
- [x ] Request reviewers & ping on Slack
- [ x] PR is linked to the ticket (fill in the closes line below)

Closes #745
