### PR TITLE
#1096 work package leads can create tasks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,8 +21,5 @@
     "editor.defaultFormatter": "Prisma.prisma"
   },
   "editor.formatOnSave": true,
-  "typescript.tsdk": "node_modules/typescript/lib",
-  "githubPullRequests.ignoredPullRequestBranches": [
-    "develop"
-  ]
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,8 @@
     "editor.defaultFormatter": "Prisma.prisma"
   },
   "editor.formatOnSave": true,
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "githubPullRequests.ignoredPullRequestBranches": [
+    "develop"
+  ]
 }

--- a/src/backend/src/services/tasks.services.ts
+++ b/src/backend/src/services/tasks.services.ts
@@ -57,18 +57,21 @@ export default class TasksService {
 
     const curWorkPackages = project.workPackages;
 
-    const isWorkPackageLead = curWorkPackages.some((workPackage) => {
-      return workPackage.wbsElement.projectLeadId === createdBy.userId;
+    const isWorkPackageLeadOrManager = curWorkPackages.some((workPackage) => {
+      return (
+        workPackage.wbsElement.projectLeadId === createdBy.userId ||
+        workPackage.wbsElement.projectManagerId === createdBy.userId
+      );
     });
 
     if (
       !isLeadership(createdBy.role) &&
       !isProjectLeadOrManager &&
-      !isWorkPackageLead &&
+      !isWorkPackageLeadOrManager &&
       !teams.some((team) => isUserOnTeam(team, createdBy))
     ) {
       throw new AccessDeniedException(
-        'Only admins, app-admins, project leads, project managers, work package leads, or current team users can create tasks'
+        'Only admins, app-admins, project leads, project managers, work package leads, work package managers, or current team users can create tasks'
       );
     }
 

--- a/src/backend/src/services/tasks.services.ts
+++ b/src/backend/src/services/tasks.services.ts
@@ -37,7 +37,11 @@ export default class TasksService {
   ): Promise<Task> {
     const requestedWbsElement = await prisma.wBS_Element.findUnique({
       where: { wbsNumber: wbsNum },
-      include: { project: { include: { teams: { ...teamQueryArgs }, wbsElement: true } } }
+      include: {
+        project: {
+          include: { teams: { ...teamQueryArgs }, wbsElement: true, workPackages: { include: { wbsElement: true } } }
+        }
+      }
     });
     if (!requestedWbsElement) throw new NotFoundException('WBS Element', wbsPipe(wbsNum));
     if (requestedWbsElement.dateDeleted) throw new DeletedException('WBS Element', wbsPipe(wbsNum));
@@ -51,7 +55,18 @@ export default class TasksService {
     const isProjectLeadOrManager =
       createdBy.userId === requestedWbsElement.projectLeadId || createdBy.userId === requestedWbsElement.projectManagerId;
 
-    if (!isLeadership(createdBy.role) && !isProjectLeadOrManager && !teams.some((team) => isUserOnTeam(team, createdBy))) {
+    const curWorkPackages = requestedWbsElement.project?.workPackages;
+
+    const isWorkPackageLead = curWorkPackages?.some((workPackage) => {
+      return workPackage.wbsElement.projectLeadId === createdBy.userId;
+    });
+
+    if (
+      !isLeadership(createdBy.role) &&
+      !isProjectLeadOrManager &&
+      isWorkPackageLead &&
+      !teams.some((team) => isUserOnTeam(team, createdBy))
+    ) {
       throw new AccessDeniedException(
         'Only admins, app-admins, project leads, project managers, or current team users can create tasks'
       );

--- a/src/backend/src/services/tasks.services.ts
+++ b/src/backend/src/services/tasks.services.ts
@@ -55,20 +55,20 @@ export default class TasksService {
     const isProjectLeadOrManager =
       createdBy.userId === requestedWbsElement.projectLeadId || createdBy.userId === requestedWbsElement.projectManagerId;
 
-    const curWorkPackages = requestedWbsElement.project?.workPackages;
+    const curWorkPackages = project.workPackages;
 
-    const isWorkPackageLead = curWorkPackages?.some((workPackage) => {
+    const isWorkPackageLead = curWorkPackages.some((workPackage) => {
       return workPackage.wbsElement.projectLeadId === createdBy.userId;
     });
 
     if (
       !isLeadership(createdBy.role) &&
       !isProjectLeadOrManager &&
-      isWorkPackageLead &&
+      !isWorkPackageLead &&
       !teams.some((team) => isUserOnTeam(team, createdBy))
     ) {
       throw new AccessDeniedException(
-        'Only admins, app-admins, project leads, project managers, or current team users can create tasks'
+        'Only admins, app-admins, project leads, project managers, work package leads, or current team users can create tasks'
       );
     }
 

--- a/src/backend/tests/tasks.test.ts
+++ b/src/backend/tests/tasks.test.ts
@@ -63,7 +63,7 @@ describe('Tasks', () => {
         TasksService.createTask(theVisitor, mockWBSNum, 'hellow world', '', mockDate, 'HIGH', 'DONE', [])
       ).rejects.toThrow(
         new AccessDeniedException(
-          'Only admins, app-admins, project leads, project managers, work package leads, or current team users can create tasks'
+          'Only admins, app-admins, project leads, project managers, work package leads, work package managers, or current team users can create tasks'
         )
       );
 

--- a/src/backend/tests/tasks.test.ts
+++ b/src/backend/tests/tasks.test.ts
@@ -63,7 +63,7 @@ describe('Tasks', () => {
         TasksService.createTask(theVisitor, mockWBSNum, 'hellow world', '', mockDate, 'HIGH', 'DONE', [])
       ).rejects.toThrow(
         new AccessDeniedException(
-          'Only admins, app-admins, project leads, project managers, or current team users can create tasks'
+          'Only admins, app-admins, project leads, project managers, work package leads, or current team users can create tasks'
         )
       );
 

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/TaskList.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/TaskList.tsx
@@ -66,14 +66,14 @@ const TaskList = ({ project }: TaskListProps) => {
   const { user } = auth;
   if (!user) return <LoadingIndicator />;
 
-  const isWorkPackageLead = project.workPackages.some((workPackage) => {
-    return workPackage.projectLead?.userId === user.userId;
+  const isWorkPackageLeadOrManager = project.workPackages.some((workPackage) => {
+    return workPackage.projectLead?.userId === user.userId || workPackage.projectManager?.userId === user.userId;
   });
 
   const createTaskPermissions =
     isLeadership(user.role) ||
     project.projectLead?.userId === user.userId ||
-    isWorkPackageLead ||
+    isWorkPackageLeadOrManager ||
     project.projectManager?.userId === user.userId ||
     project.teams.some((team) => team.head.userId === user.userId) ||
     project.teams.some((team) => team.leads.map((lead) => lead.userId).includes(user.userId));

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/TaskList.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/TaskList.tsx
@@ -66,9 +66,14 @@ const TaskList = ({ project }: TaskListProps) => {
   const { user } = auth;
   if (!user) return <LoadingIndicator />;
 
+  const isWorkPackageLead = project.workPackages.some((workPackage) => {
+    return workPackage.projectLead?.userId === user.userId;
+  });
+
   const createTaskPermissions =
     isLeadership(user.role) ||
     project.projectLead?.userId === user.userId ||
+    isWorkPackageLead ||
     project.projectManager?.userId === user.userId ||
     project.teams.some((team) => team.head.userId === user.userId) ||
     project.teams.some((team) => team.leads.map((lead) => lead.userId).includes(user.userId));


### PR DESCRIPTION
## Changes

Work package leads can now create tasks. In the front end, the create task button will now be available to wp leads. In the back end, the createTask permissions were updated to include wp leads.

## Notes

Although wp leads can now create tasks, they still don't have permission to edit tasks (in both the front and back end). Perhaps this should be changed too.

## Screenshots

![AddTask non-wp lead](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/123319639/b14d211e-ff9b-4ce7-ac6d-07712055f194)
![AddTask WP lead](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/123319639/76de9ead-3555-4527-b500-d3e252385187)
![AddTask wp-lead](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/123319639/d9c532c8-9296-4833-9d72-61e02c6f48b8)


Closes #1096 
