### PR TITLE
#1872: Added reimbursed status on frontend

### DIFF
--- a/src/frontend/src/components/ReimbursementRequestStatusPill.tsx
+++ b/src/frontend/src/components/ReimbursementRequestStatusPill.tsx
@@ -1,0 +1,45 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import Chip from '@mui/material/Chip';
+import { green, red, grey, purple, yellow, orange } from '@mui/material/colors';
+import { ReimbursementStatusType } from 'shared';
+import { ReimbursementRequestTypeTextPipe } from '../utils/enum-pipes';
+
+const determineStatusPillColor = (status: ReimbursementStatusType) => {
+  switch (status) {
+    case ReimbursementStatusType.PENDING_FINANCE:
+      return yellow[600];
+    case ReimbursementStatusType.SABO_SUBMITTED:
+      return orange[600];
+    case ReimbursementStatusType.ADVISOR_APPROVED:
+      return purple[600];
+    case ReimbursementStatusType.REIMBURSED:
+      return green[600];
+    case ReimbursementStatusType.DENIED:
+      return red[600];
+    default:
+      return grey[600];
+  }
+};
+
+const ReimbursementRequestStatusPill = ({ status }: { status: ReimbursementStatusType }) => {
+  const statusPillColor = determineStatusPillColor(status);
+  return (
+    <Chip
+      size="small"
+      label={ReimbursementRequestTypeTextPipe(status)}
+      variant="filled"
+      sx={{
+        fontSize: 12,
+        color: 'white',
+        backgroundColor: statusPillColor,
+        width: 125
+      }}
+    />
+  );
+};
+
+export default ReimbursementRequestStatusPill;

--- a/src/frontend/src/components/ReimbursementRequestStatusPill.tsx
+++ b/src/frontend/src/components/ReimbursementRequestStatusPill.tsx
@@ -5,13 +5,14 @@
 
 import Chip from '@mui/material/Chip';
 import { green, red, grey, purple, yellow, orange } from '@mui/material/colors';
+import { borderColor } from '@mui/system';
 import { ReimbursementStatusType } from 'shared';
-import { ReimbursementRequestTypeTextPipe } from '../utils/enum-pipes';
+import { displayEnum } from '../utils/pipes';
 
 const determineStatusPillColor = (status: ReimbursementStatusType) => {
   switch (status) {
     case ReimbursementStatusType.PENDING_FINANCE:
-      return yellow[600];
+      return yellow[700];
     case ReimbursementStatusType.SABO_SUBMITTED:
       return orange[600];
     case ReimbursementStatusType.ADVISOR_APPROVED:
@@ -30,7 +31,7 @@ const ReimbursementRequestStatusPill = ({ status }: { status: ReimbursementStatu
   return (
     <Chip
       size="small"
-      label={ReimbursementRequestTypeTextPipe(status)}
+      label={displayEnum(status)}
       variant="filled"
       sx={{
         fontSize: 12,

--- a/src/frontend/src/components/ReimbursementRequestStatusPill.tsx
+++ b/src/frontend/src/components/ReimbursementRequestStatusPill.tsx
@@ -5,7 +5,6 @@
 
 import Chip from '@mui/material/Chip';
 import { green, red, grey, purple, yellow, orange } from '@mui/material/colors';
-import { borderColor } from '@mui/system';
 import { ReimbursementStatusType } from 'shared';
 import { displayEnum } from '../utils/pipes';
 

--- a/src/frontend/src/layouts/PageTitle/PageTitle.tsx
+++ b/src/frontend/src/layouts/PageTitle/PageTitle.tsx
@@ -39,16 +39,18 @@ const PageTitle: React.FC<PageTitleProps> = ({ title, headerRight, tabs, sticky,
       >
         <Grid container>
           <Grid container item md={12} display="flex" alignItems={'center'}>
-            <Grid item md={chips ? 6 : 8} xs={8}>
-              <Typography variant="h4" fontSize={30}>
-                {title}
-              </Typography>
-            </Grid>
-            {chips && (
-              <Grid item md={2} xs={4}>
-                {chips}
+            <Grid container md={8} xs ={12} spacing={2}>
+              <Grid item>
+                <Typography variant="h4" fontSize={30}>
+                  {title}
+                </Typography>
               </Grid>
+              {chips && (
+                <Grid item mt={1}>
+                  {chips}
+                </Grid>
             )}
+            </Grid>
             <Grid item md={4} xs={12}>
               <Box textAlign={['left', 'right']}>{headerRight}</Box>
             </Grid>

--- a/src/frontend/src/layouts/PageTitle/PageTitle.tsx
+++ b/src/frontend/src/layouts/PageTitle/PageTitle.tsx
@@ -39,17 +39,17 @@ const PageTitle: React.FC<PageTitleProps> = ({ title, headerRight, tabs, sticky,
       >
         <Grid container>
           <Grid container item md={12} display="flex" alignItems={'center'}>
-            <Grid item md={chips ? 3 : 6} xs={8}>
+            <Grid item md={chips ? 6 : 8} xs={8}>
               <Typography variant="h4" fontSize={30}>
                 {title}
               </Typography>
             </Grid>
             {chips && (
-              <Grid item md={3} xs={4}>
+              <Grid item md={2} xs={4}>
                 {chips}
               </Grid>
             )}
-            <Grid item md={6} xs={12}>
+            <Grid item md={4} xs={12}>
               <Box textAlign={['left', 'right']}>{headerRight}</Box>
             </Grid>
           </Grid>

--- a/src/frontend/src/layouts/PageTitle/PageTitle.tsx
+++ b/src/frontend/src/layouts/PageTitle/PageTitle.tsx
@@ -39,7 +39,7 @@ const PageTitle: React.FC<PageTitleProps> = ({ title, headerRight, tabs, sticky,
       >
         <Grid container>
           <Grid container item md={12} display="flex" alignItems={'center'}>
-            <Grid container md={8} xs ={12} spacing={2}>
+            <Grid container md={8} xs={12} spacing={2}>
               <Grid item>
                 <Typography variant="h4" fontSize={30}>
                   {title}
@@ -49,7 +49,7 @@ const PageTitle: React.FC<PageTitleProps> = ({ title, headerRight, tabs, sticky,
                 <Grid item mt={1}>
                   {chips}
                 </Grid>
-            )}
+              )}
             </Grid>
             <Grid item md={4} xs={12}>
               <Box textAlign={['left', 'right']}>{headerRight}</Box>

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
@@ -15,7 +15,7 @@ import { Grid, Typography, useTheme, Link, IconButton } from '@mui/material';
 import { Box } from '@mui/system';
 import { useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { ReimbursementRequest, ReimbursementStatusType } from 'shared';
+import { ReimbursementRequest } from 'shared';
 import ActionsMenu, { ButtonInfo } from '../../../components/ActionsMenu';
 import NERModal from '../../../components/NERModal';
 import PageLayout from '../../../components/PageLayout';

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
@@ -15,7 +15,7 @@ import { Grid, Typography, useTheme, Link, IconButton } from '@mui/material';
 import { Box } from '@mui/system';
 import { useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { ReimbursementRequest } from 'shared';
+import { ReimbursementRequest, ReimbursementStatusType } from 'shared';
 import ActionsMenu, { ButtonInfo } from '../../../components/ActionsMenu';
 import NERModal from '../../../components/NERModal';
 import PageLayout from '../../../components/PageLayout';
@@ -49,6 +49,7 @@ import AddSABONumberModal from './AddSABONumberModal';
 import ReimbursementProductsView from './ReimbursementProductsView';
 import SubmitToSaboModal from './SubmitToSaboModal';
 import DownloadIcon from '@mui/icons-material/Download';
+import ReimbursementRequestStatusPill from '../../../components/ReimbursementRequestStatusPill';
 
 interface ReimbursementRequestDetailsViewProps {
   reimbursementRequest: ReimbursementRequest;
@@ -315,6 +316,8 @@ const ReimbursementRequestDetailsView: React.FC<ReimbursementRequestDetailsViewP
     }
   ];
 
+  const statuses = reimbursementRequest.reimbursementStatuses.map((status) => status.type);
+  const recentStatus = statuses[-1];
   return (
     <PageLayout
       title={`${
@@ -322,6 +325,11 @@ const ReimbursementRequestDetailsView: React.FC<ReimbursementRequestDetailsViewP
           ? `${fullNamePipe(reimbursementRequest.recipient)}'s Reimbursement Request - Denied`
           : `${fullNamePipe(reimbursementRequest.recipient)}'s Reimbursement Request`
       }`}
+      chips={
+        <Box id="status" display="flex" gap="20px">
+          {statuses.length > 0 ? <ReimbursementRequestStatusPill status={recentStatus} /> : <br></br>}
+        </Box>
+      }
       previousPages={[
         {
           name: 'Finance',

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
@@ -316,7 +316,8 @@ const ReimbursementRequestDetailsView: React.FC<ReimbursementRequestDetailsViewP
     }
   ];
 
-  const statusTypes = reimbursementRequest.reimbursementStatuses.map((status) => status.type);
+  const sortedStatus = reimbursementRequest.reimbursementStatuses.sort((a) => a.dateCreated.getDate());
+  const statusTypes = sortedStatus.map((status) => status.type);
   const recentStatus = statusTypes[statusTypes.length - 1];
   return (
     <PageLayout
@@ -326,7 +327,7 @@ const ReimbursementRequestDetailsView: React.FC<ReimbursementRequestDetailsViewP
           : `${fullNamePipe(reimbursementRequest.recipient)}'s Reimbursement Request`
       }`}
       chips={
-        <Box id="status" display="flex" gap="20px">
+        <Box id="status" display="flex">
           {statusTypes.length > 0 && <ReimbursementRequestStatusPill status={recentStatus} />}
         </Box>
       }

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
@@ -321,11 +321,7 @@ const ReimbursementRequestDetailsView: React.FC<ReimbursementRequestDetailsViewP
   const recentStatus = statusTypes[statusTypes.length - 1];
   return (
     <PageLayout
-      title={`${
-        isReimbursementRequestDenied(reimbursementRequest)
-          ? `${fullNamePipe(reimbursementRequest.recipient)}'s Reimbursement Request - Denied`
-          : `${fullNamePipe(reimbursementRequest.recipient)}'s Reimbursement Request`
-      }`}
+      title={`${fullNamePipe(reimbursementRequest.recipient)}'s Reimbursement Request`}
       chips={
         <Box id="status" display="flex">
           {statusTypes.length > 0 && <ReimbursementRequestStatusPill status={recentStatus} />}

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
@@ -316,8 +316,8 @@ const ReimbursementRequestDetailsView: React.FC<ReimbursementRequestDetailsViewP
     }
   ];
 
-  const statuses = reimbursementRequest.reimbursementStatuses.map((status) => status.type);
-  const recentStatus = statuses[-1];
+  const statusTypes = reimbursementRequest.reimbursementStatuses.map((status) => status.type);
+  const recentStatus = statusTypes[statusTypes.length - 1];
   return (
     <PageLayout
       title={`${
@@ -327,7 +327,7 @@ const ReimbursementRequestDetailsView: React.FC<ReimbursementRequestDetailsViewP
       }`}
       chips={
         <Box id="status" display="flex" gap="20px">
-          {statuses.length > 0 ? <ReimbursementRequestStatusPill status={recentStatus} /> : <br></br>}
+          {statusTypes.length > 0 && <ReimbursementRequestStatusPill status={recentStatus} />}
         </Box>
       }
       previousPages={[

--- a/src/frontend/src/utils/enum-pipes.ts
+++ b/src/frontend/src/utils/enum-pipes.ts
@@ -68,18 +68,3 @@ export const ChangeRequestStatusTextPipe: (status: ChangeRequestStatus) => strin
       return 'Open';
   }
 };
-
-export const ReimbursementRequestTypeTextPipe: (type: ReimbursementStatusType) => string = (type) => {
-  switch (type) {
-    case ReimbursementStatusType.ADVISOR_APPROVED:
-      return 'Advisor Approved';
-    case ReimbursementStatusType.DENIED:
-      return 'Denied';
-    case ReimbursementStatusType.PENDING_FINANCE:
-      return 'Pending Finance';
-    case ReimbursementStatusType.REIMBURSED:
-      return 'Reimbursed';
-    case ReimbursementStatusType.SABO_SUBMITTED:
-      return 'Sabo Submitted';
-  }
-};

--- a/src/frontend/src/utils/enum-pipes.ts
+++ b/src/frontend/src/utils/enum-pipes.ts
@@ -4,7 +4,7 @@
  */
 
 import { yellow, green, blue, purple, grey } from '@mui/material/colors';
-import { ChangeRequestStatus, ChangeRequestType, WorkPackageStage } from 'shared';
+import { ChangeRequestStatus, ChangeRequestType, ReimbursementStatusType, WorkPackageStage } from 'shared';
 
 // maps stage to the desired color
 export const WorkPackageStageColorPipe: (stage: WorkPackageStage | undefined) => string = (stage) => {
@@ -63,5 +63,20 @@ export const ChangeRequestStatusTextPipe: (status: ChangeRequestStatus) => strin
       return 'Denied';
     case ChangeRequestStatus.Open:
       return 'Open';
+  }
+};
+
+export const ReimbursementRequestTypeTextPipe: (type: ReimbursementStatusType) => string = (type) => {
+  switch (type) {
+    case ReimbursementStatusType.ADVISOR_APPROVED:
+      return 'Advisor Approved';
+    case ReimbursementStatusType.DENIED:
+      return 'Denied';
+    case ReimbursementStatusType.PENDING_FINANCE:
+      return 'Pending Finance';
+    case ReimbursementStatusType.REIMBURSED:
+      return 'Reimbursed';
+    case ReimbursementStatusType.SABO_SUBMITTED:
+      return 'Sabo Submitted';
   }
 };

--- a/src/frontend/src/utils/enum-pipes.ts
+++ b/src/frontend/src/utils/enum-pipes.ts
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 import { yellow, green, blue, purple, grey, orange } from '@mui/material/colors';
-import { ChangeRequestStatus, ChangeRequestType, ReimbursementStatusType, WorkPackageStage } from 'shared';
+import { ChangeRequestStatus, ChangeRequestType, WorkPackageStage } from 'shared';
 
 // maps stage to the desired color
 export const WorkPackageStageColorPipe: (stage: WorkPackageStage | undefined) => string = (stage) => {


### PR DESCRIPTION
## Changes

Showed chips corresponding to reimbursed status on the request details page.
Created component type, ReimbursementRequestStatusPill similar to ChangeRequestStatusPill.
Edited ReimbursementRequestDetailsView to include chips if a request has a status
Added new enum-pipe ReimbursementRequestTypeTextPipe converting status type to string.

## Notes

 Pending Finance should be a yellow chip
 Sabo Submitted should be an orange chip
 Advisor_Approved should be a purple chip
 Reimbursed should be a green chip
 Denied should be a red chip

Default is grey (can't get transparent) only appears on example because has a status with no status type.

## Screenshots
<img width="1437" alt="Screenshot 2024-02-01 at 00 43 59" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/106752975/0a8e390b-212c-405c-8392-80f1a8e1f161">

<img width="498" alt="Screenshot 2024-02-01 at 00 44 18" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/106752975/bd5cd625-7ab2-4c0b-b843-920a33ce87e1">


## To Do

- make default color transparent?

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #1872 
