### PR TITLE
Adjusted PercentRefunded calculation to fix Refund bar

### DIFF
--- a/src/frontend/src/pages/FinancePage/RefundsSection.tsx
+++ b/src/frontend/src/pages/FinancePage/RefundsSection.tsx
@@ -81,7 +81,7 @@ const Refunds = ({ userReimbursementRequests, allReimbursementRequests }: Refund
       (accumulator: number, currentVal: ReimbursementRequest) => accumulator + currentVal.totalCost,
       0
     ) - totalReceived;
-  const percentRefunded = (totalReceived / currentlyOwed) * 100;
+  const percentRefunded = (totalReceived / (currentlyOwed + totalReceived)) * 100;
 
   const tabs = [{ label: 'My Refunds', value: 0 }];
   if (user.isFinance) tabs.push({ label: 'All Club Refunds', value: 1 });


### PR DESCRIPTION
## Changes

Adjusted the way PercentRefunded is calculated to properly display the percent in the progress bar.

## Notes

Maybe consider adding a way to edit reported refunds as well as reimbursement requests. I had some issues well testing where if I put the wrong number for a refund, I couldn't correct it.

## Test Cases

- Less Than half refunded
- Half refunded
- more than half refunded

## Screenshots

![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/146089920/e65f1fad-07eb-4377-869b-668d3d9ee916)

![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/146089920/bc945dbb-afb3-43d9-85c8-45720b47ad0e)

![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/146089920/0e6763b2-9f18-45c4-bb0a-6f4f1cbb3ab5)

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ x] All commits are tagged with the ticket number
- [ x] No linting errors / newline at end of file warnings
- [ x] All code follows repository-configured prettier formatting
- [ x] No merge conflicts
- [ x] All checks passing
- [ x] Screenshots of UI changes (see Screenshots section)
- [ x] Remove any non-applicable sections of this template
- [ x] Assign the PR to yourself
- [x ] No `yarn.lock` changes (unless dependencies have changed)
- [ x] Request reviewers & ping on Slack
- [ x] PR is linked to the ticket (fill in the closes line below)

Closes #1757 
