### PR TITLE
#1763 Make change request ID an autocomplete

### DIFF
--- a/src/frontend/src/components/ChangeRequestDropdown.tsx
+++ b/src/frontend/src/components/ChangeRequestDropdown.tsx
@@ -1,4 +1,4 @@
-import { Box, FormControl, FormHelperText, FormLabel } from '@mui/material';
+import { Box, FormControl, FormLabel } from '@mui/material';
 import { isWithinInterval, subDays } from 'date-fns';
 import { Control, Controller, FieldErrors } from 'react-hook-form';
 import { AuthenticatedUser, ChangeRequest, wbsPipe } from 'shared';
@@ -67,10 +67,10 @@ const ChangeRequestDropdown = ({ control, name, errors }: ChangeRequestDropdownP
               size={'small'}
               placeholder={'Change Request ID'}
               value={approvedChangeRequestOptions.find((cr) => cr.id === value) || { id: '', label: '' }}
+              errorMessage={errors.crId}
             />
           )}
         />
-        <FormHelperText error>{errors.crId?.message}</FormHelperText>
       </FormControl>
     </Box>
   );

--- a/src/frontend/src/components/ChangeRequestDropdown.tsx
+++ b/src/frontend/src/components/ChangeRequestDropdown.tsx
@@ -65,7 +65,7 @@ const ChangeRequestDropdown = ({ control, name, errors }: ChangeRequestDropdownP
               onChange={(_event, newValue) => onChange(newValue ? newValue.id : '')}
               options={approvedChangeRequestOptions}
               size={'small'}
-              placeholder={'Change Request Id'}
+              placeholder={'Change Request ID'}
               value={approvedChangeRequestOptions.find((cr) => cr.id === value) || { id: '', label: '' }}
             />
           )}

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectForm/ProjectForm.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectForm/ProjectForm.tsx
@@ -72,7 +72,11 @@ const ProjectFormContainer: React.FC<ProjectFormContainerProps> = ({
   const schema = !project
     ? yup.object().shape({
         name: yup.string().required('Name is required!'),
-        crId: yup.number().min(1).required('crId must be a non-zero number!'),
+        crId: yup
+          .number()
+          .min(1)
+          .typeError('Change Request ID cannot be empty!')
+          .required('crId must be a non-zero number!'),
         carNumber: yup.number().min(0).required('A car number is required!'),
         teamId: yup.string().required('A Team Id is required'),
         budget: yup.number().optional(),
@@ -94,7 +98,11 @@ const ProjectFormContainer: React.FC<ProjectFormContainerProps> = ({
       })
     : yup.object().shape({
         name: yup.string().required('Name is required!'),
-        crId: yup.number().min(1).required('crId must be a non-zero number!'),
+        crId: yup
+          .number()
+          .min(1)
+          .typeError('Change Request ID cannot be empty!')
+          .required('crId must be a non-zero number!'),
         budget: yup.number().required('Budget is required!').min(0).integer('Budget must be an even dollar amount!'),
         summary: yup.string().required('Summary is required!'),
         links: yup.array().of(


### PR DESCRIPTION
## Changes

change the change request id input which used to be a `Select` to an `NERAutocomplete`

## Screenshots

default (no specified search)
<img width="1728" alt="cr-id-default" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/147638290/e363d17d-938b-4f63-9f90-e2549524b03b">

with a search
<img width="1728" alt="cr-id-search" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/147638290/7f5a191b-f6b0-4515-8ba9-088e4d6bb7f6">

submitting with empty search
<img width="1728" alt="error-with-empty-crid" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/147638290/a922a82f-1cd9-49ad-847f-eccfe483605a">

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1763 