### PR TITLE
#1738 - CR correctly auto-populates on WP/Project forms now

### DIFF
--- a/src/frontend/src/pages/ProjectDetailPage/ProjectForm/ProjectCreateContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectForm/ProjectCreateContainer.tsx
@@ -14,16 +14,13 @@ import { routes } from '../../../utils/routes';
 import { getRequiredLinkTypeNames } from '../../../utils/link.utils';
 import ErrorPage from '../../ErrorPage';
 import LoadingIndicator from '../../../components/LoadingIndicator';
+import { useQuery } from '../../../hooks/utils.hooks';
 
 const ProjectCreateContainer: React.FC = () => {
   const toast = useToast();
   const history = useHistory();
+  const query = useQuery();
 
-  //const links: { linkId: string; url: string; linkTypeName: string }[] = [];
-  //const goals: { bulletId: number; detail: string }[] = [];
-  //const features: { bulletId: number; detail: string }[] = [];
-  //const rules: { bulletId: number; detail: string }[] = [];
-  //const constraints: { bulletId: number; detail: string }[] = [];
   const [projectManagerId, setProjectManagerId] = useState<string | undefined>();
   const [projectLeadId, setProjectLeadId] = useState<string | undefined>();
 
@@ -48,7 +45,7 @@ const ProjectCreateContainer: React.FC = () => {
     teamId: String(),
     carNumber: 0,
     links: [],
-    crId: 0,
+    crId: query.get('crId') || '',
     goals: [],
     features: [],
     constraints: [],
@@ -67,7 +64,7 @@ const ProjectCreateContainer: React.FC = () => {
 
     try {
       const payload: CreateSingleProjectPayload = {
-        crId,
+        crId: Number(crId),
         name,
         carNumber,
         summary,

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectForm/ProjectEditContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectForm/ProjectEditContainer.tsx
@@ -14,6 +14,7 @@ import { ProjectFormInput } from './ProjectForm';
 import LoadingIndicator from '../../../components/LoadingIndicator';
 import ErrorPage from '../../ErrorPage';
 import { getRequiredLinkTypeNames } from '../../../utils/link.utils';
+import { useQuery } from '../../../hooks/utils.hooks';
 
 interface ProjectEditContainerProps {
   project: Project;
@@ -22,6 +23,7 @@ interface ProjectEditContainerProps {
 
 const ProjectEditContainer: React.FC<ProjectEditContainerProps> = ({ project, exitEditMode }) => {
   const toast = useToast();
+  const query = useQuery();
 
   const { name, budget, summary } = project;
   const [projectManagerId, setProjectManagerId] = useState<string | undefined>(project.projectManager?.userId.toString());
@@ -30,7 +32,6 @@ const ProjectEditContainer: React.FC<ProjectEditContainerProps> = ({ project, ex
   const features = bulletsToObject(project.features);
   const constraints = bulletsToObject(project.otherConstraints);
   const rules = rulesToObject(project.rules);
-  const crId = project.changes[0].changeRequestId;
 
   const { mutateAsync, isLoading } = useEditSingleProject(project.wbsNum);
   const {
@@ -74,7 +75,7 @@ const ProjectEditContainer: React.FC<ProjectEditContainerProps> = ({ project, ex
     teamId: '',
     carNumber: 0,
     links,
-    crId,
+    crId: query.get('crId') || project.changes[0].changeRequestId.toString(),
     goals,
     features,
     constraints,
@@ -99,7 +100,7 @@ const ProjectEditContainer: React.FC<ProjectEditContainerProps> = ({ project, ex
         summary,
         links,
         projectId: project.id,
-        crId,
+        crId: Number(crId),
         rules,
         goals,
         features,

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectForm/ProjectForm.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectForm/ProjectForm.tsx
@@ -24,7 +24,7 @@ export interface ProjectFormInput {
   budget: number;
   summary: string;
   links: LinkCreateArgs[];
-  crId: number;
+  crId: string;
   carNumber: number;
   goals: {
     bulletId: number;

--- a/src/frontend/src/pages/WorkPackageForm/WorkPackageForm.tsx
+++ b/src/frontend/src/pages/WorkPackageForm/WorkPackageForm.tsx
@@ -7,6 +7,7 @@ import LoadingIndicator from '../../components/LoadingIndicator';
 import ErrorPage from '../ErrorPage';
 import { useAllUsers } from '../../hooks/users.hooks';
 import { useSingleProject } from '../../hooks/projects.hooks';
+import { useQuery } from '../../hooks/utils.hooks';
 
 interface WorkPackageFormProps {
   wbsNum: WbsNumber;
@@ -25,6 +26,7 @@ const WorkPackageForm: React.FC<WorkPackageFormProps> = ({ wbsNum, mutateAsync, 
     error: projectError
   } = useSingleProject({ ...wbsNum, workPackageNumber: 0 });
   const { data: workPackages, isLoading: wpIsLoading, isError: wpIsError, error: wpError } = useAllWorkPackages();
+  const query = useQuery();
 
   if (wpIsLoading || !workPackages || usersIsLoading || !users || projectIsLoading || !project) return <LoadingIndicator />;
   if (usersIsError) return <ErrorPage message={usersError.message} />;
@@ -43,7 +45,7 @@ const WorkPackageForm: React.FC<WorkPackageFormProps> = ({ wbsNum, mutateAsync, 
       ? {
           ...workPackage,
           workPackageId: workPackage.id,
-          crId: workPackage!.changes[0].changeRequestId.toString(),
+          crId: query.get('crId') || workPackage!.changes[0].changeRequestId.toString(),
           stage: workPackage!.stage ?? 'NONE',
           blockedBy: workPackage!.blockedBy.map(wbsPipe),
           expectedActivities: bulletsToObject(workPackage!.expectedActivities),


### PR DESCRIPTION
## Changes

Right now on prod, there's an issue where the crID field is not correctly populating on create/edit project and edit wp when you come from a change request page. These changes should address that problem.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #1738  (issue #)
