### PR TITLE
#1659 visual indication when tabbing through delete and add

### DIFF
--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementProductTable.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementProductTable.tsx
@@ -25,6 +25,7 @@ import { ReimbursementProductCreateArgs, validateWBS, wbsPipe } from 'shared';
 import { Add, Delete } from '@mui/icons-material';
 import { Control, Controller, FieldErrors, UseFormSetValue } from 'react-hook-form';
 import { ReimbursementRequestFormInput } from './ReimbursementRequestForm';
+import { useTheme } from '@mui/system';
 
 interface ReimbursementProductTableProps {
   reimbursementProducts: ReimbursementProductCreateArgs[];
@@ -73,6 +74,9 @@ const ReimbursementProductTable: React.FC<ReimbursementProductTableProps> = ({
   const onCostBlurHandler = (value: number, index: number) => {
     setValue(`reimbursementProducts.${index}.cost`, parseFloat(value.toFixed(2)));
   };
+
+  const userTheme = useTheme();
+  const hoverColor = userTheme.palette.action.hover;
 
   return (
     <TableContainer>
@@ -147,7 +151,7 @@ const ReimbursementProductTable: React.FC<ReimbursementProductTableProps> = ({
                           <IconButton
                             sx={{
                               '&:focus': {
-                                backgroundColor: '#f5f5f5'
+                                backgroundColor: hoverColor
                               }
                             }}
                             onClick={() => removeProduct(product.index)}
@@ -162,7 +166,10 @@ const ReimbursementProductTable: React.FC<ReimbursementProductTableProps> = ({
                     sx={{
                       margin: '4px',
                       '&:focus': {
-                        backgroundColor: '#fdf8f8'
+                        backgroundColor: hoverColor
+                      },
+                      '&:hover': {
+                        backgroundColor: hoverColor
                       }
                     }}
                     startIcon={<Add />}

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementProductTable.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementProductTable.tsx
@@ -173,13 +173,14 @@ const ReimbursementProductTable: React.FC<ReimbursementProductTableProps> = ({
                       }
                     }}
                     startIcon={<Add />}
-                    onClick={() =>
+                    onClick={(e) => {
                       appendProduct({
                         wbsNum: validateWBS(key),
                         name: '',
                         cost: 0
-                      })
-                    }
+                      });
+                      e.currentTarget.blur();
+                    }}
                   >
                     Add Product
                   </Button>

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementProductTable.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementProductTable.tsx
@@ -144,7 +144,14 @@ const ReimbursementProductTable: React.FC<ReimbursementProductTableProps> = ({
                               {errors.reimbursementProducts?.[product.index]?.cost?.message}
                             </FormHelperText>
                           </FormControl>
-                          <IconButton onClick={() => removeProduct(product.index)}>
+                          <IconButton
+                            sx={{
+                              '&:focus': {
+                                backgroundColor: '#f5f5f5'
+                              }
+                            }}
+                            onClick={() => removeProduct(product.index)}
+                          >
                             <Delete />
                           </IconButton>
                         </Box>
@@ -152,7 +159,12 @@ const ReimbursementProductTable: React.FC<ReimbursementProductTableProps> = ({
                     ))}
                   </Box>
                   <Button
-                    sx={{ margin: '4px' }}
+                    sx={{
+                      margin: '4px',
+                      '&:focus': {
+                        backgroundColor: '#fdf8f8'
+                      }
+                    }}
                     startIcon={<Add />}
                     onClick={() =>
                       appendProduct({


### PR DESCRIPTION
## Changes

There is now a visual indication when tabbing through delete and add button of the products of the reimbursement request. 

## Screenshots

![add product tabbed](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/123319639/1f18f508-3bf1-4d73-bf35-18e42638082b)
![delete button tabbed](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/123319639/0a5c6b82-c980-4702-ad01-d49622b4dc25)

Closes #1659
