### PR TITLE
#1779 jake hensley change request review timeline warning showing up on deny

### DIFF
--- a/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequestView.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequestView.tsx
@@ -65,6 +65,8 @@ const ReviewChangeRequestsView: React.FC<ReviewChangeRequestViewProps> = ({
    * @param value true if review accepted, false if denied
    */
   const handleAcceptDeny = (value: boolean) => {
+    if (value === true) {
+    }
     getFieldState('accepted') ? setValue('accepted', value) : register('accepted', { value });
     if (selected !== -1) {
       setValue('psId', (cr as StandardChangeRequest).proposedSolutions[selected].id);
@@ -86,7 +88,12 @@ const ReviewChangeRequestsView: React.FC<ReviewChangeRequestViewProps> = ({
     }
     const standardChangeRequest = cr as StandardChangeRequest;
     const selectedProposedSolution = standardChangeRequest.proposedSolutions.find((ps) => ps.id === data.psId)!;
-    if (selectedProposedSolution.timelineImpact > 0 && blockingWorkPackages && blockingWorkPackages.length > 0) {
+    if (
+      data.accepted &&
+      selectedProposedSolution.timelineImpact > 0 &&
+      blockingWorkPackages &&
+      blockingWorkPackages.length > 0
+    ) {
       setSelectedTimelineImpact(selectedProposedSolution.timelineImpact);
       setShowWarning(true);
     } else {

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequestView.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequestView.tsx
@@ -65,8 +65,6 @@ const ReviewChangeRequestsView: React.FC<ReviewChangeRequestViewProps> = ({
    * @param value true if review accepted, false if denied
    */
   const handleAcceptDeny = (value: boolean) => {
-    if (value === true) {
-    }
     getFieldState('accepted') ? setValue('accepted', value) : register('accepted', { value });
     if (selected !== -1) {
       setValue('psId', (cr as StandardChangeRequest).proposedSolutions[selected].id);


### PR DESCRIPTION
## Changes

Changed the change request timeline warning from appearing when the request is denied by a reviewer.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1779
