### PR TITLE
#1758 - Finance Fix - Sort Refunds newest to oldest

### DIFF
--- a/src/frontend/src/pages/FinancePage/RefundsSection.tsx
+++ b/src/frontend/src/pages/FinancePage/RefundsSection.tsx
@@ -70,9 +70,7 @@ const Refunds = ({ userReimbursementRequests, allReimbursementRequests }: Refund
   const displayedReimbursementRequests =
     allReimbursementRequests && tabValue === 1 ? allReimbursementRequests : userReimbursementRequests;
 
-  const rows = displayedReimbursements.map(getRefundRowData).sort((a, b) => {
-    return b.date.valueOf() - a.date.valueOf();
-  });
+  const rows = displayedReimbursements.map(getRefundRowData).sort((a, b) => b.date.valueOf() - a.date.valueOf());
 
   const totalReceived = displayedReimbursements.reduce(
     (accumulator: number, currentVal: Reimbursement) => accumulator + currentVal.amount,

--- a/src/frontend/src/pages/FinancePage/RefundsSection.tsx
+++ b/src/frontend/src/pages/FinancePage/RefundsSection.tsx
@@ -70,7 +70,9 @@ const Refunds = ({ userReimbursementRequests, allReimbursementRequests }: Refund
   const displayedReimbursementRequests =
     allReimbursementRequests && tabValue === 1 ? allReimbursementRequests : userReimbursementRequests;
 
-  const rows = displayedReimbursements.map(getRefundRowData);
+  const rows = displayedReimbursements.map(getRefundRowData).sort((a, b) => {
+    return b.date.valueOf() - a.date.valueOf();
+  });
 
   const totalReceived = displayedReimbursements.reduce(
     (accumulator: number, currentVal: Reimbursement) => accumulator + currentVal.amount,


### PR DESCRIPTION
## Changes

Changed rows to display refunds from newest to oldest (based on date).

## Screenshots

<img width="1440" alt="Max #1758" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/138251570/0a76eda7-c1c2-4409-ab78-4f733151f1a2">
![Min #1758](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/138251570/3db307c7-1471-4e7f-b729-9248af7e446d)


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1758
