### PR TITLE
#1785: Disabled Project Actions Button for Guests

### DIFF
--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
@@ -157,7 +157,7 @@ const ProjectViewContainer: React.FC<ProjectViewContainerProps> = ({ project, en
         endIcon={<ArrowDropDownIcon style={{ fontSize: 28 }} />}
         variant="contained"
         id="project-actions-dropdown"
-        onClick={handleClick}
+        onClick={handleClick} disabled={isGuest(user.role)}
       >
         Actions
       </NERButton>

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
@@ -157,7 +157,8 @@ const ProjectViewContainer: React.FC<ProjectViewContainerProps> = ({ project, en
         endIcon={<ArrowDropDownIcon style={{ fontSize: 28 }} />}
         variant="contained"
         id="project-actions-dropdown"
-        onClick={handleClick} disabled={isGuest(user.role)}
+        onClick={handleClick}
+        disabled={isGuest(user.role)}
       >
         Actions
       </NERButton>


### PR DESCRIPTION
## Changes
Disabled the Actions button in a project page for guests. 

## Screenshots

<img width="957" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/65504406/19ce3157-0b02-4e81-9c85-5b4d39bee3f8">

<img width="355" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/65504406/af8cd137-8bb7-4947-ab9e-73bb8b7067b6">


## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1785 
