### PR TITLE
#1780: Fixed unit quantity and unit name not having a space

### DIFF
--- a/src/frontend/src/utils/bom.utils.ts
+++ b/src/frontend/src/utils/bom.utils.ts
@@ -28,7 +28,7 @@ export const materialToRow = (material: Material, idx: number): BomRow => {
     manufacturer: material.manufacturerName,
     manufacturerPN: material.manufacturerPartNumber,
     pdmFileName: material.pdmFileName ?? 'None',
-    quantity: material.quantity + (material.unitName ?? ''),
+    quantity: material.quantity + (material.unitName ? ' ' + material.unitName : ''),
     price: `$${centsToDollar(material.price)}`,
     subtotal: `$${centsToDollar(material.subtotal)}`,
     link: material.linkUrl,


### PR DESCRIPTION
## Changes
Changed how material.quantity and material.unitName were concatenated, adding a space in between when unitName != nothing. 

## Screenshots
<img width="108" alt="Screenshot 2024-01-24 at 10 10 02 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/148027632/1c400dbc-c9ca-4772-8591-2a47ca2e4631">

Closes #1780
