### PR TITLE
#1612 Add reimbursed status endpoint

### DIFF
--- a/src/backend/src/controllers/reimbursement-requests.controllers.ts
+++ b/src/backend/src/controllers/reimbursement-requests.controllers.ts
@@ -259,6 +259,17 @@ export default class ReimbursementRequestsController {
     }
   }
 
+  static async markReimbursementRequestAsReimbursed(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { requestId } = req.params;
+      const user = await getCurrentUser(res);
+      const updatedRequest = await ReimbursementRequestService.markReimbursementRequestAsReimbursed(requestId, user);
+      res.status(200).json(updatedRequest);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
   static async markReimbursementRequestAsDelivered(req: Request, res: Response, next: NextFunction) {
     try {
       const { requestId } = req.params;

--- a/src/backend/src/routes/reimbursement-requests.routes.ts
+++ b/src/backend/src/routes/reimbursement-requests.routes.ts
@@ -129,6 +129,11 @@ reimbursementRequestsRouter.post(
   ReimbursementRequestController.markReimbursementRequestAsDelivered
 );
 
+reimbursementRequestsRouter.post(
+  '/:requestId/reimbursed',
+  ReimbursementRequestController.markReimbursementRequestAsReimbursed
+);
+
 reimbursementRequestsRouter.get('/receipt-image/:fileId', ReimbursementRequestController.downloadReceiptImage);
 
 export default reimbursementRequestsRouter;

--- a/src/backend/src/services/reimbursement-requests.services.ts
+++ b/src/backend/src/services/reimbursement-requests.services.ts
@@ -644,6 +644,10 @@ export default class ReimbursementRequestService {
    *
    * @param reimbursementRequestId the id of the reimbursement request to mark reimbursed
    * @param submitter the user who is marking the reimbursement request as reimbursed
+   * @throws AccessDeniedException if the submitter of the request is not on the finance team
+   * @throws HttpException if the finance team does not exist
+   * @throws NotFoundException if the id is invalid or not there
+   * @throws HttpException if the reimbursement request is already marked as reimbursed or has been denied
    * @returns the created reimbursment status
    */
   static async markReimbursementRequestAsReimbursed(reimbursementRequestId: string, submitter: User) {

--- a/src/backend/tests/reimbursement-requests.test.ts
+++ b/src/backend/tests/reimbursement-requests.test.ts
@@ -575,7 +575,7 @@ describe('Reimbursement Requests', () => {
       ).rejects.toThrow(new HttpException(400, 'This reimbursement request has already been marked as reimbursed'));
     });
 
-    test('Mark Reimbursement Request as Reimbursed fails if the request has not been denied', async () => {
+    test('Mark Reimbursement Request as Reimbursed fails if the request has been denied', async () => {
       vi.spyOn(prisma.team, 'findUnique').mockResolvedValue(primsaTeam2);
       vi.spyOn(prisma.reimbursement_Request, 'findUnique').mockResolvedValue(prismaGiveMeMyMoney4);
 


### PR DESCRIPTION
## Changes

added new endpoint for marking reimbursement requests as reimbursed

## Test Cases

- is user part of the finance team
- does finance team exist
- does reimbursement request with `reimbursementRequestId` exist
- is the reimbursement request not deleted
- is reimbursement request not already marked as reimbursed
- is reimbursement request not marked as denied

## Screenshots

functionality of adding `REIMBURSED` status

postman req:
<img width="900" alt="http-req" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/147638290/2e930099-3602-44e1-be03-794f91bb82c9">

before req:
<img width="1728" alt="before-req" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/147638290/a7665866-5a55-41f9-a808-05d8cda12683">

after req:
<img width="1728" alt="after-req" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/147638290/f854f7a4-1cef-4bff-87d2-39f5d48451d1">

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1612
