### PR TITLE
#1610 Added deny reimbursement request endpoint

### DIFF
--- a/src/backend/src/controllers/reimbursement-requests.controllers.ts
+++ b/src/backend/src/controllers/reimbursement-requests.controllers.ts
@@ -230,6 +230,17 @@ export default class ReimbursementRequestsController {
     }
   }
 
+  static async denyReimbursementRequest(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { requestId } = req.params;
+      const user = await getCurrentUser(res);
+      const reimbursementStatus = await ReimbursementRequestService.denyReimbursementRequest(requestId, user);
+      res.status(200).json(reimbursementStatus);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
   static async markReimbursementRequestAsDelivered(req: Request, res: Response, next: NextFunction) {
     try {
       const { requestId } = req.params;

--- a/src/backend/src/prisma/migrations/20230629193452_finance/migration.sql
+++ b/src/backend/src/prisma/migrations/20230629193452_finance/migration.sql
@@ -2,7 +2,7 @@
 CREATE TYPE "Club_Accounts" AS ENUM ('CASH', 'BUDGET');
 
 -- CreateEnum
-CREATE TYPE "Reimbursement_Status_Type" AS ENUM ('PENDING_FINANCE', 'SABO_SUBMITTED', 'ADVISOR_APPROVED', 'REIMBURSED');
+CREATE TYPE "Reimbursement_Status_Type" AS ENUM ('PENDING_FINANCE', 'SABO_SUBMITTED', 'ADVISOR_APPROVED', 'REIMBURSED', 'DENIED');
 
 -- CreateTable
 CREATE TABLE "Reimbursement_Status" (

--- a/src/backend/src/prisma/migrations/20230629193452_finance/migration.sql
+++ b/src/backend/src/prisma/migrations/20230629193452_finance/migration.sql
@@ -2,7 +2,7 @@
 CREATE TYPE "Club_Accounts" AS ENUM ('CASH', 'BUDGET');
 
 -- CreateEnum
-CREATE TYPE "Reimbursement_Status_Type" AS ENUM ('PENDING_FINANCE', 'SABO_SUBMITTED', 'ADVISOR_APPROVED', 'REIMBURSED', 'DENIED');
+CREATE TYPE "Reimbursement_Status_Type" AS ENUM ('PENDING_FINANCE', 'SABO_SUBMITTED', 'ADVISOR_APPROVED', 'REIMBURSED');
 
 -- CreateTable
 CREATE TABLE "Reimbursement_Status" (

--- a/src/backend/src/prisma/migrations/20231109224241_deny_rr/migration.sql
+++ b/src/backend/src/prisma/migrations/20231109224241_deny_rr/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "Reimbursement_Status_Type" ADD VALUE 'DENIED';

--- a/src/backend/src/prisma/schema.prisma
+++ b/src/backend/src/prisma/schema.prisma
@@ -364,6 +364,7 @@ enum Reimbursement_Status_Type {
   SABO_SUBMITTED
   ADVISOR_APPROVED
   REIMBURSED
+  DENIED
 }
 
 model Reimbursement_Status {

--- a/src/backend/src/routes/reimbursement-requests.routes.ts
+++ b/src/backend/src/routes/reimbursement-requests.routes.ts
@@ -128,6 +128,7 @@ reimbursementRequestsRouter.post(
 
 reimbursementRequestsRouter.post('/:requestId/approve', ReimbursementRequestController.approveReimbursementRequest);
 reimbursementRequestsRouter.delete('/:requestId/delete', ReimbursementRequestController.deleteReimbursementRequest);
+reimbursementRequestsRouter.post('/:requestId/deny', ReimbursementRequestController.denyReimbursementRequest);
 
 reimbursementRequestsRouter.post(
   '/:requestId/delivered',

--- a/src/backend/src/services/reimbursement-requests.services.ts
+++ b/src/backend/src/services/reimbursement-requests.services.ts
@@ -723,10 +723,12 @@ export default class ReimbursementRequestService {
       throw new DeletedException('Reimbursement Request', reimbursementRequestId);
     }
 
-    if (
-      reimbursementRequest.reimbursementStatuses.some((status) => status.type === ReimbursementStatusType.SABO_SUBMITTED)
-    ) {
-      throw new HttpException(400, 'This reimbursement request has already been approved');
+    if (reimbursementRequest.reimbursementStatuses.some((status) => status.type === ReimbursementStatusType.DENIED)) {
+      throw new HttpException(400, 'This reimbursement request has already been denied');
+    }
+
+    if (reimbursementRequest.reimbursementStatuses.some((status) => status.type === ReimbursementStatusType.REIMBURSED)) {
+      throw new HttpException(400, 'This reimbursement request has already been reimbursed');
     }
 
     const reimbursementStatus = await prisma.reimbursement_Status.create({

--- a/src/backend/src/services/reimbursement-requests.services.ts
+++ b/src/backend/src/services/reimbursement-requests.services.ts
@@ -701,6 +701,49 @@ export default class ReimbursementRequestService {
   }
 
   /**
+   * Adds a reimbursement status with type denied to the given reimbursement request
+   *
+   * @param reimbursementRequestId the id of the reimbursement request to deny
+   * @param submitter the user who is approving the reimbursement request
+   * @returns the created reimbursment status
+   */
+  static async denyReimbursementRequest(reimbursementRequestId: string, submitter: User) {
+    await validateUserIsPartOfFinanceTeam(submitter);
+
+    const reimbursementRequest = await prisma.reimbursement_Request.findUnique({
+      where: { reimbursementRequestId },
+      include: {
+        reimbursementStatuses: true
+      }
+    });
+
+    if (!reimbursementRequest) throw new NotFoundException('Reimbursement Request', reimbursementRequestId);
+
+    if (reimbursementRequest.dateDeleted) {
+      throw new DeletedException('Reimbursement Request', reimbursementRequestId);
+    }
+
+    if (
+      reimbursementRequest.reimbursementStatuses.some((status) => status.type === ReimbursementStatusType.SABO_SUBMITTED)
+    ) {
+      throw new HttpException(400, 'This reimbursement request has already been approved');
+    }
+
+    const reimbursementStatus = await prisma.reimbursement_Status.create({
+      data: {
+        type: ReimbursementStatusType.DENIED,
+        userId: submitter.userId,
+        reimbursementRequestId: reimbursementRequest.reimbursementRequestId
+      },
+      include: {
+        user: true
+      }
+    });
+
+    return reimbursementStatusTransformer(reimbursementStatus);
+  }
+
+  /**
    * Downloads the receipt image file with the given google file id
    *
    * @param fileId the google file id of the receipt image

--- a/src/backend/tests/reimbursement-requests.test.ts
+++ b/src/backend/tests/reimbursement-requests.test.ts
@@ -19,6 +19,8 @@ import {
   prismaGiveMeMyMoney,
   prismaGiveMeMyMoney2,
   prismaGiveMeMyMoney3,
+  prismaGiveMeMyMoney4,
+  prismaGiveMeMyMoney5,
   prismaReimbursementStatus,
   sharedGiveMeMyMoney
 } from './test-data/reimbursement-requests.test-data';
@@ -607,15 +609,23 @@ describe('Reimbursement Requests', () => {
       ).rejects.toThrow(new DeletedException('Reimbursement Request', GiveMeMyMoney2.reimbursementRequestId));
     });
 
-    test('Deny Reimbursement Request fails if the request has already been approved', async () => {
+    test('Deny Reimbursement Request fails if the request has already been denied', async () => {
       vi.spyOn(prisma.team, 'findUnique').mockResolvedValue(primsaTeam2);
-      vi.spyOn(prisma.reimbursement_Request, 'findUnique').mockResolvedValue(prismaGiveMeMyMoney2);
+      vi.spyOn(prisma.reimbursement_Request, 'findUnique').mockResolvedValue(prismaGiveMeMyMoney4);
 
       await expect(
-        ReimbursementRequestService.denyReimbursementRequest(prismaGiveMeMyMoney2.reimbursementRequestId, alfred)
-      ).rejects.toThrow(new HttpException(400, 'This reimbursement request has already been approved'));
+        ReimbursementRequestService.denyReimbursementRequest(prismaGiveMeMyMoney4.reimbursementRequestId, alfred)
+      ).rejects.toThrow(new HttpException(400, 'This reimbursement request has already been denied'));
     });
-    test('Deny Reimbursment Request success', async () => {
+    test('Deny Reimbursement Request fails if the request has already been reimbursed', async () => {
+      vi.spyOn(prisma.team, 'findUnique').mockResolvedValue(primsaTeam2);
+      vi.spyOn(prisma.reimbursement_Request, 'findUnique').mockResolvedValue(prismaGiveMeMyMoney5);
+
+      await expect(
+        ReimbursementRequestService.denyReimbursementRequest(prismaGiveMeMyMoney5.reimbursementRequestId, alfred)
+      ).rejects.toThrow(new HttpException(400, 'This reimbursement request has already been reimbursed'));
+    });
+    test('Deny Reimbursement Request success', async () => {
       vi.spyOn(prisma.team, 'findUnique').mockResolvedValue(primsaTeam2);
       vi.spyOn(prisma.reimbursement_Request, 'findUnique').mockResolvedValue(prismaGiveMeMyMoney3);
       vi.spyOn(prisma.reimbursement_Status, 'create').mockResolvedValue(prismaReimbursementStatus);

--- a/src/backend/tests/test-data/reimbursement-requests.test-data.ts
+++ b/src/backend/tests/test-data/reimbursement-requests.test-data.ts
@@ -111,6 +111,24 @@ export const prismaReimbursementStatus2: PrismaReimbursementStatus & { user: Use
   user: alfred
 };
 
+export const prismaReimbursementStatus3: PrismaReimbursementStatus & { user: User } = {
+  reimbursementStatusId: 3,
+  type: 'DENIED',
+  userId: 0,
+  dateCreated: new Date('23/8/2023'),
+  reimbursementRequestId: GiveMeMyMoney.reimbursementRequestId,
+  user: alfred
+};
+
+export const prismaReimbursementStatus4: PrismaReimbursementStatus & { user: User } = {
+  reimbursementStatusId: 3,
+  type: 'REIMBURSED',
+  userId: 0,
+  dateCreated: new Date('23/8/2023'),
+  reimbursementRequestId: GiveMeMyMoney.reimbursementRequestId,
+  user: alfred
+};
+
 export const prismaGiveMeMyMoney2: Prisma.Reimbursement_RequestGetPayload<typeof reimbursementRequestQueryArgs> = {
   ...GiveMeMyMoney,
   receiptPictures: [],
@@ -125,6 +143,26 @@ export const prismaGiveMeMyMoney3: Prisma.Reimbursement_RequestGetPayload<typeof
   ...GiveMeMyMoney,
   receiptPictures: [],
   reimbursementStatuses: [prismaReimbursementStatus2],
+  recipient: batman,
+  vendor: PopEyes,
+  reimbursementProducts: [{ ...GiveMeMoneyProduct, wbsElement: prismaWbsElement1 }],
+  expenseType: Parts
+};
+
+export const prismaGiveMeMyMoney4: Prisma.Reimbursement_RequestGetPayload<typeof reimbursementRequestQueryArgs> = {
+  ...GiveMeMyMoney,
+  receiptPictures: [],
+  reimbursementStatuses: [prismaReimbursementStatus3],
+  recipient: batman,
+  vendor: PopEyes,
+  reimbursementProducts: [{ ...GiveMeMoneyProduct, wbsElement: prismaWbsElement1 }],
+  expenseType: Parts
+};
+
+export const prismaGiveMeMyMoney5: Prisma.Reimbursement_RequestGetPayload<typeof reimbursementRequestQueryArgs> = {
+  ...GiveMeMyMoney,
+  receiptPictures: [],
+  reimbursementStatuses: [prismaReimbursementStatus4],
   recipient: batman,
   vendor: PopEyes,
   reimbursementProducts: [{ ...GiveMeMoneyProduct, wbsElement: prismaWbsElement1 }],

--- a/src/frontend/src/utils/reimbursement-request.utils.ts
+++ b/src/frontend/src/utils/reimbursement-request.utils.ts
@@ -59,6 +59,9 @@ export const cleanReimbursementRequestStatus = (status: ReimbursementStatusType)
     case ReimbursementStatusType.SABO_SUBMITTED: {
       return 'Submitted to Sabo';
     }
+    case ReimbursementStatusType.DENIED: {
+      return 'Denied';
+    }
   }
 };
 

--- a/src/shared/src/types/reimbursement-requests-types.ts
+++ b/src/shared/src/types/reimbursement-requests-types.ts
@@ -10,7 +10,8 @@ export enum ReimbursementStatusType {
   PENDING_FINANCE = 'PENDING_FINANCE',
   SABO_SUBMITTED = 'SABO_SUBMITTED',
   ADVISOR_APPROVED = 'ADVISOR_APPROVED',
-  REIMBURSED = 'REIMBURSED'
+  REIMBURSED = 'REIMBURSED',
+  DENIED = 'DENIED'
 }
 
 export interface ReimbursementStatus {


### PR DESCRIPTION
## Changes

Added a denied reimbursement status type and endpoint to allow someone from the finance team to mark a reimbursement request as denied.

## Notes

Right now you can't deny a RR if its been deleted, denied, or reimbursed, not sure if should also add if approved. 

## Test Cases

- Deny Reimbursement Request fails if Submitter not on Finance Team
- Deny Reimbursement Request fails if Finance Team does not exist
- Deny Reimbursement Request fails if the Request does not exist
- Deny Reimbursement Request fails if the Request has been deleted
- Deny Reimbursement Request fails if the request has already been denied
- Deny Reimbursement Request fails if the request has already been reimbursed
- Deny Reimbursement Request success

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1610
