### PR TITLE
#955: Adjusted the dropdowns for the "Actions" button under Project V…

### DIFF
--- a/src/frontend/src/components/ActionsMenu.tsx
+++ b/src/frontend/src/components/ActionsMenu.tsx
@@ -40,7 +40,19 @@ const ActionsMenu: React.FC<ActionsMenuProps> = ({ buttons, title = 'Actions' })
       >
         {title}
       </NERButton>
-      <Menu open={dropdownOpen} anchorEl={anchorEl} onClose={handleDropdownClose}>
+      <Menu
+        open={dropdownOpen}
+        anchorEl={anchorEl}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'right'
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'right'
+        }}
+        onClose={handleDropdownClose}
+      >
         {buttons.flatMap((button, index) => {
           return [
             button.dividerTop && <Divider key={`${index}-divider`} />,

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
@@ -117,6 +117,7 @@ const ProjectViewContainer: React.FC<ProjectViewContainerProps> = ({ project, en
             `${routes.CHANGE_REQUESTS_NEW}?wbsNum=${projectWbsPipe(project.wbsNum)}&budgetChange=${budgetIncrease}`
           )
         }
+        divider={true}
         disabled={!isLeadership(user.role) || budgetIncrease <= 0}
       >
         <ListItemIcon>
@@ -176,8 +177,8 @@ const ProjectViewContainer: React.FC<ProjectViewContainerProps> = ({ project, en
       >
         <EditButton />
         <CreateChangeRequestButton />
-        <SuggestBudgetIncreaseButton />
         {teamAsHeadId && <AssignToMyTeamButton />}
+        <SuggestBudgetIncreaseButton />
         <DeleteButton />
       </Menu>
     </Box>

--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.tsx
@@ -128,6 +128,7 @@ const WorkPackageViewContainer: React.FC<WorkPackageViewContainerProps> = ({
       to={routes.CHANGE_REQUESTS_NEW_WITH_WBS + wbsPipe(workPackage.wbsNum)}
       disabled={!allowRequestChange}
       onClick={handleDropdownClose}
+      divider={true}
     >
       <ListItemIcon>
         <SyncAltIcon fontSize="small" />
@@ -145,7 +146,19 @@ const WorkPackageViewContainer: React.FC<WorkPackageViewContainerProps> = ({
       >
         Actions
       </NERButton>
-      <Menu open={dropdownOpen} anchorEl={anchorEl} onClose={handleDropdownClose}>
+      <Menu
+        open={dropdownOpen}
+        anchorEl={anchorEl}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'right'
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'right'
+        }}
+        onClose={handleDropdownClose}
+      >
         {editButton}
         {workPackage.status === WbsElementStatus.Inactive ? activateButton : ''}
         {workPackage.status === WbsElementStatus.Active ? stageGateButton : ''}


### PR DESCRIPTION
## Right align actions menu and line above delete

Adjust the dropdown for the "Actions" button under Project Review, WorkPackage View, and ChangeRequest Action Menu, so that they are right aligned with the "Actions" box. Also added a divider above each "Delete" button in the "Actions" dropdown. Switched the order of two buttons in the actions dropdown under Project View. Switched "Unassign from My Team" and "Suggest Budget Increase"

## Screenshots
<img width="1506" alt="Screenshot 2024-01-25 at 10 49 46 AM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/156729120/2cd4f744-c2c2-460f-ab8b-5fe76abf42c8">

<img width="676" alt="Screenshot 2024-01-25 at 10 50 34 AM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/156729120/4abd601c-46d3-4715-9c69-61e6714c5106">

<img width="1491" alt="Screenshot 2024-01-25 at 10 51 25 AM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/156729120/3c47e093-a12f-476e-906b-f8dbd02f2975">

<img width="618" alt="Screenshot 2024-01-25 at 10 51 59 AM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/156729120/1d20004c-9a31-463d-bea1-050803491ad3">

<img width="1507" alt="Screenshot 2024-01-25 at 10 52 23 AM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/156729120/362ec92c-cefc-41a8-b4ff-a9bdf4dfaab3">

<img width="498" alt="Screenshot 2024-01-25 at 10 52 48 AM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/156729120/955a5330-4fe9-4942-ab65-a00da73e13e1">

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #955 
