### PR TITLE
#1661: added auto-incrementing identifier in RR

### DIFF
--- a/src/backend/src/prisma/migrations/20230629193452_finance/migration.sql
+++ b/src/backend/src/prisma/migrations/20230629193452_finance/migration.sql
@@ -32,6 +32,7 @@ CREATE TABLE "Receipt" (
 -- CreateTable
 CREATE TABLE "Reimbursement_Request" (
     "reimbursementRequestId" TEXT NOT NULL,
+    "identifier" SERIAL NOT NULL,
     "saboId" INTEGER,
     "dateCreated" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "dateDeleted" TIMESTAMP(3),

--- a/src/backend/src/prisma/migrations/20230629193452_finance/migration.sql
+++ b/src/backend/src/prisma/migrations/20230629193452_finance/migration.sql
@@ -32,7 +32,6 @@ CREATE TABLE "Receipt" (
 -- CreateTable
 CREATE TABLE "Reimbursement_Request" (
     "reimbursementRequestId" TEXT NOT NULL,
-    "identifier" SERIAL NOT NULL,
     "saboId" INTEGER,
     "dateCreated" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "dateDeleted" TIMESTAMP(3),

--- a/src/backend/src/prisma/migrations/20240129020615_rr_identifier/migration.sql
+++ b/src/backend/src/prisma/migrations/20240129020615_rr_identifier/migration.sql
@@ -14,7 +14,7 @@ CREATE UNIQUE INDEX "Reimbursement_Request_identifier_key" ON "Reimbursement_Req
 WITH CTE AS (
     SELECT 
         "reimbursementRequestId",
-        ROW_NUMBER() OVER (ORDER BY "dateCreated" DESC) AS new_identifier
+        ROW_NUMBER() OVER (ORDER BY "dateCreated" ASC) AS new_identifier
     FROM 
         "Reimbursement_Request"
     WHERE

--- a/src/backend/src/prisma/migrations/20240129020615_rr_identifier/migration.sql
+++ b/src/backend/src/prisma/migrations/20240129020615_rr_identifier/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[identifier]` on the table `Reimbursement_Request` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "Reimbursement_Request" ADD COLUMN     "identifier" SERIAL NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Reimbursement_Request_identifier_key" ON "Reimbursement_Request"("identifier");

--- a/src/backend/src/prisma/migrations/20240129020615_rr_identifier/migration.sql
+++ b/src/backend/src/prisma/migrations/20240129020615_rr_identifier/migration.sql
@@ -9,3 +9,18 @@ ALTER TABLE "Reimbursement_Request" ADD COLUMN     "identifier" SERIAL NOT NULL;
 
 -- CreateIndex
 CREATE UNIQUE INDEX "Reimbursement_Request_identifier_key" ON "Reimbursement_Request"("identifier");
+
+-- Assign Identifier to all old Reimbursement Requests based on their dateCreated order
+WITH CTE AS (
+    SELECT 
+        "reimbursementRequestId",
+        ROW_NUMBER() OVER (ORDER BY "dateCreated") AS new_identifier
+    FROM 
+        "Reimbursement_Request"
+    WHERE
+        "identifier" IS NULL
+)
+UPDATE "Reimbursement_Request" AS rr
+SET "identifier" = cte.new_identifier
+FROM CTE
+WHERE rr."reimbursementRequestId" = CTE."reimbursementRequestId";

--- a/src/backend/src/prisma/migrations/20240129020615_rr_identifier/migration.sql
+++ b/src/backend/src/prisma/migrations/20240129020615_rr_identifier/migration.sql
@@ -6,27 +6,27 @@
 */
 -- Select all old RRs that has no identifier in dateCreated ascending order
 CREATE TEMP TABLE cte_table AS (
-	WITH CTE AS (
-		SELECT 
-			"reimbursementRequestId",
-			row_number() OVER (ORDER BY "dateCreated" ASC) AS new_identifier
-		FROM 
-			"Reimbursement_Request"
-	)
-	SELECT * FROM CTE
+    WITH CTE AS (
+        SELECT 
+            "reimbursementRequestId",
+            row_number() OVER (ORDER BY "dateCreated" ASC, "reimbursementRequestId" ASC) AS new_identifier
+        FROM 
+            "Reimbursement_Request"
+    )
+    SELECT * FROM CTE
 );
 
 -- AlterTable
 ALTER TABLE "Reimbursement_Request" ADD COLUMN     "identifier" SERIAL NOT NULL;
-
--- CreateIndex
-CREATE UNIQUE INDEX "Reimbursement_Request_identifier_key" ON "Reimbursement_Request"("identifier");
 
 -- Assign Identifier to all old Reimbursement Requests based on their dateCreated order
 UPDATE "Reimbursement_Request" AS rr
 SET "identifier" = "cte_table".new_identifier
 FROM cte_table
 WHERE rr."reimbursementRequestId" = "cte_table"."reimbursementRequestId";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Reimbursement_Request_identifier_key" ON "Reimbursement_Request"("identifier");
 
 -- Remove the temporary table
 DROP TABLE cte_table;

--- a/src/backend/src/prisma/migrations/20240129020615_rr_identifier/migration.sql
+++ b/src/backend/src/prisma/migrations/20240129020615_rr_identifier/migration.sql
@@ -4,6 +4,18 @@
   - A unique constraint covering the columns `[identifier]` on the table `Reimbursement_Request` will be added. If there are existing duplicate values, this will fail.
 
 */
+-- Select all old RRs that has no identifier in dateCreated ascending order
+CREATE TEMP TABLE cte_table AS (
+	WITH CTE AS (
+		SELECT 
+			"reimbursementRequestId",
+			row_number() OVER (ORDER BY "dateCreated" ASC) AS new_identifier
+		FROM 
+			"Reimbursement_Request"
+	)
+	SELECT * FROM CTE
+);
+
 -- AlterTable
 ALTER TABLE "Reimbursement_Request" ADD COLUMN     "identifier" SERIAL NOT NULL;
 
@@ -11,16 +23,10 @@ ALTER TABLE "Reimbursement_Request" ADD COLUMN     "identifier" SERIAL NOT NULL;
 CREATE UNIQUE INDEX "Reimbursement_Request_identifier_key" ON "Reimbursement_Request"("identifier");
 
 -- Assign Identifier to all old Reimbursement Requests based on their dateCreated order
-WITH CTE AS (
-    SELECT 
-        "reimbursementRequestId",
-        ROW_NUMBER() OVER (ORDER BY "dateCreated" ASC) AS new_identifier
-    FROM 
-        "Reimbursement_Request"
-    WHERE
-        "identifier" IS NULL
-)
 UPDATE "Reimbursement_Request" AS rr
-SET "identifier" = cte.new_identifier
-FROM CTE
-WHERE rr."reimbursementRequestId" = CTE."reimbursementRequestId";
+SET "identifier" = "cte_table".new_identifier
+FROM cte_table
+WHERE rr."reimbursementRequestId" = "cte_table"."reimbursementRequestId";
+
+-- Remove the temporary table
+DROP TABLE cte_table;

--- a/src/backend/src/prisma/migrations/20240129020615_rr_identifier/migration.sql
+++ b/src/backend/src/prisma/migrations/20240129020615_rr_identifier/migration.sql
@@ -14,7 +14,7 @@ CREATE UNIQUE INDEX "Reimbursement_Request_identifier_key" ON "Reimbursement_Req
 WITH CTE AS (
     SELECT 
         "reimbursementRequestId",
-        ROW_NUMBER() OVER (ORDER BY "dateCreated") AS new_identifier
+        ROW_NUMBER() OVER (ORDER BY "dateCreated" DESC) AS new_identifier
     FROM 
         "Reimbursement_Request"
     WHERE

--- a/src/backend/src/prisma/schema.prisma
+++ b/src/backend/src/prisma/schema.prisma
@@ -399,6 +399,7 @@ model Receipt {
 
 model Reimbursement_Request {
   reimbursementRequestId String                  @id @default(uuid())
+  identifier             Int                     @unique @default(autoincrement())
   saboId                 Int?                    @unique
   dateCreated            DateTime                @default(now())
   dateDeleted            DateTime?

--- a/src/backend/src/prisma/seed.ts
+++ b/src/backend/src/prisma/seed.ts
@@ -956,6 +956,27 @@ const performSeed: () => Promise<void> = async () => {
     100
   );
 
+  await ReimbursementRequestService.createReimbursementRequest(
+    thomasEmrax,
+    new Date(),
+    vendor.vendorId,
+    ClubAccount.BUDGET,
+    [],
+    [
+      {
+        name: 'BOX',
+        reason: {
+          carNumber: 1,
+          projectNumber: 1,
+          workPackageNumber: 0
+        },
+        cost: 10000
+      }
+    ],
+    expenseType.expenseTypeId,
+    200
+  );
+
   /**
    * Bill of Materials
    */

--- a/src/backend/src/transformers/reimbursement-requests.transformer.ts
+++ b/src/backend/src/transformers/reimbursement-requests.transformer.ts
@@ -43,6 +43,7 @@ export const reimbursementRequestTransformer = (
 ): ReimbursementRequest => {
   return {
     reimbursementRequestId: reimbursementRequest.reimbursementRequestId,
+    identifier: reimbursementRequest.identifier,
     saboId: reimbursementRequest.saboId ?? undefined,
     dateCreated: reimbursementRequest.dateCreated,
     dateDeleted: reimbursementRequest.dateDeleted ?? undefined,

--- a/src/backend/tests/test-data/reimbursement-requests.test-data.ts
+++ b/src/backend/tests/test-data/reimbursement-requests.test-data.ts
@@ -43,6 +43,7 @@ export const Parts: PrismaExpenseType = {
 
 export const GiveMeMyMoney: PrismaReimbursementRequest = {
   reimbursementRequestId: '',
+  identifier: 1,
   saboId: null,
   dateCreated: new Date('20/8/2023'),
   dateDeleted: null,
@@ -57,6 +58,7 @@ export const GiveMeMyMoney: PrismaReimbursementRequest = {
 
 export const GiveMeMyMoney2: PrismaReimbursementRequest = {
   reimbursementRequestId: '',
+  identifier: 2,
   saboId: null,
   dateCreated: new Date('20/8/2023'),
   dateDeleted: new Date('25/8/2023'),
@@ -210,6 +212,7 @@ export const prismaGiveMeMyMoney3Approved: Prisma.Reimbursement_RequestGetPayloa
 
 export const sharedGiveMeMyMoney: ReimbursementRequest = {
   reimbursementRequestId: GiveMeMyMoney.reimbursementRequestId,
+  identifier: GiveMeMyMoney.identifier,
   dateCreated: GiveMeMyMoney.dateCreated,
   dateOfExpense: GiveMeMyMoney.dateOfExpense,
   totalCost: GiveMeMyMoney.totalCost,

--- a/src/shared/src/types/reimbursement-requests-types.ts
+++ b/src/shared/src/types/reimbursement-requests-types.ts
@@ -31,6 +31,7 @@ export interface Receipt {
 
 export interface ReimbursementRequest {
   reimbursementRequestId: string;
+  identifier: number;
   saboId?: number;
   dateCreated: Date;
   dateDeleted?: Date;


### PR DESCRIPTION
## Changes

- Added auto-incrementing integer field in RR scheme as an identifier
-  Updated the RR shared type
- Updated all RR getter endpoints to return RR with its identifier field
- Added SQL code in the new migration file so all old RRs get an identifier assigned in the `dateCreated` order
- Confirmed `yarn prisma:reset` works fine

## Test Cases

- Case A
- Confirmed all RR getter endpoints return RR with its identifier field
- Case B
- Confirmed RR seed data gets identifier field

## Screenshots

### RR seed data gets an identifier field
![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/91857946/58681386-0b4c-422e-8535-8c8ae3ef035c)

### Get a single RR with an identifier
![#1661-RR-get-updated-RR](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/91857946/8a7d77c7-b14d-4a89-bbe3-2181b50ceeeb)

### Get all RR with an identifier
![#1661-RR-get-all-RRs](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/91857946/bb743fdd-0a2c-4fbc-8691-9cc3dc44a1a3)

### All old RRs get sorted in dateCreated order
![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/91857946/b5579775-bf0d-4b01-a17c-deb3865398c7)


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
