### PR TITLE
#1168: Added persistent filters for CR table

### DIFF
--- a/src/frontend/src/pages/ChangeRequestsPage/ChangeRequestsTable.tsx
+++ b/src/frontend/src/pages/ChangeRequestsPage/ChangeRequestsTable.tsx
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { DataGrid, GridColDef, GridRow, GridRowProps, GridToolbar } from '@mui/x-data-grid';
+import { DataGrid, GridColDef, GridFilterModel, GridRow, GridRowProps, GridToolbar } from '@mui/x-data-grid';
 import { routes } from '../../utils/routes';
 import { datePipe, fullNamePipe, wbsPipe } from '../../utils/pipes';
 import { useAllChangeRequests } from '../../hooks/change-requests.hooks';
@@ -135,6 +135,11 @@ const ChangeRequestsTable: React.FC = () => {
     }
   ];
 
+  const filterValues = JSON.parse(
+    // sets filter to a default value if no filter is stored in local storage
+    localStorage.getItem('changeRequestsTableFilter') ?? '{"columnField": "crId", "operatorValue": "=", "value": ""}'
+  );
+
   return (
     <div>
       <DataGrid
@@ -182,7 +187,21 @@ const ChangeRequestsTable: React.FC = () => {
             quickFilterProps: { debounceMs: 500 }
           }
         }}
+        onFilterModelChange={(filterModel: GridFilterModel) => {
+          localStorage.setItem('changeRequestsTableFilter', JSON.stringify(filterModel.items[0]));
+        }}
         initialState={{
+          filter: {
+            filterModel: {
+              items: [
+                {
+                  columnField: filterValues.columnField,
+                  operatorValue: filterValues.operatorValue,
+                  value: filterValues.value
+                }
+              ]
+            }
+          },
           sorting: {
             sortModel: [{ field: 'crId', sort: 'desc' }]
           },


### PR DESCRIPTION
## Changes

Added onFilterModelChange listener for DataGrid that stores the changed fields as a JSON string in local storage. Added filter for the initialState of DataGrid that grabs the saved fields from local storage (after parsing JSON string back into an object) and defaults to a set of default values if filter does not exist in local storage.

## Notes

Basically the same code as I did for #1167 but a different variable name for the filter being saved in local storage and a different default filter value.

## Test Cases

- Tested reloading page
- Tested going to another page on the site and going back
- Tested closing and opening in a new tab

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1168
