### PR TITLE
#1542 Create LinkType endpoint

### DIFF
--- a/src/backend/src/controllers/projects.controllers.ts
+++ b/src/backend/src/controllers/projects.controllers.ts
@@ -155,6 +155,18 @@ export default class ProjectsController {
     }
   }
 
+  static async createLinkType(req: Request, res: Response, next: NextFunction) {
+    try {
+      const user: User = await getCurrentUser(res);
+      const { name, iconName, required } = req.body;
+
+      const newLinkType = await ProjectsService.createLinkType(user, name, iconName, required);
+      res.status(200).json(newLinkType);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
   static async createAssembly(req: Request, res: Response, next: NextFunction) {
     try {
       const user: User = await getCurrentUser(res);

--- a/src/backend/src/routes/projects.routes.ts
+++ b/src/backend/src/routes/projects.routes.ts
@@ -32,7 +32,14 @@ const projectValidators = [
   intMinZero(body('projectManagerId').optional())
 ];
 
-projectRouter.post('/link-types/create', ProjectsController.createLinkType);
+projectRouter.post(
+  '/link-types/create',
+  nonEmptyString(body('name')),
+  nonEmptyString(body('iconName')),
+  body('required').isBoolean(),
+  validateInputs,
+  ProjectsController.createLinkType
+);
 
 projectRouter.post(
   '/create',

--- a/src/backend/src/routes/projects.routes.ts
+++ b/src/backend/src/routes/projects.routes.ts
@@ -32,6 +32,8 @@ const projectValidators = [
   intMinZero(body('projectManagerId').optional())
 ];
 
+projectRouter.post('/link-types/create', ProjectsController.createLinkType);
+
 projectRouter.post(
   '/create',
   intMinZero(body('carNumber')),

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -491,12 +491,12 @@ export default class ProjectsService {
    * @param iconName the name of the icon for the new LinkType
    * @param required is the new LinkType required
    * @param user the user who is creating the new LinkType
-   * @throws AccessDeniedException if the submitter of the request is not an admin or head
+   * @throws AccessDeniedException if the submitter of the request is not an admin
    * @throws HttpException if a LinkType of the given name already exists
    * @returns the created LinkType
    */
   static async createLinkType(user: User, name: string, iconName: string, required: boolean): Promise<LinkType> {
-    if (!isHead(user.role)) throw new AccessDeniedException('Only heads and above can create link types');
+    if (!isAdmin(user.role)) throw new AccessDeniedException('Only admins can create link types');
 
     const existingLinkType = await prisma.linkType.findUnique({
       where: { name }

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -485,6 +485,39 @@ export default class ProjectsService {
   }
 
   /**
+   * Creates a new LinkType with the given information
+   *
+   * @param name the name of the new LinkType
+   * @param iconName the name of the icon for the new LinkType
+   * @param required is the new LinkType required
+   * @param user the user who is marking the reimbursement request as reimbursed
+   * @throws AccessDeniedException if the submitter of the request is not an admin or head
+   * @throws HttpException if a LinkType of the given name already exists
+   * @returns the created LinkType
+   */
+  static async createLinkType(user: User, name: string, iconName: string, required: boolean): Promise<LinkType> {
+    if (!isHead(user.role)) throw new AccessDeniedException('Only heads and above can create link types');
+
+    const existingLinkType = await prisma.linkType.findUnique({
+      where: { name }
+    });
+
+    if (existingLinkType) throw new HttpException(400, 'LinkType with that name already exists');
+
+    const linkType = await prisma.linkType.create({
+      data: {
+        name,
+        creatorId: user.userId,
+        iconName,
+        required
+      },
+      ...linkTypeQueryArgs
+    });
+
+    return linkTypeTransformer(linkType);
+  }
+
+  /**
    * Creates a new Material
    * @param creator the user creating the material
    * @param name the name of the material

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -490,7 +490,7 @@ export default class ProjectsService {
    * @param name the name of the new LinkType
    * @param iconName the name of the icon for the new LinkType
    * @param required is the new LinkType required
-   * @param user the user who is marking the reimbursement request as reimbursed
+   * @param user the user who is creating the new LinkType
    * @throws AccessDeniedException if the submitter of the request is not an admin or head
    * @throws HttpException if a LinkType of the given name already exists
    * @returns the created LinkType

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -5,6 +5,8 @@ import { aquaman, batman, wonderwoman, superman, theVisitor } from './test-data/
 import {
   prismaProject1,
   sharedProject1,
+  prismaLinkType1,
+  prismaLinkType2,
   prismaAssembly1,
   toolMaterial,
   prismaManufacturer1,
@@ -298,6 +300,33 @@ describe('Projects', () => {
       expect(res).toBe(sharedProject1);
       expect(prisma.project.findFirst).toBeCalledTimes(1);
       expect(prisma.user.update).toBeCalledTimes(1);
+    });
+  });
+
+  describe('Create LinkType', () => {
+    test('Create LinkType Type fails for non heads or admins', async () => {
+      await expect(
+        ProjectsService.createLinkType(wonderwoman, prismaLinkType1.name, prismaLinkType1.iconName, prismaLinkType1.required)
+      ).rejects.toThrow(new AccessDeniedException('Only heads and above can create link types'));
+    });
+
+    test('Create LinkType Type fails if LinkType with name already exists', async () => {
+      await expect(
+        ProjectsService.createLinkType(batman, prismaLinkType1.name, prismaLinkType1.iconName, prismaLinkType1.required)
+      ).rejects.toThrow(new HttpException(400, 'LinkType with that name already exists'));
+    });
+
+    test('Create LinkType successfully returns new LinkType', async () => {
+      vi.spyOn(prisma.linkType, 'create').mockResolvedValue(prismaLinkType2);
+
+      const linkType = await ProjectsService.createLinkType(
+        batman,
+        prismaLinkType2.name,
+        prismaLinkType2.iconName,
+        prismaLinkType2.required
+      );
+
+      expect(linkType).toStrictEqual(prismaLinkType2);
     });
   });
 

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -311,16 +311,15 @@ describe('Projects', () => {
     });
 
     test('Create LinkType Type fails if LinkType with name already exists', async () => {
+      vi.spyOn(prisma.linkType, 'findUnique').mockResolvedValue({ ...prismaLinkType2, creatorId: batman.userId });
       await expect(
         ProjectsService.createLinkType(batman, prismaLinkType1.name, prismaLinkType1.iconName, prismaLinkType1.required)
       ).rejects.toThrow(new HttpException(400, 'LinkType with that name already exists'));
     });
 
     test('Create LinkType successfully returns new LinkType', async () => {
-      vi.spyOn(prisma.linkType, 'create').mockResolvedValue({
-        ...prismaLinkType2,
-        creatorId: batman.userId
-      });
+      vi.spyOn(prisma.linkType, 'findUnique').mockResolvedValue(null);
+      vi.spyOn(prisma.linkType, 'create').mockResolvedValue({ ...prismaLinkType2, creatorId: batman.userId });
 
       const linkType = await ProjectsService.createLinkType(
         batman,

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -317,7 +317,10 @@ describe('Projects', () => {
     });
 
     test('Create LinkType successfully returns new LinkType', async () => {
-      vi.spyOn(prisma.linkType, 'create').mockResolvedValue(prismaLinkType2);
+      vi.spyOn(prisma.linkType, 'create').mockResolvedValue({
+        ...prismaLinkType2,
+        creatorId: batman.userId
+      });
 
       const linkType = await ProjectsService.createLinkType(
         batman,

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -307,7 +307,7 @@ describe('Projects', () => {
     test('Create LinkType Type fails for non heads or admins', async () => {
       await expect(
         ProjectsService.createLinkType(wonderwoman, prismaLinkType1.name, prismaLinkType1.iconName, prismaLinkType1.required)
-      ).rejects.toThrow(new AccessDeniedException('Only heads and above can create link types'));
+      ).rejects.toThrow(new AccessDeniedException('Only admins can create link types'));
     });
 
     test('Create LinkType Type fails if LinkType with name already exists', async () => {

--- a/src/backend/tests/test-data/projects.test-data.ts
+++ b/src/backend/tests/test-data/projects.test-data.ts
@@ -8,7 +8,7 @@ import {
   Manufacturer,
   Unit
 } from '@prisma/client';
-import { Project as SharedProject, WbsElementStatus } from 'shared';
+import { Project as SharedProject, WbsElementStatus, LinkType } from 'shared';
 import projectQueryArgs from '../../src/prisma-query-args/projects.query-args';
 import { prismaTeam1 } from './teams.test-data';
 import { batman, superman } from './users.test-data';
@@ -125,6 +125,22 @@ export const sharedProject1: SharedProject = {
   teams: [],
   materials: [],
   assemblies: []
+};
+
+export const prismaLinkType1: LinkType = {
+  name: 'Confluence',
+  dateCreated: new Date('01-21-2024'),
+  creator: batman,
+  required: true,
+  iconName: 'ConfluenceIcon'
+};
+
+export const prismaLinkType2: LinkType = {
+  name: 'YouTube',
+  dateCreated: new Date('01-21-2024'),
+  creator: batman,
+  required: true,
+  iconName: 'YouTubeIcon'
 };
 
 export const prismaAssembly1: Assembly = {


### PR DESCRIPTION
## Changes

created an endpoint to create new LinkType for admin and head users

## Test Cases

- is user a head or admin+
- does a LinkType with the same name already exist
- does endpoint actually create and return a new LinkType

## Screenshots

manual postman req
<img width="849" alt="postman-req" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/147638290/f81d1487-ea5d-46a5-83e1-a165da7c9a6a">

before req
<img width="1726" alt="before-req" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/147638290/3f9e5b84-bfad-4394-b917-f301bc8aa56b">

after req
<img width="1720" alt="after-req" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/147638290/f0ca6ef7-7bee-4fa3-9159-7bf0bec93984">


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1542
