### PR TITLE
#1486 - Remove 'any' type from LinksEditView.tsx

### DIFF
--- a/src/frontend/src/components/Link/LinksEditView.tsx
+++ b/src/frontend/src/components/Link/LinksEditView.tsx
@@ -13,7 +13,7 @@ const LinksEditView: React.FC<{
   ls: FieldArrayWithId[];
   register: UseFormRegister<ProjectFormInput>;
   watch: UseFormWatch<ProjectFormInput>;
-  append: UseFieldArrayAppend<any, any>;
+  append: UseFieldArrayAppend<ProjectFormInput, 'links'>;
   remove: UseFieldArrayRemove;
 }> = ({ ls, register, append, remove, watch }) => {
   const { isLoading, isError, error, data: linkTypes } = useAllLinkTypes();

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectForm/LinksEditView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectForm/LinksEditView.tsx
@@ -1,13 +1,13 @@
-import { useAllLinkTypes } from '../../hooks/projects.hooks';
-import LoadingIndicator from '../LoadingIndicator';
-import ErrorPage from '../../pages/ErrorPage';
+import { useAllLinkTypes } from '../../../hooks/projects.hooks';
+import LoadingIndicator from '../../../components/LoadingIndicator';
+import ErrorPage from '../../ErrorPage';
 import { IconButton, MenuItem, Select, TextField } from '@mui/material';
 import { FieldArrayWithId, UseFieldArrayAppend, UseFieldArrayRemove, UseFormRegister, UseFormWatch } from 'react-hook-form';
 import DeleteIcon from '@mui/icons-material/Delete';
-import { getRequiredLinkTypeNames } from '../../utils/link.utils';
-import { ProjectFormInput } from '../../pages/ProjectDetailPage/ProjectForm/ProjectForm';
+import { getRequiredLinkTypeNames } from '../../../utils/link.utils';
+import { ProjectFormInput } from './ProjectForm';
 import { Box } from '@mui/system';
-import { NERButton } from '../NERButton';
+import { NERButton } from '../../../components/NERButton';
 
 const LinksEditView: React.FC<{
   ls: FieldArrayWithId[];

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectForm/ProjectForm.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectForm/ProjectForm.tsx
@@ -12,7 +12,7 @@ import { Box, Stack, Typography } from '@mui/material';
 import ReactHookEditableList from '../../../components/ReactHookEditableList';
 import NERSuccessButton from '../../../components/NERSuccessButton';
 import NERFailButton from '../../../components/NERFailButton';
-import LinksEditView from '../../../components/Link/LinksEditView';
+import LinksEditView from './LinksEditView';
 import PageLayout from '../../../components/PageLayout';
 import ProjectFormDetails from './ProjectFormDetails';
 import { useAllUsers } from '../../../hooks/users.hooks';


### PR DESCRIPTION
## Changes

Replaced all occurrences of type 'any' with the appropriate interface and string.

## Checklist
- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1486 
