### PR TITLE
#1521 BOM create manufacturer endpoint

### DIFF
--- a/src/backend/src/controllers/projects.controllers.ts
+++ b/src/backend/src/controllers/projects.controllers.ts
@@ -127,4 +127,15 @@ export default class ProjectsController {
       next(error);
     }
   }
+
+  static async createManufacturer(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { name } = req.body;
+      const user = await getCurrentUser(res);
+      const createdManufacturer = await ProjectsService.createManufacturer(user, name);
+      res.status(200).json(createdManufacturer);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
 }

--- a/src/backend/src/routes/projects.routes.ts
+++ b/src/backend/src/routes/projects.routes.ts
@@ -47,5 +47,6 @@ projectRouter.post(
 projectRouter.post('/:wbsNum/set-team', nonEmptyString(body('teamId')), validateInputs, ProjectsController.setProjectTeam);
 projectRouter.delete('/:wbsNum/delete', ProjectsController.deleteProject);
 projectRouter.post('/:wbsNum/favorite', ProjectsController.toggleFavorite);
+projectRouter.post('/bom/manufacturer/create', nonEmptyString(body('name')), validateInputs, ProjectsController.createManufacturer);
 
 export default projectRouter;

--- a/src/backend/src/routes/projects.routes.ts
+++ b/src/backend/src/routes/projects.routes.ts
@@ -47,6 +47,8 @@ projectRouter.post(
 projectRouter.post('/:wbsNum/set-team', nonEmptyString(body('teamId')), validateInputs, ProjectsController.setProjectTeam);
 projectRouter.delete('/:wbsNum/delete', ProjectsController.deleteProject);
 projectRouter.post('/:wbsNum/favorite', ProjectsController.toggleFavorite);
+
+/**************** BOM Section ****************/
 projectRouter.post(
   '/bom/manufacturer/create',
   nonEmptyString(body('name')),

--- a/src/backend/src/routes/projects.routes.ts
+++ b/src/backend/src/routes/projects.routes.ts
@@ -47,6 +47,11 @@ projectRouter.post(
 projectRouter.post('/:wbsNum/set-team', nonEmptyString(body('teamId')), validateInputs, ProjectsController.setProjectTeam);
 projectRouter.delete('/:wbsNum/delete', ProjectsController.deleteProject);
 projectRouter.post('/:wbsNum/favorite', ProjectsController.toggleFavorite);
-projectRouter.post('/bom/manufacturer/create', nonEmptyString(body('name')), validateInputs, ProjectsController.createManufacturer);
+projectRouter.post(
+  '/bom/manufacturer/create',
+  nonEmptyString(body('name')),
+  validateInputs,
+  ProjectsController.createManufacturer
+);
 
 export default projectRouter;

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -612,7 +612,7 @@ export default class ProjectsService {
       }
     });
 
-    if (manufacturer) throw new HttpException(400, `${name} already exists as a manufacturer!`);
+    if (!!manufacturer) throw new HttpException(400, `${name} already exists as a manufacturer!`);
 
     const newManufacturer = await prisma.manufacturer.create({
       data: { name, dateCreated: new Date(), creatorId: submitter.userId }

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -602,4 +602,14 @@ export default class ProjectsService {
       })
     ).map(linkTypeTransformer);
   }
+
+  static async createManufacturer(submitter: User, name: string) {
+    if (isGuest(submitter.role)) throw new AccessDeniedGuestException('create manufacturers');
+
+    const manufacturer = await prisma.manufacturer.create({
+      data: { name, dateCreated: new Date(), creatorId: submitter.userId }
+    });
+
+    return manufacturer;
+  }
 }

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -612,7 +612,7 @@ export default class ProjectsService {
       }
     });
 
-    if (manufacturer) throw new HttpException(400, `The following manufacturer already exists: ${name}`);
+    if (manufacturer) throw new HttpException(400, `${name} already exists as a manufacturer!`);
 
     const newManufacturer = await prisma.manufacturer.create({
       data: { name, dateCreated: new Date(), creatorId: submitter.userId }

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -606,10 +606,18 @@ export default class ProjectsService {
   static async createManufacturer(submitter: User, name: string) {
     if (isGuest(submitter.role)) throw new AccessDeniedGuestException('create manufacturers');
 
-    const manufacturer = await prisma.manufacturer.create({
+    const manufacturer = await prisma.manufacturer.findUnique({
+      where: {
+        name
+      }
+    });
+
+    if (manufacturer) throw new HttpException(400, `The following manufacturer already exists: ${name}`);
+
+    const newManufacturer = await prisma.manufacturer.create({
       data: { name, dateCreated: new Date(), creatorId: submitter.userId }
     });
 
-    return manufacturer;
+    return newManufacturer;
   }
 }

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -603,6 +603,13 @@ export default class ProjectsService {
     ).map(linkTypeTransformer);
   }
 
+  /**
+   * Creates a new Manufacturer
+   * @param submitter the user who's creating the manufacturer
+   * @param name the name of the manufacturer
+   * @returns the newly created manufacturer
+   * @throws if the submitter is a guest or the given manufacturer name already exists
+   */
   static async createManufacturer(submitter: User, name: string) {
     if (isGuest(submitter.role)) throw new AccessDeniedGuestException('create manufacturers');
 
@@ -612,7 +619,7 @@ export default class ProjectsService {
       }
     });
 
-    if (!!manufacturer) throw new HttpException(400, `${name} already exists as a manufacturer!`);
+    if (manufacturer) throw new HttpException(400, `${name} already exists as a manufacturer!`);
 
     const newManufacturer = await prisma.manufacturer.create({
       data: { name, dateCreated: new Date(), creatorId: submitter.userId }

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -262,7 +262,7 @@ describe('Projects', () => {
     });
 
     test('createManufacturer throws an error if manufacturer already exists', async () => {
-      vi.spyOn(prisma.manufacturer, 'create').mockResolvedValue(prismaManufacturer1);
+      vi.spyOn(prisma.manufacturer, 'findUnique').mockResolvedValue(prismaManufacturer1);
 
       await expect(ProjectsService.createManufacturer(batman, 'Manufacturer1')).rejects.toThrow(
         new HttpException(400, 'Manufacturer1 already exists as a manufacturer!')

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -255,21 +255,21 @@ describe('Projects', () => {
   });
 
   describe('Manufacturer Tests', () => {
-    test('Create Manufacturer throws an error if user is guest', async () => {
+    test('createManufacturer throws an error if user is a guest', async () => {
       await expect(ProjectsService.createManufacturer(wonderwoman, 'NAME')).rejects.toThrow(
         new AccessDeniedGuestException('create manufacturers')
       );
     });
 
-    test('Create Manufacturer throws an error if manufacturer already exists', async () => {
+    test('createManufacturer throws an error if manufacturer already exists', async () => {
       vi.spyOn(prisma.manufacturer, 'create').mockResolvedValue(prismaManufacturer1);
 
       await expect(ProjectsService.createManufacturer(batman, 'Manufacturer1')).rejects.toThrow(
-        new HttpException(400, 'The following manufacturer already exists: Manufacturer1')
+        new HttpException(400, 'Manufacturer1 already exists as a manufacturer!')
       );
     });
 
-    test('Create Manufacturer successfully returns correct Name and Creator ID', async () => {
+    test('createManufacturer works as intended and successfully returns correct name and creator ID', async () => {
       vi.spyOn(prisma.manufacturer, 'findUnique').mockResolvedValue(null);
       vi.spyOn(prisma.manufacturer, 'create').mockResolvedValue(prismaManufacturer1);
 

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -2,7 +2,7 @@ import prisma from '../src/prisma/prisma';
 import { getHighestProjectNumber } from '../src/utils/projects.utils';
 import * as changeRequestUtils from '../src/utils/change-requests.utils';
 import { aquaman, batman, wonderwoman } from './test-data/users.test-data';
-import { prismaProject1, sharedProject1 } from './test-data/projects.test-data';
+import { prismaManufacturer1, prismaProject1, sharedProject1 } from './test-data/projects.test-data';
 import { prismaChangeRequest1 } from './test-data/change-requests.test-data';
 import { prismaTeam1 } from './test-data/teams.test-data';
 import * as projectTransformer from '../src/transformers/projects.transformer';
@@ -256,9 +256,17 @@ describe('Projects', () => {
 
   describe('Manufacturer Tests', () => {
     test('Create Manufacturer throws an error if user is guest', async () => {
-      await expect(ProjectsService.createManufacturer(wonderwoman, 'HOLA BUDDY')).rejects.toThrow(
+      await expect(ProjectsService.createManufacturer(wonderwoman, 'NAME')).rejects.toThrow(
         new AccessDeniedGuestException('create manufacturers')
       );
+    });
+
+    test('Create Manufacturer successfully returns correct Creator ID', async () => {
+      vi.spyOn(prisma.manufacturer, 'create').mockResolvedValue(prismaManufacturer1);
+
+      const manufacturer = await ProjectsService.createManufacturer(batman, 'Manufacturer1');
+
+      expect(manufacturer.creatorId).toBe(prismaManufacturer1.creatorId);
     });
   });
 });

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -9,6 +9,7 @@ import * as projectTransformer from '../src/transformers/projects.transformer';
 import ProjectsService from '../src/services/projects.services';
 import {
   AccessDeniedAdminOnlyException,
+  AccessDeniedGuestException,
   DeletedException,
   HttpException,
   NotFoundException
@@ -250,6 +251,14 @@ describe('Projects', () => {
       expect(res).toBe(sharedProject1);
       expect(prisma.project.findFirst).toBeCalledTimes(1);
       expect(prisma.user.update).toBeCalledTimes(1);
+    });
+  });
+
+  describe('Manufacturer Tests', () => {
+    test('Create Manufacturer throws an error if user is guest', async () => {
+      await expect(ProjectsService.createManufacturer(wonderwoman, 'HOLA BUDDY')).rejects.toThrow(
+        new AccessDeniedGuestException('create manufacturers')
+      );
     });
   });
 });

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -261,11 +261,21 @@ describe('Projects', () => {
       );
     });
 
-    test('Create Manufacturer successfully returns correct Creator ID', async () => {
+    test('Create Manufacturer throws an error if manufacturer already exists', async () => {
+      vi.spyOn(prisma.manufacturer, 'create').mockResolvedValue(prismaManufacturer1);
+
+      await expect(ProjectsService.createManufacturer(batman, 'Manufacturer1')).rejects.toThrow(
+        new HttpException(400, 'The following manufacturer already exists: Manufacturer1')
+      );
+    });
+
+    test('Create Manufacturer successfully returns correct Name and Creator ID', async () => {
+      vi.spyOn(prisma.manufacturer, 'findUnique').mockResolvedValue(null);
       vi.spyOn(prisma.manufacturer, 'create').mockResolvedValue(prismaManufacturer1);
 
       const manufacturer = await ProjectsService.createManufacturer(batman, 'Manufacturer1');
 
+      expect(manufacturer.name).toBe(prismaManufacturer1.name);
       expect(manufacturer.creatorId).toBe(prismaManufacturer1.creatorId);
     });
   });

--- a/src/backend/tests/test-data/projects.test-data.ts
+++ b/src/backend/tests/test-data/projects.test-data.ts
@@ -1,4 +1,4 @@
-import { Prisma, WBS_Element_Status as PrismaWBSElementStatus, Project } from '@prisma/client';
+import { Prisma, WBS_Element_Status as PrismaWBSElementStatus, Project, Manufacturer } from '@prisma/client';
 import { Project as SharedProject, WbsElementStatus } from 'shared';
 import projectQueryArgs from '../../src/prisma-query-args/projects.query-args';
 import { prismaTeam1 } from './teams.test-data';
@@ -96,4 +96,10 @@ export const sharedProject1: SharedProject = {
   workPackages: [],
   tasks: [],
   teams: []
+};
+
+export const prismaManufacturer1: Manufacturer = {
+  name: 'Manufacturer1',
+  dateCreated: new Date('10-1-2023'),
+  creatorId: 1
 };


### PR DESCRIPTION
## Changes

Created create manufacturer endpoint and added backend tests for this endpoint.

## Test Cases

- Create manufacturer when User is a guest (should reject)
- Create manufacturer when manufacturer with the given name already exists (should reject)
- Create manufacturer when User is not a guest and the manufacturer's name doesn't already exist (should create manufacturer successfully)

Added tests to the projects backend tests and manually tested with Postman (see below).

## Screenshots

createManufacturer works as intended
<img width="1348" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/92332953/c317df71-7c0e-415f-8e86-14e386550719">

createManufacturer throws an error if manufacturer name already exists
<img width="1348" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/92332953/392bf53c-c0d0-4734-ae4f-ae3492d554bb">

createManufacturer throws an error if user is a guest
<img width="1348" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/92332953/d6c733e2-64bb-4b10-86f7-3f06f52bd3c4">

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1521
