### PR TITLE
#1825 Force reload page on theme change

### DIFF
--- a/src/frontend/src/pages/SettingsPage/UserSettings/UserSettings.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserSettings/UserSettings.tsx
@@ -42,11 +42,13 @@ const UserSettings: React.FC<UserSettingsProps> = ({ currentSettings }) => {
   const handleConfirm = async ({ defaultTheme, slackId }: SettingsFormInput) => {
     setEdit(false);
     try {
+      const refreshOnNewTheme: boolean = currentSettings.defaultTheme !== defaultTheme;
       await updateUserSettings({
         id: currentSettings.id,
         defaultTheme,
         slackId
       });
+      if (refreshOnNewTheme) window.location.reload();
     } catch (e) {
       if (e instanceof Error) {
         toast.error(e.message);


### PR DESCRIPTION
## Changes

force page to reload on theme change

## Test Cases

- page only reloads if the theme changes, if the theme stays the same or the slack id changes but the theme doesn't change, settings will save without a page reload

## Screenshots

N/A - run locally to see test case above

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1825
