### PR TITLE
#1595: Linked team names to detail pages in admin tools

### DIFF
--- a/src/frontend/src/pages/AdminToolsPage/TeamsTools.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/TeamsTools.tsx
@@ -80,12 +80,8 @@ const TeamsTools = () => {
     .map(userToAutocompleteOption);
 
   const teamTableRows = allTeams.map((team) => (
-    <TableRow>
-      <TableCell sx={{ border: '2px solid black' }}>
-        <Link component={RouterLink} to={`${routes.TEAMS}/${team.teamId}`} sx={{ color: 'inherit', textDecoration: 'none' }}>
-          {team.teamName}
-        </Link>
-      </TableCell>
+    <TableRow component={RouterLink} to={`${routes.TEAMS}/${team.teamId}`} sx={{ color: 'inherit', textDecoration: 'none' }}>
+      <TableCell sx={{ border: '2px solid black' }}>{team.teamName}</TableCell>
       <TableCell sx={{ border: '2px solid black' }}>{fullNamePipe(team.head)}</TableCell>
       <TableCell align="center" sx={{ border: '2px solid black' }}>
         {team.members.length}

--- a/src/frontend/src/pages/AdminToolsPage/TeamsTools.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/TeamsTools.tsx
@@ -1,4 +1,6 @@
-import { Box, FormControl, FormLabel, Grid, TableCell, TableRow } from '@mui/material';
+import { Box, FormControl, FormLabel, Grid, Link, TableCell, TableRow } from '@mui/material';
+import { routes } from '../../utils/routes';
+import { Link as RouterLink } from 'react-router-dom';
 import PageBlock from '../../layouts/PageBlock';
 import { NERButton } from '../../components/NERButton';
 import { useAllTeams, useCreateTeam } from '../../hooks/teams.hooks';
@@ -79,7 +81,11 @@ const TeamsTools = () => {
 
   const teamTableRows = allTeams.map((team) => (
     <TableRow>
-      <TableCell sx={{ border: '2px solid black' }}>{team.teamName}</TableCell>
+      <TableCell sx={{ border: '2px solid black' }}>
+        <Link component={RouterLink} to={`${routes.TEAMS}/${team.teamId}`} sx={{ color: 'inherit', textDecoration: 'none' }}>
+          {team.teamName}
+        </Link>
+      </TableCell>
       <TableCell sx={{ border: '2px solid black' }}>{fullNamePipe(team.head)}</TableCell>
       <TableCell align="center" sx={{ border: '2px solid black' }}>
         {team.members.length}

--- a/src/frontend/src/pages/AdminToolsPage/TeamsTools.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/TeamsTools.tsx
@@ -1,4 +1,4 @@
-import { Box, FormControl, FormLabel, Grid, Link, TableCell, TableRow } from '@mui/material';
+import { Box, FormControl, FormLabel, Grid, TableCell, TableRow } from '@mui/material';
 import { routes } from '../../utils/routes';
 import { Link as RouterLink } from 'react-router-dom';
 import PageBlock from '../../layouts/PageBlock';


### PR DESCRIPTION
## Changes

Linked team names to respective pages, so when you click on a team in the list of teams on the admin tools page it takes you to the detail page for that team.

## Notes

No notes.

## Test Cases

- Tested for each of the mock teams.

## To Do

No to-dos.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1595 
