### PR TITLE
#1528 Create assign material assembly route and controller

### DIFF
--- a/src/backend/src/controllers/projects.controllers.ts
+++ b/src/backend/src/controllers/projects.controllers.ts
@@ -161,4 +161,16 @@ export default class ProjectsController {
       next(error);
     }
   }
+
+  static async assignMaterialAssembly(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { materialId } = req.params;
+      const { assemblyId } = req.body;
+      const user = await getCurrentUser(res);
+      const updatedMaterial = await ProjectsService.assignMaterialAssembly(user, materialId, assemblyId);
+      res.status(200).json(updatedMaterial);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
 }

--- a/src/backend/src/routes/projects.routes.ts
+++ b/src/backend/src/routes/projects.routes.ts
@@ -62,12 +62,12 @@ projectRouter.post('/bom/material-type/create', nonEmptyString(body('name')), Pr
 projectRouter.post(
   '/bom/assembly/:wbsNum/create',
   nonEmptyString(body('name')),
-  nonEmptyString(body('pdmFileName')).optional(),
+  nonEmptyString(body('pdmFileName').optional()),
   ProjectsController.createAssembly
 );
 projectRouter.post(
   '/bom/material/:materialId/assign-assembly',
-  nonEmptyString(body('assemblyId')),
+  nonEmptyString(body('assemblyId').optional()),
   validateInputs,
   ProjectsController.assignMaterialAssembly
 );

--- a/src/backend/src/routes/projects.routes.ts
+++ b/src/backend/src/routes/projects.routes.ts
@@ -66,6 +66,7 @@ projectRouter.post(
 projectRouter.post(
   '/bom/material/:materialId/assign-assembly',
   nonEmptyString(body('assemblyId')),
+  validateInputs,
   ProjectsController.assignMaterialAssembly
 );
 projectRouter.post(

--- a/src/backend/src/routes/projects.routes.ts
+++ b/src/backend/src/routes/projects.routes.ts
@@ -62,5 +62,10 @@ projectRouter.post(
   nonEmptyString(body('pdmFileName')).optional(),
   ProjectsController.createAssembly
 );
+projectRouter.post(
+  '/bom/material/:materialId/assign-assembly',
+  nonEmptyString(body('assemblyId')),
+  ProjectsController.assignMaterialAssembly
+);
 
 export default projectRouter;

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -44,7 +44,6 @@ import { linkTypeTransformer } from '../transformers/links.transformer';
 import { updateLinks, linkToChangeListValue } from '../utils/links.utils';
 import { manufacturerTransformer } from '../transformers/manufacturer.transformer';
 import { isUserPartOfTeams } from '../utils/teams.utils';
-import { disconnect } from 'process';
 
 export default class ProjectsService {
   /**
@@ -893,6 +892,7 @@ export default class ProjectsService {
       where: { materialId },
       include: { wbsElement: true, assembly: true }
     });
+
     if (!material) throw new NotFoundException('Material', materialId);
 
     const project = await prisma.project.findFirst({
@@ -911,6 +911,7 @@ export default class ProjectsService {
         `Only leadership or above, or someone on the project's team can assign materials to assemblies`
       );
 
+    //assigning the material to a new assembly
     if (assemblyId) {
       const assembly = await prisma.assembly.findUnique({
         where: { assemblyId },
@@ -933,8 +934,8 @@ export default class ProjectsService {
 
       return updatedMaterial;
     }
+    //unassigning material from an existing assembly
     if (material.assemblyId) {
-      // Assign a material on a project to a different assembly
       await prisma.assembly.update({
         where: { assemblyId: material.assemblyId },
         data: { materials: { disconnect: { materialId } } },

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -887,9 +887,10 @@ export default class ProjectsService {
    * @throws if the submitter does not have the relevant positions
    * @returns the updated material
    */
-  static async assignMaterialAssembly(submitter: User, materialId: string, assemblyId: undefined | string) {
+  static async assignMaterialAssembly(submitter: User, materialId: string, assemblyId?: string) {
     const material = await prisma.material.findUnique({ where: { materialId } });
     if (!material) throw new NotFoundException('Material', materialId);
+
     const project = await prisma.project.findFirst({
       where: {
         wbsElementId: material.wbsElementId
@@ -902,26 +903,22 @@ export default class ProjectsService {
 
     // Permission: leadership and up, anyone on project team
     if (!(isLeadership(submitter.role) || isUserPartOfTeams(project.teams, submitter)))
-      throw new AccessDeniedException('Only leadership or above can create a material type');
+      throw new AccessDeniedException('Only leadership or above can assign materials to assemblies');
 
-    if (assemblyId === undefined) {
-      // Unassign material from current assembly if assembly id is undefined
-      const updatedMaterial = await prisma.material.update({ where: { materialId }, data: { assemblyId: undefined } });
-      return updatedMaterial;
+    if (assemblyId) {
+      const assembly = await prisma.assembly.findUnique({
+        where: { assemblyId },
+        include: { wbsElement: true }
+      });
+      if (!assembly) throw new NotFoundException('Assembly', assemblyId);
+
+      // Confirm that the assembly's wbsElement is the same as the material's wbsElement
+      if (material.wbsElementId !== assembly.wbsElementId)
+        throw new HttpException(
+          400,
+          `The WBS element of the material (${material.wbsElementId}) and assembly (${assembly.wbsElementId}) do not match`
+        );
     }
-
-    const assembly = await prisma.assembly.findUnique({
-      where: { assemblyId },
-      include: { wbsElement: true }
-    });
-    if (!assembly) throw new NotFoundException('Assembly', assemblyId);
-
-    // Confirm that the assembly's wbsElement is the same as the material's wbsElement
-    if (material.wbsElementId !== assembly.wbsElementId)
-      throw new HttpException(
-        400,
-        `The WBS element of the material (${material.wbsElementId}) and assembly (${assembly.wbsElementId}) do not match`
-      );
 
     // Assign a material on a project to a different assembly
     const updatedMaterial = await prisma.material.update({ where: { materialId }, data: { assemblyId } });

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -838,6 +838,13 @@ export default class ProjectsService {
     });
     if (!project) throw new NotFoundException('Project', assembly.wbsElementId);
 
+    // Confirm that the assembly's wbsElement is the same as the material's wbsElement
+    if (material.wbsElementId !== assembly.wbsElementId)
+      throw new HttpException(
+        400,
+        `The WBS element of the material (${material.wbsElementId}) and assembly (${assembly.wbsElementId}) do not match`
+      );
+
     // Permission: leadership and up, anyone on project team
     if (!(isLeadership(submitter.role) || isUserPartOfTeams(project.teams, submitter)))
       throw new AccessDeniedException('Only leadership or above can create a material type');

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -728,7 +728,7 @@ export default class ProjectsService {
       throw new AccessDeniedException('Only leadership or above can create a material type');
 
     const material = await prisma.material.findUnique({ where: { materialId } });
-    if (!material) throw new HttpException(400, `The material ${materialId} does not exist`);
+    if (!material) throw new NotFoundException('Material', materialId);
 
     // Assign a material on a project to a different assembly
     const updatedMaterial = await prisma.material.update({ where: { materialId }, data: { assemblyId } });

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -730,6 +730,9 @@ export default class ProjectsService {
     const material = await prisma.material.findUnique({ where: { materialId } });
     if (!material) throw new NotFoundException('Material', materialId);
 
+    const assembly = await prisma.assembly.findUnique({ where: { assemblyId } });
+    if (!assembly) throw new NotFoundException('Assembly', assemblyId);
+
     // Assign a material on a project to a different assembly
     const updatedMaterial = await prisma.material.update({ where: { materialId }, data: { assemblyId } });
     return updatedMaterial;

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -723,7 +723,7 @@ export default class ProjectsService {
    * @throws if the submitter does not have the relevant positions
    */
   static async assignMaterialAssembly(submitter: User, materialId: string, assemblyId: string) {
-    // TODO: Permission: leadership and up, anyone on project team
+    // Permission: leadership and up, anyone on project team
     if (!isLeadership(submitter.role))
       throw new AccessDeniedException('Only leadership or above can create a material type');
 

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -818,6 +818,7 @@ export default class ProjectsService {
    * @param materialId the material that will be moved
    * @param assemblyId the assembly to change the material to
    * @throws if the submitter does not have the relevant positions
+   * @returns the updated material
    */
   static async assignMaterialAssembly(submitter: User, materialId: string, assemblyId: string) {
     const material = await prisma.material.findUnique({ where: { materialId } });
@@ -838,7 +839,7 @@ export default class ProjectsService {
     if (!project) throw new NotFoundException('Project', assembly.wbsElementId);
 
     // Permission: leadership and up, anyone on project team
-    if (!(isLeadership(submitter.role) || isUserPartOfTeams(project?.teams, submitter)))
+    if (!(isLeadership(submitter.role) || isUserPartOfTeams(project.teams, submitter)))
       throw new AccessDeniedException('Only leadership or above can create a material type');
 
     // Assign a material on a project to a different assembly

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -714,4 +714,11 @@ export default class ProjectsService {
 
     return newMaterialType;
   }
+
+  /**
+   * Assign a material on a project to a different assembly
+   */
+  static async assignMaterialAssembly(submitter: User, materialId: string, assemblyId: string) {
+    // TODO: Permission: leadership and up, anyone on project team
+  }
 }

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -717,6 +717,10 @@ export default class ProjectsService {
 
   /**
    * Assign a material on a project to a different assembly
+   * @param submitter the submitter
+   * @param materialId the material that will be moved
+   * @param assemblyId the assembly to change the material to
+   * @throws if the submitter does not have the relevant positions
    */
   static async assignMaterialAssembly(submitter: User, materialId: string, assemblyId: string) {
     // TODO: Permission: leadership and up, anyone on project team
@@ -726,6 +730,7 @@ export default class ProjectsService {
     const material = await prisma.material.findUnique({ where: { materialId } });
     if (!material) throw new HttpException(400, `The material ${materialId} does not exist`);
 
+    // Assign a material on a project to a different assembly
     const updatedMaterial = await prisma.material.update({ where: { materialId }, data: { assemblyId } });
     return updatedMaterial;
   }

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -720,5 +720,13 @@ export default class ProjectsService {
    */
   static async assignMaterialAssembly(submitter: User, materialId: string, assemblyId: string) {
     // TODO: Permission: leadership and up, anyone on project team
+    if (!isLeadership(submitter.role))
+      throw new AccessDeniedException('Only leadership or above can create a material type');
+
+    const material = await prisma.material.findUnique({ where: { materialId } });
+    if (!material) throw new HttpException(400, `The material ${materialId} does not exist`);
+
+    const updatedMaterial = await prisma.material.update({ where: { materialId }, data: { assemblyId } });
+    return updatedMaterial;
   }
 }

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -837,7 +837,6 @@ export default class ProjectsService {
       ...projectQueryArgs
     });
     if (!project) throw new NotFoundException('Project', assembly.wbsElementId);
-    console.log(project);
 
     // Permission: leadership and up, anyone on project team
     if (!(isLeadership(submitter.role) || isUserPartOfTeams(project.teams, submitter)))

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -837,6 +837,7 @@ export default class ProjectsService {
       ...projectQueryArgs
     });
     if (!project) throw new NotFoundException('Project', assembly.wbsElementId);
+    console.log(project);
 
     // Permission: leadership and up, anyone on project team
     if (!(isLeadership(submitter.role) || isUserPartOfTeams(project.teams, submitter)))

--- a/src/backend/src/utils/errors.utils.ts
+++ b/src/backend/src/utils/errors.utils.ts
@@ -111,4 +111,5 @@ type ExceptionObjectNames =
   | 'Expense Type'
   | 'Reimbursement Request'
   | 'User Secure Settings'
-  | 'Image File';
+  | 'Image File'
+  | 'Material';

--- a/src/backend/src/utils/errors.utils.ts
+++ b/src/backend/src/utils/errors.utils.ts
@@ -112,4 +112,5 @@ type ExceptionObjectNames =
   | 'Reimbursement Request'
   | 'User Secure Settings'
   | 'Image File'
-  | 'Material';
+  | 'Material'
+  | 'Assembly';

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -756,16 +756,14 @@ describe('Projects', () => {
     });
 
     test('assignment fails because the wbsElements do not match', async () => {
-      vi.spyOn(prisma.material, 'findUnique').mockResolvedValue({
-        ...prismaMaterial1,
-        wbsElementId: 1,
-        wbsElement: prismaWbsElement1
-      });
-      vi.spyOn(prisma.assembly, 'findUnique').mockResolvedValue({
+      const material = { ...prismaMaterial1, wbsElementId: 1, wbsElement: prismaWbsElement1 };
+      vi.spyOn(prisma.material, 'findUnique').mockResolvedValue(material);
+      const assembly = {
         ...prismaAssembly1,
         wbsElementId: 2,
         wbsElement: { ...prismaWbsElement1, wbsElementId: 2, projectNumber: 1 }
-      });
+      };
+      vi.spyOn(prisma.assembly, 'findUnique').mockResolvedValue(assembly);
       await expect(ProjectsService.assignMaterialAssembly(superman, 'mid', 'aid')).rejects.toThrow(
         new HttpException(400, `The WBS element of the material (1.2.0) and assembly (1.1.0) do not match`)
       );

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -695,6 +695,14 @@ describe('Projects', () => {
       );
     });
 
+    test('assignment fails because the wbsElements do not match', async () => {
+      vi.spyOn(prisma.material, 'findUnique').mockResolvedValue({ ...prismaMaterial1, wbsElementId: 1 });
+      vi.spyOn(prisma.assembly, 'findUnique').mockResolvedValue({ ...prismaAssembly1, wbsElementId: 2 });
+      await expect(ProjectsService.assignMaterialAssembly(superman, 'mid', 'aid')).rejects.toThrow(
+        new HttpException('400', `The WBS element of the material (1) and assembly (2) do not match`)
+      );
+    });
+
     test('assignment successful', async () => {
       vi.spyOn(prisma.material, 'findUnique').mockResolvedValue(prismaMaterial1);
       vi.spyOn(prisma.assembly, 'findUnique').mockResolvedValue(prismaAssembly1);

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -717,5 +717,19 @@ describe('Projects', () => {
       const updatedMaterial = await ProjectsService.assignMaterialAssembly(aquaman, 'mid', 'updated-aid');
       expect(updatedMaterial).toBe(expectedUpdatedToolMaterial);
     });
+
+    test('unassigning material from assebly works', async () => {
+      vi.spyOn(prisma.material, 'findUnique').mockResolvedValue(prismaMaterial1);
+      vi.spyOn(prisma.project, 'findFirst').mockResolvedValue(prismaProject1);
+
+      const expectedUpdatedToolMaterial: Material = {
+        ...prismaMaterial1,
+        assemblyId: null
+      };
+      vi.spyOn(prisma.material, 'update').mockResolvedValue(expectedUpdatedToolMaterial);
+
+      const updatedMaterial = await ProjectsService.assignMaterialAssembly(aquaman, 'mid', undefined);
+      expect(updatedMaterial).toBe(expectedUpdatedToolMaterial);
+    });
   });
 });

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -734,7 +734,7 @@ describe('Projects', () => {
       vi.spyOn(prisma.project, 'findFirst').mockResolvedValue(project);
 
       await expect(ProjectsService.assignMaterialAssembly(theVisitor, 'mid', 'aid')).rejects.toThrow(
-        new AccessDeniedException('Only leadership or above can create a material type')
+        new AccessDeniedException('Only leadership or above can assign materials to assemblies')
       );
     });
 
@@ -798,6 +798,8 @@ describe('Projects', () => {
     });
 
     test('Deleting assembly fails if assembly does not exist', async () => {
+      vi.spyOn(prisma.assembly, 'findUnique').mockResolvedValue(null);
+
       await expect(ProjectsService.deleteAssembly('New Assembly', batman)).rejects.toThrow(
         new NotFoundException('Assembly', 'New Assembly')
       );

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -669,30 +669,30 @@ describe('Projects', () => {
   });
 
   describe('assigning material assemblies', () => {
-    // test('assignment fails because of permissions', async () => {
-    //   vi.spyOn(prisma.material, 'findUnique').mockResolvedValue(prismaMaterial1);
-    //   vi.spyOn(prisma.assembly, 'findUnique').mockResolvedValue(prismaAssembly1);
-    //   vi.spyOn(prisma.project, 'findFirst').mockResolvedValue(prismaProject1);
+    test('assignment fails because of permissions', async () => {
+      vi.spyOn(prisma.material, 'findUnique').mockResolvedValue(prismaMaterial1);
+      vi.spyOn(prisma.assembly, 'findUnique').mockResolvedValue(prismaAssembly1);
+      vi.spyOn(prisma.project, 'findFirst').mockResolvedValue({ teams: [prismaTeam1] });
 
-    //   await expect(ProjectsService.assignMaterialAssembly(theVisitor, 'mid', 'aid')).rejects.toThrow(
-    //     new AccessDeniedException('Only leadership or above can create a material type')
-    //   );
-    // });
+      await expect(ProjectsService.assignMaterialAssembly(theVisitor, 'mid', 'aid')).rejects.toThrow(
+        new AccessDeniedException('Only leadership or above can create a material type')
+      );
+    });
 
-    // test('assignment fails because of invalid material id', async () => {
-    //   vi.spyOn(prisma.material, 'findUnique').mockResolvedValue(null);
-    //   await expect(ProjectsService.assignMaterialAssembly(superman, 'invalid-mid', 'aid')).rejects.toThrow(
-    //     new NotFoundException('Material', 'invalid-mid')
-    //   );
-    // });
+    test('assignment fails because of invalid material id', async () => {
+      vi.spyOn(prisma.material, 'findUnique').mockResolvedValue(null);
+      await expect(ProjectsService.assignMaterialAssembly(superman, 'invalid-mid', 'aid')).rejects.toThrow(
+        new NotFoundException('Material', 'invalid-mid')
+      );
+    });
 
-    // test('assignment fails because of invalid assembly id', async () => {
-    //   vi.spyOn(prisma.material, 'findUnique').mockResolvedValue(prismaMaterial1);
-    //   vi.spyOn(prisma.assembly, 'findUnique').mockResolvedValue(null);
-    //   await expect(ProjectsService.assignMaterialAssembly(superman, 'mid', 'invalid-aid')).rejects.toThrow(
-    //     new NotFoundException('Assembly', 'invalid-aid')
-    //   );
-    // });
+    test('assignment fails because of invalid assembly id', async () => {
+      vi.spyOn(prisma.material, 'findUnique').mockResolvedValue(prismaMaterial1);
+      vi.spyOn(prisma.assembly, 'findUnique').mockResolvedValue(null);
+      await expect(ProjectsService.assignMaterialAssembly(superman, 'mid', 'invalid-aid')).rejects.toThrow(
+        new NotFoundException('Assembly', 'invalid-aid')
+      );
+    });
 
     test('assignment successful', async () => {
       vi.spyOn(prisma.material, 'findUnique').mockResolvedValue(prismaMaterial1);

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -672,7 +672,8 @@ describe('Projects', () => {
     test('assignment fails because of permissions', async () => {
       vi.spyOn(prisma.material, 'findUnique').mockResolvedValue(prismaMaterial1);
       vi.spyOn(prisma.assembly, 'findUnique').mockResolvedValue(prismaAssembly1);
-      vi.spyOn(prisma.project, 'findFirst').mockResolvedValue({ teams: [prismaTeam1] });
+      const project = { ...prismaProject1, teams: [{ members: [aquaman], leads: [superman] }] };
+      vi.spyOn(prisma.project, 'findFirst').mockResolvedValue(project);
 
       await expect(ProjectsService.assignMaterialAssembly(theVisitor, 'mid', 'aid')).rejects.toThrow(
         new AccessDeniedException('Only leadership or above can create a material type')

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -669,30 +669,35 @@ describe('Projects', () => {
   });
 
   describe('assigning material assemblies', () => {
-    test('assignment fails because of permissions', async () => {
-      await expect(ProjectsService.assignMaterialAssembly(theVisitor, 'mid', 'aid')).rejects.toThrow(
-        new AccessDeniedException('Only leadership or above can create a material type')
-      );
-    });
+    // test('assignment fails because of permissions', async () => {
+    //   vi.spyOn(prisma.material, 'findUnique').mockResolvedValue(prismaMaterial1);
+    //   vi.spyOn(prisma.assembly, 'findUnique').mockResolvedValue(prismaAssembly1);
+    //   vi.spyOn(prisma.project, 'findFirst').mockResolvedValue(prismaProject1);
 
-    test('assignment fails because of invalid material id', async () => {
-      vi.spyOn(prisma.material, 'findUnique').mockResolvedValue(null);
-      await expect(ProjectsService.assignMaterialAssembly(superman, 'invalid-mid', 'aid')).rejects.toThrow(
-        new NotFoundException('Material', 'invalid-mid')
-      );
-    });
+    //   await expect(ProjectsService.assignMaterialAssembly(theVisitor, 'mid', 'aid')).rejects.toThrow(
+    //     new AccessDeniedException('Only leadership or above can create a material type')
+    //   );
+    // });
 
-    test('assignment fails because of invalid assembly id', async () => {
-      vi.spyOn(prisma.material, 'findUnique').mockResolvedValue(prismaMaterial1);
-      vi.spyOn(prisma.assembly, 'findUnique').mockResolvedValue(null);
-      await expect(ProjectsService.assignMaterialAssembly(superman, 'mid', 'invalid-aid')).rejects.toThrow(
-        new NotFoundException('Assembly', 'invalid-aid')
-      );
-    });
+    // test('assignment fails because of invalid material id', async () => {
+    //   vi.spyOn(prisma.material, 'findUnique').mockResolvedValue(null);
+    //   await expect(ProjectsService.assignMaterialAssembly(superman, 'invalid-mid', 'aid')).rejects.toThrow(
+    //     new NotFoundException('Material', 'invalid-mid')
+    //   );
+    // });
+
+    // test('assignment fails because of invalid assembly id', async () => {
+    //   vi.spyOn(prisma.material, 'findUnique').mockResolvedValue(prismaMaterial1);
+    //   vi.spyOn(prisma.assembly, 'findUnique').mockResolvedValue(null);
+    //   await expect(ProjectsService.assignMaterialAssembly(superman, 'mid', 'invalid-aid')).rejects.toThrow(
+    //     new NotFoundException('Assembly', 'invalid-aid')
+    //   );
+    // });
 
     test('assignment successful', async () => {
       vi.spyOn(prisma.material, 'findUnique').mockResolvedValue(prismaMaterial1);
       vi.spyOn(prisma.assembly, 'findUnique').mockResolvedValue(prismaAssembly1);
+      vi.spyOn(prisma.project, 'findFirst').mockResolvedValue(prismaProject1);
 
       const expectedUpdatedToolMaterial: Material = {
         ...prismaMaterial1,
@@ -700,7 +705,7 @@ describe('Projects', () => {
       };
       vi.spyOn(prisma.material, 'update').mockResolvedValue(expectedUpdatedToolMaterial);
 
-      const updatedMaterial = await ProjectsService.assignMaterialAssembly(superman, 'mid', 'updated-aid');
+      const updatedMaterial = await ProjectsService.assignMaterialAssembly(aquaman, 'mid', 'updated-aid');
       expect(updatedMaterial).toBe(expectedUpdatedToolMaterial);
     });
   });

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -1,7 +1,7 @@
 import prisma from '../src/prisma/prisma';
 import { getHighestProjectNumber } from '../src/utils/projects.utils';
 import * as changeRequestUtils from '../src/utils/change-requests.utils';
-import { aquaman, batman, wonderwoman, superman } from './test-data/users.test-data';
+import { aquaman, batman, wonderwoman, superman, theVisitor } from './test-data/users.test-data';
 import {
   prismaProject1,
   sharedProject1,
@@ -475,5 +475,27 @@ describe('Projects', () => {
       expect(materialType.name).toBe('NERSoftwareTools');
       expect(prisma.material_Type.create).toBeCalledTimes(1);
     });
+  });
+
+  describe('assigning material assemblies', () => {
+    test('assignment fails because of permissions', async () => {
+      await expect(ProjectsService.assignMaterialAssembly(theVisitor, 'mid', 'aid')).rejects.toThrow(
+        new AccessDeniedException('Only leadership or above can create a material type')
+      );
+    });
+    test('assignment fails because of invalid material id', async () => {
+      vi.spyOn(prisma.material, 'findUnique').mockResolvedValue(null);
+      await expect(ProjectsService.assignMaterialAssembly(superman, 'invalid-mid', 'aid')).rejects.toThrow(
+        new NotFoundException('Material', 'invalid-mid')
+      );
+    });
+    test('assignment fails because of invalid assembly id', async () => {
+      vi.spyOn(prisma.material, 'findUnique').mockResolvedValue(toolMaterial);
+      vi.spyOn(prisma.assembly, 'findUnique').mockResolvedValue(null);
+      await expect(ProjectsService.assignMaterialAssembly(superman, 'mid', 'invalid-aid')).rejects.toThrow(
+        new NotFoundException('Assembly', 'invalid-aid')
+      );
+    });
+    // test('assignment successful', async () => {});
   });
 });

--- a/src/backend/tests/test-data/projects.test-data.ts
+++ b/src/backend/tests/test-data/projects.test-data.ts
@@ -112,7 +112,7 @@ export const prismaAssembly1: Assembly = {
   pdmFileName: 'file.txt',
   dateCreated: new Date('10-19-2023'),
   userCreatedId: batman.userId,
-  wbsElementId: 66,
+  wbsElementId: sharedProject1.id,
   dateDeleted: null,
   userDeletedId: null,
   assemblyId: '1'

--- a/src/backend/tests/test-data/projects.test-data.ts
+++ b/src/backend/tests/test-data/projects.test-data.ts
@@ -6,8 +6,6 @@ import {
   WBS_Element_Status as PrismaWBSElementStatus,
   Project,
   Manufacturer,
-  Assembly,
-  Material,
   Unit
 } from '@prisma/client';
 import { Project as SharedProject, WbsElementStatus } from 'shared';

--- a/src/backend/tests/test-data/projects.test-data.ts
+++ b/src/backend/tests/test-data/projects.test-data.ts
@@ -4,7 +4,8 @@ import {
   WBS_Element_Status as PrismaWBSElementStatus,
   Project,
   Manufacturer,
-  Assembly
+  Assembly,
+  Material
 } from '@prisma/client';
 import { Project as SharedProject, WbsElementStatus } from 'shared';
 import projectQueryArgs from '../../src/prisma-query-args/projects.query-args';
@@ -126,4 +127,26 @@ export const toolMaterial: PrismaMaterialType = {
   name: 'NERSoftwareTools',
   dateCreated: new Date(),
   creatorId: batman.userId
+};
+
+export const prismaMaterial1: Material = {
+  materialId: '1',
+  assemblyId: '1',
+  dateCreated: new Date('2023-11-07'),
+  linkUrl: 'https://eample.com',
+  manufacturerName: 'Manufacturer1',
+  manufacturerPartNumber: '1',
+  materialTypeName: 'NERSoftwareTools',
+  name: prismaManufacturer1.name,
+  notes: 'Sample notes',
+  pdmFileName: 'pdmname',
+  price: 10,
+  quantity: 89,
+  status: 'ORDERED',
+  subtotal: 1,
+  unitName: 'Unit',
+  userCreatedId: batman.userId,
+  wbsElementId: sharedProject1.id,
+  dateDeleted: null,
+  userDeletedId: null
 };

--- a/src/backend/tests/test-data/projects.test-data.ts
+++ b/src/backend/tests/test-data/projects.test-data.ts
@@ -171,7 +171,7 @@ export const prismaMaterial1: Material = {
   materialId: '1',
   assemblyId: '1',
   dateCreated: new Date('2023-11-07'),
-  linkUrl: 'https://eample.com',
+  linkUrl: 'https://example.com',
   manufacturerName: 'Manufacturer1',
   manufacturerPartNumber: '1',
   materialTypeName: 'NERSoftwareTools',


### PR DESCRIPTION
## Changes

Endpoint to assign a Material on a project to a different assembly.





## Test Cases

- material/assembly id doesnt exist
- insufficient permission
- successful change


## To Do



- [x] Tests

## Checklist


- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1528
