### PR TITLE
#1989 hard deleted delete manufacturer endpoint

### DIFF
--- a/src/backend/src/prisma/migrations/20240208041850_deleted_date_deleted_from_manufacturer/migration.sql
+++ b/src/backend/src/prisma/migrations/20240208041850_deleted_date_deleted_from_manufacturer/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `dateDeleted` on the `Manufacturer` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Manufacturer" DROP COLUMN "dateDeleted";

--- a/src/backend/src/prisma/schema.prisma
+++ b/src/backend/src/prisma/schema.prisma
@@ -565,7 +565,6 @@ model Manufacturer {
   dateCreated   DateTime
   userCreatedId Int
   userCreated   User       @relation(name: "manufacturerCreator", fields: [userCreatedId], references: [userId])
-  dateDeleted   DateTime?
   materials     Material[]
 }
 

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -751,13 +751,10 @@ export default class ProjectsService {
 
     if (manufacturer.dateDeleted) throw new DeletedException('Manufacturer', manufacturer.name);
 
-    const dateDeleted: Date = new Date();
-    const deletedManufacturer = await prisma.manufacturer.update({
+    //const dateDeleted: Date = new Date();
+    const deletedManufacturer = await prisma.manufacturer.delete({
       where: {
         name: manufacturer.name
-      },
-      data: {
-        dateDeleted
       }
     });
 

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -749,9 +749,6 @@ export default class ProjectsService {
       throw new NotFoundException('Manufacturer', name);
     }
 
-    if (manufacturer.dateDeleted) throw new DeletedException('Manufacturer', manufacturer.name);
-
-    //const dateDeleted: Date = new Date();
     const deletedManufacturer = await prisma.manufacturer.delete({
       where: {
         name: manufacturer.name

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -742,20 +742,26 @@ export default class ProjectsService {
     const manufacturer = await prisma.manufacturer.findFirst({
       where: {
         name
-      }
+      },
+      ...manufacturerQueryArgs
     });
 
     if (!manufacturer) {
       throw new NotFoundException('Manufacturer', name);
     }
 
+    if (manufacturer.materials.length > 0) {
+      throw new HttpException(400, 'Cannot delete manufacturer if it has materials associated with it');
+    }
+
     const deletedManufacturer = await prisma.manufacturer.delete({
       where: {
         name: manufacturer.name
-      }
+      },
+      ...manufacturerQueryArgs
     });
 
-    return deletedManufacturer;
+    return manufacturerTransformer(deletedManufacturer);
   }
   /**
    * Get all the manufacturers in the database.

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -1039,6 +1039,10 @@ export default class ProjectsService {
     if (!project) throw new NotFoundException('Project', material.wbsElementId);
     if (project.wbsElement.dateDeleted) throw new DeletedException('Project', project.projectId);
 
+    const perms = isLeadership(submitter.role) || isUserPartOfTeams(project.teams, submitter);
+
+    if (!perms) throw new AccessDeniedException('update material');
+
     if (assemblyId) {
       const assembly = await prisma.assembly.findFirst({ where: { assemblyId } });
       if (!assembly) throw new NotFoundException('Assembly', assemblyId);
@@ -1049,21 +1053,12 @@ export default class ProjectsService {
     });
     if (!materialType) throw new NotFoundException('Material Type', materialTypeName);
 
-    const manufacturer = await prisma.manufacturer.findFirst({
-      where: { name: manufacturerName }
-    });
-    if (!manufacturer) throw new NotFoundException('Manufacturer', manufacturerName);
-
     if (unitName) {
       const unit = await prisma.unit.findFirst({
         where: { name: unitName }
       });
       if (!unit) throw new NotFoundException('Unit', unitName);
     }
-
-    const perms = isLeadership(submitter.role) || isUserPartOfTeams(project.teams, submitter);
-
-    if (!perms) throw new AccessDeniedException('update material');
 
     const updatedMaterial = await prisma.material.update({
       where: { materialId },

--- a/src/backend/src/transformers/manufacturer.transformer.ts
+++ b/src/backend/src/transformers/manufacturer.transformer.ts
@@ -16,7 +16,6 @@ const manufacturerTransformer = (
     dateCreated: manufacturer.dateCreated,
     userCreatedId: manufacturer.userCreatedId,
     userCreated: manufacturer.userCreated,
-    dateDeleted: manufacturer.dateDeleted ?? undefined,
     materials: manufacturer.materials.map(materialPreviewTransformer)
   };
 };

--- a/src/backend/src/transformers/material.transformer.ts
+++ b/src/backend/src/transformers/material.transformer.ts
@@ -48,7 +48,7 @@ export const materialTransformer = (material: Prisma.MaterialGetPayload<typeof m
     unitName: material.unitName ?? undefined,
     quantityUnit: material.quantityUnit ?? undefined,
     materialType: { ...material.materialType, dateDeleted: material.materialType.dateDeleted ?? undefined },
-    manufacturer: { ...material.manufacturer, dateDeleted: material.manufacturer.dateDeleted ?? undefined },
+    manufacturer: material.manufacturer,
     notes: material.notes ?? undefined
   };
 };

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -744,13 +744,6 @@ describe('Projects', () => {
       expect(prisma.project.update).toHaveBeenCalledTimes(0);
     });
 
-    test('deleteManufacturer fails when manufacturer has been deleted', async () => {
-      vi.spyOn(prisma.manufacturer, 'findFirst').mockResolvedValue(prismaManufacturer2);
-      await expect(async () => await ProjectsService.deleteManufacturer(batman, prismaManufacturer2.name)).rejects.toThrow(
-        new DeletedException('Manufacturer', prismaManufacturer2.name)
-      );
-    });
-
     test('Get all Manufacturer works', async () => {
       vi.spyOn(prisma.manufacturer, 'findMany').mockResolvedValue([]);
 

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -18,7 +18,9 @@ import {
   prismaMaterial2,
   prismaProject2,
   mockLinkType1,
-  transformedMockLinkType1
+  transformedMockLinkType1,
+  manufacturer1,
+  manufacturer2
 } from './test-data/projects.test-data';
 import { prismaChangeRequest1 } from './test-data/change-requests.test-data';
 import { primsaTeam2, prismaTeam1 } from './test-data/teams.test-data';
@@ -710,24 +712,33 @@ describe('Projects', () => {
       expect(manufacturer.userCreatedId).toBe(prismaManufacturer1.userCreatedId);
     });
 
-    test('deleteManufacturer works', async () => {
-      vi.spyOn(prisma.manufacturer, 'findFirst').mockResolvedValue(prismaManufacturer1);
-      vi.spyOn(prisma.manufacturer, 'delete').mockResolvedValue(prismaManufacturer1);
+    test('deleteManufacturer fails when there is materials in it', async () => {
+      vi.spyOn(prisma.manufacturer, 'findFirst').mockResolvedValue(manufacturer2);
+  
+      await expect(ProjectsService.deleteManufacturer(batman, 'Manufacturer2')).rejects.toThrow(
+        new HttpException(400, 'Cannot delete manufacturer if it has materials associated with it')
+      );
+    });
 
-      const manufacturer = await ProjectsService.deleteManufacturer(batman, prismaManufacturer1.name);
+    test('deleteManufacturer works', async () => {
+      vi.spyOn(prisma.manufacturer, 'findFirst').mockResolvedValue(manufacturer1);
+      vi.spyOn(prisma.manufacturer, 'delete').mockResolvedValue(manufacturer1);
+
+      const manufacturer = await ProjectsService.deleteManufacturer(batman, manufacturer1.name);
       expect(prisma.manufacturer.delete).toBeCalledTimes(1);
 
-      expect(manufacturer).toStrictEqual(prismaManufacturer1);
+      expect(manufacturer).toStrictEqual(manufacturer1);
       expect(prisma.manufacturer.findFirst).toHaveBeenCalledTimes(1);
+      expect(prisma.manufacturer.delete).toHaveBeenCalledTimes(1);
     });
 
     test('deleteManufacturer fails when user is not at least Head', async () => {
-      vi.spyOn(prisma.manufacturer, 'findFirst').mockResolvedValue(prismaManufacturer1);
-      vi.spyOn(prisma.manufacturer, 'update').mockResolvedValue(prismaManufacturer1);
+      vi.spyOn(prisma.manufacturer, 'findFirst').mockResolvedValue(manufacturer1);
+      vi.spyOn(prisma.manufacturer, 'update').mockResolvedValue(manufacturer1);
 
-      await expect(
-        async () => await ProjectsService.deleteManufacturer(wonderwoman, prismaManufacturer1.name)
-      ).rejects.toThrow(new AccessDeniedException('Only heads and above can delete a manufacturer'));
+      await expect(async () => await ProjectsService.deleteManufacturer(wonderwoman, manufacturer1.name)).rejects.toThrow(
+        new AccessDeniedException('Only heads and above can delete a manufacturer')
+      );
 
       expect(prisma.project.findFirst).toHaveBeenCalledTimes(0);
       expect(prisma.project.update).toHaveBeenCalledTimes(0);

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -712,13 +712,13 @@ describe('Projects', () => {
 
     test('deleteManufacturer works', async () => {
       vi.spyOn(prisma.manufacturer, 'findFirst').mockResolvedValue(prismaManufacturer1);
-      vi.spyOn(prisma.manufacturer, 'update').mockResolvedValue(prismaManufacturer1);
+      vi.spyOn(prisma.manufacturer, 'delete').mockResolvedValue(prismaManufacturer1);
 
       const manufacturer = await ProjectsService.deleteManufacturer(batman, prismaManufacturer1.name);
+      expect(prisma.manufacturer.delete).toBeCalledTimes(1);
 
       expect(manufacturer).toStrictEqual(prismaManufacturer1);
       expect(prisma.manufacturer.findFirst).toHaveBeenCalledTimes(1);
-      expect(prisma.manufacturer.update).toHaveBeenCalledTimes(1);
     });
 
     test('deleteManufacturer fails when user is not at least Head', async () => {

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -714,7 +714,7 @@ describe('Projects', () => {
 
     test('deleteManufacturer fails when there is materials in it', async () => {
       vi.spyOn(prisma.manufacturer, 'findFirst').mockResolvedValue(manufacturer2);
-  
+
       await expect(ProjectsService.deleteManufacturer(batman, 'Manufacturer2')).rejects.toThrow(
         new HttpException(400, 'Cannot delete manufacturer if it has materials associated with it')
       );

--- a/src/backend/tests/test-data/projects.test-data.ts
+++ b/src/backend/tests/test-data/projects.test-data.ts
@@ -8,7 +8,7 @@ import {
   Manufacturer as PrismaManufacturer,
   Unit
 } from '@prisma/client';
-import { Project as SharedProject, WbsElementStatus, LinkType, Manufacturer, Material, MaterialStatus} from 'shared';
+import { Project as SharedProject, WbsElementStatus, LinkType, Manufacturer, Material, MaterialStatus } from 'shared';
 import projectQueryArgs from '../../src/prisma-query-args/projects.query-args';
 import { prismaTeam1 } from './teams.test-data';
 import { batman, superman } from './users.test-data';
@@ -198,7 +198,7 @@ export const material1: Material = {
   status: MaterialStatus.Ordered,
   materialTypeName: 'logs',
   materialType: {
-    name: "material",
+    name: 'material',
     dateCreated: new Date('2022-12-22'),
     userCreatedId: 4
   },
@@ -208,26 +208,26 @@ export const material1: Material = {
     dateCreated: new Date('2024-01-05'),
     userCreatedId: 6
   },
-  manufacturerPartNumber: "11223",
+  manufacturerPartNumber: '11223',
   quantity: new Decimal(8),
   price: 20,
   subtotal: 2000,
   linkUrl: 'https://example.com',
-  notes: "IDK",
-}
+  notes: 'IDK'
+};
 
 export const prismaManufacturer1: PrismaManufacturer = {
   name: 'PrismaManufacturer1',
   dateCreated: new Date('10-1-2023'),
   userCreatedId: 1,
-  dateDeleted: null,
+  dateDeleted: null
 };
 
 export const prismaManufacturer2: PrismaManufacturer = {
   name: 'name',
   dateCreated: new Date('10-18-2023'),
   userCreatedId: 1,
-  dateDeleted: new Date('10-18-2023'),
+  dateDeleted: new Date('10-18-2023')
 };
 
 export const manufacturer1: Manufacturer = {
@@ -236,7 +236,7 @@ export const manufacturer1: Manufacturer = {
   userCreatedId: 1,
   userCreated: batman,
   dateDeleted: new Date('02-19-2023'),
-  materials: [],
+  materials: []
 };
 
 export const manufacturer2: Manufacturer = {
@@ -245,7 +245,7 @@ export const manufacturer2: Manufacturer = {
   userCreatedId: 1,
   userCreated: batman,
   dateDeleted: new Date('02-19-2023'),
-  materials: [material1],
+  materials: [material1]
 };
 
 export const toolMaterial: PrismaMaterialType = {

--- a/src/backend/tests/test-data/projects.test-data.ts
+++ b/src/backend/tests/test-data/projects.test-data.ts
@@ -219,15 +219,13 @@ export const material1: Material = {
 export const prismaManufacturer1: PrismaManufacturer = {
   name: 'PrismaManufacturer1',
   dateCreated: new Date('10-1-2023'),
-  userCreatedId: 1,
-  dateDeleted: null
+  userCreatedId: 1
 };
 
 export const prismaManufacturer2: PrismaManufacturer = {
   name: 'name',
   dateCreated: new Date('10-18-2023'),
   userCreatedId: 1,
-  dateDeleted: new Date('10-18-2023')
 };
 
 export const manufacturer1: Manufacturer = {
@@ -235,7 +233,6 @@ export const manufacturer1: Manufacturer = {
   dateCreated: new Date('02-19-2023'),
   userCreatedId: 1,
   userCreated: batman,
-  dateDeleted: new Date('02-19-2023'),
   materials: []
 };
 
@@ -244,7 +241,6 @@ export const manufacturer2: Manufacturer = {
   dateCreated: new Date('02-19-2023'),
   userCreatedId: 1,
   userCreated: batman,
-  dateDeleted: new Date('02-19-2023'),
   materials: [material1]
 };
 

--- a/src/backend/tests/test-data/projects.test-data.ts
+++ b/src/backend/tests/test-data/projects.test-data.ts
@@ -1,14 +1,14 @@
 import {
   Assembly,
-  Material,
+  Material as PrismaMaterial,
   Material_Type as PrismaMaterialType,
   Prisma,
   WBS_Element_Status as PrismaWBSElementStatus,
   Project,
-  Manufacturer,
+  Manufacturer as PrismaManufacturer,
   Unit
 } from '@prisma/client';
-import { Project as SharedProject, WbsElementStatus, LinkType } from 'shared';
+import { Project as SharedProject, WbsElementStatus, LinkType, Manufacturer, Material, MaterialStatus} from 'shared';
 import projectQueryArgs from '../../src/prisma-query-args/projects.query-args';
 import { prismaTeam1 } from './teams.test-data';
 import { batman, superman } from './users.test-data';
@@ -166,7 +166,7 @@ export const prismaUnit: Unit = {
   name: 'FT'
 };
 
-export const prismaMaterial: Material = {
+export const prismaMaterial: PrismaMaterial = {
   materialId: 'id',
   assemblyId: 'assemblyId',
   name: 'name',
@@ -187,18 +187,65 @@ export const prismaMaterial: Material = {
   unitName: 'FT',
   linkUrl: 'https://www.google.com'
 };
-export const prismaManufacturer1: Manufacturer = {
-  name: 'Manufacturer1',
+
+export const material1: Material = {
+  materialId: '2',
+  name: 'wood',
+  wbsElementId: 1,
+  dateCreated: new Date('2023-02-20'),
+  userCreatedId: 3,
+  userCreated: batman,
+  status: MaterialStatus.Ordered,
+  materialTypeName: 'logs',
+  materialType: {
+    name: "material",
+    dateCreated: new Date('2022-12-22'),
+    userCreatedId: 4
+  },
+  manufacturerName: 'Amazon',
+  manufacturer: {
+    name: 'Big Company',
+    dateCreated: new Date('2024-01-05'),
+    userCreatedId: 6
+  },
+  manufacturerPartNumber: "11223",
+  quantity: new Decimal(8),
+  price: 20,
+  subtotal: 2000,
+  linkUrl: 'https://example.com',
+  notes: "IDK",
+}
+
+export const prismaManufacturer1: PrismaManufacturer = {
+  name: 'PrismaManufacturer1',
   dateCreated: new Date('10-1-2023'),
   userCreatedId: 1,
-  dateDeleted: null
+  dateDeleted: null,
 };
 
-export const prismaManufacturer2: Manufacturer = {
+export const prismaManufacturer2: PrismaManufacturer = {
   name: 'name',
   dateCreated: new Date('10-18-2023'),
   userCreatedId: 1,
-  dateDeleted: new Date('10-18-2023')
+  dateDeleted: new Date('10-18-2023'),
+};
+
+export const manufacturer1: Manufacturer = {
+  name: 'Manufacturer1',
+  dateCreated: new Date('02-19-2023'),
+  userCreatedId: 1,
+  userCreated: batman,
+  dateDeleted: new Date('02-19-2023'),
+  materials: [],
+};
+
+export const manufacturer2: Manufacturer = {
+  name: 'Manufacturer2',
+  dateCreated: new Date('02-19-2023'),
+  userCreatedId: 1,
+  userCreated: batman,
+  dateDeleted: new Date('02-19-2023'),
+  materials: [material1],
 };
 
 export const toolMaterial: PrismaMaterialType = {
@@ -208,7 +255,7 @@ export const toolMaterial: PrismaMaterialType = {
   dateDeleted: null
 };
 
-export const prismaMaterial2: Material = {
+export const prismaMaterial2: PrismaMaterial = {
   materialId: 'id',
   assemblyId: 'assemblyId',
   name: 'name2',
@@ -230,7 +277,7 @@ export const prismaMaterial2: Material = {
   linkUrl: 'https://www.google.com'
 };
 
-export const prismaMaterial1: Material = {
+export const prismaMaterial1: PrismaMaterial = {
   materialId: '1',
   assemblyId: '1',
   dateCreated: new Date('2023-11-07'),

--- a/src/backend/tests/test-data/projects.test-data.ts
+++ b/src/backend/tests/test-data/projects.test-data.ts
@@ -225,7 +225,7 @@ export const prismaManufacturer1: PrismaManufacturer = {
 export const prismaManufacturer2: PrismaManufacturer = {
   name: 'name',
   dateCreated: new Date('10-18-2023'),
-  userCreatedId: 1,
+  userCreatedId: 1
 };
 
 export const manufacturer1: Manufacturer = {

--- a/src/shared/src/types/bom-types.ts
+++ b/src/shared/src/types/bom-types.ts
@@ -45,7 +45,6 @@ export interface Manufacturer {
   dateCreated: Date;
   userCreatedId: number;
   userCreated: User;
-  dateDeleted?: Date;
   materials: MaterialPreview[];
 }
 


### PR DESCRIPTION
## Changes

Made the delete manufacturer a hard delete 

## Test Cases
- Made a postman test to check if it hard deleted
- made a test to make sure it throws an exception when a manufacturer is trying to get deleted while it still has materials

## Description
- Added seed data in projects.test-data
     - created local Finishline data on manufacturer and material and changed the original manufacturer to prismaManufacturer
- Deleted dateDeleted attribute of the manufacturer in the schema and created a migration
     - We deleted it because we are hard deleting dataDeleted from the manufacturer so we don't need that variable anymore
- Tested on Postman to see if a manufacturer is hard deleted:

![Screenshot 2024-02-06 205701](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/88903298/78a8c8d4-07c9-4b74-ab1c-fdf3b44ad407)



- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1989 
