### PR TITLE
#1312 scrollbar cutting off wp cards homescreen

### DIFF
--- a/src/frontend/src/pages/HomePage/UpcomingDeadlines.tsx
+++ b/src/frontend/src/pages/HomePage/UpcomingDeadlines.tsx
@@ -26,8 +26,22 @@ const UpcomingDeadlines: React.FC = () => {
     return <ErrorPage message={workPackages.error.message} error={workPackages.error} />;
   }
 
+  window.addEventListener('load', checkOverflow);
+  window.addEventListener('resize', checkOverflow);
+
+  const container = document.getElementById('container');
+  const content = container?.querySelector('.content');
+
+  function checkOverflow() {
+    if (container !== null && container !== undefined && content !== null && content !== undefined) {
+      const hasOverflow = content.scrollHeight > container.clientHeight || content.scrollWidth > container.scrollWidth;
+      container.style.overflow = hasOverflow ? 'scroll' : 'auto';
+    }
+  }
+
   const fullDisplay = (
     <Box
+      id="container"
       sx={{
         display: 'flex',
         flexDirection: 'row',
@@ -78,7 +92,7 @@ const UpcomingDeadlines: React.FC = () => {
         </FormControl>
       }
     >
-      <Grid container>{workPackages.isLoading ? <LoadingIndicator /> : fullDisplay}</Grid>
+      {workPackages.isLoading ? <LoadingIndicator /> : fullDisplay}
     </PageBlock>
   );
 };

--- a/src/frontend/src/pages/HomePage/UpcomingDeadlines.tsx
+++ b/src/frontend/src/pages/HomePage/UpcomingDeadlines.tsx
@@ -14,7 +14,7 @@ import { useAllWorkPackages } from '../../hooks/work-packages.hooks';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import PageBlock from '../../layouts/PageBlock';
 import ErrorPage from '../ErrorPage';
-import { Grid, Typography, useTheme } from '@mui/material';
+import { Typography, useTheme } from '@mui/material';
 import WorkPackageCard from './WorkPackageCard';
 
 const UpcomingDeadlines: React.FC = () => {
@@ -26,22 +26,8 @@ const UpcomingDeadlines: React.FC = () => {
     return <ErrorPage message={workPackages.error.message} error={workPackages.error} />;
   }
 
-  window.addEventListener('load', checkOverflow);
-  window.addEventListener('resize', checkOverflow);
-
-  const container = document.getElementById('container');
-  const content = container?.querySelector('.content');
-
-  function checkOverflow() {
-    if (container !== null && container !== undefined && content !== null && content !== undefined) {
-      const hasOverflow = content.scrollHeight > container.clientHeight || content.scrollWidth > container.scrollWidth;
-      container.style.overflow = hasOverflow ? 'scroll' : 'auto';
-    }
-  }
-
   const fullDisplay = (
     <Box
-      id="container"
       sx={{
         display: 'flex',
         flexDirection: 'row',

--- a/src/frontend/src/pages/HomePage/WorkPackagesByTimelineStatus.tsx
+++ b/src/frontend/src/pages/HomePage/WorkPackagesByTimelineStatus.tsx
@@ -11,7 +11,7 @@ import { timelinePipe } from '../../utils/pipes';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import PageBlock from '../../layouts/PageBlock';
 import ErrorPage from '../ErrorPage';
-import { FormControl, InputLabel, MenuItem, Select, useTheme } from '@mui/material';
+import { FormControl, Grid, InputLabel, MenuItem, Select, useTheme } from '@mui/material';
 import WorkPackageCard from './WorkPackageCard';
 
 const WorkPackagesByTimelineStatus: React.FC = () => {

--- a/src/frontend/src/pages/HomePage/WorkPackagesByTimelineStatus.tsx
+++ b/src/frontend/src/pages/HomePage/WorkPackagesByTimelineStatus.tsx
@@ -11,7 +11,7 @@ import { timelinePipe } from '../../utils/pipes';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import PageBlock from '../../layouts/PageBlock';
 import ErrorPage from '../ErrorPage';
-import { FormControl, Grid, InputLabel, MenuItem, Select, useTheme } from '@mui/material';
+import { FormControl, InputLabel, MenuItem, Select, useTheme } from '@mui/material';
 import WorkPackageCard from './WorkPackageCard';
 
 const WorkPackagesByTimelineStatus: React.FC = () => {


### PR DESCRIPTION
## Changes

Deleted 'Grid container' tag in UpcomingDeadlines.tsx file

## Notes

- The amount of space underneath the scrollbar in Safari is very small, which doesn't look the nicest, but not sure if this is something that needs to be fixed
- Occasionally when you click on 'Ahead' in Safari for 'Work Packages by Timeline Status', the work package card doesn't show up (only a slice of it shows up), but maybe this is just a glitch or something
- When you zoom out a lot in Safari and Chrome, there is a lot of black space underneath the 'Work Packages by Timeline Status' box, which I'm pretty sure already existed before I did this ticket, but doesn't look the nicest either
- For some reason the scrollbar is much larger than it used to be
- I forgot to take screenshots of the smallest possible views in Safari and Chrome, so if whoever reviewing my PR could make sure that the UI still looks okay for the smallest possible views, that would be awesome, sorry about that

## Test Cases

- Yarn test:frontend + yarn test:backend pass all tests
- Manually tested on FinishLine using a variety of different numbers of work packages (to see if the layout looked fine there was no scrollbar, when there was a scrollbar, etc.) 
- Manually tested on FinishLine for both the 'Upcoming Deadlines' and the 'Work Packages by Timeline Status' sections
- Manually tested on FinishLine on both Safari and Chrome

## Screenshots

Chrome 

<img width="1440" alt="Screen Shot 2024-03-02 at 9 01 01 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/60333735/5ba27d16-ed1f-43ac-9840-81e176cc0ceb">

Safari

<img width="1440" alt="Screen Shot 2024-03-02 at 9 01 11 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/60333735/aa205100-8c86-47e8-8ffa-9de0fd7d24fa">

## Checklist

- [X] All commits are tagged with the ticket number
- [X] No linting errors / newline at end of file warnings
- [X] All code follows repository-configured prettier formatting
- [X] No merge conflicts
- [X] All checks passing
- [X] Screenshots of UI changes (see Screenshots section)
- [X] Remove any non-applicable sections of this template
- [X] Assign the PR to yourself
- [X] No `yarn.lock` changes (unless dependencies have changed)
- [X] Request reviewers & ping on Slack
- [X] PR is linked to the ticket (fill in the closes line below)

Closes #1312 
