### PR TITLE
#1574: autocomplete added (first attempt)

### DIFF
--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
@@ -123,6 +123,10 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
     return { label: expenseTypePipe(expenseType), id: expenseType.expenseTypeId };
   };
 
+  const vendorsToAutocomplete = (vendorName: Vendor): { label: string; id: string } => {
+    return { label: vendorName.name, id: vendorName.vendorId };
+  };
+
   return (
     <form
       onSubmit={(e) => {
@@ -151,17 +155,27 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
               <Controller
                 name="vendorId"
                 control={control}
-                render={({ field: { onChange, value } }) => (
-                  <Select onChange={(newValue) => onChange(newValue.target.value)} value={value} error={!!errors.vendorId}>
-                    {allVendors
-                      .sort((a, b) => a.name.localeCompare(b.name))
-                      .map((vendor) => (
-                        <MenuItem key={vendor.vendorId} value={vendor.vendorId}>
-                          {vendor.name}
-                        </MenuItem>
-                      ))}
-                  </Select>
-                )}
+                render={({ field: { onChange, value } }) => {
+                  const mappedVendors = allVendors.sort((a, b) => a.name.localeCompare(b.name)).map(vendorsToAutocomplete);
+
+                  const onClear = () => {
+                    setValue('vendorId', '');
+                    onChange('');
+                  };
+
+                  return (
+                    <NERAutocomplete
+                      id={'vendorName'}
+                      size="medium"
+                      options={mappedVendors}
+                      value={mappedVendors.find((vendorName) => vendorName.id === value) || null}
+                      placeholder=""
+                      onChange={(_event, newValue) => {
+                        newValue ? onChange(newValue.id) : onClear();
+                      }}
+                    />
+                  );
+                }}
               />
               <FormHelperText error>{errors.vendorId?.message}</FormHelperText>
             </FormControl>

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
@@ -167,7 +167,7 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
                       id={'vendor'}
                       size="medium"
                       options={mappedVendors}
-                      value={mappedVendors.find((vendor) => vendor.id === value)}
+                      value={mappedVendors.find((vendor) => vendor.id === value) || null}
                       placeholder="Select Vendor"
                       onChange={(_event, newValue) => {
                         newValue ? onChange(newValue.id) : onClear();

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
@@ -123,8 +123,8 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
     return { label: expenseTypePipe(expenseType), id: expenseType.expenseTypeId };
   };
 
-  const vendorsToAutocomplete = (vendorName: Vendor): { label: string; id: string } => {
-    return { label: vendorName.name, id: vendorName.vendorId };
+  const vendorsToAutocomplete = (vendor: Vendor): { label: string; id: string } => {
+    return { label: vendor.name, id: vendor.vendorId };
   };
 
   return (
@@ -157,7 +157,6 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
                 control={control}
                 render={({ field: { onChange, value } }) => {
                   const mappedVendors = allVendors.sort((a, b) => a.name.localeCompare(b.name)).map(vendorsToAutocomplete);
-
                   const onClear = () => {
                     setValue('vendorId', '');
                     onChange('');
@@ -165,11 +164,11 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
 
                   return (
                     <NERAutocomplete
-                      id={'vendorName'}
+                      id={'vendor'}
                       size="medium"
                       options={mappedVendors}
-                      value={mappedVendors.find((vendorName) => vendorName.id === value) || null}
-                      placeholder=""
+                      value={mappedVendors.find((vendor) => vendor.id === value)}
+                      placeholder="Select Vendor"
                       onChange={(_event, newValue) => {
                         newValue ? onChange(newValue.id) : onClear();
                       }}


### PR DESCRIPTION
## Changes

I replaced the MUI Select with the NERAutocomplete component.

## Notes

When I tried to create a reimbursement form, it returned an error "Failed to Upload Receipt(s): No access, refresh token, API key or refresh handler callback is set."

## Screenshots



https://github.com/Northeastern-Electric-Racing/FinishLine/assets/90310958/53d5d22a-fadc-434f-a1d6-b8e84f559125




## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1574
