### PR TITLE
#2119-BOM-price-label-change

### DIFF
--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/BOMTableWrapper.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/BOMTableWrapper.tsx
@@ -16,7 +16,6 @@ import { bomBaseColDef } from '../../../../utils/bom.utils';
 import NERModal from '../../../../components/NERModal';
 import { renderLinkBOM, renderStatusBOM } from './BOMTableCustomCells';
 
-
 interface BOMTableWrapperProps {
   project: Project;
 }
@@ -130,8 +129,6 @@ const BOMTableWrapper: React.FC<BOMTableWrapperProps> = ({ project }) => {
     }
     return actions;
   };
-  
-  
 
   const columns: GridColumns<any> = [
     {
@@ -205,7 +202,7 @@ const BOMTableWrapper: React.FC<BOMTableWrapperProps> = ({ project }) => {
     {
       ...bomBaseColDef,
       field: 'price',
-      headerName: 'Price per Unit', 
+      headerName: 'Price per Unit',
       type: 'number',
       sortable: false,
       filterable: false

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/BOMTableWrapper.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/BOMTableWrapper.tsx
@@ -16,6 +16,7 @@ import { bomBaseColDef } from '../../../../utils/bom.utils';
 import NERModal from '../../../../components/NERModal';
 import { renderLinkBOM, renderStatusBOM } from './BOMTableCustomCells';
 
+
 interface BOMTableWrapperProps {
   project: Project;
 }
@@ -129,6 +130,8 @@ const BOMTableWrapper: React.FC<BOMTableWrapperProps> = ({ project }) => {
     }
     return actions;
   };
+  
+  
 
   const columns: GridColumns<any> = [
     {
@@ -202,7 +205,7 @@ const BOMTableWrapper: React.FC<BOMTableWrapperProps> = ({ project }) => {
     {
       ...bomBaseColDef,
       field: 'price',
-      headerName: 'Price per Unit',
+      headerName: 'Price per Unit', 
       type: 'number',
       sortable: false,
       filterable: false

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/BOMTableWrapper.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/BOMTableWrapper.tsx
@@ -202,7 +202,7 @@ const BOMTableWrapper: React.FC<BOMTableWrapperProps> = ({ project }) => {
     {
       ...bomBaseColDef,
       field: 'price',
-      headerName: 'Price',
+      headerName: 'Price per Unit',
       type: 'number',
       sortable: false,
       filterable: false

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialForm.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialForm.tsx
@@ -21,7 +21,7 @@ const schema = yup.object().shape({
   manufacturerName: yup.string().required('Select a Manufacturer'),
   manufacturerPartNumber: yup.string().required('Manufacturer Part Number is required!'),
   quantity: yup.number().required('Enter a quantity!'),
-  price: yup.number().required('Price is required!'),
+  price: yup.number().required('Price per Unit is required!'),
   unitName: yup.string().optional(),
   linkUrl: yup.string().required('URL is required!').url('Invalid URL'),
   notes: yup.string().optional()

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
@@ -230,7 +230,9 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
         </Grid>
         <Grid item xs={3}>
           <FormControl fullWidth>
-            <FormLabel>Price per Unit</FormLabel>
+            <div style={{ whiteSpace: 'normal' }}>
+              <FormLabel>Price per Unit</FormLabel>
+            </div>
             <Controller
               name={`price`}
               control={control}

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
@@ -230,9 +230,7 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
         </Grid>
         <Grid item xs={3}>
           <FormControl fullWidth>
-            <div style={{ whiteSpace: 'normal' }}>
-              <FormLabel>Price per Unit</FormLabel>
-            </div>
+            <FormLabel style={{ whiteSpace: 'normal' }}>Price per Unit</FormLabel>
             <Controller
               name={`price`}
               control={control}

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
@@ -230,7 +230,7 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
         </Grid>
         <Grid item xs={3}>
           <FormControl fullWidth>
-            <FormLabel>Price</FormLabel>
+            <FormLabel>Price per Unit</FormLabel>
             <Controller
               name={`price`}
               control={control}

--- a/src/frontend/src/utils/bom.utils.ts
+++ b/src/frontend/src/utils/bom.utils.ts
@@ -3,6 +3,7 @@ import { GridColDefStyle } from './tables';
 import { centsToDollar } from './pipes';
 import { DataGrid, GridValidRowModel } from '@mui/x-data-grid';
 import { styled } from '@mui/system';
+import { wrap } from 'module';
 
 export interface BomRow extends GridValidRowModel {
   id: string;
@@ -49,7 +50,7 @@ export const bomTableStyles = {
       display: 'none'
     },
     '.MuiDataGrid-cell': {
-      borderBottom: 'none'
+      borderBottom: 'none' 
     },
     '&.MuiDataGrid-root': {
       border: 'none'
@@ -62,6 +63,10 @@ export const bomTableStyles = {
     },
     '.MuiDataGrid-columnHeader:focus-within': {
       outline: 'none'
+    }, 
+    '& .MuiDataGrid-columnHeaderTitle': {
+      whiteSpace: "normal",
+      lineHeight: "normal"
     }
   }
 };
@@ -100,6 +105,7 @@ export const BOM_TABLE_ROW_COUNT = 'tl-table-row-count';
 
 export const bomBaseColDef: GridColDefStyle = {
   flex: 1,
+  whitespace: 'wrap',
   align: 'center',
   headerAlign: 'center',
   headerClassName: 'super-app-theme--header'

--- a/src/frontend/src/utils/bom.utils.ts
+++ b/src/frontend/src/utils/bom.utils.ts
@@ -3,7 +3,6 @@ import { GridColDefStyle } from './tables';
 import { centsToDollar } from './pipes';
 import { DataGrid, GridValidRowModel } from '@mui/x-data-grid';
 import { styled } from '@mui/system';
-import { wrap } from 'module';
 
 export interface BomRow extends GridValidRowModel {
   id: string;
@@ -105,7 +104,6 @@ export const BOM_TABLE_ROW_COUNT = 'tl-table-row-count';
 
 export const bomBaseColDef: GridColDefStyle = {
   flex: 1,
-  whitespace: 'wrap',
   align: 'center',
   headerAlign: 'center',
   headerClassName: 'super-app-theme--header'

--- a/src/frontend/src/utils/bom.utils.ts
+++ b/src/frontend/src/utils/bom.utils.ts
@@ -49,7 +49,7 @@ export const bomTableStyles = {
       display: 'none'
     },
     '.MuiDataGrid-cell': {
-      borderBottom: 'none' 
+      borderBottom: 'none'
     },
     '&.MuiDataGrid-root': {
       border: 'none'
@@ -62,10 +62,10 @@ export const bomTableStyles = {
     },
     '.MuiDataGrid-columnHeader:focus-within': {
       outline: 'none'
-    }, 
+    },
     '& .MuiDataGrid-columnHeaderTitle': {
-      whiteSpace: "normal",
-      lineHeight: "normal"
+      whiteSpace: 'normal',
+      lineHeight: 'normal'
     }
   }
 };


### PR DESCRIPTION
## Changes
All instances with the label 'Price' are renamed to 'Price per Unit' in the frontend 

## Test Cases
- ran yarn test:frontend

## Screenshots
1) normal sized window 
<img width="1512" alt="Screenshot 2024-02-21 at 10 37 05 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/147781368/e2f352ed-f220-4ddc-aa05-d58b43364517">


2) smallest window 
<img width="503" alt="Screenshot 2024-02-21 at 10 36 47 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/147781368/966e85ed-c52a-4526-83f7-5235aa0d11e2">

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #2119
