### PR TITLE
#1307 : Changed dateReviewed to dateImplemented

### DIFF
--- a/src/backend/src/transformers/change-requests.transformer.ts
+++ b/src/backend/src/transformers/change-requests.transformer.ts
@@ -5,6 +5,7 @@ import { wbsNumOf } from '../utils/utils';
 import { calculateChangeRequestStatus, convertCRScopeWhyType } from '../utils/change-requests.utils';
 import proposedSolutionTransformer from './proposed-solutions.transformer';
 import userTransformer from './user.transformer';
+import { getDateImplemented } from '../utils/change-requests.utils';
 
 const changeRequestTransformer = (
   changeRequest: Prisma.Change_RequestGetPayload<typeof changeRequestRelationArgs>
@@ -23,11 +24,7 @@ const changeRequestTransformer = (
     dateReviewed: changeRequest.dateReviewed ?? undefined,
     accepted: changeRequest.accepted ?? undefined,
     reviewNotes: changeRequest.reviewNotes ?? undefined,
-    dateImplemented: changeRequest.changes.reduce(
-      (res: Date | undefined, change) =>
-        !res || change.dateImplemented.valueOf() > res.valueOf() ? change.dateImplemented : res,
-      undefined
-    ),
+    dateImplemented: getDateImplemented(changeRequest),
     implementedChanges: changeRequest.changes.map((change) => ({
       wbsNum: wbsNumOf(change.wbsElement),
       changeId: change.changeId,

--- a/src/backend/src/utils/change-requests.utils.ts
+++ b/src/backend/src/utils/change-requests.utils.ts
@@ -170,7 +170,7 @@ export const calculateChangeRequestStatus = (
 export const getDateImplemented = (changeRequest: Change_Request & { changes: Change[] }): Date | undefined => {
   return changeRequest.changes.reduce(
     (res: Date | undefined, change) =>
-      !res || change.dateImplemented.valueOf() > res.valueOf() ? change.dateImplemented : res,
+      !res || change.dateImplemented.valueOf() < res.valueOf() ? change.dateImplemented : res,
     undefined
   );
 };

--- a/src/backend/src/utils/change-requests.utils.ts
+++ b/src/backend/src/utils/change-requests.utils.ts
@@ -134,7 +134,7 @@ export const updateBlocking = async (
  * @throws if the change request is unreviewed, denied, or deleted
  */
 export const validateChangeRequestAccepted = async (crId: number) => {
-  const changeRequest = await prisma.change_Request.findUnique({ where: { crId } });
+  const changeRequest = await prisma.change_Request.findUnique({ where: { crId }, include: { changes: true}});
   const currentDate = new Date();
 
   if (!changeRequest) throw new NotFoundException('Change Request', crId);
@@ -142,10 +142,10 @@ export const validateChangeRequestAccepted = async (crId: number) => {
   if (changeRequest.accepted === null) throw new HttpException(400, 'Cannot implement an unreviewed change request');
   if (!changeRequest.accepted) throw new HttpException(400, 'Cannot implement a denied change request');
   if (!changeRequest.dateReviewed) throw new HttpException(400, 'Cannot use an unreviewed change request');
-  if (currentDate.getTime() - changeRequest.dateReviewed.getTime() > 1000 * 60 * 60 * 24 * 5)
+  if (currentDate.getTime() - changeRequest.changes[0].dateImplemented.getTime() > 1000 * 60 * 60 * 24 * 5)
     throw new HttpException(400, 'Cannot tie changes to outdated change request');
 
-  return changeRequest;
+  return changeRequest; 
 };
 
 /**

--- a/src/backend/src/utils/change-requests.utils.ts
+++ b/src/backend/src/utils/change-requests.utils.ts
@@ -1,6 +1,6 @@
 import prisma from '../prisma/prisma';
-import { Scope_CR_Why_Type, Team, User, Prisma, Change_Request } from '@prisma/client';
-import { addWeeksToDate, ChangeRequestReason } from 'shared';
+import { Scope_CR_Why_Type, Team, User, Prisma, Change_Request, Change } from '@prisma/client';
+import { addWeeksToDate, ChangeRequest, ChangeRequestReason } from 'shared';
 import { sendMessage } from '../integrations/slack';
 import { HttpException, NotFoundException } from './errors.utils';
 import { ChangeRequestStatus } from 'shared';
@@ -142,7 +142,8 @@ export const validateChangeRequestAccepted = async (crId: number) => {
   if (changeRequest.accepted === null) throw new HttpException(400, 'Cannot implement an unreviewed change request');
   if (!changeRequest.accepted) throw new HttpException(400, 'Cannot implement a denied change request');
   if (!changeRequest.dateReviewed) throw new HttpException(400, 'Cannot use an unreviewed change request');
-  if (currentDate.getTime() - changeRequest.changes[0].dateImplemented.getTime() > 1000 * 60 * 60 * 24 * 5)
+  const dateImplemented = getDateImplemented(changeRequest);
+  if (dateImplemented !== undefined && currentDate.getTime() - dateImplemented.getTime() > 1000 * 60 * 60 * 24 * 5)
     throw new HttpException(400, 'Cannot tie changes to outdated change request');
 
   return changeRequest;
@@ -164,6 +165,14 @@ export const calculateChangeRequestStatus = (
     return ChangeRequestStatus.Denied;
   }
   return ChangeRequestStatus.Open;
+};
+
+export const getDateImplemented = (changeRequest: Change_Request & { changes: Change[] }): Date | undefined => {
+  return changeRequest.changes.reduce(
+    (res: Date | undefined, change) =>
+      !res || change.dateImplemented.valueOf() > res.valueOf() ? change.dateImplemented : res,
+    undefined
+  );
 };
 
 /**

--- a/src/backend/src/utils/change-requests.utils.ts
+++ b/src/backend/src/utils/change-requests.utils.ts
@@ -134,7 +134,7 @@ export const updateBlocking = async (
  * @throws if the change request is unreviewed, denied, or deleted
  */
 export const validateChangeRequestAccepted = async (crId: number) => {
-  const changeRequest = await prisma.change_Request.findUnique({ where: { crId }, include: { changes: true}});
+  const changeRequest = await prisma.change_Request.findUnique({ where: { crId }, include: { changes: true } });
   const currentDate = new Date();
 
   if (!changeRequest) throw new NotFoundException('Change Request', crId);
@@ -145,7 +145,7 @@ export const validateChangeRequestAccepted = async (crId: number) => {
   if (currentDate.getTime() - changeRequest.changes[0].dateImplemented.getTime() > 1000 * 60 * 60 * 24 * 5)
     throw new HttpException(400, 'Cannot tie changes to outdated change request');
 
-  return changeRequest; 
+  return changeRequest;
 };
 
 /**

--- a/src/backend/src/utils/change-requests.utils.ts
+++ b/src/backend/src/utils/change-requests.utils.ts
@@ -1,6 +1,6 @@
 import prisma from '../prisma/prisma';
 import { Scope_CR_Why_Type, Team, User, Prisma, Change_Request, Change } from '@prisma/client';
-import { addWeeksToDate, ChangeRequest, ChangeRequestReason } from 'shared';
+import { addWeeksToDate, ChangeRequestReason } from 'shared';
 import { sendMessage } from '../integrations/slack';
 import { HttpException, NotFoundException } from './errors.utils';
 import { ChangeRequestStatus } from 'shared';

--- a/src/backend/src/utils/change-requests.utils.ts
+++ b/src/backend/src/utils/change-requests.utils.ts
@@ -143,7 +143,7 @@ export const validateChangeRequestAccepted = async (crId: number) => {
   if (!changeRequest.accepted) throw new HttpException(400, 'Cannot implement a denied change request');
   if (!changeRequest.dateReviewed) throw new HttpException(400, 'Cannot use an unreviewed change request');
   const dateImplemented = getDateImplemented(changeRequest);
-  if (dateImplemented !== undefined && currentDate.getTime() - dateImplemented.getTime() > 1000 * 60 * 60 * 24 * 5)
+  if (dateImplemented && currentDate.getTime() - dateImplemented.getTime() > 1000 * 60 * 60 * 24 * 5)
     throw new HttpException(400, 'Cannot tie changes to outdated change request');
 
   return changeRequest;

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -23,7 +23,9 @@ const mockGetHighestProjectNumber = getHighestProjectNumber as jest.Mock<Promise
 
 describe('Projects', () => {
   beforeEach(() => {
-    vi.spyOn(changeRequestUtils, 'validateChangeRequestAccepted').mockImplementation(async (_crId) => prismaChangeRequest1);
+    vi.spyOn(changeRequestUtils, 'validateChangeRequestAccepted').mockImplementation(async (_crId) => {
+      return { ...prismaChangeRequest1, changes: [] };
+    });
     vi.spyOn(projectTransformer, 'default').mockReturnValue(sharedProject1);
     vi.spyOn(WorkPackagesService, 'deleteWorkPackage').mockImplementation(async (_user: User, _wbsNum: WbsNumber) => {});
   });

--- a/src/backend/tests/work-packages.test.ts
+++ b/src/backend/tests/work-packages.test.ts
@@ -61,7 +61,7 @@ describe('Work Packages', () => {
 
   beforeEach(() => {
     vi.spyOn(changeRequestUtils, 'validateChangeRequestAccepted').mockImplementation(async (_crId) => {
-      return prismaChangeRequest1;
+      return { ...prismaChangeRequest1, changes: [] };
     });
 
     vi.spyOn(workPackageTransformer, 'default').mockReturnValue(sharedWorkPackage);

--- a/src/frontend/src/components/ChangeRequestDropdown.tsx
+++ b/src/frontend/src/components/ChangeRequestDropdown.tsx
@@ -12,7 +12,7 @@ const getFilteredChangeRequests = (changeRequests: ChangeRequest[], user: Authen
   const fiveDaysAgo = subDays(today, 5);
 
   const filteredRequests = changeRequests.filter(
-    (cr) => cr.dateReviewed && cr.accepted && isWithinInterval(cr.dateReviewed, { start: fiveDaysAgo, end: today })
+    (cr) => cr.dateImplemented && cr.accepted && isWithinInterval(cr.dateImplemented, { start: fiveDaysAgo, end: today })
   );
 
   // The current user's CRs should be at the top


### PR DESCRIPTION
## Changes

In both the back-end and front-end, I changed dateReviewed to dateImplemented by accessing the changeRequest's first change and using its Date.

## Notes

I wasn't able to test it properly using prisma studio so i wasn't able to make sure the front-end autocomplete works as it should


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1307 
