### PR TITLE
#1441 associated CR's not deleted on WP delete

### DIFF
--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -599,7 +599,7 @@ export default class WorkPackagesService {
                   wbsElementId
                 },
                 data: {
-                  accepted: true,
+                  accepted: false,
                   dateReviewed: dateDeleted
                 }
               }

--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -590,7 +590,7 @@ export default class WorkPackagesService {
         workPackageId
       },
       data: {
-        // Soft delete the given wp's wbs by soft deleting crs and task
+        // Soft delete the given wp's wbs by setting crs to denied and soft deleting tasks
         wbsElement: {
           update: {
             changeRequests: {

--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -599,8 +599,8 @@ export default class WorkPackagesService {
                   wbsElementId
                 },
                 data: {
-                  dateDeleted,
-                  deletedByUserId
+                  accepted: true,
+                  dateReviewed: dateDeleted
                 }
               }
             },


### PR DESCRIPTION
## Changes

set all change requests to denied when a workPackage is deleted 

## Notes

No tests failed on backend so no update, lmk if I should make some.


## To Do

- [ ] update backend tests?
- [ ] check if the change request is open, before deleting?

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #1441 
