### PR TITLE
#1593 - Made changes to change-request.services

### DIFF
--- a/src/backend/src/services/change-requests.services.ts
+++ b/src/backend/src/services/change-requests.services.ts
@@ -700,6 +700,7 @@ export default class ChangeRequestsService {
       ...changeRequestQueryArgs
     });
 
+
     if (!foundCR) throw new NotFoundException('Change Request', crId);
 
     if (foundCR.submitterId !== submitter.userId)
@@ -708,6 +709,8 @@ export default class ChangeRequestsService {
     if (foundCR.dateDeleted) throw new DeletedException('Change Request', crId);
 
     if (foundCR.reviewerId) throw new HttpException(400, `Cannot request a review on an already reviewed change request`);
+
+    const oldReviewers = foundCR.requestedReviewers
 
     const reviewerIds = reviewers.map((reviewer) => {
       return {
@@ -725,8 +728,12 @@ export default class ChangeRequestsService {
     });
 
     // send slack message to CR reviewers
+
     reviewers.forEach(async (user) => {
+      //if (!oldReviewers.includes(user)) {
+      console.log("sending slack noti")
       await sendSlackRequestedReviewNotification(user.userSettings!.slackId, changeRequestTransformer(foundCR));
+      //}
     });
   }
 }


### PR DESCRIPTION
## Changes

Added an if statement that checks if the user who is about to be pinged is present in the old reviewers list.

## To Do

_Any remaining things that need to get done_

- [✅] The request CR service method is updated to only send slack notifications to new reviewers


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #1593 
