### PR TITLE
#2079- added budget/cash refund source column to the request table

### DIFF
--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestsSection.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestsSection.tsx
@@ -7,7 +7,11 @@ import { centsToDollar, datePipe, dateUndefinedPipe, fullNamePipe, undefinedPipe
 import ColumnHeader from './FinanceComponents/ColumnHeader';
 import FinanceTabs from './FinanceComponents/FinanceTabs';
 import { routes } from '../../utils/routes';
-import { cleanReimbursementRequestStatus, createReimbursementRequestRowData } from '../../utils/reimbursement-request.utils';
+import {
+  cleanReimbursementRequestStatus,
+  createReimbursementRequestRowData,
+  cleanReimbursementRequestRefundSource
+} from '../../utils/reimbursement-request.utils';
 
 interface ReimbursementRequestTableProps {
   userReimbursementRequests: ReimbursementRequest[];
@@ -65,7 +69,7 @@ const ReimbursementRequestTable = ({
                 <TableCell align="center">{dateUndefinedPipe(row.dateSubmittedToSabo)}</TableCell>
                 <TableCell align="center">{row.vendor.name}</TableCell>
                 <TableCell align="center">{cleanReimbursementRequestStatus(row.status)}</TableCell>
-                <TableCell align="center">{row.refundSource}</TableCell>
+                <TableCell align="center">{cleanReimbursementRequestRefundSource(row.refundSource)}</TableCell>
               </TableRow>
             ))}
           </TableBody>

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestsSection.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestsSection.tsx
@@ -3,15 +3,18 @@ import { Link as RouterLink } from 'react-router-dom';
 import { useState } from 'react';
 import { ReimbursementRequest, isAdmin } from 'shared';
 import { useCurrentUser } from '../../hooks/users.hooks';
-import { centsToDollar, datePipe, dateUndefinedPipe, fullNamePipe, undefinedPipe } from '../../utils/pipes';
+import {
+  centsToDollar,
+  codeAndRefundSourceName,
+  datePipe,
+  dateUndefinedPipe,
+  fullNamePipe,
+  undefinedPipe
+} from '../../utils/pipes';
 import ColumnHeader from './FinanceComponents/ColumnHeader';
 import FinanceTabs from './FinanceComponents/FinanceTabs';
 import { routes } from '../../utils/routes';
-import {
-  cleanReimbursementRequestStatus,
-  createReimbursementRequestRowData,
-  cleanReimbursementRequestRefundSource
-} from '../../utils/reimbursement-request.utils';
+import { cleanReimbursementRequestStatus, createReimbursementRequestRowData } from '../../utils/reimbursement-request.utils';
 
 interface ReimbursementRequestTableProps {
   userReimbursementRequests: ReimbursementRequest[];
@@ -50,8 +53,8 @@ const ReimbursementRequestTable = ({
               <ColumnHeader title="Date Submitted" />
               <ColumnHeader title="Date Submitted To Sabo" />
               <ColumnHeader title="Vendor" />
-              <ColumnHeader title="Status" />
               <ColumnHeader title="Refund Source" />
+              <ColumnHeader title="Status" />
             </TableRow>
           </TableHead>
           <TableBody>
@@ -68,8 +71,8 @@ const ReimbursementRequestTable = ({
                 <TableCell align="center">{datePipe(row.dateSubmitted)}</TableCell>
                 <TableCell align="center">{dateUndefinedPipe(row.dateSubmittedToSabo)}</TableCell>
                 <TableCell align="center">{row.vendor.name}</TableCell>
+                <TableCell align="center">{codeAndRefundSourceName(row.refundSource)}</TableCell>
                 <TableCell align="center">{cleanReimbursementRequestStatus(row.status)}</TableCell>
-                <TableCell align="center">{cleanReimbursementRequestRefundSource(row.refundSource)}</TableCell>
               </TableRow>
             ))}
           </TableBody>

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestsSection.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestsSection.tsx
@@ -53,7 +53,7 @@ const ReimbursementRequestTable = ({
               <ColumnHeader title="Date Submitted" />
               <ColumnHeader title="Date Submitted To Sabo" />
               <ColumnHeader title="Vendor" />
-              <ColumnHeader title="Refund Source" />
+              {tabValue === 1 && <ColumnHeader title="Refund Source" />}
               <ColumnHeader title="Status" />
             </TableRow>
           </TableHead>
@@ -71,7 +71,7 @@ const ReimbursementRequestTable = ({
                 <TableCell align="center">{datePipe(row.dateSubmitted)}</TableCell>
                 <TableCell align="center">{dateUndefinedPipe(row.dateSubmittedToSabo)}</TableCell>
                 <TableCell align="center">{row.vendor.name}</TableCell>
-                <TableCell align="center">{codeAndRefundSourceName(row.refundSource)}</TableCell>
+                {tabValue === 1 && <TableCell align="center">{codeAndRefundSourceName(row.refundSource)}</TableCell>}
                 <TableCell align="center">{cleanReimbursementRequestStatus(row.status)}</TableCell>
               </TableRow>
             ))}

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestsSection.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestsSection.tsx
@@ -47,6 +47,7 @@ const ReimbursementRequestTable = ({
               <ColumnHeader title="Date Submitted To Sabo" />
               <ColumnHeader title="Vendor" />
               <ColumnHeader title="Status" />
+              <ColumnHeader title="Refund Source" />
             </TableRow>
           </TableHead>
           <TableBody>
@@ -64,6 +65,7 @@ const ReimbursementRequestTable = ({
                 <TableCell align="center">{dateUndefinedPipe(row.dateSubmittedToSabo)}</TableCell>
                 <TableCell align="center">{row.vendor.name}</TableCell>
                 <TableCell align="center">{cleanReimbursementRequestStatus(row.status)}</TableCell>
+                <TableCell align="center">{row.refundSource}</TableCell>
               </TableRow>
             ))}
           </TableBody>

--- a/src/frontend/src/utils/reimbursement-request.utils.ts
+++ b/src/frontend/src/utils/reimbursement-request.utils.ts
@@ -1,5 +1,4 @@
 import {
-  ClubAccount,
   Project,
   Reimbursement,
   ReimbursementProduct,
@@ -67,17 +66,6 @@ export const cleanReimbursementRequestStatus = (status: ReimbursementStatusType)
     }
     case ReimbursementStatusType.DENIED: {
       return 'Denied';
-    }
-  }
-};
-
-export const cleanReimbursementRequestRefundSource = (refundSource: ClubAccount) => {
-  switch (refundSource) {
-    case ClubAccount.BUDGET: {
-      return 'Budget';
-    }
-    case ClubAccount.CASH: {
-      return 'Cash';
     }
   }
 };

--- a/src/frontend/src/utils/reimbursement-request.utils.ts
+++ b/src/frontend/src/utils/reimbursement-request.utils.ts
@@ -122,6 +122,7 @@ export const createReimbursementRequestRowData = (reimbursementRequest: Reimburs
     status: getCurrentReimbursementStatus(reimbursementRequest.reimbursementStatuses).type,
     dateSubmittedToSabo: getReimbursementRequestDateSubmittedToSabo(reimbursementRequest),
     submitter: reimbursementRequest.recipient,
-    vendor: reimbursementRequest.vendor
+    vendor: reimbursementRequest.vendor,
+    refundSource: reimbursementRequest.account
   };
 };

--- a/src/frontend/src/utils/reimbursement-request.utils.ts
+++ b/src/frontend/src/utils/reimbursement-request.utils.ts
@@ -1,4 +1,5 @@
 import {
+  ClubAccount,
   Project,
   Reimbursement,
   ReimbursementProduct,
@@ -66,6 +67,17 @@ export const cleanReimbursementRequestStatus = (status: ReimbursementStatusType)
     }
     case ReimbursementStatusType.DENIED: {
       return 'Denied';
+    }
+  }
+};
+
+export const cleanReimbursementRequestRefundSource = (refundSource: ClubAccount) => {
+  switch (refundSource) {
+    case ClubAccount.BUDGET: {
+      return 'Budget';
+    }
+    case ClubAccount.CASH: {
+      return 'Cash';
     }
   }
 };


### PR DESCRIPTION
## Changes

- added a new column to the request table labeled "Refund Source" that contains either cash or budget

## Notes

I couldn't figure out a way to change the reimbursement request to show "BUDGET". I can go back and figure that out, but for now I am assuming that since it is able to display "CASH" it would also be able to display "BUDGET".

## Test Cases

- Case A: Refund Source column displays "CASH" in browser window
- Case B: Refund source column displays "CASH" in smaller window

## Screenshots

![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/124754518/78cad591-6aa3-4d35-9b53-86b80c568e9f)
![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/124754518/1580d9bb-40cf-4923-b968-bb0d91e3d626)


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [X] All commits are tagged with the ticket number
- [X] No linting errors / newline at end of file warnings
- [X] All code follows repository-configured prettier formatting
- [X] No merge conflicts
- [X] All checks passing
- [X] Screenshots of UI changes (see Screenshots section)
- [X] Remove any non-applicable sections of this template
- [X] Assign the PR to yourself
- [X] No `yarn.lock` changes (unless dependencies have changed)
- [X] Request reviewers & ping on Slack
- [X] PR is linked to the ticket (fill in the closes line below)

Closes #2079
