### PR TITLE
#1593-Made a check for old reviewers before pinging

### DIFF
--- a/src/backend/tests/change-requests.test.ts
+++ b/src/backend/tests/change-requests.test.ts
@@ -457,9 +457,10 @@ describe('Change Requests', () => {
       expect(prisma.change_Request.findUnique).toHaveBeenCalledTimes(1);
     });
 
+    const changeRequest = { ...prismaChangeRequest1, requestedReviewers: [] };
     test('Change request successfully assigned reviewers', async () => {
       vi.spyOn(prisma.user, 'findMany').mockResolvedValue([batmanWithUserSettings]);
-      vi.spyOn(prisma.change_Request, 'findUnique').mockResolvedValue({ ...prismaChangeRequest1, requestedReviewers: [] });
+      vi.spyOn(prisma.change_Request, 'findUnique').mockResolvedValue(changeRequest);
       vi.spyOn(prisma.change_Request, 'update').mockResolvedValue(prismaChangeRequest1);
 
       await ChangeRequestsService.requestCRReview(batman, [1], 1);

--- a/src/backend/tests/change-requests.test.ts
+++ b/src/backend/tests/change-requests.test.ts
@@ -459,7 +459,7 @@ describe('Change Requests', () => {
 
     test('Change request successfully assigned reviewers', async () => {
       vi.spyOn(prisma.user, 'findMany').mockResolvedValue([batmanWithUserSettings]);
-      vi.spyOn(prisma.change_Request, 'findUnique').mockResolvedValue(prismaChangeRequest1);
+      vi.spyOn(prisma.change_Request, 'findUnique').mockResolvedValue({ ...prismaChangeRequest1, requestedReviewers: [] });
       vi.spyOn(prisma.change_Request, 'update').mockResolvedValue(prismaChangeRequest1);
 
       await ChangeRequestsService.requestCRReview(batman, [1], 1);


### PR DESCRIPTION
## Changes

Created a new list of the old requested reviewers
Filtered out those of the new reviewers who were apart of the old reviewers

## Test Cases
Prereq: Adding a slackbot to the .env file and changing the local finishline slackId to mine
- Case 1:  Tested if I was spam pinged by the Slackbot
- Case 2: Made sure I was spammed by doing the opposite with my filter 

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [ ] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1593 