### PR TITLE
#1445 Finance Fixes - Enforce No Duplicate Vendor Names on the Backend

### DIFF
--- a/src/backend/src/services/reimbursement-requests.services.ts
+++ b/src/backend/src/services/reimbursement-requests.services.ts
@@ -439,7 +439,7 @@ export default class ReimbursementRequestService {
    * @returns the created vendor
    */
   static async createVendor(submitter: User, name: string) {
-    const vendorNameFromDatabase = await prisma.vendor.findUnique({
+    const vendorNameFromDatabase = await prisma.vendor.findUnique({ 
       where: { name: name },
     });
     if (vendorNameFromDatabase == null) throw new HttpException(400, 'Submitted vendor name is the same as an existing vendor name.');

--- a/src/backend/src/services/reimbursement-requests.services.ts
+++ b/src/backend/src/services/reimbursement-requests.services.ts
@@ -439,10 +439,10 @@ export default class ReimbursementRequestService {
    * @returns the created vendor
    */
   static async createVendor(submitter: User, name: string) {
-    const vendorNameFromDatabase = await prisma.vendor.findUnique({ 
+    const vendorNameFromDatabase = await prisma.vendor.findUnique({
       where: { name: name },
     });
-    if (vendorNameFromDatabase == null) throw new HttpException(400, 'Submitted vendor name is the same as an existing vendor name.');
+    if (vendorNameFromDatabase != null) throw new HttpException(400, 'Submitted vendor name is the same as an existing vendor name.');
     if (!isAdmin(submitter.role)) throw new AccessDeniedAdminOnlyException('create vendors');
 
     const vendor = await prisma.vendor.create({

--- a/src/backend/src/services/reimbursement-requests.services.ts
+++ b/src/backend/src/services/reimbursement-requests.services.ts
@@ -439,6 +439,10 @@ export default class ReimbursementRequestService {
    * @returns the created vendor
    */
   static async createVendor(submitter: User, name: string) {
+    const vendorNameFromDatabase = await prisma.vendor.findUnique({
+      where: { name: name },
+    });
+    if (vendorNameFromDatabase == null) throw new HttpException(400, 'Submitted vendor name is the same as an existing vendor name.');
     if (!isAdmin(submitter.role)) throw new AccessDeniedAdminOnlyException('create vendors');
 
     const vendor = await prisma.vendor.create({


### PR DESCRIPTION
## Changes

Modified the createVendor function in reimbursement-requests.services.ts. Throws a 400 HTTP Exception if the vendor name already exists.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ X] All commits are tagged with the ticket number
- [X ] No linting errors / newline at end of file warnings
- [X ] All code follows repository-configured prettier formatting
- [ X] No merge conflicts
- [ X] All checks passing
- [ X] Screenshots of UI changes (see Screenshots section)
- [ X] Remove any non-applicable sections of this template
- [ X] Assign the PR to yourself
- [X ] No `yarn.lock` changes (unless dependencies have changed)
- [ X] Request reviewers & ping on Slack
- [ X] PR is linked to the ticket (fill in the closes line below)

Closes #1445
