### PR TITLE
#1754 Display form error if CR with no proposed solution

### DIFF
--- a/src/frontend/src/pages/CreateChangeRequestPage/CreateChangeRequest.tsx
+++ b/src/frontend/src/pages/CreateChangeRequestPage/CreateChangeRequest.tsx
@@ -52,7 +52,7 @@ const CreateChangeRequest: React.FC<CreateChangeRequestProps> = () => {
   const handleConfirm = async (data: FormInput) => {
     const requestHasASolution: boolean = proposedSolutions.length !== 0;
     try {
-      if (!requestHasASolution) throw new Error('FormError: You must submit a Proposed Solution!');
+      if (!requestHasASolution) throw new Error('Error: You must have at least one Proposed Solution Added');
       await mutateAsync({
         ...data,
         wbsNum: validateWBS(wbsNum),

--- a/src/frontend/src/pages/CreateChangeRequestPage/CreateChangeRequest.tsx
+++ b/src/frontend/src/pages/CreateChangeRequestPage/CreateChangeRequest.tsx
@@ -50,7 +50,9 @@ const CreateChangeRequest: React.FC<CreateChangeRequestProps> = () => {
   if (isError) return <ErrorPage message={error?.message} />;
 
   const handleConfirm = async (data: FormInput) => {
+    const requestHasASolution: boolean = proposedSolutions.length !== 0;
     try {
+      if (!requestHasASolution) throw new Error('FormError: You must submit a Proposed Solution!');
       await mutateAsync({
         ...data,
         wbsNum: validateWBS(wbsNum),
@@ -61,7 +63,7 @@ const CreateChangeRequest: React.FC<CreateChangeRequestProps> = () => {
         toast.error(e.message);
       }
     } finally {
-      history.push(routes.CHANGE_REQUESTS);
+      if (requestHasASolution) history.push(routes.CHANGE_REQUESTS);
     }
   };
 


### PR DESCRIPTION
## Changes

if a change request is submitted but there is no proposed solution, display a form error instead of allowing a submission with an immediate error

## Notes

works by seeing if `proposedSolutions: ProposedSolution[]` is empty or not. shouldn't have to worry about malformed data entering `proposedSolutions` because of TS type annotation, i.e. if there is something in `proposedSolutions`, it is a valid proposed solution

## Test Cases

- errors if there are no proposed solutions and a user attempts to submit the form

## Screenshots

<img width="1724" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/147638290/52f12865-d913-47b5-8d27-b44f11d73ffe">

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1754
