### PR TITLE
2005-fixed bug when manufacturer and unit prompt is cancelled in proj…

### DIFF
--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialForm.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialForm.tsx
@@ -70,7 +70,7 @@ const MaterialForm: React.FC<MaterialFormProps> = ({ submitText, onSubmit, defau
       manufacturerPartNumber: defaultValues?.manufacturerPartNumber ?? '',
       quantity: defaultValues?.quantity ?? 0,
       manufacturerName: defaultValues?.manufacturerName ?? '',
-      pdmFileName: defaultValues?.pdmFileName ?? '',
+      pdmFileName: defaultValues?.pdmFileName,
       price: defaultValues?.price ?? 0,
       unitName: defaultValues?.unitName,
       linkUrl: defaultValues?.linkUrl ?? '',

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
@@ -138,11 +138,11 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
                       const manufacturerName = prompt('Enter Manufacturer Name');
                       if (manufacturerName) {
                         createManufacturer(manufacturerName);
-                      } else {
-                        event.target.value = field.value;
+                        field.onChange(event);
                       }
+                    } else {
+                      field.onChange(event);
                     }
-                    field.onChange(event);
                   }}
                 >
                   {allManufacturers.map((manufacturer) => (
@@ -211,11 +211,10 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
                         const unitName = prompt('Enter Unit Name');
                         if (unitName) {
                           createUnit(unitName);
-                        } else {
-                          event.target.value = field.value === undefined ? '' : field.value;
                         }
+                      } else {
+                        field.onChange(event);
                       }
-                      if (event.target.value !== '') field.onChange(event);
                     }}
                   >
                     {allUnits.map((unit) => (

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
@@ -141,9 +141,8 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
                       } else {
                         event.target.value = field.value;
                       }
-                    } else {
-                      field.onChange(event);
                     }
+                    field.onChange(event);
                   }}
                 >
                   {allManufacturers.map((manufacturer) => (
@@ -215,9 +214,8 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
                         } else {
                           event.target.value = field.value === undefined ? '' : field.value;
                         }
-                      } else {
-                        field.onChange(event);
                       }
+                      field.onChange(event);
                     }}
                   >
                     {allUnits.map((unit) => (

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
@@ -6,6 +6,7 @@ import ReactHookTextField from '../../../../../components/ReactHookTextField';
 import { MaterialFormInput } from './MaterialForm';
 import NERFormModal from '../../../../../components/NERFormModal';
 import DetailDisplay from '../../../../../components/DetailDisplay';
+import { useState } from 'react';
 
 export interface MaterialFormViewProps {
   submitText: 'Add' | 'Edit';
@@ -46,6 +47,8 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
   const price = watch('price');
   const unit = watch('unitName');
   const subtotal = quantity && price ? (unit ? price : quantity * price) : 0;
+
+  const [prevSelectedUnitVal, setPrevSelectedUnitVal] = useState('');
 
   const onCostBlurHandler = (value: number) => {
     setValue(`price`, parseFloat(value.toFixed(2)));
@@ -107,7 +110,6 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
                   variant="outlined"
                   error={!!errors.materialTypeName}
                   helperText={errors.materialTypeName?.message}
-                  value={field.value}
                 >
                   {allMaterialTypes.map((type) => (
                     <MenuItem key={type.name} value={type.name}>
@@ -133,7 +135,6 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
                   variant="outlined"
                   error={!!errors.manufacturerName}
                   helperText={errors.manufacturerName?.message}
-                  key={field.value}
                   onChange={(event) => {
                     const selectedValue = event.target.value;
                     if (selectedValue === 'createManufacturer') {
@@ -207,7 +208,7 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
                     variant="outlined"
                     error={!!errors.unitName}
                     helperText={errors.unitName?.message}
-                    key={field.value}
+                    value={field.value || ''}
                     onChange={(event) => {
                       const selectedValue = event.target.value;
                       if (selectedValue === 'createUnit') {

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
@@ -1,20 +1,11 @@
 import { FormControl, FormHelperText, FormLabel, Grid, InputAdornment, MenuItem, TextField } from '@mui/material';
-import { Box, getValue } from '@mui/system';
-import {
-  Control,
-  Controller,
-  FieldErrors,
-  UseFormHandleSubmit,
-  UseFormSetValue,
-  UseFormWatch,
-  useForm
-} from 'react-hook-form';
+import { Box } from '@mui/system';
+import { Control, Controller, FieldErrors, UseFormHandleSubmit, UseFormSetValue, UseFormWatch } from 'react-hook-form';
 import { Assembly, Manufacturer, MaterialType, Unit } from 'shared';
 import ReactHookTextField from '../../../../../components/ReactHookTextField';
 import { MaterialFormInput } from './MaterialForm';
 import NERFormModal from '../../../../../components/NERFormModal';
 import DetailDisplay from '../../../../../components/DetailDisplay';
-import { useState } from 'react';
 
 export interface MaterialFormViewProps {
   submitText: 'Add' | 'Edit';

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
@@ -1,11 +1,20 @@
 import { FormControl, FormHelperText, FormLabel, Grid, InputAdornment, MenuItem, TextField } from '@mui/material';
-import { Box } from '@mui/system';
-import { Control, Controller, FieldErrors, UseFormHandleSubmit, UseFormSetValue, UseFormWatch } from 'react-hook-form';
+import { Box, getValue } from '@mui/system';
+import {
+  Control,
+  Controller,
+  FieldErrors,
+  UseFormHandleSubmit,
+  UseFormSetValue,
+  UseFormWatch,
+  useForm
+} from 'react-hook-form';
 import { Assembly, Manufacturer, MaterialType, Unit } from 'shared';
 import ReactHookTextField from '../../../../../components/ReactHookTextField';
 import { MaterialFormInput } from './MaterialForm';
 import NERFormModal from '../../../../../components/NERFormModal';
 import DetailDisplay from '../../../../../components/DetailDisplay';
+import { useState } from 'react';
 
 export interface MaterialFormViewProps {
   submitText: 'Add' | 'Edit';
@@ -107,6 +116,7 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
                   variant="outlined"
                   error={!!errors.materialTypeName}
                   helperText={errors.materialTypeName?.message}
+                  value={field.value}
                 >
                   {allMaterialTypes.map((type) => (
                     <MenuItem key={type.name} value={type.name}>
@@ -132,23 +142,27 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
                   variant="outlined"
                   error={!!errors.manufacturerName}
                   helperText={errors.manufacturerName?.message}
+                  key={field.value}
+                  onChange={(event) => {
+                    const selectedValue = event.target.value;
+                    if (selectedValue === 'createManufacturer') {
+                      const manufacturerName = prompt('Enter Manufacturer Name');
+                      if (manufacturerName) {
+                        createManufacturer(manufacturerName);
+                      } else {
+                        event.target.value = field.value;
+                      }
+                    } else {
+                      field.onChange(event);
+                    }
+                  }}
                 >
                   {allManufacturers.map((manufacturer) => (
                     <MenuItem key={manufacturer.name} value={manufacturer.name}>
                       {manufacturer.name}
                     </MenuItem>
                   ))}
-                  <MenuItem
-                    value="createManufacturer"
-                    onClick={() => {
-                      const manufacturerName = prompt('Enter Manufacturer Name');
-                      if (manufacturerName) {
-                        createManufacturer(manufacturerName);
-                      }
-                    }}
-                  >
-                    + Create Manufacturer
-                  </MenuItem>
+                  <MenuItem value="createManufacturer">+ Create Manufacturer</MenuItem>
                 </TextField>
               )}
             />
@@ -202,23 +216,27 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
                     variant="outlined"
                     error={!!errors.unitName}
                     helperText={errors.unitName?.message}
+                    key={field.value}
+                    onChange={(event) => {
+                      const selectedValue = event.target.value;
+                      if (selectedValue === 'createUnit') {
+                        const unitName = prompt('Enter Unit Name');
+                        if (unitName) {
+                          createUnit(unitName);
+                        } else {
+                          event.target.value = field.value === undefined ? '' : field.value;
+                        }
+                      } else {
+                        field.onChange(event);
+                      }
+                    }}
                   >
                     {allUnits.map((unit) => (
                       <MenuItem key={unit.name} value={unit.name}>
                         {unit.name}
                       </MenuItem>
                     ))}
-                    <MenuItem
-                      value="createUnit"
-                      onClick={() => {
-                        const unitName = prompt('Enter Unit Name');
-                        if (unitName) {
-                          createUnit(unitName);
-                        }
-                      }}
-                    >
-                      + Create Unit
-                    </MenuItem>
+                    <MenuItem value="createUnit">+ Create Unit</MenuItem>
                   </TextField>
                 )}
               />

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
@@ -6,7 +6,6 @@ import ReactHookTextField from '../../../../../components/ReactHookTextField';
 import { MaterialFormInput } from './MaterialForm';
 import NERFormModal from '../../../../../components/NERFormModal';
 import DetailDisplay from '../../../../../components/DetailDisplay';
-import { useState } from 'react';
 
 export interface MaterialFormViewProps {
   submitText: 'Add' | 'Edit';
@@ -47,8 +46,6 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
   const price = watch('price');
   const unit = watch('unitName');
   const subtotal = quantity && price ? (unit ? price : quantity * price) : 0;
-
-  const [prevSelectedUnitVal, setPrevSelectedUnitVal] = useState('');
 
   const onCostBlurHandler = (value: number) => {
     setValue(`price`, parseFloat(value.toFixed(2)));

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
@@ -215,7 +215,7 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
                           event.target.value = field.value === undefined ? '' : field.value;
                         }
                       }
-                      field.onChange(event);
+                      if (event.target.value !== '') field.onChange(event);
                     }}
                   >
                     {allUnits.map((unit) => (


### PR DESCRIPTION
…ect BOM

## Changes

I moved the prompt to an onChange prop on the manufacturer and unit Text Fields and did some logic to reset 
text Field to original selection when cancelled. 

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [X] All commits are tagged with the ticket number
- [X] No linting errors / newline at end of file warnings
- [X] All code follows repository-configured prettier formatting
- [X] No merge conflicts
- [X] Remove any non-applicable sections of this template
- [X] Assign the PR to yourself
- [X] No `yarn.lock` changes (unless dependencies have changed)
- [X] Request reviewers & ping on Slack
- [X] PR is linked to the ticket (fill in the closes line below)

Closes # 2005
