### PR TITLE
remove any from teams.hooks.ts

### DIFF
--- a/src/frontend/src/hooks/teams.hooks.ts
+++ b/src/frontend/src/hooks/teams.hooks.ts
@@ -38,7 +38,7 @@ export const useSingleTeam = (teamId: string) => {
 
 export const useSetTeamMembers = (teamId: string) => {
   const queryClient = useQueryClient();
-  return useMutation<{ message: string }, Error, any>(
+  return useMutation<{ message: string }, Error, number[]>(
     ['teams', 'edit'],
     async (userIds: number[]) => {
       const { data } = await setTeamMembers(teamId, userIds);
@@ -70,7 +70,7 @@ export const useSetTeamHead = (teamId: string) => {
 
 export const useEditTeamDescription = (teamId: string) => {
   const queryClient = useQueryClient();
-  return useMutation<{ message: string }, Error, any>(
+  return useMutation<{ message: string }, Error, string>(
     ['teams', 'edit'],
     async (description: string) => {
       const { data } = await setTeamDescription(teamId, description);
@@ -86,7 +86,7 @@ export const useEditTeamDescription = (teamId: string) => {
 
 export const useDeleteTeam = () => {
   const queryClient = useQueryClient();
-  return useMutation<{ message: string }, Error, any>(
+  return useMutation<{ message: string }, Error, string>(
     ['teams', 'delete'],
     async (teamId: string) => {
       const { data } = await deleteTeam(teamId);
@@ -118,7 +118,7 @@ export const useCreateTeam = () => {
 
 export const useSetTeamLeads = (teamId: string) => {
   const queryClient = useQueryClient();
-  return useMutation<Team, Error, any>(
+  return useMutation<Team, Error, number[]>(
     ['teams', 'edit'],
     async (userIds: number[]) => {
       const { data } = await setTeamLeads(teamId, userIds);


### PR DESCRIPTION
## Changes

Remove the type "any" from the teams.hooks.ts file. The types were either changed to "number[]" or "string."

## Notes

## Test Cases

## Screenshots

## To Do

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1491
