### PR TITLE
#1577 receipt display update

### DIFF
--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
@@ -9,7 +9,7 @@ import CheckIcon from '@mui/icons-material/Check';
 import ConfirmationNumberIcon from '@mui/icons-material/ConfirmationNumber';
 import DeleteIcon from '@mui/icons-material/Delete';
 import LocalShippingIcon from '@mui/icons-material/LocalShipping';
-import { Grid, Typography, useTheme } from '@mui/material';
+import { Grid, Typography, useTheme, Link, IconButton } from '@mui/material';
 import { Box } from '@mui/system';
 import { useState } from 'react';
 import { useHistory } from 'react-router-dom';
@@ -30,6 +30,7 @@ import {
   undefinedPipe
 } from '../../../utils/pipes';
 import {
+  imageDownloadUrl,
   imagePreviewUrl,
   isReimbursementRequestAdvisorApproved,
   isReimbursementRequestSaboSubmitted
@@ -38,6 +39,7 @@ import { routes } from '../../../utils/routes';
 import AddSABONumberModal from './AddSABONumberModal';
 import ReimbursementProductsView from './ReimbursementProductsView';
 import SubmitToSaboModal from './SubmitToSaboModal';
+import DownloadIcon from '@mui/icons-material/Download';
 
 interface ReimbursementRequestDetailsViewProps {
   reimbursementRequest: ReimbursementRequest;
@@ -175,11 +177,19 @@ const ReimbursementRequestDetailsView: React.FC<ReimbursementRequestDetailsViewP
         <Typography variant="h5">Receipts</Typography>
         {reimbursementRequest.receiptPictures.map((receipt) => {
           return (
-            <iframe
-              style={{ height: `200px`, width: '50%' }}
-              src={imagePreviewUrl(receipt.googleFileId)}
-              title={receipt.name}
-            />
+            <Box>
+              <Link href={receipt.googleFileId} target="_blank" underline="hover" fontSize={19}>
+                {receipt.name}
+              </Link>
+              <IconButton href={imageDownloadUrl(receipt.googleFileId)}>
+                <DownloadIcon />
+              </IconButton>
+              <iframe
+                style={{ height: `200px`, width: '50%' }}
+                src={imagePreviewUrl(receipt.googleFileId)}
+                title={receipt.name}
+              />
+            </Box>
           );
         })}
       </Box>

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
@@ -32,7 +32,6 @@ import {
 import {
   imageDownloadUrl,
   imageFileUrl,
-  imagePreviewUrl,
   isReimbursementRequestAdvisorApproved,
   isReimbursementRequestSaboSubmitted
 } from '../../../utils/reimbursement-request.utils';

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
@@ -175,23 +175,18 @@ const ReimbursementRequestDetailsView: React.FC<ReimbursementRequestDetailsViewP
   const ReceiptsView = () => {
     return (
       <Box sx={{ maxHeight: `250px`, overflow: reimbursementRequest.receiptPictures.length > 0 ? 'auto' : 'none' }}>
-        <Typography variant="h5">Receipts</Typography>
-        {reimbursementRequest.receiptPictures.map((receipt, index, arr) => {
+        <Box sx={{ position: 'sticky', top: 0, background: theme.palette.background.default, pb: 1, zIndex: 1 }}>
+          <Typography variant="h5">Receipts</Typography>
+        </Box>
+        {reimbursementRequest.receiptPictures.map((receipt) => {
           return (
-            <Box sx={{ mb: arr.length !== index + 1 ? 5 : 0 }}>
-              <Box sx={{ width: '50%', display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end' }}>
-                <Link href={imageFileUrl(receipt.googleFileId)} target="_blank" underline="hover">
-                  {receipt.name}
-                </Link>
-                <IconButton href={imageDownloadUrl(receipt.googleFileId)}>
-                  <DownloadIcon />
-                </IconButton>
-              </Box>
-              <iframe
-                style={{ height: `200px`, width: '50%' }}
-                src={imagePreviewUrl(receipt.googleFileId)}
-                title={receipt.name}
-              />
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              <Link href={imageFileUrl(receipt.googleFileId)} target="_blank" underline="hover" sx={{ mr: 1, fontSize: 30 }}>
+                {receipt.name}
+              </Link>
+              <IconButton href={imageDownloadUrl(receipt.googleFileId)}>
+                <DownloadIcon sx={{ fontSize: 30 }} />
+              </IconButton>
             </Box>
           );
         })}

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
@@ -31,6 +31,7 @@ import {
 } from '../../../utils/pipes';
 import {
   imageDownloadUrl,
+  imageFileUrl,
   imagePreviewUrl,
   isReimbursementRequestAdvisorApproved,
   isReimbursementRequestSaboSubmitted
@@ -147,7 +148,7 @@ const ReimbursementRequestDetailsView: React.FC<ReimbursementRequestDetailsViewP
             <Grid item xs={6} textAlign={'center'} mt={-2}>
               <Typography fontSize={50}>Total Cost</Typography>
             </Grid>
-            <Grid xs={6} mt={-2} sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Grid xs={6} mt={-2} sx={{ display: 'flex', alignItems: 'center' }}>
               <Typography fontSize={50}>{`$${centsToDollar(reimbursementRequest.totalCost)}`}</Typography>
             </Grid>
           </Grid>
@@ -175,15 +176,17 @@ const ReimbursementRequestDetailsView: React.FC<ReimbursementRequestDetailsViewP
     return (
       <Box sx={{ maxHeight: `250px`, overflow: reimbursementRequest.receiptPictures.length > 0 ? 'auto' : 'none' }}>
         <Typography variant="h5">Receipts</Typography>
-        {reimbursementRequest.receiptPictures.map((receipt) => {
+        {reimbursementRequest.receiptPictures.map((receipt, index, arr) => {
           return (
-            <Box>
-              <Link href={receipt.googleFileId} target="_blank" underline="hover" fontSize={19}>
-                {receipt.name}
-              </Link>
-              <IconButton href={imageDownloadUrl(receipt.googleFileId)}>
-                <DownloadIcon />
-              </IconButton>
+            <Box sx={{ mb: arr.length !== index + 1 ? 5 : 0 }}>
+              <Box sx={{ width: '50%', display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end' }}>
+                <Link href={imageFileUrl(receipt.googleFileId)} target="_blank" underline="hover">
+                  {receipt.name}
+                </Link>
+                <IconButton href={imageDownloadUrl(receipt.googleFileId)}>
+                  <DownloadIcon />
+                </IconButton>
+              </Box>
               <iframe
                 style={{ height: `200px`, width: '50%' }}
                 src={imagePreviewUrl(receipt.googleFileId)}

--- a/src/frontend/src/utils/reimbursement-request.utils.ts
+++ b/src/frontend/src/utils/reimbursement-request.utils.ts
@@ -90,6 +90,8 @@ export const getReimbursementRequestDateSubmittedToSabo = (reimbursementRequest:
 
 export const imagePreviewUrl = (googleFileId: string) => `https://drive.google.com/file/d/${googleFileId}/preview`;
 
+export const imageDownloadUrl = (googleFileId: string) => `https://drive.google.com/uc?export=download&id=${googleFileId}`;
+
 export const getRefundRowData = (refund: Reimbursement) => {
   return { date: refund.dateCreated, amount: refund.amount, recipient: refund.userSubmitted };
 };

--- a/src/frontend/src/utils/reimbursement-request.utils.ts
+++ b/src/frontend/src/utils/reimbursement-request.utils.ts
@@ -90,6 +90,8 @@ export const getReimbursementRequestDateSubmittedToSabo = (reimbursementRequest:
 
 export const imagePreviewUrl = (googleFileId: string) => `https://drive.google.com/file/d/${googleFileId}/preview`;
 
+export const imageFileUrl = (googleFileId: string) => `https://drive.google.com/file/d/${googleFileId}`;
+
 export const imageDownloadUrl = (googleFileId: string) => `https://drive.google.com/uc?export=download&id=${googleFileId}`;
 
 export const getRefundRowData = (refund: Reimbursement) => {


### PR DESCRIPTION
## Changes

Removed the image preview for the receipts (discussed in Slack) and replaced them with the the name that's also a link to the file in Google Drive and a download button. Also made the Receipts header sticky.

## Notes

- ~~Will change from draft once Brody and Zach approve on Slack.~~ Design approved by Brody and Zach in Slack!
- Had to put a Z index on the Box for the Receipts header as the download buttons would overlap and appear on top of the Box for some reason

## Screenshots

Big Screen
<img width="1512" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/92332953/55f1c964-52e5-4a99-96ef-ae5e17250086">

Sticky header in action
<img width="1512" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/92332953/efc3f606-13b0-4ebd-9fea-229a5f0a9158">

Small Screen
<img width="455" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/92332953/163a7148-a48a-4f38-8b23-526b0d0df374">


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1577  (issue #)
