### PR TITLE
#1758 Finance Fixes - Sort refunds newest to oldest

### DIFF
--- a/src/frontend/src/pages/FinancePage/RefundsSection.tsx
+++ b/src/frontend/src/pages/FinancePage/RefundsSection.tsx
@@ -112,16 +112,28 @@ const Refunds = ({ userReimbursementRequests, allReimbursementRequests }: Refund
               </TableRow>
             </TableHead>
             <TableBody>
-              {rows.map((row, index) => (
-                <TableRow
-                  key={`${row.date}-$${row.amount}-${index}`}
-                  sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
-                >
-                  <TableCell align="center">{datePipe(row.date)}</TableCell>
-                  <TableCell align="center">{centsToDollar(row.amount)}</TableCell>
-                  {tabValue === 1 && <TableCell align="center">{fullNamePipe(row.recipient)}</TableCell>}
-                </TableRow>
-              ))}
+              {rows
+                .reverse()
+                .sort((a, b) => {
+                  const dateA = new Date(a.date);
+                  const dateB = new Date(b.date);
+
+                  //leave out time (real time taken care of by order in database)
+                  const dayA = new Date(dateA.getFullYear(), dateA.getMonth(), dateA.getDate());
+                  const dayB = new Date(dateB.getFullYear(), dateB.getMonth(), dateB.getDate());
+
+                  return dayB.valueOf() - dayA.valueOf();
+                })
+                .map((row, index) => (
+                  <TableRow
+                    key={`${row.date}-$${row.amount}-${index}`}
+                    sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
+                  >
+                    <TableCell align="center">{datePipe(row.date)}</TableCell>
+                    <TableCell align="center">{centsToDollar(row.amount)}</TableCell>
+                    {tabValue === 1 && <TableCell align="center">{fullNamePipe(row.recipient)}</TableCell>}
+                  </TableRow>
+                ))}
             </TableBody>
           </Table>
         </TableContainer>


### PR DESCRIPTION
## Changes

Changed row to display refunds from newest to oldest (based on date + position in database).

## Notes

I had to sort by day and not time.  There was a bug where you submit {**sub1**} at 9:00 for dateA and submit {**sub2**} the next real day for dateA (but at 14:00). {**sub1**} would display first even though it was submitted before {**sub2**} because the date was the same but the time was auto generated when the refund was submitted.

Might be better to implement this elsewhere lmk.

## Test Cases

-  edge case: described above ^

## Screenshots

![Max screen #1758](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/138251570/957b3968-f244-479f-800e-cb3821dd29c4)
![Min Screen #1758](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/138251570/19bd342a-b8b4-4f46-a3d3-26ea177b97c4)

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1758
