### PR TITLE
#1554 form validation fix for crID for project/wp edit

### DIFF
--- a/src/frontend/src/components/ChangeRequestDropdown.tsx
+++ b/src/frontend/src/components/ChangeRequestDropdown.tsx
@@ -34,7 +34,6 @@ interface ChangeRequestDropdownProps {
   control: Control<any, any>;
   name: string;
   errors: FieldErrors<ChangeRequest>;
-  errorMessage?: FieldError;
 }
 
 const ChangeRequestDropdown = ({ control, name, errors }: ChangeRequestDropdownProps) => {

--- a/src/frontend/src/components/ChangeRequestDropdown.tsx
+++ b/src/frontend/src/components/ChangeRequestDropdown.tsx
@@ -1,6 +1,6 @@
-import { Box, FormControl, FormLabel, MenuItem, Select, SelectChangeEvent } from '@mui/material';
+import { Box, FormControl, FormHelperText, FormLabel, MenuItem, Select, SelectChangeEvent } from '@mui/material';
 import { isWithinInterval, subDays } from 'date-fns';
-import { Control, Controller } from 'react-hook-form';
+import { Control, Controller, FieldError, FieldErrors } from 'react-hook-form';
 import { AuthenticatedUser, ChangeRequest, wbsPipe } from 'shared';
 import { useAllChangeRequests } from '../hooks/change-requests.hooks';
 import { useCurrentUser } from '../hooks/users.hooks';
@@ -33,9 +33,11 @@ const getFilteredChangeRequests = (changeRequests: ChangeRequest[], user: Authen
 interface ChangeRequestDropdownProps {
   control: Control<any, any>;
   name: string;
+  errors: FieldErrors<ChangeRequest>;
+  errorMessage?: FieldError;
 }
 
-const ChangeRequestDropdown = ({ control, name }: ChangeRequestDropdownProps) => {
+const ChangeRequestDropdown = ({ control, name, errors, errorMessage }: ChangeRequestDropdownProps) => {
   const user = useCurrentUser();
   const { isLoading, data: changeRequests } = useAllChangeRequests();
   if (isLoading || !changeRequests) return <LoadingIndicator />;
@@ -64,6 +66,7 @@ const ChangeRequestDropdown = ({ control, name }: ChangeRequestDropdownProps) =>
               size={'small'}
               placeholder={'Change Request Id'}
               sx={{ width: 200, textAlign: 'left' }}
+              error={!!errorMessage}
               MenuProps={{
                 anchorOrigin: {
                   vertical: 'bottom',
@@ -83,6 +86,7 @@ const ChangeRequestDropdown = ({ control, name }: ChangeRequestDropdownProps) =>
             </Select>
           )}
         />
+        <FormHelperText error>{errors.crId?.message}</FormHelperText>
       </FormControl>
     </Box>
   );

--- a/src/frontend/src/components/ChangeRequestDropdown.tsx
+++ b/src/frontend/src/components/ChangeRequestDropdown.tsx
@@ -37,7 +37,7 @@ interface ChangeRequestDropdownProps {
   errorMessage?: FieldError;
 }
 
-const ChangeRequestDropdown = ({ control, name, errors, errorMessage }: ChangeRequestDropdownProps) => {
+const ChangeRequestDropdown = ({ control, name, errors }: ChangeRequestDropdownProps) => {
   const user = useCurrentUser();
   const { isLoading, data: changeRequests } = useAllChangeRequests();
   if (isLoading || !changeRequests) return <LoadingIndicator />;
@@ -66,7 +66,7 @@ const ChangeRequestDropdown = ({ control, name, errors, errorMessage }: ChangeRe
               size={'small'}
               placeholder={'Change Request Id'}
               sx={{ width: 200, textAlign: 'left' }}
-              error={!!errorMessage}
+              error={!!errors.crId}
               MenuProps={{
                 anchorOrigin: {
                   vertical: 'bottom',

--- a/src/frontend/src/components/ChangeRequestDropdown.tsx
+++ b/src/frontend/src/components/ChangeRequestDropdown.tsx
@@ -1,6 +1,6 @@
 import { Box, FormControl, FormHelperText, FormLabel, MenuItem, Select, SelectChangeEvent } from '@mui/material';
 import { isWithinInterval, subDays } from 'date-fns';
-import { Control, Controller, FieldError, FieldErrors } from 'react-hook-form';
+import { Control, Controller, FieldErrors } from 'react-hook-form';
 import { AuthenticatedUser, ChangeRequest, wbsPipe } from 'shared';
 import { useAllChangeRequests } from '../hooks/change-requests.hooks';
 import { useCurrentUser } from '../hooks/users.hooks';

--- a/src/frontend/src/pages/CreditsPage/CreditsPage.tsx
+++ b/src/frontend/src/pages/CreditsPage/CreditsPage.tsx
@@ -132,7 +132,8 @@ const CreditsPage: React.FC = () => {
     { name: 'Kevin Polackal', color: '#800080' },
     { name: 'Lily Shiomitsu', color: '#008080' },
     { name: 'Kevin Yang', color: '#0000FF' },
-    { name: 'Qihong Wu', color: '#87CEEB' }
+    { name: 'Qihong Wu', color: '#87CEEB' },
+    { name: 'Jessica Zhao', color: '#6495ED' }
   ];
 
   const snark = ['Add your name!', "Shouldn't you do it yourself?", 'Seriously', 'go', 'do', 'it'];

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditContainer.tsx
@@ -180,7 +180,7 @@ const ProjectEditContainer: React.FC<ProjectEditContainerProps> = ({ project, ex
     <PageLayout
       title={`${wbsPipe(project.wbsNum)} - ${project.name}`}
       previousPages={[{ name: 'Projects', route: routes.PROJECTS }]}
-      headerRight={<ChangeRequestDropdown control={control} name="crId" errors={errors} errorMessage={errors.crId} />}
+      headerRight={<ChangeRequestDropdown control={control} name="crId" errors={errors} />}
     >
       <form
         id="project-edit-form"

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectEdit/ProjectEditContainer.tsx
@@ -39,7 +39,13 @@ const schema = yup.object().shape({
       url: yup.string().required('URL is required!').url('Invalid URL')
     })
   ),
-  summary: yup.string().required('Summary is required!')
+  summary: yup.string().required('Summary is required!'),
+  crId: yup
+    .number()
+    .required('CR ID is required')
+    .typeError('CR ID must be a number')
+    .integer('CR ID must be an integer')
+    .min(1, 'CR ID must be greater than or equal to 1')
 });
 
 interface ProjectEditContainerProps {
@@ -174,7 +180,7 @@ const ProjectEditContainer: React.FC<ProjectEditContainerProps> = ({ project, ex
     <PageLayout
       title={`${wbsPipe(project.wbsNum)} - ${project.name}`}
       previousPages={[{ name: 'Projects', route: routes.PROJECTS }]}
-      headerRight={<ChangeRequestDropdown control={control} name="crId" />}
+      headerRight={<ChangeRequestDropdown control={control} name="crId" errors={errors} errorMessage={errors.crId} />}
     >
       <form
         id="project-edit-form"

--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditContainer.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageEditContainer/WorkPackageEditContainer.tsx
@@ -33,7 +33,13 @@ const schema = yup.object().shape({
     .date()
     .required('Start Date is required!')
     .test('start-date-valid', 'start date is not valid', startDateTester),
-  duration: yup.number().required()
+  duration: yup.number().required(),
+  crId: yup
+    .number()
+    .required('CR ID is required')
+    .typeError('CR ID must be a number')
+    .integer('CR ID must be an integer')
+    .min(1, 'CR ID must be greater than or equal to 1')
 });
 
 interface WorkPackageEditContainerProps {
@@ -171,7 +177,7 @@ const WorkPackageEditContainer: React.FC<WorkPackageEditContainerProps> = ({ wor
         { name: 'Projects', route: routes.PROJECTS },
         { name: `${projectWbsString} - ${workPackage.projectName}`, route: `${routes.PROJECTS}/${projectWbsString}` }
       ]}
-      headerRight={<ChangeRequestDropdown control={control} name="crId" />}
+      headerRight={<ChangeRequestDropdown control={control} name="crId" errors={errors} />}
     >
       <form
         id="work-package-edit-form"


### PR DESCRIPTION
## Changes

Added an error message if crID isn't filled out on the work package/ project edit forms.

## Screenshots
<img width="1470" alt="Screenshot 2023-10-11 at 8 55 47 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/132928939/99268a5f-44ac-4cae-935c-e25597b1eb4d">
<img width="225" alt="Screenshot 2023-10-11 at 8 55 52 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/132928939/162214ce-478c-4148-ae56-bf5f226e68a9">


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1554 
