### PR TITLE
#2011 delete design review endpoint

### DIFF
--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -11,6 +11,7 @@ import changeRequestsRouter from './src/routes/change-requests.routes';
 import descriptionBulletsRouter from './src/routes/description-bullets.routes';
 import tasksRouter from './src/routes/tasks.routes';
 import reimbursementRequestsRouter from './src/routes/reimbursement-requests.routes';
+import designReviewRouter from './src/routes/design-review.routes';
 
 const app = express();
 const port = process.env.PORT || 3001;
@@ -52,6 +53,7 @@ app.use('/change-requests', changeRequestsRouter);
 app.use('/description-bullets', descriptionBulletsRouter);
 app.use('/tasks', tasksRouter);
 app.use('/reimbursement-requests', reimbursementRequestsRouter);
+app.use('/design-reviews', designReviewRouter);
 app.use('/', (_req, res) => {
   res.json('Welcome to FinishLine');
 });

--- a/src/backend/src/controllers/design-review.controllers.ts
+++ b/src/backend/src/controllers/design-review.controllers.ts
@@ -1,1 +1,17 @@
-export default class DesignReviewController {}
+import { User } from '@prisma/client';
+import { Request, Response, NextFunction } from 'express';
+import { getCurrentUser } from '../utils/auth.utils';
+import DesignReviewService from '../services/design-review.services';
+
+export default class DesignReviewController {
+  static async deleteDesignReview(req: Request, res: Response, next: NextFunction) {
+    try {
+      const drId: string = req.params.designReviewId;
+      const user: User = await getCurrentUser(res);
+      await DesignReviewService.deleteDesignReview(user, drId);
+      return res.status(200);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+}

--- a/src/backend/src/routes/design-review.routes.ts
+++ b/src/backend/src/routes/design-review.routes.ts
@@ -1,5 +1,8 @@
 import express from 'express';
+import DesignReviewController from '../controllers/design-review.controllers';
 
 const designReviewRouter = express.Router();
+
+designReviewRouter.delete('/:drId/delete', DesignReviewController.deleteDesignReview);
 
 export default designReviewRouter;

--- a/src/backend/src/services/design-review.services.ts
+++ b/src/backend/src/services/design-review.services.ts
@@ -1,1 +1,30 @@
-export default class DesignReviewService {}
+import { isAdmin } from 'shared';
+import prisma from '../prisma/prisma';
+import { AccessDeniedAdminOnlyException, DeletedException, NotFoundException } from '../utils/errors.utils';
+import { User } from '@prisma/client';
+
+export default class DesignReviewService {
+  /**
+   * Deletes a design review
+   * @param submitter the user who deleted the design review
+   * @param designReviewId the id of the design review to be deleted
+   */
+
+  static async deleteDesignReview(submitter: User, designReviewId: string): Promise<void> {
+    const designReview = await prisma.design_Review.findUnique({
+      where: { designReviewId }
+    });
+
+    if (!designReview) throw new NotFoundException('Design Review', designReviewId);
+
+    if (!(isAdmin(submitter.role) || submitter.userId === designReview.userCreatedId))
+      throw new AccessDeniedAdminOnlyException('delete design reviews');
+
+    if (designReview.dateDeleted) throw new DeletedException('Design Review', designReviewId);
+
+    await prisma.design_Review.update({
+      where: { designReviewId },
+      data: { dateDeleted: new Date(), userDeleted: { connect: { userId: submitter.userId } } }
+    });
+  }
+}

--- a/src/backend/src/utils/errors.utils.ts
+++ b/src/backend/src/utils/errors.utils.ts
@@ -120,4 +120,5 @@ type ExceptionObjectNames =
   | 'Manufacturer'
   | 'Unit'
   | 'Material'
-  | 'Link Type';
+  | 'Link Type'
+  | 'Design Review';


### PR DESCRIPTION
## Changes

Added a backend endpoint for deleting design reviews
 on the route '/design-reviews/:drId/delete'
 Only admins or the creator of a design review should be able to delete it
 soft delete where I update the dateDeleted and userDeleted



## Test Cases

None yet

## Screenshots



_If you did any manual testing (e.g., with Postman), put screenshots of the http request and before and after of the db_



## To Do

_Any remaining things that need to get done_

- [ ] watch the postman tutorial
- [ ] add backend tests
- [ ] manual test with postman

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #2011 
