### PR TITLE
#1876: Add Material Type Modal Shouldn't Say 'Manufacturer Name'

### DIFF
--- a/src/frontend/src/pages/AdminToolsPage/BOMConfig/CreateManufacturerFormModal.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/BOMConfig/CreateManufacturerFormModal.tsx
@@ -10,7 +10,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { useCreateManufacturer } from '../../../hooks/bom.hooks';
 
 const schema = yup.object().shape({
-  name: yup.string().required('Vendor Name is Required')
+  name: yup.string().required('Manufacturer Name is Required')
 });
 
 interface CreateManufacturerProps {

--- a/src/frontend/src/pages/AdminToolsPage/BOMConfig/CreateMaterialTypeFormModal.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/BOMConfig/CreateMaterialTypeFormModal.tsx
@@ -10,7 +10,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { useCreateMaterialType } from '../../../hooks/bom.hooks';
 
 const schema = yup.object().shape({
-  name: yup.string().required('Vendor Name is Required')
+  name: yup.string().required('Material Type is Required')
 });
 
 interface CreateMaterialTypeModalProps {
@@ -56,11 +56,11 @@ const CreateMaterialTypeModal: React.FC<CreateMaterialTypeModalProps> = ({ showM
       reset={() => reset({ name: '' })}
       handleUseFormSubmit={handleSubmit}
       onFormSubmit={onSubmit}
-      formId="new-manufacturer-form"
+      formId="new-material-type-form"
       showCloseButton
     >
       <FormControl>
-        <FormLabel>Manufacturer Name</FormLabel>
+        <FormLabel>Material Type</FormLabel>
         <ReactHookTextField name="name" control={control} sx={{ width: 1 }} />
         <FormHelperText error>{errors.name?.message}</FormHelperText>
       </FormControl>


### PR DESCRIPTION
## Changes

changed 'vendor' to 'manufacturer' in manufacturer modal and changed 'manufacturer' to 'material type' in material type modal"

## Screenshots

<img width="1440" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/147440322/05fd8936-4a60-4470-81cc-f1432444886d">

<img width="1440" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/147440322/7c8c43cc-fc97-49c7-8b01-1f61d54631ab">


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1876
