### PR TITLE
#1770 bom bug fixes

### DIFF
--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/EditMaterialModal.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/EditMaterialModal.tsx
@@ -36,7 +36,7 @@ const EditMaterialModal: React.FC<EditMaterialModalProps> = ({ open, onHide, mat
     <MaterialForm
       submitText="Edit"
       onSubmit={onSubmit}
-      defaultValues={{ ...material, nerPartNumber: material.manufacturerPartNumber }}
+      defaultValues={{ ...material, nerPartNumber: material.manufacturerPartNumber, price: material.price / 100 }}
       wbsElement={wbsElement}
       onHide={onHide}
       open={open}

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOMTab.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOMTab.tsx
@@ -43,7 +43,7 @@ const BOMTab = ({ project }: { project: Project }) => {
             <Box sx={{ backgroundColor: theme.palette.background.paper, padding: '8px 14px 8px 14px', borderRadius: '6px' }}>
               Total Cost: ${centsToDollar(totalCost)}
             </Box>
-            {totalCost > project.budget && (
+            {totalCost > project.budget * 100 && (
               <Tooltip title="Current Total Cost Exceeds Budget!" placement="top" arrow>
                 <WarningIcon color="warning" fontSize="large" />
               </Tooltip>


### PR DESCRIPTION
## Changes

- Over budget alert only appears when appropriate
- Editing a material no longer multiplies price by 100

## Notes

It may be best to store material prices in cents, but this would require migration

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1770 
