### PR TITLE
#2113: set defaultValue for requestReviewDropdown to already request…

### DIFF
--- a/src/frontend/src/pages/ChangeRequestDetailPage/ChangeRequestActionMenu.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ChangeRequestActionMenu.tsx
@@ -41,18 +41,18 @@ const ChangeRequestActionMenu: React.FC<ChangeRequestActionMenuProps> = ({
   const toast = useToast();
   const currentUser = useCurrentUser();
   const history = useHistory();
-  const [reviewerIds, setReviewerIds] = useState<number[]>([]);
+  const [reviewers, setReviewers] = useState(changeRequest.requestedReviewers.map(taskUserToAutocompleteOption));
   const { data: users, isLoading: isLoadingAllUsers, isError: isErrorAllUsers, error: errorAllUsers } = useAllUsers();
 
   if (isErrorAllUsers) return <ErrorPage message={errorAllUsers?.message} />;
   if (isLoadingAllUsers || !users) return <LoadingIndicator />;
 
   const handleRequestReviewerClick = async () => {
-    if (reviewerIds.length === 0) {
+    if (reviewers.length === 0) {
       toast.error('Must select at least one reviewer to request review from');
     } else {
       try {
-        await requestCRReview({ userIds: reviewerIds });
+        await requestCRReview({ userIds: reviewers.map((user) => user.id) });
         toast.success('Review Successfully Requested!');
       } catch (e) {
         if (e instanceof Error) {
@@ -95,8 +95,8 @@ const ChangeRequestActionMenu: React.FC<ChangeRequestActionMenuProps> = ({
         multiple
         options={users.filter((user) => isLeadership(user.role)).map(taskUserToAutocompleteOption)}
         getOptionLabel={(option) => option.label}
-        onChange={(_, values) => setReviewerIds(values.map((value) => value.id))}
-        defaultValue={changeRequest.requestedReviewers.map(taskUserToAutocompleteOption)}
+        onChange={(_, values) => setReviewers(values)}
+        defaultValue={reviewers}
         renderTags={() => null}
         renderOption={(props, option, { selected }) => (
           <li {...props}>

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ChangeRequestActionMenu.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ChangeRequestActionMenu.tsx
@@ -110,11 +110,7 @@ const ChangeRequestActionMenu: React.FC<ChangeRequestActionMenuProps> = ({
           </li>
         )}
         renderInput={(params) => (
-          <TextField
-            {...params}
-            variant="standard"
-            placeholder={`${changeRequest.requestedReviewers.length} Reviewers Selected`}
-          />
+          <TextField {...params} variant="standard" placeholder={`${reviewers.length} Reviewers Selected`} />
         )}
       />
 

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ChangeRequestActionMenu.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ChangeRequestActionMenu.tsx
@@ -86,7 +86,6 @@ const ChangeRequestActionMenu: React.FC<ChangeRequestActionMenuProps> = ({
       />
     </div>
   );
-
   const requestReviewerDropdown = () => (
     <>
       <Autocomplete
@@ -97,6 +96,7 @@ const ChangeRequestActionMenu: React.FC<ChangeRequestActionMenuProps> = ({
         options={users.filter((user) => isLeadership(user.role)).map(taskUserToAutocompleteOption)}
         getOptionLabel={(option) => option.label}
         onChange={(_, values) => setReviewerIds(values.map((value) => value.id))}
+        defaultValue={changeRequest.requestedReviewers.map(taskUserToAutocompleteOption)}
         renderTags={() => null}
         renderOption={(props, option, { selected }) => (
           <li {...props}>
@@ -110,7 +110,11 @@ const ChangeRequestActionMenu: React.FC<ChangeRequestActionMenuProps> = ({
           </li>
         )}
         renderInput={(params) => (
-          <TextField {...params} variant="standard" placeholder={`${reviewerIds.length} Reviewers Selected`} />
+          <TextField
+            {...params}
+            variant="standard"
+            placeholder={`${changeRequest.requestedReviewers.length} Reviewers Selected`}
+          />
         )}
       />
 


### PR DESCRIPTION

## Changes

- Set defaultValue for requestReviewDropdown to already requested reviewers, such that they are pre-selected. 
- Changed the '# (number of) Reviewers Selected' preview to display the correct amount of reviewers selected. 


## Notes

Note, when users are selecting additional reviewers, the # in the preview will not change until after there is a successful call to 'request review'. i.e. no live update of # of boxes selected.

## Test Cases

- Tested within Admin page: Valid Reviewers save as preselected and update # of reviewers accordingly. 
- Tested on user page: Valid Reviewers save as preselected and update # of reviewers accordingly. View from Reviewer's page also shows the preselected values. 
- Reviewers can also be unselected and the page will update accordingly. 

## Screenshots

<img width="1405" alt="Screenshot 2024-02-27 at 4 30 37 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/68077342/76421bb3-5d4c-4e0e-b3e4-67b62d4cfbeb">
<img width="1405" alt="Screenshot 2024-02-27 at 4 31 17 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/68077342/1d26a5de-7b29-462f-b6b9-3bfa41f11448">

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [X] All commits are tagged with the ticket number
- [X] No linting errors / newline at end of file warnings
- [X] All code follows repository-configured prettier formatting
- [X] No merge conflicts
- [x] All checks passing
- [X] Screenshots of UI changes (see Screenshots section)
- [X] Remove any non-applicable sections of this template
- [X] Assign the PR to yourself
- [X] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [X] PR is linked to the ticket (fill in the closes line below)

Closes # 
[2113](https://github.com/Northeastern-Electric-Racing/FinishLine/issues/2113)
