### PR TITLE
#1308: changed flexDirection to 'column' for xs screens

### DIFF
--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementProductTable.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementProductTable.tsx
@@ -96,7 +96,7 @@ const ReimbursementProductTable: React.FC<ReimbursementProductTableProps> = ({
                   <Box sx={{ display: 'flex', flexWrap: 'wrap', listStyle: 'none', p: 0.5, m: 0 }} component={'ul'}>
                     {uniqueWbsElementsWithProducts.get(key)?.map((product, index) => (
                       <ListItem key={product.index}>
-                        <Box sx={{ display: 'flex-row', flexDirection: { sm: 'row', xs: 'column' } }}>
+                        <Box sx={{ display: 'flex', flexDirection: { sm: 'row', xs: 'column' } }}>
                           <Controller
                             name={`reimbursementProducts.${product.index}.name`}
                             control={control}
@@ -127,7 +127,7 @@ const ReimbursementProductTable: React.FC<ReimbursementProductTableProps> = ({
                                   startAdornment: <InputAdornment position="start">$</InputAdornment>
                                 }}
                                 onBlur={(e) => onCostBlurHandler(parseFloat(e.target.value), product.index)}
-                                sx={{ width: '50%', mt: { xs: '10px' } }}
+                                sx={{ width: '50%', mt: { sm: '0px', xs: '10px' } }}
                                 error={!!errors.reimbursementProducts?.[product.index]?.cost}
                               />
                             )}

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementProductTable.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementProductTable.tsx
@@ -96,7 +96,7 @@ const ReimbursementProductTable: React.FC<ReimbursementProductTableProps> = ({
                   <Box sx={{ display: 'flex', flexWrap: 'wrap', listStyle: 'none', p: 0.5, m: 0 }} component={'ul'}>
                     {uniqueWbsElementsWithProducts.get(key)?.map((product, index) => (
                       <ListItem key={product.index}>
-                        <Box sx={{ display: 'flex', flexDirection: 'row' }}>
+                        <Box sx={{ display: 'flex', flexDirection: { sm: 'row', xs: 'column'} }}>
                           <Controller
                             name={`reimbursementProducts.${product.index}.name`}
                             control={control}

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementProductTable.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementProductTable.tsx
@@ -96,7 +96,7 @@ const ReimbursementProductTable: React.FC<ReimbursementProductTableProps> = ({
                   <Box sx={{ display: 'flex', flexWrap: 'wrap', listStyle: 'none', p: 0.5, m: 0 }} component={'ul'}>
                     {uniqueWbsElementsWithProducts.get(key)?.map((product, index) => (
                       <ListItem key={product.index}>
-                        <Box sx={{ display: 'flex-row', flexDirection: { sm: 'row', xs: 'column'} }}>
+                        <Box sx={{ display: 'flex-row', flexDirection: { sm: 'row', xs: 'column' } }}>
                           <Controller
                             name={`reimbursementProducts.${product.index}.name`}
                             control={control}
@@ -127,8 +127,7 @@ const ReimbursementProductTable: React.FC<ReimbursementProductTableProps> = ({
                                   startAdornment: <InputAdornment position="start">$</InputAdornment>
                                 }}
                                 onBlur={(e) => onCostBlurHandler(parseFloat(e.target.value), product.index)}
-                                sx={{ width: '50%', 
-                                      mt: {xs: '10px' } }}
+                                sx={{ width: '50%', mt: { xs: '10px' } }}
                                 error={!!errors.reimbursementProducts?.[product.index]?.cost}
                               />
                             )}

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementProductTable.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementProductTable.tsx
@@ -127,7 +127,8 @@ const ReimbursementProductTable: React.FC<ReimbursementProductTableProps> = ({
                                   startAdornment: <InputAdornment position="start">$</InputAdornment>
                                 }}
                                 onBlur={(e) => onCostBlurHandler(parseFloat(e.target.value), product.index)}
-                                sx={{ width: '50%' }}
+                                sx={{ width: '50%', 
+                                      mt: {xs: '10px' } }}
                                 error={!!errors.reimbursementProducts?.[product.index]?.cost}
                               />
                             )}

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementProductTable.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementProductTable.tsx
@@ -96,7 +96,7 @@ const ReimbursementProductTable: React.FC<ReimbursementProductTableProps> = ({
                   <Box sx={{ display: 'flex', flexWrap: 'wrap', listStyle: 'none', p: 0.5, m: 0 }} component={'ul'}>
                     {uniqueWbsElementsWithProducts.get(key)?.map((product, index) => (
                       <ListItem key={product.index}>
-                        <Box sx={{ display: 'flex', flexDirection: { sm: 'row', xs: 'column'} }}>
+                        <Box sx={{ display: 'flex-row', flexDirection: { sm: 'row', xs: 'column'} }}>
                           <Controller
                             name={`reimbursementProducts.${product.index}.name`}
                             control={control}


### PR DESCRIPTION
## Changes

changed flexDirection in the <Box> component to be "column" for xs screens. still "row" for s screens and larger


## Screenshots

<img width="556" alt="Screenshot 2023-09-28 at 6 19 14 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/80065258/6a98bfc0-5b11-4705-b1ca-776f90238ce0">


## Checklist

- [X] All commits are tagged with the ticket number
- [X] No linting errors / newline at end of file warnings
- [X] All code follows repository-configured prettier formatting
- [X] No merge conflicts
- [X] All checks passing
- [X] Screenshots of UI changes (see Screenshots section)
- [X] Remove any non-applicable sections of this template
- [X] Assign the PR to yourself
- [X] No `yarn.lock` changes (unless dependencies have changed)
- [X] Request reviewers & ping on Slack
- [X] PR is linked to the ticket (fill in the closes line below)

Closes #1308
