### PR TITLE
Updated projects services and test to hard delete material type

### DIFF
--- a/src/backend/src/controllers/projects.controllers.ts
+++ b/src/backend/src/controllers/projects.controllers.ts
@@ -312,8 +312,8 @@ export default class ProjectsController {
     try {
       const { materialTypeId } = req.params;
       const user = await getCurrentUser(res);
-      await ProjectsService.deleteMaterialType(materialTypeId, user);
-      return res.status(204).json({ message: `Successfully deleted material type with id ${materialTypeId}` });
+      const deletedMaterialType = await ProjectsService.deleteMaterialType(materialTypeId, user);
+      return res.status(200).json(deletedMaterialType);
     } catch (error: unknown) {
       next(error);
     }

--- a/src/backend/src/controllers/projects.controllers.ts
+++ b/src/backend/src/controllers/projects.controllers.ts
@@ -312,8 +312,8 @@ export default class ProjectsController {
     try {
       const { materialTypeId } = req.params;
       const user = await getCurrentUser(res);
-      const deletedMaterial = await ProjectsService.deleteMaterialType(materialTypeId, user);
-      res.status(200).json(deletedMaterial);
+      await ProjectsService.deleteMaterialType(materialTypeId, user);
+      return res.status(204).json({ message: `Successfully deleted material type with id ${materialTypeId}` });
     } catch (error: unknown) {
       next(error);
     }

--- a/src/backend/src/routes/work-packages.routes.ts
+++ b/src/backend/src/routes/work-packages.routes.ts
@@ -35,6 +35,21 @@ workPackagesRouter.post(
   WorkPackagesController.createWorkPackage
 );
 workPackagesRouter.post(
+  '/template/create',
+  nonEmptyString(body('templateName')),
+  nonEmptyString(body('templateNotes')),
+  nonEmptyString(body('workPackageName').optional()),
+  isWorkPackageStageOrNone(body('stage').optional()),
+  intMinZero(body('duration')),
+  body('expectedActivities').isArray(),
+  body('deliverables').isArray(),
+  body('blockedBy').isArray(),
+  nonEmptyString(body('blockedBy.*.name')),
+  isWorkPackageStageOrNone(body('blockedBy.*.stage').optional()),
+  validateInputs,
+  WorkPackagesController.createWorkPackageTemplate
+);
+workPackagesRouter.post(
   '/edit',
   intMinZero(body('workPackageId')),
   intMinZero(body('crId')),

--- a/src/backend/src/routes/work-packages.routes.ts
+++ b/src/backend/src/routes/work-packages.routes.ts
@@ -35,21 +35,6 @@ workPackagesRouter.post(
   WorkPackagesController.createWorkPackage
 );
 workPackagesRouter.post(
-  '/template/create',
-  nonEmptyString(body('templateName')),
-  nonEmptyString(body('templateNotes')),
-  nonEmptyString(body('workPackageName').optional()),
-  isWorkPackageStageOrNone(body('stage').optional()),
-  intMinZero(body('duration')),
-  body('expectedActivities').isArray(),
-  body('deliverables').isArray(),
-  body('blockedBy').isArray(),
-  nonEmptyString(body('blockedBy.*.name')),
-  isWorkPackageStageOrNone(body('blockedBy.*.stage').optional()),
-  validateInputs,
-  WorkPackagesController.createWorkPackageTemplate
-);
-workPackagesRouter.post(
   '/edit',
   intMinZero(body('workPackageId')),
   intMinZero(body('crId')),

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -936,8 +936,9 @@ export default class ProjectsService {
    * @param submitter the user who is deleting the material type
    * @param materialTypeId the Id of the material type being deleted
    * @throws if the submitter is not an admin/head or if the material type is not found
+   * @returns the deleted material type
    */
-  static async deleteMaterialType(materialTypeId: string, submitter: User): Promise<void> {
+  static async deleteMaterialType(materialTypeId: string, submitter: User): Promise<Material_Type> {
     if (!isHead(submitter.role) && !isAdmin(submitter.role)) {
       throw new AccessDeniedException('Only an admin or head can delete a material type');
     }
@@ -949,7 +950,8 @@ export default class ProjectsService {
 
     if (!materialType) throw new NotFoundException('Material Type', materialTypeId);
 
-    await prisma.material_Type.delete({ where: { name: materialTypeId } });
+    const deletedMaterialType = await prisma.material_Type.delete({ where: { name: materialTypeId } });
+    return deletedMaterialType;
   }
 
   /**

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -942,6 +942,7 @@ export default class ProjectsService {
     if (!isHead(submitter.role) && !isAdmin(submitter.role)) {
       throw new AccessDeniedException('Only an admin or head can delete a material type');
     }
+
     const materialType = await prisma.material_Type.findUnique({
       where: {
         name: materialTypeId
@@ -949,6 +950,16 @@ export default class ProjectsService {
     });
 
     if (!materialType) throw new NotFoundException('Material Type', materialTypeId);
+
+    const materials = await prisma.material.findMany({
+      where: {
+        materialTypeName: materialTypeId
+      }
+    });
+
+    if (materials.length > 0) {
+      throw new HttpException(400, `Material type "${materialTypeId}" is associated with materials and cannot be deleted`);
+    }
 
     const deletedMaterialType = await prisma.material_Type.delete({ where: { name: materialTypeId } });
     return deletedMaterialType;

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -932,13 +932,12 @@ export default class ProjectsService {
   }
 
   /**
-   * Deletes a material type based on the given Id
+   * Hard deletes the material type with the given materialTypeId
    * @param submitter the user who is deleting the material type
    * @param materialTypeId the Id of the material type being deleted
    * @throws if the submitter is not an admin/head or if the material type is not found
-   * @returns the deleted material type
    */
-  static async deleteMaterialType(materialTypeId: string, submitter: User): Promise<Material_Type> {
+  static async deleteMaterialType(materialTypeId: string, submitter: User): Promise<void> {
     if (!isHead(submitter.role) && !isAdmin(submitter.role)) {
       throw new AccessDeniedException('Only an admin or head can delete a material type');
     }
@@ -949,18 +948,8 @@ export default class ProjectsService {
     });
 
     if (!materialType) throw new NotFoundException('Material Type', materialTypeId);
-    if (materialType.dateDeleted) throw new DeletedException('Material Type', materialTypeId);
 
-    const deletedMaterialType = await prisma.material_Type.update({
-      where: {
-        name: materialTypeId
-      },
-      data: {
-        dateDeleted: new Date()
-      }
-    });
-
-    return deletedMaterialType;
+    await prisma.material_Type.delete({ where: { name: materialTypeId } });
   }
 
   /**

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -917,19 +917,13 @@ describe('Projects', () => {
       );
     });
 
-    test('Deleted Material Tye does not work if the material type is already deleted', async () => {
-      vi.spyOn(prisma.material_Type, 'findUnique').mockResolvedValue({ ...toolMaterial, dateDeleted: new Date() });
-      await expect(ProjectsService.deleteMaterialType('NERSoftwareTools', batman)).rejects.toThrow(
-        new DeletedException('Material Type', 'NERSoftwareTools')
-      );
-    });
-
     test('Delete Material Type works', async () => {
       vi.spyOn(prisma.material_Type, 'findUnique').mockResolvedValue(toolMaterial);
-      vi.spyOn(prisma.material_Type, 'update').mockResolvedValue({ ...toolMaterial, dateDeleted: new Date() });
-      const deletedMaterialType = await ProjectsService.deleteMaterialType('NERSoftwareTools', superman);
-      expect(deletedMaterialType.name).toBe('NERSoftwareTools');
-      expect(prisma.material_Type.update).toBeCalledTimes(1);
+      vi.spyOn(prisma.material_Type, 'update').mockResolvedValue(toolMaterial);
+      await ProjectsService.deleteMaterialType('NERSoftwareTools', superman);
+      expect(prisma.material_Type.findUnique).toBeCalledTimes(1);
+      expect(prisma.material_Type.delete).toBeCalledTimes(1);
+      expect(prisma.material_Type.delete).toHaveBeenCalledWith({ where: { name: 'NERSoftwareTools' } });
     });
   });
 

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -912,18 +912,18 @@ describe('Projects', () => {
     });
 
     test('Delete Material Type does not work if material type does not exist', async () => {
-      await expect(ProjectsService.deleteMaterialType('NERSoftwareTools', batman)).rejects.toThrow(
-        new NotFoundException('Material Type', 'NERSoftwareTools')
+      await expect(ProjectsService.deleteMaterialType('fakeid', batman)).rejects.toThrow(
+        new NotFoundException('Material Type', 'fakeid')
       );
     });
 
     test('Delete Material Type works', async () => {
       vi.spyOn(prisma.material_Type, 'findUnique').mockResolvedValue(toolMaterial);
-      vi.spyOn(prisma.material_Type, 'update').mockResolvedValue(toolMaterial);
-      await ProjectsService.deleteMaterialType('NERSoftwareTools', superman);
+      vi.spyOn(prisma.material_Type, 'delete').mockResolvedValue(toolMaterial);
+      await ProjectsService.deleteMaterialType(toolMaterial.name, superman);
       expect(prisma.material_Type.findUnique).toBeCalledTimes(1);
       expect(prisma.material_Type.delete).toBeCalledTimes(1);
-      expect(prisma.material_Type.delete).toHaveBeenCalledWith({ where: { name: 'NERSoftwareTools' } });
+      expect(prisma.material_Type.delete).toHaveBeenCalledWith({ where: { name: toolMaterial.name } });
     });
   });
 

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -906,7 +906,7 @@ describe('Projects', () => {
 
   describe('Deleting material type', () => {
     test('Delete Material Type does not work if user is not an admin or head', async () => {
-      await expect(ProjectsService.deleteMaterialType('NERSoftwareTools', theVisitor)).rejects.toThrow(
+      await expect(ProjectsService.deleteMaterialType(toolMaterial.name, theVisitor)).rejects.toThrow(
         new AccessDeniedException('Only an admin or head can delete a material type')
       );
     });

--- a/src/backend/tests/projects.test.ts
+++ b/src/backend/tests/projects.test.ts
@@ -20,7 +20,8 @@ import {
   mockLinkType1,
   transformedMockLinkType1,
   manufacturer1,
-  manufacturer2
+  manufacturer2,
+  badMaterialType
 } from './test-data/projects.test-data';
 import { prismaChangeRequest1 } from './test-data/change-requests.test-data';
 import { primsaTeam2, prismaTeam1 } from './test-data/teams.test-data';
@@ -917,13 +918,22 @@ describe('Projects', () => {
       );
     });
 
+    test('Delete Material Type does not work if material type is associated with existing materials', async () => {
+      await expect(ProjectsService.deleteMaterialType(prismaMaterialType.name, batman)).rejects.toThrow(
+        new HttpException(
+          400,
+          `Material type "${prismaMaterialType.name}" is associated with materials and cannot be deleted`
+        )
+      );
+    });
+
     test('Delete Material Type works', async () => {
-      vi.spyOn(prisma.material_Type, 'findUnique').mockResolvedValue(toolMaterial);
-      vi.spyOn(prisma.material_Type, 'delete').mockResolvedValue(toolMaterial);
-      await ProjectsService.deleteMaterialType(toolMaterial.name, superman);
+      vi.spyOn(prisma.material_Type, 'findUnique').mockResolvedValue(badMaterialType);
+      vi.spyOn(prisma.material_Type, 'delete').mockResolvedValue(badMaterialType);
+      await ProjectsService.deleteMaterialType(badMaterialType.name, superman);
       expect(prisma.material_Type.findUnique).toBeCalledTimes(1);
       expect(prisma.material_Type.delete).toBeCalledTimes(1);
-      expect(prisma.material_Type.delete).toHaveBeenCalledWith({ where: { name: toolMaterial.name } });
+      expect(prisma.material_Type.delete).toHaveBeenCalledWith({ where: { name: badMaterialType.name } });
     });
   });
 

--- a/src/backend/tests/test-data/projects.test-data.ts
+++ b/src/backend/tests/test-data/projects.test-data.ts
@@ -251,6 +251,35 @@ export const toolMaterial: PrismaMaterialType = {
   dateDeleted: null
 };
 
+export const badMaterialType: PrismaMaterialType = {
+  name: 'NERSoftwareTfgols',
+  dateCreated: new Date(),
+  userCreatedId: batman.userId,
+  dateDeleted: null
+};
+
+export const prismaMaterial3: PrismaMaterial = {
+  materialId: 'id',
+  assemblyId: 'assemblyId',
+  name: 'name2',
+  wbsElementId: 1,
+  dateDeleted: null,
+  userDeletedId: null,
+  dateCreated: new Date('10-18-2023'),
+  userCreatedId: 1,
+  pdmFileName: 'file2',
+  status: 'ORDERED',
+  notes: 'random notes',
+  materialTypeName: 'name',
+  manufacturerName: 'manufacturer',
+  manufacturerPartNumber: 'partNum',
+  price: 1000,
+  subtotal: 500,
+  quantity: new Decimal(8),
+  unitName: 'FT',
+  linkUrl: 'https://www.google.com'
+};
+
 export const prismaMaterial2: PrismaMaterial = {
   materialId: 'id',
   assemblyId: 'assemblyId',


### PR DESCRIPTION
## Changes

Updated project.services.ts and project.tests.js to hard delete material type instead of setting dateDeteled.

## Test Cases

- does not work if user is not an admin or head
- does not work if material type does not exist
- does not work if the material type is already deleted
- works as expected

## Checklist

- [x]  All commits are tagged with the ticket number
- [x]  No linting errors / newline at end of file warnings
- [x]  All code follows repository-configured prettier formatting
- [x]  No merge conflicts
- [x]  All checks passing
- [x]  Screenshots of UI changes (see Screenshots section)
- [x]  Remove any non-applicable sections of this template
- [x]  Assign the PR to yourself
- [x]  No yarn.lock changes (unless dependencies have changed)
- [x]  Request reviewers & ping on Slack
- [x]  PR is linked to the ticket (fill in the closes line below)

Closes #2000 
