### PR TITLE
#2087 fixed phonenumber error throwing

### DIFF
--- a/src/backend/src/services/users.services.ts
+++ b/src/backend/src/services/users.services.ts
@@ -290,7 +290,7 @@ export default class UsersService {
     phoneNumber: string
   ): Promise<string> {
     const existingUser = await prisma.user_Secure_Settings.findFirst({
-      where: { phoneNumber }
+      where: { phoneNumber, userId: { not: user.userId } } // excludes current user from check
     });
 
     if (existingUser) {

--- a/src/backend/src/services/users.services.ts
+++ b/src/backend/src/services/users.services.ts
@@ -290,7 +290,7 @@ export default class UsersService {
     phoneNumber: string
   ): Promise<string> {
     const existingUser = await prisma.user_Secure_Settings.findFirst({
-      where: { phoneNumber, userId: { not: user.userId } } // excludes current user from check
+      where: { phoneNumber, userId: { not: user.userId } } // excludes the current user from check
     });
 
     if (existingUser) {

--- a/src/backend/tests/change-requests.test.ts
+++ b/src/backend/tests/change-requests.test.ts
@@ -349,6 +349,7 @@ describe('Change Requests', () => {
       expect(prisma.scope_CR.findUnique).toHaveBeenCalledTimes(1);
       expect(prisma.proposed_Solution.create).toHaveBeenCalledTimes(1);
     });
+  });
 
   describe('Delete Change Request', () => {
     test('User does not have permissions', async () => {

--- a/src/backend/tests/change-requests.test.ts
+++ b/src/backend/tests/change-requests.test.ts
@@ -350,11 +350,6 @@ describe('Change Requests', () => {
       expect(prisma.proposed_Solution.create).toHaveBeenCalledTimes(1);
     });
 
-    test('the associated scope cr does not exist'), async() => {
-      // finish later lol
-    }
-  });
-
   describe('Delete Change Request', () => {
     test('User does not have permissions', async () => {
       await expect(() => ChangeRequestsService.deleteChangeRequest(wonderwoman, 1)).rejects.toThrow(

--- a/src/backend/tests/change-requests.test.ts
+++ b/src/backend/tests/change-requests.test.ts
@@ -349,6 +349,10 @@ describe('Change Requests', () => {
       expect(prisma.scope_CR.findUnique).toHaveBeenCalledTimes(1);
       expect(prisma.proposed_Solution.create).toHaveBeenCalledTimes(1);
     });
+
+    test('the associated scope cr does not exist'), async() => {
+      // finish later lol
+    }
   });
 
   describe('Delete Change Request', () => {


### PR DESCRIPTION
## Changes
Ensures that when updating a user's secure settings, the method checks for the uniqueness of the phone number while excluding the current user from the duplicate check

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #2087
