### PR TITLE
#1755: Added Reimbursement Disclaimer

### DIFF
--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
@@ -11,6 +11,7 @@ import {
   MenuItem,
   Select,
   TextField,
+  Tooltip,
   Typography,
   Snackbar,
   Alert,
@@ -226,7 +227,12 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
             <FormControl fullWidth>
               <Box style={{ display: 'flex', verticalAlign: 'middle', alignItems: 'center' }}>
                 <FormLabel>Date of Expense</FormLabel>
-                <HelpIcon style={{ fontSize: 'medium', color: '#939393', marginLeft: '8px' }} />
+                <Tooltip
+                  title="Reimbursement with Different Purchase Dates Should be on Different Requests"
+                  placement="right"
+                >
+                  <HelpIcon style={{ fontSize: 'medium', marginLeft: '5px' }} />
+                </Tooltip>
               </Box>
               <Controller
                 name="dateOfExpense"

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
@@ -1,4 +1,3 @@
-// The reimbursement form code just redo this.
 import { Delete } from '@mui/icons-material';
 import HelpIcon from '@mui/icons-material/Help';
 import {
@@ -228,7 +227,7 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
               <Box style={{ display: 'flex', verticalAlign: 'middle', alignItems: 'center' }}>
                 <FormLabel>Date of Expense</FormLabel>
                 <Tooltip
-                  title="Reimbursement with Different Purchase Dates Should be on Different Requests"
+                  title="Reimbursements with Different Purchase Dates Should be on Different Requests"
                   placement="right"
                 >
                   <HelpIcon style={{ fontSize: 'medium', marginLeft: '5px' }} />

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
@@ -1,5 +1,5 @@
 // The reimbursement form code just redo this.
-import { Delete, Help } from '@mui/icons-material';
+import { Delete } from '@mui/icons-material';
 import HelpIcon from '@mui/icons-material/Help';
 import {
   FormControl,

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
@@ -1,4 +1,6 @@
-import { Delete } from '@mui/icons-material';
+// The reimbursement form code just redo this.
+import { Delete, Help } from '@mui/icons-material';
+import HelpIcon from '@mui/icons-material/Help';
 import {
   FormControl,
   FormHelperText,
@@ -120,7 +122,10 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
   );
 
   const expenseTypesToAutocomplete = (expenseType: ExpenseType): { label: string; id: string } => {
-    return { label: expenseTypePipe(expenseType), id: expenseType.expenseTypeId };
+    return {
+      label: expenseTypePipe(expenseType),
+      id: expenseType.expenseTypeId
+    };
   };
 
   const vendorsToAutocomplete = (vendor: Vendor): { label: string; id: string } => {
@@ -133,7 +138,12 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
         e.stopPropagation();
         handleSubmit(onSubmit)(e);
       }}
-      style={{ minHeight: 'calc(100vh - 161px)', display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}
+      style={{
+        minHeight: 'calc(100vh - 161px)',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between'
+      }}
     >
       {!hasSecureSettingsSet && (
         <Snackbar anchorOrigin={{ vertical: 'top', horizontal: 'center' }} open={true}>
@@ -214,7 +224,10 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
           </Grid>
           <Grid item xs={6}>
             <FormControl fullWidth>
-              <FormLabel>Date of Expense</FormLabel>
+              <Box style={{ display: 'flex', verticalAlign: 'middle', alignItems: 'center' }}>
+                <FormLabel>Date of Expense</FormLabel>
+                <HelpIcon style={{ fontSize: 'medium', color: '#939393', marginLeft: '8px' }} />
+              </Box>
               <Controller
                 name="dateOfExpense"
                 control={control}


### PR DESCRIPTION
## Changes

Added question icon to the right of "Date of Expense" on the reimbursement request form. Tooltip appears on hover stating 'Reimbursement with Different Purchase Dates Should be on Different Requests'.

## Screenshots

<img width="1431" alt="FullScreen" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/54627422/c803c25e-8fe0-4cef-9a30-afd7f76da721">
<img width="494" alt="SmallestWindow" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/54627422/20963dcb-0358-428c-a4d8-4101390ee38d">

## Checklist
- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1755