### PR TITLE
#1543: added endpoint and tests to edit LinkType

### DIFF
--- a/src/backend/src/controllers/projects.controllers.ts
+++ b/src/backend/src/controllers/projects.controllers.ts
@@ -369,4 +369,16 @@ export default class ProjectsController {
       next(error);
     }
   }
+
+  static async editLinkType(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { linkTypeId } = req.params;
+      const { name, iconName, required } = req.body;
+      const submitter = await getCurrentUser(res);
+      const linkTypeUpdated = await ProjectsService.editLinkType(linkTypeId, name, iconName, required, submitter);
+      res.status(200).json(linkTypeUpdated);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
 }

--- a/src/backend/src/controllers/projects.controllers.ts
+++ b/src/backend/src/controllers/projects.controllers.ts
@@ -373,9 +373,9 @@ export default class ProjectsController {
   static async editLinkType(req: Request, res: Response, next: NextFunction) {
     try {
       const { linkTypeId } = req.params;
-      const { name, iconName, required } = req.body;
+      const { iconName, required } = req.body;
       const submitter = await getCurrentUser(res);
-      const linkTypeUpdated = await ProjectsService.editLinkType(linkTypeId, name, iconName, required, submitter);
+      const linkTypeUpdated = await ProjectsService.editLinkType(linkTypeId, iconName, required, submitter);
       res.status(200).json(linkTypeUpdated);
     } catch (error: unknown) {
       next(error);

--- a/src/backend/src/routes/projects.routes.ts
+++ b/src/backend/src/routes/projects.routes.ts
@@ -124,7 +124,6 @@ projectRouter.get('/bom/units', ProjectsController.getAllUnits);
 
 projectRouter.post(
   '/link-types/:linkTypeId/edit',
-  nonEmptyString(body('name')),
   nonEmptyString(body('iconName')),
   body('required').isBoolean(),
   validateInputs,

--- a/src/backend/src/routes/projects.routes.ts
+++ b/src/backend/src/routes/projects.routes.ts
@@ -122,4 +122,13 @@ projectRouter.post('/bom/material/:materialId/delete', ProjectsController.delete
 projectRouter.post('/bom/units/create', nonEmptyString(body('name')), ProjectsController.createUnit);
 projectRouter.get('/bom/units', ProjectsController.getAllUnits);
 
+projectRouter.post(
+  '/link-types/:linkTypeId/edit',
+  nonEmptyString(body('name')),
+  nonEmptyString(body('iconName')),
+  body('required').isBoolean(),
+  validateInputs,
+  ProjectsController.editLinkType
+);
+
 export default projectRouter;

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -1,4 +1,4 @@
-import { Role, Material_Type, User, Assembly, Material_Status, Material } from '@prisma/client';
+import { Role, Material_Type, User, Assembly, Material_Status, Material, Prisma } from '@prisma/client';
 import {
   isAdmin,
   isGuest,
@@ -1098,7 +1098,7 @@ export default class ProjectsService {
       throw new Error(`A linkType with the name '${name}' already exists.`);
     }
 
-    let linkTypeUpdated;
+    let linkTypeUpdated: Prisma.LinkTypeGetPayload<typeof linkTypeQueryArgs> | null = null;
 
     await prisma.$transaction(async (prisma) => {
       // update the LinkType
@@ -1108,7 +1108,8 @@ export default class ProjectsService {
           name,
           iconName,
           required
-        }
+        },
+        ...linkTypeQueryArgs
       });
       // update the foreign key references in the Link table if the name changed
       if (linkTypeId !== name) {
@@ -1118,6 +1119,9 @@ export default class ProjectsService {
         });
       }
     });
-    return linkTypeUpdated;
+    if (linkTypeUpdated) {
+      return linkTypeTransformer(linkTypeUpdated);
+    }
+    throw new Error('LinkType update failed');
   }
 }

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -1098,9 +1098,6 @@ export default class ProjectsService {
       },
       ...linkTypeQueryArgs
     });
-    if (linkTypeUpdated) {
-      return linkTypeTransformer(linkTypeUpdated);
-    }
-    throw new Error('LinkType update failed');
+    return linkTypeTransformer(linkTypeUpdated);
   }
 }

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -1,4 +1,4 @@
-import { Role, Material_Type, User, Assembly, Material_Status, Material, Prisma } from '@prisma/client';
+import { Role, Material_Type, User, Assembly, Material_Status, Material } from '@prisma/client';
 import {
   isAdmin,
   isGuest,

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -1071,4 +1071,53 @@ export default class ProjectsService {
 
     return { ...newUnit, materials: [] };
   }
+
+  /**
+   * Updates the linkType's name, iconName, or required.
+   * @param linkTypeId the current name/id of the linkType
+   * @param name the new name/id of the linkType
+   * @param iconName the new iconName
+   * @param required the new required status
+   * @param submitter user requesting the edit
+   */
+  static async editLinkType(linkTypeId: string, name: string, iconName: string, required: boolean, submitter: User) {
+    if (!isHead(submitter.role)) throw new AccessDeniedException('Only the head or admin can update the linkType');
+
+    // check if the linkType we are trying to update exists
+    const linkType = await prisma.linkType.findUnique({
+      where: { name: linkTypeId }
+    });
+
+    if (!linkType) throw new NotFoundException('Link Type', linkTypeId);
+
+    // check if the new name already exists in the databse
+    const existingLinkType = await prisma.linkType.findUnique({
+      where: { name }
+    });
+    if (existingLinkType && existingLinkType.name !== linkTypeId) {
+      throw new Error(`A linkType with the name '${name}' already exists.`);
+    }
+
+    let linkTypeUpdated;
+
+    await prisma.$transaction(async (prisma) => {
+      // update the LinkType
+      linkTypeUpdated = await prisma.linkType.update({
+        where: { name: linkTypeId },
+        data: {
+          name,
+          iconName,
+          required
+        }
+      });
+      // update the foreign key references in the Link table if the name changed
+      if (linkTypeId !== name) {
+        await prisma.link.updateMany({
+          where: { linkTypeName: linkTypeId },
+          data: { linkTypeName: name }
+        });
+      }
+    });
+    return linkTypeUpdated;
+  }
 }

--- a/src/backend/src/utils/errors.utils.ts
+++ b/src/backend/src/utils/errors.utils.ts
@@ -118,4 +118,5 @@ type ExceptionObjectNames =
   | 'Material Type'
   | 'Manufacturer'
   | 'Unit'
-  | 'Material';
+  | 'Material'
+  | 'Link Type';

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -1093,68 +1093,29 @@ describe('Projects', () => {
     test('Edit LinkType fails if the submitter is not an admin or a head', async () => {
       vi.spyOn(prisma.linkType, 'findUnique').mockResolvedValue(mockLinkType1);
       await expect(
-        ProjectsService.editLinkType(
-          mockLinkType1.name,
-          mockLinkType1.name,
-          mockLinkType1.iconName,
-          !mockLinkType1.required,
-          aquaman
-        )
+        ProjectsService.editLinkType(mockLinkType1.name, mockLinkType1.iconName, !mockLinkType1.required, aquaman)
       ).rejects.toThrow(new AccessDeniedException('Only the head or admin can update the linkType'));
     });
     test('Throws error if linkType not found', async () => {
       vi.spyOn(prisma.linkType, 'findUnique').mockResolvedValue(null);
       await expect(
-        ProjectsService.editLinkType(
-          mockLinkType1.name,
-          mockLinkType1.name,
-          mockLinkType1.iconName,
-          !mockLinkType1.required,
-          batman
-        )
+        ProjectsService.editLinkType(mockLinkType1.name, mockLinkType1.iconName, !mockLinkType1.required, batman)
       ).rejects.toThrow(new NotFoundException('Link Type', mockLinkType1.name));
-    });
-    test('Throws error if a linktype with the new name already exists', async () => {
-      vi.spyOn(prisma.linkType, 'findUnique').mockResolvedValueOnce(mockLinkType1).mockResolvedValueOnce(mockLinkType2);
-      await expect(
-        ProjectsService.editLinkType(
-          mockLinkType1.name,
-          mockLinkType2.name,
-          mockLinkType1.iconName,
-          !mockLinkType1.required,
-          batman
-        )
-      ).rejects.toThrow(new Error(`A linkType with the name 'Tutorial1' already exists.`));
     });
     test('LinkType edits successfully, changes its foreign key in Link objects as well', async () => {
       vi.spyOn(prisma.linkType, 'findUnique').mockResolvedValue(mockLinkType1);
-      vi.spyOn(prisma.linkType, 'update').mockResolvedValue({ ...mockLinkType1, name: 'Doc2' });
-      vi.spyOn(prisma.link, 'updateMany').mockResolvedValue({ count: 5 });
-      vi.spyOn(prisma, '$transaction').mockImplementation(async (callback) => {
-        return callback(prisma);
-      });
+      vi.spyOn(prisma.linkType, 'update').mockResolvedValue({ ...mockLinkType1, iconName: 'Doc2' });
 
-      const updated = await ProjectsService.editLinkType(
-        mockLinkType1.name,
-        'Doc2',
-        mockLinkType1.iconName,
-        mockLinkType1.required,
-        batman
-      );
+      const updated = await ProjectsService.editLinkType(mockLinkType1.name, 'Doc2', mockLinkType1.required, batman);
 
       expect(updated).toEqual(transformedMockLinkType1);
       expect(prisma.linkType.update).toHaveBeenCalledWith({
         where: { name: mockLinkType1.name },
         data: {
-          name: 'Doc2',
-          iconName: mockLinkType1.iconName,
+          iconName: 'Doc2',
           required: mockLinkType1.required
         },
         ...linkTypeQueryArgs
-      });
-      expect(prisma.link.updateMany).toHaveBeenCalledWith({
-        where: { linkTypeName: mockLinkType1.name },
-        data: { linkTypeName: 'Doc2' }
       });
     });
   });

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -1090,7 +1090,7 @@ describe('Projects', () => {
   });
   describe('editLinkTypes', () => {
     test('Edit LinkType fails if the submitter is not an admin or a head', async () => {
-      vi.spyOn(prisma.linkType, 'findUnique').mockResolvedValue(mockLinkType1);
+      vi.spyOn(prisma.linkType, 'findUnique').mockResolvedValue({ ...mockLinkType1, creatorId: batman.userId });
       await expect(
         ProjectsService.editLinkType(mockLinkType1.name, mockLinkType1.iconName, !mockLinkType1.required, aquaman)
       ).rejects.toThrow(new AccessDeniedException('Only the head or admin can update the linkType'));
@@ -1102,7 +1102,7 @@ describe('Projects', () => {
       ).rejects.toThrow(new NotFoundException('Link Type', mockLinkType1.name));
     });
     test('LinkType edits successfully, changes its foreign key in Link objects as well', async () => {
-      vi.spyOn(prisma.linkType, 'findUnique').mockResolvedValue(mockLinkType1);
+      vi.spyOn(prisma.linkType, 'findUnique').mockResolvedValue({ ...mockLinkType1, creatorId: batman.userId });
       vi.spyOn(prisma.linkType, 'update').mockResolvedValue({ ...mockLinkType1, iconName: 'Doc2' });
 
       const updated = await ProjectsService.editLinkType(mockLinkType1.name, 'Doc2', mockLinkType1.required, batman);

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -16,7 +16,6 @@ import {
   prismaMaterial2,
   prismaProject2,
   mockLinkType1,
-  mockLinkType2,
   transformedMockLinkType1
 } from './test-data/projects.test-data';
 import { prismaChangeRequest1 } from './test-data/change-requests.test-data';

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -16,7 +16,8 @@ import {
   prismaMaterial2,
   prismaProject2,
   mockLinkType1,
-  mockLinkType2
+  mockLinkType2,
+  transformedMockLinkType1
 } from './test-data/projects.test-data';
 import { prismaChangeRequest1 } from './test-data/change-requests.test-data';
 import { primsaTeam2, prismaTeam1 } from './test-data/teams.test-data';
@@ -34,6 +35,7 @@ import { prismaWbsElement1 } from './test-data/wbs-element.test-data';
 import WorkPackagesService from '../src/services/work-packages.services';
 import { validateWBS, WbsNumber } from 'shared';
 import { Material, Material_Status, User } from '@prisma/client';
+import linkTypeQueryArgs from '../src/prisma-query-args/link-types.query-args';
 
 vi.mock('../src/utils/projects.utils');
 const mockGetHighestProjectNumber = getHighestProjectNumber as jest.Mock<Promise<number>>;
@@ -1128,7 +1130,7 @@ describe('Projects', () => {
       vi.spyOn(prisma.linkType, 'findUnique').mockResolvedValue(mockLinkType1);
       vi.spyOn(prisma.linkType, 'update').mockResolvedValue({ ...mockLinkType1, name: 'Doc2' });
       vi.spyOn(prisma.link, 'updateMany').mockResolvedValue({ count: 5 });
-      vi.spyOn(prisma, '$transaction').mockImplementation((callback) => {
+      vi.spyOn(prisma, '$transaction').mockImplementation(async (callback) => {
         return callback(prisma);
       });
 
@@ -1140,14 +1142,15 @@ describe('Projects', () => {
         batman
       );
 
-      expect(updated).toEqual({ ...mockLinkType1, name: 'Doc2' });
+      expect(updated).toEqual(transformedMockLinkType1);
       expect(prisma.linkType.update).toHaveBeenCalledWith({
         where: { name: mockLinkType1.name },
         data: {
           name: 'Doc2',
           iconName: mockLinkType1.iconName,
           required: mockLinkType1.required
-        }
+        },
+        ...linkTypeQueryArgs
       });
       expect(prisma.link.updateMany).toHaveBeenCalledWith({
         where: { linkTypeName: mockLinkType1.name },

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -1103,7 +1103,11 @@ describe('Projects', () => {
     });
     test('LinkType edits successfully, changes its foreign key in Link objects as well', async () => {
       vi.spyOn(prisma.linkType, 'findUnique').mockResolvedValue({ ...mockLinkType1, creatorId: batman.userId });
-      vi.spyOn(prisma.linkType, 'update').mockResolvedValue({ ...mockLinkType1, iconName: 'Doc2' });
+      vi.spyOn(prisma.linkType, 'update').mockResolvedValue({
+        ...mockLinkType1,
+        creatorId: batman.userId,
+        iconName: 'Doc2'
+      });
 
       const updated = await ProjectsService.editLinkType(mockLinkType1.name, 'Doc2', mockLinkType1.required, batman);
 

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -14,7 +14,9 @@ import {
   prismaMaterialType,
   prismaUnit,
   prismaMaterial2,
-  prismaProject2
+  prismaProject2,
+  mockLinkType1,
+  mockLinkType2
 } from './test-data/projects.test-data';
 import { prismaChangeRequest1 } from './test-data/change-requests.test-data';
 import { primsaTeam2, prismaTeam1 } from './test-data/teams.test-data';
@@ -1083,6 +1085,74 @@ describe('Projects', () => {
       await expect(async () => await ProjectsService.deleteMaterial(batman, prismaMaterial.materialId)).rejects.toThrow(
         new DeletedException('Material', prismaMaterial.materialId)
       );
+    });
+  });
+  describe('editLinkTypes', () => {
+    test('Edit LinkType fails if the submitter is not an admin or a head', async () => {
+      vi.spyOn(prisma.linkType, 'findUnique').mockResolvedValue(mockLinkType1);
+      await expect(
+        ProjectsService.editLinkType(
+          mockLinkType1.name,
+          mockLinkType1.name,
+          mockLinkType1.iconName,
+          !mockLinkType1.required,
+          aquaman
+        )
+      ).rejects.toThrow(new AccessDeniedException('Only the head or admin can update the linkType'));
+    });
+    test('Throws error if linkType not found', async () => {
+      vi.spyOn(prisma.linkType, 'findUnique').mockResolvedValue(null);
+      await expect(
+        ProjectsService.editLinkType(
+          mockLinkType1.name,
+          mockLinkType1.name,
+          mockLinkType1.iconName,
+          !mockLinkType1.required,
+          batman
+        )
+      ).rejects.toThrow(new NotFoundException('Link Type', mockLinkType1.name));
+    });
+    test('Throws error if a linktype with the new name already exists', async () => {
+      vi.spyOn(prisma.linkType, 'findUnique').mockResolvedValueOnce(mockLinkType1).mockResolvedValueOnce(mockLinkType2);
+      await expect(
+        ProjectsService.editLinkType(
+          mockLinkType1.name,
+          mockLinkType2.name,
+          mockLinkType1.iconName,
+          !mockLinkType1.required,
+          batman
+        )
+      ).rejects.toThrow(new Error(`A linkType with the name 'Tutorial1' already exists.`));
+    });
+    test('LinkType edits successfully, changes its foreign key in Link objects as well', async () => {
+      vi.spyOn(prisma.linkType, 'findUnique').mockResolvedValue(mockLinkType1);
+      vi.spyOn(prisma.linkType, 'update').mockResolvedValue({ ...mockLinkType1, name: 'Doc2' });
+      vi.spyOn(prisma.link, 'updateMany').mockResolvedValue({ count: 5 });
+      vi.spyOn(prisma, '$transaction').mockImplementation((callback) => {
+        return callback(prisma);
+      });
+
+      const updated = await ProjectsService.editLinkType(
+        mockLinkType1.name,
+        'Doc2',
+        mockLinkType1.iconName,
+        mockLinkType1.required,
+        batman
+      );
+
+      expect(updated).toEqual({ ...mockLinkType1, name: 'Doc2' });
+      expect(prisma.linkType.update).toHaveBeenCalledWith({
+        where: { name: mockLinkType1.name },
+        data: {
+          name: 'Doc2',
+          iconName: mockLinkType1.iconName,
+          required: mockLinkType1.required
+        }
+      });
+      expect(prisma.link.updateMany).toHaveBeenCalledWith({
+        where: { linkTypeName: mockLinkType1.name },
+        data: { linkTypeName: 'Doc2' }
+      });
     });
   });
 });

--- a/src/backend/tests/test-data/projects.test-data.ts
+++ b/src/backend/tests/test-data/projects.test-data.ts
@@ -6,10 +6,9 @@ import {
   WBS_Element_Status as PrismaWBSElementStatus,
   Project,
   Manufacturer,
-  Unit,
-  LinkType
+  Unit
 } from '@prisma/client';
-import { Project as SharedProject, WbsElementStatus } from 'shared';
+import { LinkType, Project as SharedProject, WbsElementStatus } from 'shared';
 import projectQueryArgs from '../../src/prisma-query-args/projects.query-args';
 import { prismaTeam1 } from './teams.test-data';
 import { batman, superman } from './users.test-data';
@@ -239,14 +238,14 @@ export const prismaMaterial1: Material = {
 export const mockLinkType1: LinkType = {
   name: 'Doc1',
   dateCreated: new Date('2024-01-23'),
-  creatorId: 1,
+  creator: batman,
   iconName: 'file',
   required: true
 };
 export const transformedMockLinkType1 = {
   name: 'Doc1',
   dateCreated: new Date('2024-01-23'),
-  creator: undefined,
+  creator: batman,
   iconName: 'Doc2',
   required: true
 };

--- a/src/backend/tests/test-data/projects.test-data.ts
+++ b/src/backend/tests/test-data/projects.test-data.ts
@@ -6,7 +6,8 @@ import {
   WBS_Element_Status as PrismaWBSElementStatus,
   Project,
   Manufacturer,
-  Unit
+  Unit,
+  LinkType
 } from '@prisma/client';
 import { Project as SharedProject, WbsElementStatus } from 'shared';
 import projectQueryArgs from '../../src/prisma-query-args/projects.query-args';
@@ -233,4 +234,19 @@ export const prismaMaterial1: Material = {
   wbsElementId: sharedProject1.id,
   dateDeleted: null,
   userDeletedId: null
+};
+
+export const mockLinkType1: LinkType = {
+  name: 'Doc1',
+  dateCreated: new Date('2024-01-23'),
+  creatorId: 1,
+  iconName: 'file',
+  required: true
+};
+export const mockLinkType2: LinkType = {
+  name: 'Tutorial1',
+  dateCreated: new Date('2024-01-23'),
+  creatorId: 1,
+  iconName: 'video',
+  required: true
 };

--- a/src/backend/tests/test-data/projects.test-data.ts
+++ b/src/backend/tests/test-data/projects.test-data.ts
@@ -243,6 +243,13 @@ export const mockLinkType1: LinkType = {
   iconName: 'file',
   required: true
 };
+export const transformedMockLinkType1 = {
+  name: 'Doc2',
+  dateCreated: new Date('2024-01-23'),
+  creator: undefined,
+  iconName: 'file',
+  required: true
+};
 export const mockLinkType2: LinkType = {
   name: 'Tutorial1',
   dateCreated: new Date('2024-01-23'),

--- a/src/backend/tests/test-data/projects.test-data.ts
+++ b/src/backend/tests/test-data/projects.test-data.ts
@@ -8,7 +8,7 @@ import {
   Manufacturer,
   Unit
 } from '@prisma/client';
-import { LinkType, Project as SharedProject, WbsElementStatus } from 'shared';
+import { Project as SharedProject, WbsElementStatus, LinkType } from 'shared';
 import projectQueryArgs from '../../src/prisma-query-args/projects.query-args';
 import { prismaTeam1 } from './teams.test-data';
 import { batman, superman } from './users.test-data';

--- a/src/backend/tests/test-data/projects.test-data.ts
+++ b/src/backend/tests/test-data/projects.test-data.ts
@@ -244,10 +244,10 @@ export const mockLinkType1: LinkType = {
   required: true
 };
 export const transformedMockLinkType1 = {
-  name: 'Doc2',
+  name: 'Doc1',
   dateCreated: new Date('2024-01-23'),
   creator: undefined,
-  iconName: 'file',
+  iconName: 'Doc2',
   required: true
 };
 export const mockLinkType2: LinkType = {

--- a/src/backend/tests/test-data/projects.test-data.ts
+++ b/src/backend/tests/test-data/projects.test-data.ts
@@ -250,10 +250,3 @@ export const transformedMockLinkType1 = {
   iconName: 'Doc2',
   required: true
 };
-export const mockLinkType2: LinkType = {
-  name: 'Tutorial1',
-  dateCreated: new Date('2024-01-23'),
-  creatorId: 1,
-  iconName: 'video',
-  required: true
-};


### PR DESCRIPTION
## Changes

Added an endpoint(route, controller, service) to change the LinkType at the specified route. Added unit tests for the Service and tested the controller through Manual testing.

## Notes

- I allow APP_ADMIN to access the endpoint as the role is technically an admin, let me know if I should change that.
- Since the name is a primary key and a foreign key I only change it if no other LinkType has the same name and once the name is changed I change the foreign key in all the Links with this LinkType.

## Test Cases

- Edit LinkType fails if the submitter is not an admin or a head
- Throws error if linkType not found
- Throws error if a linktype with the new name already exists
- LinkType edits successfully, changes its foreign key in Link objects as well

## Screenshots

Postman testing:
before:
![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/68555142/67122570-c81c-4a4f-98b4-0bc5b1bf03bb)

after:
<img width="472" alt="Screenshot 2024-01-27 at 15 02 39" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/68555142/dd475fa2-ee45-4526-9bd5-f4f81a799e5c">


## To Do

None as far as I checked.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1543
