### PR TITLE
#2081 Receipt Upload not Required in RR form locally

### DIFF
--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementRequestForm.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementRequestForm.tsx
@@ -24,8 +24,6 @@ import { useHistory } from 'react-router-dom';
 import { routes } from '../../../utils/routes';
 import { useCurrentUserSecureSettings } from '../../../hooks/users.hooks';
 
-const RECEIPT_REQUIRED = import.meta.env.VITE_RR_RECEIPT_REQUIREMENT || 'disabled';
-
 export interface ReimbursementRequestInformation {
   vendorId: string;
   dateOfExpense: Date;
@@ -50,6 +48,8 @@ interface ReimbursementRequestFormProps {
   previousPage: string;
 }
 
+const RECEIPT_REQUIRED = import.meta.env.VITE_RR_RECEIPT_REQUIREMENT || 'disabled';
+
 const schema = yup.object().shape({
   vendorId: yup.string().required('Vendor is required'),
   account: yup.string().required('Account is required'),
@@ -70,7 +70,7 @@ const schema = yup.object().shape({
     .required('reimbursement products required')
     .min(1, 'At least one Reimbursement Product is required'),
   receiptFiles:
-    // The requirement for receipt uploads is disabled by default on development to make testing easier;
+    // The requirements for receipt uploads is disabled by default on development to make testing easier;
     // if testing proper receipt uploads is needed, create an environment variable called VITE_RR_RECEIPT_REQUIREMENT
     // in src/frontend/.env and set it to 'enabled'.
     import.meta.env.MODE === 'development' && RECEIPT_REQUIRED !== 'enabled'

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementRequestForm.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementRequestForm.tsx
@@ -67,11 +67,14 @@ const schema = yup.object().shape({
     )
     .required('reimbursement products required')
     .min(1, 'At least one Reimbursement Product is required'),
-  receiptFiles: yup
-    .array()
-    .required('receipt files required')
-    .min(1, 'At least one Receipt is required')
-    .max(7, 'At most 7 Receipts are allowed')
+  receiptFiles:
+    import.meta.env.MODE === 'development'
+      ? yup.array()
+      : yup
+          .array()
+          .required('receipt files required')
+          .min(1, 'At least one Receipt is required')
+          .max(7, 'At most 7 Receipts are allowed')
 });
 
 const ReimbursementRequestForm: React.FC<ReimbursementRequestFormProps> = ({

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementRequestForm.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementRequestForm.tsx
@@ -24,6 +24,8 @@ import { useHistory } from 'react-router-dom';
 import { routes } from '../../../utils/routes';
 import { useCurrentUserSecureSettings } from '../../../hooks/users.hooks';
 
+const RECEIPT_REQUIRED = import.meta.env.VITE_RR_RECEIPT_REQUIREMENT || 'disabled';
+
 export interface ReimbursementRequestInformation {
   vendorId: string;
   dateOfExpense: Date;
@@ -68,7 +70,10 @@ const schema = yup.object().shape({
     .required('reimbursement products required')
     .min(1, 'At least one Reimbursement Product is required'),
   receiptFiles:
-    import.meta.env.MODE === 'development'
+    // The requirement for receipt uploads is disabled by default on development to make testing easier;
+    // if testing proper receipt uploads is needed, create an environment variable called VITE_RR_RECEIPT_REQUIREMENT
+    // in src/frontend/.env and set it to 'enabled'.
+    import.meta.env.MODE === 'development' && RECEIPT_REQUIRED !== 'enabled'
       ? yup.array()
       : yup
           .array()

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementRequestForm.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementRequestForm.tsx
@@ -48,7 +48,7 @@ interface ReimbursementRequestFormProps {
   previousPage: string;
 }
 
-const RECEIPT_REQUIRED = import.meta.env.VITE_RR_RECEIPT_REQUIREMENT || 'disabled';
+const RECEIPTS_REQUIRED = import.meta.env.VITE_RR_RECEIPT_REQUIREMENT || 'disabled';
 
 const schema = yup.object().shape({
   vendorId: yup.string().required('Vendor is required'),
@@ -73,7 +73,7 @@ const schema = yup.object().shape({
     // The requirements for receipt uploads is disabled by default on development to make testing easier;
     // if testing proper receipt uploads is needed, create an environment variable called VITE_RR_RECEIPT_REQUIREMENT
     // in src/frontend/.env and set it to 'enabled'.
-    import.meta.env.MODE === 'development' && RECEIPT_REQUIRED !== 'enabled'
+    import.meta.env.MODE === 'development' && RECEIPTS_REQUIRED !== 'enabled'
       ? yup.array()
       : yup
           .array()


### PR DESCRIPTION
## Changes
Changed the receiptFiles part of the yup schema to check if in dev or not and to not have it required if in dev.
Added checking for a frontend environment variable to reenable the requirement for receiptFiles.

## Test Cases

- Manually tested creating a RR with no receipt upload
- Manually tested editing a RR and deleting all receipts and saving 
- Manually tested added env var (set as "enabled") and creating a RR with no receipt upload

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #2081
