### PR TITLE
#954: fixed bug with stage when editing workpackage

### DIFF
--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -362,7 +362,7 @@ export default class WorkPackagesService {
     let changes = [];
     // get the changes or undefined for each of the fields
     const nameChangeJson = createChange('name', originalWorkPackage.wbsElement.name, name, crId, userId, wbsElementId!);
-    const stageChangeJson = createChange('stage', originalWorkPackage.stage, stage ?? 'None', crId, userId, wbsElementId!);
+    const stageChangeJson = createChange('stage', originalWorkPackage.stage, stage, crId, userId, wbsElementId!);
     const startDateChangeJson = createChange(
       'start date',
       originalWorkPackage.startDate.toDateString(),

--- a/src/backend/src/utils/changes.utils.ts
+++ b/src/backend/src/utils/changes.utils.ts
@@ -39,7 +39,7 @@ export const createChange = (
   implementerId: number,
   wbsElementId: number
 ): ChangeCreateArgs | undefined => {
-  if (oldValue == null) {
+  if (oldValue == null && newValue !== null) {
     return {
       changeRequestId: crId,
       implementerId,

--- a/src/backend/src/utils/changes.utils.ts
+++ b/src/backend/src/utils/changes.utils.ts
@@ -46,6 +46,13 @@ export const createChange = (
       wbsElementId,
       detail: `Added ${nameOfField} "${newValue}"`
     };
+  } else if (oldValue !== null && newValue == null) {
+    return {
+      changeRequestId: crId,
+      implementerId,
+      wbsElementId,
+      detail: `Deleted ${nameOfField} "${oldValue}"`
+    };
   } else if (oldValue !== newValue) {
     return {
       changeRequestId: crId,


### PR DESCRIPTION
## Changes

I edited the createChange function in the changes.utils.ts file, such that when the old value is null, it will not add a null stage when the new value is null. The stage change in workpackage-services file was also changed so that a null new stage will not return 'None'.

## Notes


## Screenshots

![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/144744548/c18d7dec-6f6a-42d4-8e29-2bdcd6b45a35)
![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/144744548/29bd5924-641d-4515-990b-15a2d3c13d4d)

When a workpackage is edited and the stage is not changed, it does not alert any changes to the stage.

## To Do

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #954
