### PR TITLE
#1641 other CRs from user popup

### DIFF
--- a/src/frontend/src/components/ChangeRequestDetailCard.tsx
+++ b/src/frontend/src/components/ChangeRequestDetailCard.tsx
@@ -106,7 +106,7 @@ const ChangeRequestDetailCard: React.FC<ChangeRequestDetailCardProps> = ({ chang
   const ChangeRequestTypeView = () => determineChangeRequestTypeView(changeRequest);
   const pillColor = determineChangeRequestPillColor(changeRequest.type);
   return (
-    <Card sx={{ width: 300, mr: 1, mb: 1, borderRadius: 5 }}>
+    <Card sx={{ minWidth: 300, width: 300, mr: 1, mb: 1, borderRadius: 5 }}>
       <CardContent>
         <Grid container justifyContent="space-between" alignItems="center">
           <Grid item>

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ChangeRequestDetailsView.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ChangeRequestDetailsView.tsx
@@ -147,7 +147,6 @@ const ChangeRequestDetailsView: React.FC<ChangeRequestDetailsProps> = ({
         changes={changeRequest.implementedChanges || []}
         overallDateImplemented={changeRequest.dateImplemented}
       />
-
       {reviewModalShow && (
         <ReviewChangeRequest modalShow={reviewModalShow} handleClose={handleReviewClose} cr={changeRequest} />
       )}

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ChangeRequestDetailsView.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ChangeRequestDetailsView.tsx
@@ -30,6 +30,7 @@ import LoadingIndicator from '../../components/LoadingIndicator';
 import ErrorPage from '../ErrorPage';
 import PageLayout from '../../components/PageLayout';
 import ChangeRequestActionMenu from './ChangeRequestActionMenu';
+import OtherChangeRequestsPopupTabs from './OtherChangeRequestsPopupTabs';
 
 const buildDetails = (cr: ChangeRequest): ReactElement => {
   switch (cr.type) {
@@ -146,12 +147,14 @@ const ChangeRequestDetailsView: React.FC<ChangeRequestDetailsProps> = ({
         changes={changeRequest.implementedChanges || []}
         overallDateImplemented={changeRequest.dateImplemented}
       />
+
       {reviewModalShow && (
         <ReviewChangeRequest modalShow={reviewModalShow} handleClose={handleReviewClose} cr={changeRequest} />
       )}
       {deleteModalShow && (
         <DeleteChangeRequest modalShow={deleteModalShow} handleClose={handleDeleteClose} cr={changeRequest} />
       )}
+      <OtherChangeRequestsPopupTabs changeRequest={changeRequest} />
     </PageLayout>
   );
 };

--- a/src/frontend/src/pages/ChangeRequestDetailPage/OtherChangeRequestsPopupTabs.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/OtherChangeRequestsPopupTabs.tsx
@@ -27,7 +27,7 @@ const OtherChangeRequestsPopupTabs: React.FC<OtherChangeRequestsPopupTabsProps> 
   if (isError) return <ErrorPage error={error} message={error.message} />;
 
   // the CRs submitted or reviewed by the submitter of this CR
-  const crFromSameUser = changeRequests?.filter(
+  const crsFromSubmitter = changeRequests?.filter(
     (cr) =>
       (cr.submitter.userId === changeRequest.submitter.userId || cr.reviewer?.userId === changeRequest.submitter.userId) &&
       cr.crId !== changeRequest.crId
@@ -42,9 +42,7 @@ const OtherChangeRequestsPopupTabs: React.FC<OtherChangeRequestsPopupTabsProps> 
           {tab === value ? <ExpandMore sx={{ pl: 0.5 }} /> : <ExpandLess sx={{ pl: 0.5 }} />}
         </Typography>
       }
-      onClick={() => {
-        tab === value && setTab(0);
-      }}
+      onClick={() => tab === value && setTab(0)}
     />
   );
 
@@ -111,7 +109,7 @@ const OtherChangeRequestsPopupTabs: React.FC<OtherChangeRequestsPopupTabsProps> 
       >
         {displayTab(1, `Other CR's from ${changeRequest.submitter.firstName} ${changeRequest.submitter.lastName}`)}
       </Tabs>
-      <Collapse in={tab !== 0}>{tab === 1 && displayCRCards(crFromSameUser || [])}</Collapse>
+      <Collapse in={tab !== 0}>{tab === 1 && displayCRCards(crsFromSubmitter || [])}</Collapse>
     </Box>
   );
 };

--- a/src/frontend/src/pages/ChangeRequestDetailPage/OtherChangeRequestsPopupTabs.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/OtherChangeRequestsPopupTabs.tsx
@@ -55,8 +55,8 @@ const OtherChangeRequestsPopupTabs: React.FC<OtherChangeRequestsPopupTabsProps> 
         justifyContent: 'flex-start',
         padding: '20px',
         background: theme.palette.background.paper,
-        borderTop: `solid ${theme.palette.divider}`,
-        borderLeft: `solid ${theme.palette.divider}`
+        borderTop: `solid 1px ${theme.palette.divider}`,
+        borderLeft: `solid 1px ${theme.palette.divider}`
       }}
     >
       {crList.map((cr: ChangeRequest) => (
@@ -83,7 +83,7 @@ const OtherChangeRequestsPopupTabs: React.FC<OtherChangeRequestsPopupTabsProps> 
           },
           '& button': {
             background: theme.palette.background.paper,
-            border: `solid ${theme.palette.divider}`,
+            border: `solid 1px ${theme.palette.divider}`,
             color: theme.palette.text.primary,
             textTransform: 'none'
           },
@@ -91,7 +91,7 @@ const OtherChangeRequestsPopupTabs: React.FC<OtherChangeRequestsPopupTabsProps> 
             color: theme.palette.text.primary,
             borderBottom: 'transparent'
           },
-          mb: '-1.5px'
+          mb: '-1px'
         }}
       >
         {displayTab(1, `Other CR's from ${changeRequest.submitter.firstName} ${changeRequest.submitter.lastName}`)}

--- a/src/frontend/src/pages/ChangeRequestDetailPage/OtherChangeRequestsPopupTabs.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/OtherChangeRequestsPopupTabs.tsx
@@ -11,6 +11,7 @@ import { useAllChangeRequests } from '../../hooks/change-requests.hooks';
 import { ExpandLess, ExpandMore } from '@mui/icons-material';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import ErrorPage from '../ErrorPage';
+import { fullNamePipe } from '../../utils/pipes';
 
 interface OtherChangeRequestsPopupTabsProps {
   changeRequest: ChangeRequest;
@@ -27,15 +28,20 @@ const OtherChangeRequestsPopupTabs: React.FC<OtherChangeRequestsPopupTabsProps> 
   if (isError) return <ErrorPage error={error} message={error.message} />;
 
   // the CRs submitted or reviewed by the submitter of this CR
-  const crsFromSubmitter = changeRequests?.filter(
-    (cr) =>
-      (cr.submitter.userId === changeRequest.submitter.userId || cr.reviewer?.userId === changeRequest.submitter.userId) &&
-      cr.crId !== changeRequest.crId
-  );
+  const crsFromSubmitter = changeRequests
+    ?.filter(
+      (cr) =>
+        (cr.submitter.userId === changeRequest.submitter.userId || cr.reviewer?.userId === changeRequest.submitter.userId) &&
+        cr.crId !== changeRequest.crId
+    )
+    .sort((a: ChangeRequest, b: ChangeRequest) => {
+      return b.dateSubmitted.getTime() - a.dateSubmitted.getTime();
+    });
 
   const displayTab = (value: number, title: string) => (
     <Tab
       value={value}
+      sx={{ borderRadius: '16px 16px 0 0' }}
       label={
         <Typography sx={{ display: 'flex' }}>
           {title}
@@ -107,7 +113,7 @@ const OtherChangeRequestsPopupTabs: React.FC<OtherChangeRequestsPopupTabsProps> 
           mb: '-1px'
         }}
       >
-        {displayTab(1, `Other CR's from ${changeRequest.submitter.firstName} ${changeRequest.submitter.lastName}`)}
+        {displayTab(1, `Other CR's from ${fullNamePipe(changeRequest.submitter)}`)}
       </Tabs>
       <Collapse in={tab !== 0}>{tab === 1 && displayCRCards(crsFromSubmitter || [])}</Collapse>
     </Box>

--- a/src/frontend/src/pages/ChangeRequestDetailPage/OtherChangeRequestsPopupTabs.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/OtherChangeRequestsPopupTabs.tsx
@@ -86,7 +86,7 @@ const OtherChangeRequestsPopupTabs: React.FC<OtherChangeRequestsPopupTabsProps> 
         position: 'fixed',
         bottom: '0px',
         left: '65px',
-        width: `calc(100% - 65px)`
+        width: 'calc(100% - 65px)'
       }}
     >
       <Tabs

--- a/src/frontend/src/pages/ChangeRequestDetailPage/OtherChangeRequestsPopupTabs.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/OtherChangeRequestsPopupTabs.tsx
@@ -39,7 +39,7 @@ const OtherChangeRequestsPopupTabs: React.FC<OtherChangeRequestsPopupTabsProps> 
       label={
         <Typography sx={{ display: 'flex' }}>
           {title}
-          {tab === value ? <ExpandMore sx={{ paddingLeft: 0.5 }} /> : <ExpandLess sx={{ paddingLeft: 0.5 }} />}
+          {tab === value ? <ExpandMore sx={{ pl: 0.5 }} /> : <ExpandLess sx={{ pl: 0.5 }} />}
         </Typography>
       }
       onClick={() => {
@@ -70,7 +70,8 @@ const OtherChangeRequestsPopupTabs: React.FC<OtherChangeRequestsPopupTabsProps> 
       sx={{
         position: 'fixed',
         bottom: '0px',
-        width: '100%'
+        left: '65px',
+        minWidth: '100%'
       }}
     >
       <Tabs
@@ -90,7 +91,7 @@ const OtherChangeRequestsPopupTabs: React.FC<OtherChangeRequestsPopupTabsProps> 
             color: theme.palette.text.primary,
             borderBottom: 'transparent'
           },
-          marginBottom: '-3px'
+          mb: '-1px'
         }}
       >
         {displayTab(1, `Other CR's from ${changeRequest.submitter.firstName} ${changeRequest.submitter.lastName}`)}

--- a/src/frontend/src/pages/ChangeRequestDetailPage/OtherChangeRequestsPopupTabs.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/OtherChangeRequestsPopupTabs.tsx
@@ -1,3 +1,8 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
 import React, { useState } from 'react';
 import { Box, useTheme, Collapse, Tabs, Tab, Typography } from '@mui/material';
 import { ChangeRequest } from 'shared';
@@ -10,6 +15,7 @@ import ErrorPage from '../ErrorPage';
 interface OtherChangeRequestsPopupTabsProps {
   changeRequest: ChangeRequest;
 }
+
 const OtherChangeRequestsPopupTabs: React.FC<OtherChangeRequestsPopupTabsProps> = ({
   changeRequest
 }: OtherChangeRequestsPopupTabsProps) => {
@@ -27,6 +33,21 @@ const OtherChangeRequestsPopupTabs: React.FC<OtherChangeRequestsPopupTabsProps> 
       cr.crId !== changeRequest.crId
   );
 
+  const displayTab = (value: number, title: string) => (
+    <Tab
+      value={value}
+      label={
+        <Typography sx={{ display: 'flex' }}>
+          {title}
+          {tab === value ? <ExpandMore sx={{ paddingLeft: 0.5 }} /> : <ExpandLess sx={{ paddingLeft: 0.5 }} />}
+        </Typography>
+      }
+      onClick={() => {
+        tab === value && setTab(0);
+      }}
+    />
+  );
+
   const displayCRCards = (crList: ChangeRequest[]) => (
     <Box
       sx={{
@@ -34,8 +55,8 @@ const OtherChangeRequestsPopupTabs: React.FC<OtherChangeRequestsPopupTabsProps> 
         justifyContent: 'flex-start',
         padding: '20px',
         background: theme.palette.background.paper,
-        borderTop: 'solid black',
-        minWidth: '100vw'
+        borderTop: `solid ${theme.palette.divider}`,
+        borderLeft: `solid ${theme.palette.divider}`
       }}
     >
       {crList.map((cr: ChangeRequest) => (
@@ -49,7 +70,7 @@ const OtherChangeRequestsPopupTabs: React.FC<OtherChangeRequestsPopupTabsProps> 
       sx={{
         position: 'fixed',
         bottom: '0px',
-        left: '65px'
+        width: '100%'
       }}
     >
       <Tabs
@@ -61,45 +82,20 @@ const OtherChangeRequestsPopupTabs: React.FC<OtherChangeRequestsPopupTabsProps> 
           },
           '& button': {
             background: theme.palette.background.paper,
-            borderRight: 'solid grey',
-            borderTop: 'solid grey',
+            border: `solid ${theme.palette.divider}`,
             color: theme.palette.text.primary,
             textTransform: 'none'
           },
           '& button.Mui-selected': {
-            color: theme.palette.text.primary
-          }
+            color: theme.palette.text.primary,
+            borderBottom: 'transparent'
+          },
+          marginBottom: '-3px'
         }}
       >
-        <Tab
-          value={1}
-          label={
-            <Typography sx={{ display: 'flex' }}>
-              Other CR's from {changeRequest.submitter.firstName} {changeRequest.submitter.lastName}
-              {tab === 1 ? <ExpandMore sx={{ paddingLeft: 0.5 }} /> : <ExpandLess sx={{ paddingLeft: 0.5 }} />}
-            </Typography>
-          }
-          onClick={() => {
-            tab === 1 && setTab(0);
-          }}
-        />
-        <Tab
-          value={2}
-          label={
-            <Typography sx={{ display: 'flex' }}>
-              Placeholder
-              {tab === 2 ? <ExpandMore sx={{ paddingLeft: 0.5 }} /> : <ExpandLess sx={{ paddingLeft: 0.5 }} />}
-            </Typography>
-          }
-          onClick={() => {
-            tab === 2 && setTab(0);
-          }}
-        />
+        {displayTab(1, `Other CR's from ${changeRequest.submitter.firstName} ${changeRequest.submitter.lastName}`)}
       </Tabs>
-      <Collapse in={tab !== 0}>
-        {tab === 1 && displayCRCards(crFromSameUser || [])}
-        {tab === 2 && displayCRCards(changeRequests || [])}
-      </Collapse>
+      <Collapse in={tab !== 0}>{tab === 1 && displayCRCards(crFromSameUser || [])}</Collapse>
     </Box>
   );
 };

--- a/src/frontend/src/pages/ChangeRequestDetailPage/OtherChangeRequestsPopupTabs.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/OtherChangeRequestsPopupTabs.tsx
@@ -1,0 +1,107 @@
+import React, { useState } from 'react';
+import { Box, useTheme, Collapse, Tabs, Tab, Typography } from '@mui/material';
+import { ChangeRequest } from 'shared';
+import ChangeRequestDetailCard from '../../components/ChangeRequestDetailCard';
+import { useAllChangeRequests } from '../../hooks/change-requests.hooks';
+import { ExpandLess, ExpandMore } from '@mui/icons-material';
+import LoadingIndicator from '../../components/LoadingIndicator';
+import ErrorPage from '../ErrorPage';
+
+interface OtherChangeRequestsPopupTabsProps {
+  changeRequest: ChangeRequest;
+}
+const OtherChangeRequestsPopupTabs: React.FC<OtherChangeRequestsPopupTabsProps> = ({
+  changeRequest
+}: OtherChangeRequestsPopupTabsProps) => {
+  const theme = useTheme();
+  const [tab, setTab] = useState(0);
+  const { data: changeRequests, isError, isLoading, error } = useAllChangeRequests();
+
+  if (isLoading) return <LoadingIndicator />;
+  if (isError) return <ErrorPage error={error} message={error.message} />;
+
+  // the CRs submitted or reviewed by the submitter of this CR
+  const crFromSameUser = changeRequests?.filter(
+    (cr) =>
+      (cr.submitter.userId === changeRequest.submitter.userId || cr.reviewer?.userId === changeRequest.submitter.userId) &&
+      cr.crId !== changeRequest.crId
+  );
+
+  const displayCRCards = (crList: ChangeRequest[]) => (
+    <Box
+      sx={{
+        display: 'flex',
+        justifyContent: 'flex-start',
+        padding: '20px',
+        background: theme.palette.background.paper,
+        borderTop: 'solid black',
+        minWidth: '100vw'
+      }}
+    >
+      {crList.map((cr: ChangeRequest) => (
+        <ChangeRequestDetailCard changeRequest={cr}></ChangeRequestDetailCard>
+      ))}
+    </Box>
+  );
+
+  return (
+    <Box
+      sx={{
+        position: 'fixed',
+        bottom: '0px',
+        left: '65px'
+      }}
+    >
+      <Tabs
+        value={tab}
+        onChange={(e, newValue: number) => setTab(newValue)}
+        sx={{
+          '.MuiTabs-indicator': {
+            background: 'transparent'
+          },
+          '& button': {
+            background: theme.palette.background.paper,
+            borderRight: 'solid grey',
+            borderTop: 'solid grey',
+            color: theme.palette.text.primary,
+            textTransform: 'none'
+          },
+          '& button.Mui-selected': {
+            color: theme.palette.text.primary
+          }
+        }}
+      >
+        <Tab
+          value={1}
+          label={
+            <Typography sx={{ display: 'flex' }}>
+              Other CR's from {changeRequest.submitter.firstName} {changeRequest.submitter.lastName}
+              {tab === 1 ? <ExpandMore sx={{ paddingLeft: 0.5 }} /> : <ExpandLess sx={{ paddingLeft: 0.5 }} />}
+            </Typography>
+          }
+          onClick={() => {
+            tab === 1 && setTab(0);
+          }}
+        />
+        <Tab
+          value={2}
+          label={
+            <Typography sx={{ display: 'flex' }}>
+              Placeholder
+              {tab === 2 ? <ExpandMore sx={{ paddingLeft: 0.5 }} /> : <ExpandLess sx={{ paddingLeft: 0.5 }} />}
+            </Typography>
+          }
+          onClick={() => {
+            tab === 2 && setTab(0);
+          }}
+        />
+      </Tabs>
+      <Collapse in={tab !== 0}>
+        {tab === 1 && displayCRCards(crFromSameUser || [])}
+        {tab === 2 && displayCRCards(changeRequests || [])}
+      </Collapse>
+    </Box>
+  );
+};
+
+export default OtherChangeRequestsPopupTabs;

--- a/src/frontend/src/pages/ChangeRequestDetailPage/OtherChangeRequestsPopupTabs.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/OtherChangeRequestsPopupTabs.tsx
@@ -73,7 +73,7 @@ const OtherChangeRequestsPopupTabs: React.FC<OtherChangeRequestsPopupTabsProps> 
       }}
     >
       {crList.length !== 0 ? (
-        crList.map((cr: ChangeRequest) => <ChangeRequestDetailCard changeRequest={cr}></ChangeRequestDetailCard>)
+        crList.map((cr: ChangeRequest) => <ChangeRequestDetailCard changeRequest={cr} />)
       ) : (
         <Typography>No related change requests.</Typography>
       )}

--- a/src/frontend/src/pages/ChangeRequestDetailPage/OtherChangeRequestsPopupTabs.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/OtherChangeRequestsPopupTabs.tsx
@@ -91,7 +91,7 @@ const OtherChangeRequestsPopupTabs: React.FC<OtherChangeRequestsPopupTabsProps> 
             color: theme.palette.text.primary,
             borderBottom: 'transparent'
           },
-          mb: '-1px'
+          mb: '-1.5px'
         }}
       >
         {displayTab(1, `Other CR's from ${changeRequest.submitter.firstName} ${changeRequest.submitter.lastName}`)}

--- a/src/frontend/src/pages/ChangeRequestDetailPage/OtherChangeRequestsPopupTabs.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/OtherChangeRequestsPopupTabs.tsx
@@ -56,12 +56,27 @@ const OtherChangeRequestsPopupTabs: React.FC<OtherChangeRequestsPopupTabsProps> 
         padding: '20px',
         background: theme.palette.background.paper,
         borderTop: `solid 1px ${theme.palette.divider}`,
-        borderLeft: `solid 1px ${theme.palette.divider}`
+        borderLeft: `solid 1px ${theme.palette.divider}`,
+        '&::-webkit-scrollbar': {
+          height: '20px'
+        },
+        '&::-webkit-scrollbar-track': {
+          backgroundColor: 'transparent'
+        },
+        '&::-webkit-scrollbar-thumb': {
+          backgroundColor: theme.palette.divider,
+          borderRadius: '20px',
+          border: '6px solid transparent',
+          backgroundClip: 'content-box'
+        },
+        overflowX: 'scroll'
       }}
     >
-      {crList.map((cr: ChangeRequest) => (
-        <ChangeRequestDetailCard changeRequest={cr}></ChangeRequestDetailCard>
-      ))}
+      {crList.length !== 0 ? (
+        crList.map((cr: ChangeRequest) => <ChangeRequestDetailCard changeRequest={cr}></ChangeRequestDetailCard>)
+      ) : (
+        <Typography>No related change requests.</Typography>
+      )}
     </Box>
   );
 
@@ -71,7 +86,7 @@ const OtherChangeRequestsPopupTabs: React.FC<OtherChangeRequestsPopupTabsProps> 
         position: 'fixed',
         bottom: '0px',
         left: '65px',
-        minWidth: '100%'
+        width: `calc(100% - 65px)`
       }}
     >
       <Tabs


### PR DESCRIPTION
## Changes

Added a new component for the Tabs that will go on the bottom of the Change Request Details page and added the tab for other CRs submitted or reviewed by the submitter of the current CR. The popup will scroll if the size of all the CRs exceed the max width of the container. Added text for when there's no related CRs and the popup has no cards.

## Notes

- ~~Can't scroll through the popup: The seed data doesn't have enough CRs that would require scrolling for the pop up for this ticket's tab, but I tested the popup with cards for each of the seeded CRs and cards get cut off and you can't scroll through them. I'm stuck on how to implement this.~~
- I had to do some weird border and margin manipulation to make it so that the active tab didn't have a bottom border so that the currently active tab looks like it's "connected" to the collapsible box. 

## Screenshots

Collapsed - Full Screen
<img width="1440" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/92332953/9d873a29-2205-4752-af05-058a37ab3d47">

Open - Full Screen
<img width="1440" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/92332953/f1403291-b2d4-4c2e-b7fa-3ff5d82e11d3">

Open (empty) - Full Screen
<img width="1440" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/92332953/526e4d5e-b960-47de-ac38-02232fdc9a29">

Collapsed - Little Screen
<img width="490" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/92332953/fed98257-b247-4b14-b4c4-b9485fda2cc8">

Open - Little Screen
<img width="490" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/92332953/e8e7986f-39b1-4af1-8b75-ba99c53288ca">

Open (empty) - Little Screen
<img width="490" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/92332953/28117486-0bf0-4033-8aee-6422cd02a0c6">

### How the popup looks with another Tab

Collapsed
<img width="1440" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/92332953/fbc3268e-aec6-4f00-b882-afb35413fad3">

Open (This ticket's tab active)
<img width="1440" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/92332953/c17000f1-db72-4e0e-8787-6db5405e1522">

Open (Other tab active)
<img width="1440" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/92332953/133308bc-2718-44a9-9c38-60bfc01c7496">

### How the popup looks when scrollable

Popup when unscrolled
<img width="1440" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/92332953/9d47e97c-851f-4db4-9ccb-55bf8a2d9a3d">

Popup when scrolled all the way to the end
<img width="1440" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/92332953/e71c76c0-2775-430e-9423-d14ee0ae38b0">

Popup when scrolled somewhere random
<img width="1440" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/92332953/5ecd1b86-1b47-4402-a7f1-120dd6be30f6">

## To Do

_Any remaining things that need to get done_

- [x] Be able to scroll through the popup window

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1641
