### PR TITLE
#1505 removed any type

### DIFF
--- a/src/backend/tests/work-packages.test.ts
+++ b/src/backend/tests/work-packages.test.ts
@@ -105,7 +105,7 @@ describe('Work Packages', () => {
       vi.spyOn(prisma.wBS_Element, 'findUnique').mockResolvedValueOnce({
         ...prismaWbsElement1,
         project: prismaProject1
-      } as any);
+      } as typeof prismaWbsElement1);
 
       const callCreateWP = async () => {
         return await WorkPackageService.createWorkPackage.apply(null, createWorkPackageArgs);
@@ -248,7 +248,7 @@ describe('Work Packages', () => {
       vi.spyOn(prisma.work_Package, 'findFirst').mockResolvedValue({
         ...prismaWorkPackage1,
         wbsElement: { dateDeleted: new Date() }
-      } as any);
+      } as typeof prismaWorkPackage1);
 
       await expect(() => WorkPackageService.deleteWorkPackage(batman, wbsNum)).rejects.toThrow(
         new DeletedException('Work Package', '1.2.3')
@@ -258,7 +258,10 @@ describe('Work Packages', () => {
     });
 
     test('Work package successfully deleted', async () => {
-      vi.spyOn(prisma.work_Package, 'findFirst').mockResolvedValue({ ...prismaWorkPackage1, wbsElement: {} } as any);
+      vi.spyOn(prisma.work_Package, 'findFirst').mockResolvedValue({
+        ...prismaWorkPackage1,
+        wbsElement: {}
+      } as typeof prismaWorkPackage1);
       vi.spyOn(prisma.work_Package, 'update').mockResolvedValue(prismaWorkPackage1);
 
       await WorkPackageService.deleteWorkPackage(batman, wbsNum);


### PR DESCRIPTION
## Changes

Removed `any` type from "work package already deleted" , "work package successfully deleted" , "createWorkPackage fails if any elements in the blocked by are null" tests

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1505
