### PR TITLE
#1308 fixed description label to be directly above cost label and trash for xs screens

### DIFF
--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementProductTable.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementProductTable.tsx
@@ -113,7 +113,15 @@ const ReimbursementProductTable: React.FC<ReimbursementProductTableProps> = ({
                   <Box sx={{ display: 'flex', flexWrap: 'wrap', listStyle: 'none', p: 0.5, m: 0 }} component={'ul'}>
                     {uniqueWbsElementsWithProducts.get(key)?.map((product, index) => (
                       <ListItem key={product.index}>
-                        <Box sx={{ display: 'flex', flexDirection: 'row' }}>
+                        <Box
+                          sx={{
+                            display: 'flex',
+                            flexDirection: {
+                              xs: 'column',
+                              sm: 'row'
+                            }
+                          }}
+                        >
                           <FormControl sx={{ width: '50%', marginRight: '4px' }}>
                             <Controller
                               name={`reimbursementProducts.${product.index}.name`}
@@ -134,41 +142,43 @@ const ReimbursementProductTable: React.FC<ReimbursementProductTableProps> = ({
                               {errors.reimbursementProducts?.[product.index]?.name?.message}
                             </FormHelperText>
                           </FormControl>
-                          <FormControl sx={{ width: '50%' }}>
-                            <Controller
-                              name={`reimbursementProducts.${product.index}.cost`}
-                              control={control}
-                              render={({ field }) => (
-                                <TextField
-                                  {...field}
-                                  label={'Cost'}
-                                  size={'small'}
-                                  variant={'outlined'}
-                                  type="number"
-                                  autoComplete="off"
-                                  InputProps={{
-                                    startAdornment: <InputAdornment position="start">$</InputAdornment>
-                                  }}
-                                  onBlur={(e) => onCostBlurHandler(parseFloat(e.target.value), product.index)}
-                                  sx={{ width: '100%' }}
-                                  error={!!errors.reimbursementProducts?.[product.index]?.cost}
-                                />
-                              )}
-                            />
-                            <FormHelperText error>
-                              {errors.reimbursementProducts?.[product.index]?.cost?.message}
-                            </FormHelperText>
-                          </FormControl>
-                          <IconButton
-                            sx={{
-                              '&:focus': {
-                                backgroundColor: hoverColor
-                              }
-                            }}
-                            onClick={() => removeProduct(product.index)}
-                          >
-                            <Delete />
-                          </IconButton>
+                          <Box sx={{ display: 'flex', flexDirection: 'row' }}>
+                            <FormControl sx={{ width: '50%' }}>
+                              <Controller
+                                name={`reimbursementProducts.${product.index}.cost`}
+                                control={control}
+                                render={({ field }) => (
+                                  <TextField
+                                    {...field}
+                                    label={'Cost'}
+                                    size={'small'}
+                                    variant={'outlined'}
+                                    type="number"
+                                    autoComplete="off"
+                                    InputProps={{
+                                      startAdornment: <InputAdornment position="start">$</InputAdornment>
+                                    }}
+                                    onBlur={(e) => onCostBlurHandler(parseFloat(e.target.value), product.index)}
+                                    sx={{ width: '100%' }}
+                                    error={!!errors.reimbursementProducts?.[product.index]?.cost}
+                                  />
+                                )}
+                              />
+                              <FormHelperText error>
+                                {errors.reimbursementProducts?.[product.index]?.cost?.message}
+                              </FormHelperText>
+                            </FormControl>
+                            <IconButton
+                              sx={{
+                                '&:focus': {
+                                  backgroundColor: hoverColor
+                                }
+                              }}
+                              onClick={() => removeProduct(product.index)}
+                            >
+                              <Delete />
+                            </IconButton>
+                          </Box>
                         </Box>
                       </ListItem>
                     ))}
@@ -248,5 +258,4 @@ const ReimbursementProductTable: React.FC<ReimbursementProductTableProps> = ({
     </TableContainer>
   );
 };
-
 export default ReimbursementProductTable;


### PR DESCRIPTION
## Changes

- changed the flexDirection to 'column' for xs screens on line 120.
- added a new box to contain the only cost label and trash which is in the original box containing the description label, cost label, and trash. 


## Notes

I can go back and add some padding between the description label and the cost label if necessary. Additionally, if the width of the description box needs to be changed at a certain screen width I can fix that. 

## Test Cases

- Case A: Screen width over 600
- Case B: Screen width under 600

## Screenshots

<img width="1291" alt="Screenshot 2024-02-05 at 9 58 21 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/147998712/ede659c2-fd44-427b-8f0f-07678ddda111">


<img width="1509" alt="Screenshot 2024-02-05 at 9 57 38 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/147998712/3d190074-7812-4511-9cf8-4987f34b344e">



## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #1308 
