### PR TITLE
#1877 matthew egg change bom links notes

### DIFF
--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/BOMTableCustomCells.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/BOMTableCustomCells.tsx
@@ -1,15 +1,8 @@
 import { Box } from '@mui/system';
 import { GridRenderCellParams } from '@mui/x-data-grid';
 import { MaterialStatus } from 'shared';
-import { Link, Typography } from '@mui/material';
+import { Typography } from '@mui/material';
 import { displayEnum } from '../../../../utils/pipes';
-
-export const renderLinkBOM = (params: GridRenderCellParams) =>
-  params.value && (
-    <Link href={params.value} target="_blank" underline="hover" sx={{ pl: 1 }}>
-      Buyer Link
-    </Link>
-  );
 
 export const renderStatusBOM = (params: GridRenderCellParams) => {
   if (!params.value) return;

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/BOMTableWrapper.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/BOMTableWrapper.tsx
@@ -13,10 +13,10 @@ import { useToast } from '../../../../hooks/toasts.hooks';
 import { useAssignMaterialToAssembly, useDeleteMaterial } from '../../../../hooks/bom.hooks';
 import LoadingIndicator from '../../../../components/LoadingIndicator';
 import EditMaterialModal from './MaterialForm/EditMaterialModal';
-import { Link, Typography } from '@mui/material';
+import { Typography } from '@mui/material';
 import { bomBaseColDef } from '../../../../utils/bom.utils';
 import NERModal from '../../../../components/NERModal';
-import { renderLinkBOM, renderStatusBOM } from './BOMTableCustomCells';
+import { renderStatusBOM } from './BOMTableCustomCells';
 
 interface BOMTableWrapperProps {
   project: Project;
@@ -55,18 +55,6 @@ const BOMTableWrapper: React.FC<BOMTableWrapperProps> = ({ project }) => {
       }
     }
   };
-
-  const renderNotes = (params: GridRenderCellParams) =>
-    params.value && (
-      <Link
-        onClick={() => {
-          setSelectedMaterialId(params.row.materialId);
-          setModalShow(true);
-        }}
-      >
-        See Notes
-      </Link>
-    );
 
   const editPerms =
     isLeadership(user.role) ||

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/BOMTableWrapper.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/BOMTableWrapper.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react';
 import { Project, isLeadership } from 'shared';
 import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
+import LinkIcon from '@mui/icons-material/Link';
+import NotesIcon from '@mui/icons-material/Notes';
 import MoveToInboxIcon from '@mui/icons-material/MoveToInbox';
 import { useCurrentUser } from '../../../../hooks/users.hooks';
 import BOMTable from './BOMTable';
@@ -103,6 +105,30 @@ const BOMTableWrapper: React.FC<BOMTableWrapperProps> = ({ project }) => {
           }}
         />
       );
+      actions.push(
+        <GridActionsCellItem
+          icon={<LinkIcon fontSize="small" />}
+          label="Link"
+          showInMenu
+          disabled={!editPerms}
+          onClick={() => {
+            window.open(params.row.link, '_blank');
+          }}
+        />
+      );
+      actions.push(
+        <GridActionsCellItem
+          icon={<NotesIcon fontSize="small" />}
+          label="Notes"
+          showInMenu
+          disabled={!editPerms}
+          onClick={() => {
+            setSelectedMaterialId(params.row.materialId);
+            setModalShow(true);
+          }}
+        />
+      );
+
       assemblies.forEach((assembly) => {
         if (!(material && assembly.assemblyId === material.assemblyId)) {
           actions.push(
@@ -212,24 +238,6 @@ const BOMTableWrapper: React.FC<BOMTableWrapperProps> = ({ project }) => {
       field: 'subtotal',
       headerName: 'Subtotal',
       type: 'number',
-      sortable: false,
-      filterable: false
-    },
-    {
-      ...bomBaseColDef,
-      field: 'link',
-      headerName: 'Link',
-      type: 'string',
-      renderCell: renderLinkBOM,
-      sortable: false,
-      filterable: false
-    },
-    {
-      ...bomBaseColDef,
-      field: 'notes',
-      headerName: 'Notes',
-      type: 'string',
-      renderCell: renderNotes,
       sortable: false,
       filterable: false
     },

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
@@ -94,6 +94,24 @@ const ProjectViewContainer: React.FC<ProjectViewContainerProps> = ({ project, en
     </MenuItem>
   );
 
+  const LinkButton = () => (
+    <MenuItem onClick={handleClickEdit} disabled={isGuest(user.role)}>
+      <ListItemIcon>
+        <EditIcon fontSize="small" />
+      </ListItemIcon>
+      Link
+    </MenuItem>
+  );
+
+  const NotesButton = () => (
+    <MenuItem onClick={handleClickEdit} disabled={isGuest(user.role)}>
+      <ListItemIcon>
+        <EditIcon fontSize="small" />
+      </ListItemIcon>
+      Notes
+    </MenuItem>
+  );
+
   const CreateChangeRequestButton = () => (
     <MenuItem
       component={Link}


### PR DESCRIPTION
## Changes

Moved the information from the "Link" and "Notes" sections into the action item menu on the side of each BOM entry.

## Notes

If the team likes this solution, I just have to remove some deprecated functions that helped render information in the "Link" and "Notes" sections.

## Screenshots

![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/102161618/6f8534c8-af54-475f-91ef-036010c9b0d2)


## To Do

- [ ] Clean up the code a little

## Checklist

- [X] All commits are tagged with the ticket number
- [X] No linting errors / newline at end of file warnings
- [X] All code follows repository-configured prettier formatting
- [X] No merge conflicts
- [ ] All checks passing
- [X] Screenshots of UI changes (see Screenshots section)
- [X] Remove any non-applicable sections of this template
- [X] Assign the PR to yourself
- [X] No `yarn.lock` changes (unless dependencies have changed)
- [X] Request reviewers & ping on Slack
- [X] PR is linked to the ticket (fill in the closes line below)

Closes #1877
