### PR TITLE
#1792 - added user type checks to prevent guests from editing secure settings

### DIFF
--- a/src/frontend/src/pages/SettingsPage/UserSecureSettings/UserSecureSettings.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserSecureSettings/UserSecureSettings.tsx
@@ -95,10 +95,10 @@ const UserSecureSettings: React.FC<SecureSettingsProps> = ({ currentSettings }) 
         {!edit ? (
           <UserSecureSettingsView settings={currentSettings} />
         ) : (
-          !isGuest(user.role) && <UserSecureSettingsEdit currentSettings={currentSettings} onSubmit={handleConfirm} />
+          <UserSecureSettingsEdit currentSettings={currentSettings} onSubmit={handleConfirm} />
         )}
       </Grid>
-      {!isGuest(user.role) && edit && (
+      {edit && (
         <Box
           sx={{
             display: { xs: 'flex', sm: 'none' },

--- a/src/frontend/src/pages/SettingsPage/UserSecureSettings/UserSecureSettings.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserSecureSettings/UserSecureSettings.tsx
@@ -71,11 +71,12 @@ const UserSecureSettings: React.FC<SecureSettingsProps> = ({ currentSettings }) 
     <PageBlock
       title="User Secure Settings"
       headerRight={
-        !edit && !isGuest(user.role) ? (
+        !isGuest(user.role) &&
+        (!edit ? (
           <IconButton onClick={() => setEdit(true)}>
             <EditIcon fontSize="small" />
           </IconButton>
-        ) : !isGuest(user.role) ? (
+        ) : (
           <Box
             className="d-flex flex-row"
             sx={{
@@ -87,17 +88,17 @@ const UserSecureSettings: React.FC<SecureSettingsProps> = ({ currentSettings }) 
               Save
             </NERSuccessButton>
           </Box>
-        ) : null
+        ))
       }
     >
       <Grid container>
         {!edit ? (
           <UserSecureSettingsView settings={currentSettings} />
         ) : (
-          <UserSecureSettingsEdit currentSettings={currentSettings} onSubmit={handleConfirm} />
+          !isGuest(user.role) && <UserSecureSettingsEdit currentSettings={currentSettings} onSubmit={handleConfirm} />
         )}
       </Grid>
-      {edit && (
+      {!isGuest(user.role) && edit && (
         <Box
           sx={{
             display: { xs: 'flex', sm: 'none' },

--- a/src/frontend/src/pages/SettingsPage/UserSecureSettings/UserSecureSettings.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserSecureSettings/UserSecureSettings.tsx
@@ -16,8 +16,8 @@ import { useToast } from '../../../hooks/toasts.hooks';
 import UserSecureSettingsView from './UserSecureSettingsView';
 import UserSecureSettingsEdit from './UserSecureSettingsEdit';
 import { UserSecureSettings as UserSecureSettingsType } from 'shared';
-import { useAuth } from '../../../hooks/auth.hooks';
-import { Auth } from '../../../utils/types';
+import { useCurrentUser } from '../../../hooks/users.hooks';
+import { isGuest } from 'shared';
 
 interface SecureSettingsProps {
   currentSettings: UserSecureSettingsType;
@@ -33,7 +33,7 @@ export interface SecureSettingsFormInput {
 }
 
 const UserSecureSettings: React.FC<SecureSettingsProps> = ({ currentSettings }) => {
-  const auth: Auth = useAuth();
+  const [edit, setEdit] = useState(false);
 
   const {
     mutateAsync: updateSecureUserSettings,
@@ -43,10 +43,7 @@ const UserSecureSettings: React.FC<SecureSettingsProps> = ({ currentSettings }) 
   } = useUpdateUserSecureSettings();
 
   const toast = useToast();
-  const [edit, setEdit] = useState(false);
-
-  const { user } = auth;
-  if (!user) return <LoadingIndicator />;
+  const user = useCurrentUser();
 
   if (updateUserSettingsIsLoading) return <LoadingIndicator />;
   if (updateUserSettingsIsError) return <ErrorPage error={updateUserSettingsError!} />;
@@ -74,11 +71,11 @@ const UserSecureSettings: React.FC<SecureSettingsProps> = ({ currentSettings }) 
     <PageBlock
       title="User Secure Settings"
       headerRight={
-        !edit && user.role !== 'GUEST' ? (
+        !edit && !isGuest(user.role) ? (
           <IconButton onClick={() => setEdit(true)}>
             <EditIcon fontSize="small" />
           </IconButton>
-        ) : user.role !== 'GUEST' ? (
+        ) : !isGuest(user.role) ? (
           <Box
             className="d-flex flex-row"
             sx={{

--- a/src/frontend/src/pages/SettingsPage/UserSecureSettings/UserSecureSettings.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserSecureSettings/UserSecureSettings.tsx
@@ -16,6 +16,8 @@ import { useToast } from '../../../hooks/toasts.hooks';
 import UserSecureSettingsView from './UserSecureSettingsView';
 import UserSecureSettingsEdit from './UserSecureSettingsEdit';
 import { UserSecureSettings as UserSecureSettingsType } from 'shared';
+import { useAuth } from '../../../hooks/auth.hooks';
+import { Auth } from '../../../utils/types';
 
 interface SecureSettingsProps {
   currentSettings: UserSecureSettingsType;
@@ -31,14 +33,20 @@ export interface SecureSettingsFormInput {
 }
 
 const UserSecureSettings: React.FC<SecureSettingsProps> = ({ currentSettings }) => {
-  const [edit, setEdit] = useState(false);
+  const auth: Auth = useAuth();
+
   const {
     mutateAsync: updateSecureUserSettings,
     isLoading: updateUserSettingsIsLoading,
     isError: updateUserSettingsIsError,
     error: updateUserSettingsError
   } = useUpdateUserSecureSettings();
+
   const toast = useToast();
+  const [edit, setEdit] = useState(false);
+
+  const { user } = auth;
+  if (!user) return <LoadingIndicator />;
 
   if (updateUserSettingsIsLoading) return <LoadingIndicator />;
   if (updateUserSettingsIsError) return <ErrorPage error={updateUserSettingsError!} />;
@@ -66,11 +74,11 @@ const UserSecureSettings: React.FC<SecureSettingsProps> = ({ currentSettings }) 
     <PageBlock
       title="User Secure Settings"
       headerRight={
-        !edit ? (
+        !edit && user.role !== 'GUEST' ? (
           <IconButton onClick={() => setEdit(true)}>
             <EditIcon fontSize="small" />
           </IconButton>
-        ) : (
+        ) : user.role !== 'GUEST' ? (
           <Box
             className="d-flex flex-row"
             sx={{
@@ -82,7 +90,7 @@ const UserSecureSettings: React.FC<SecureSettingsProps> = ({ currentSettings }) 
               Save
             </NERSuccessButton>
           </Box>
-        )
+        ) : null
       }
     >
       <Grid container>


### PR DESCRIPTION
## Changes

Added user type checking to prevent guests from editing their secure settings.

## Notes

None

## Test Cases

Compared an admin, lead, team member and guest to make sure that only guests were unable to edit their settings.

## Screenshots
Image of admin logged in to FinishLine
![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/102161618/599ff682-2530-434a-9b84-f3814f421369)

Image of Admin User (guest) logged in to FinishLine
![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/102161618/f39e7625-af07-4b5a-9430-998de6d16147)

## To Do

Review and receive feedback

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1792
