### PR TITLE
1767: Right justify edit button for members edit

### DIFF
--- a/src/frontend/src/pages/TeamsPage/TeamMembersPageBlock.tsx
+++ b/src/frontend/src/pages/TeamsPage/TeamMembersPageBlock.tsx
@@ -202,10 +202,10 @@ const TeamMembersPageBlock: React.FC<TeamMembersPageBlockProps> = ({ team }) => 
 
   const NonEditingMembersView = () => (
     <Grid container>
-      <Grid item xs={11} lg="auto" style={{ maxWidth: 'fit-content' }}>
+      <Grid item xs={9} md={10} lg={11}>
         <DetailDisplay label="Members" content={team.members.map((member) => fullNamePipe(member)).join(', ')} />
       </Grid>
-      <Grid item xs={1} mt={-1} display={'flex'} justifyContent={'flex-end'}>
+      <Grid item xs={3} md={2} lg={1} container justifyContent="flex-end">
         {editMembersPerms && <IconButton children={<Edit />} onClick={() => setIsEditingMembers(true)} />}
       </Grid>
     </Grid>


### PR DESCRIPTION
## Changes

Adjusted the position of the edit pencil button to always stay on the right side for the members on the teams page

## Screenshots
Normal sized window:
<img width="1436" alt="Screenshot 2024-01-28 at 11 03 40 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/144746283/ff22b1bd-e5cd-4114-a350-262afeeb87c8">

Small window:
<img width="537" alt="Screenshot 2024-01-28 at 11 03 34 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/144746283/f2f0f8d2-3290-400b-8b93-c813d558615c">

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1767 
