### PR TITLE
#1597 right align pencil icon

### DIFF
--- a/src/frontend/src/pages/TeamsPage/TeamMembersPageBlock.tsx
+++ b/src/frontend/src/pages/TeamsPage/TeamMembersPageBlock.tsx
@@ -183,7 +183,7 @@ const TeamMembersPageBlock: React.FC<TeamMembersPageBlockProps> = ({ team }) => 
         <DetailDisplay label="Head" content={fullNamePipe(team.head)} />
       </Grid>
       <Grid item xs={1} mt={-1} display={'flex'} justifyContent={'flex-end'}>
-        {hasPerms && <IconButton children={<Edit />} onClick={() => setIsEditingLeads(true)} />}
+        {hasPerms && <IconButton children={<Edit />} onClick={() => setIsEditingHead(true)} />}
       </Grid>
     </Grid>
   );

--- a/src/frontend/src/pages/TeamsPage/TeamMembersPageBlock.tsx
+++ b/src/frontend/src/pages/TeamsPage/TeamMembersPageBlock.tsx
@@ -179,18 +179,18 @@ const TeamMembersPageBlock: React.FC<TeamMembersPageBlockProps> = ({ team }) => 
 
   const NonEditingHeadView = () => (
     <Grid container>
-      <Grid item>
+      <Grid item xs={11} lg="auto">
         <DetailDisplay label="Head" content={fullNamePipe(team.head)} />
       </Grid>
-      <Grid item mt={-1}>
-        {hasPerms && <IconButton children={<Edit />} onClick={() => setIsEditingHead(true)} />}
+      <Grid item xs={1} mt={-1}>
+        {hasPerms && <IconButton children={<Edit />} onClick={() => setIsEditingLeads(true)} />}
       </Grid>
     </Grid>
   );
 
   const NonEditingLeadsView = () => (
     <Grid container>
-      <Grid item xs={11} lg="auto">
+      <Grid item xs={11}>
         <DetailDisplay label="Leads" content={team.leads.map((lead) => fullNamePipe(lead)).join(', ')} />
       </Grid>
       <Grid item xs={1} mt={-1}>

--- a/src/frontend/src/pages/TeamsPage/TeamMembersPageBlock.tsx
+++ b/src/frontend/src/pages/TeamsPage/TeamMembersPageBlock.tsx
@@ -179,10 +179,10 @@ const TeamMembersPageBlock: React.FC<TeamMembersPageBlockProps> = ({ team }) => 
 
   const NonEditingHeadView = () => (
     <Grid container>
-      <Grid item xs={11} lg="auto">
+      <Grid item xs={11}>
         <DetailDisplay label="Head" content={fullNamePipe(team.head)} />
       </Grid>
-      <Grid item xs={1} mt={-1}>
+      <Grid item xs={1} mt={-1} display={'flex'} justifyContent={'flex-end'}>
         {hasPerms && <IconButton children={<Edit />} onClick={() => setIsEditingLeads(true)} />}
       </Grid>
     </Grid>
@@ -193,7 +193,7 @@ const TeamMembersPageBlock: React.FC<TeamMembersPageBlockProps> = ({ team }) => 
       <Grid item xs={11}>
         <DetailDisplay label="Leads" content={team.leads.map((lead) => fullNamePipe(lead)).join(', ')} />
       </Grid>
-      <Grid item xs={1} mt={-1}>
+      <Grid item xs={1} mt={-1} display={'flex'} justifyContent={'flex-end'}>
         {hasPerms && <IconButton children={<Edit />} onClick={() => setIsEditingLeads(true)} />}
       </Grid>
     </Grid>
@@ -201,10 +201,10 @@ const TeamMembersPageBlock: React.FC<TeamMembersPageBlockProps> = ({ team }) => 
 
   const NonEditingMembersView = () => (
     <Grid container>
-      <Grid item xs={11} lg="auto">
+      <Grid item xs={11}>
         <DetailDisplay label="Members" content={team.members.map((member) => fullNamePipe(member)).join(', ')} />
       </Grid>
-      <Grid item xs={1} mt={-1}>
+      <Grid item xs={1} mt={-1} display={'flex'} justifyContent={'flex-end'}>
         {hasPerms && <IconButton children={<Edit />} onClick={() => setIsEditingMembers(true)} />}
       </Grid>
     </Grid>


### PR DESCRIPTION
## Changes

Right aligned the pencil icon by adding `justifyContent={'flex-end'}` to the grid items 


## Screenshots

<img width="1512" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/99198350/2e19b563-8a0c-4660-8a42-63524b6f8808">

<img width="464" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/99198350/0fd57300-1758-4273-8325-f08ee08669dc">

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1597 
