### PR TITLE
#issue-2003 added info icon to the manufacturer field

### DIFF
--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
@@ -124,7 +124,7 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
             <FormLabel>
               Manufacturer
               <DynamicTooltip title={`Make sure to enter the manufacturer and not the distributor!`}>
-                <InfoIcon sx={{ marginTop: '5px', marginLeft: 0.4, height: 11 }} />
+                <InfoIcon sx={{ marginTop: '5px', marginLeft: 0.2, height: 11 }} />
               </DynamicTooltip>
             </FormLabel>
             <Controller

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
@@ -124,7 +124,7 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
             <FormLabel>
               Manufacturer
               <DynamicTooltip title={`Make sure to enter the manufacturer and not the distributor`}>
-                <InfoIcon />
+                <InfoIcon sx={{ marginLeft: 1, height: 20 }} />
               </DynamicTooltip>
             </FormLabel>
             <Controller

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
@@ -123,8 +123,8 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
           <FormControl fullWidth>
             <FormLabel>
               Manufacturer
-              <DynamicTooltip title={`Make sure to enter the manufacturer and not the distributor`}>
-                <InfoIcon sx={{ marginLeft: 1, height: 20 }} />
+              <DynamicTooltip title={`Make sure to enter the manufacturer and not the distributor!`}>
+                <InfoIcon sx={{ marginLeft: 0.4, height: 15 }} />
               </DynamicTooltip>
             </FormLabel>
             <Controller

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
@@ -124,7 +124,7 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
             <FormLabel>
               Manufacturer
               <DynamicTooltip title={`Make sure to enter the manufacturer and not the distributor!`}>
-                <InfoIcon sx={{ marginLeft: 0.4, height: 15 }} />
+                <InfoIcon sx={{ marginTop: '5px', marginLeft: 0.4, height: 11 }} />
               </DynamicTooltip>
             </FormLabel>
             <Controller

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
@@ -6,6 +6,8 @@ import ReactHookTextField from '../../../../../components/ReactHookTextField';
 import { MaterialFormInput } from './MaterialForm';
 import NERFormModal from '../../../../../components/NERFormModal';
 import DetailDisplay from '../../../../../components/DetailDisplay';
+import DynamicTooltip from '../../../../../components/DynamicTooltip';
+import InfoIcon from '@mui/icons-material/Info';
 
 export interface MaterialFormViewProps {
   submitText: 'Add' | 'Edit';
@@ -119,7 +121,12 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
         </Grid>
         <Grid item xs={4}>
           <FormControl fullWidth>
-            <FormLabel>Manufacturer</FormLabel>
+            <FormLabel>
+              Manufacturer
+              <DynamicTooltip title={`Make sure to enter the manufacturer and not the distributor`}>
+                <InfoIcon />
+              </DynamicTooltip>
+            </FormLabel>
             <Controller
               name="manufacturerName"
               control={control}

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
@@ -129,7 +129,7 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
             <FormLabel>
               Manufacturer
               <DynamicTooltip title={`Make sure to enter the manufacturer and not the distributor!`}>
-                <InfoIcon sx={{ marginTop: '5px', marginLeft: 0.2, height: 11 }} />
+                <InfoIcon sx={{ height: 11 }} />
               </DynamicTooltip>
             </FormLabel>
             <Controller


### PR DESCRIPTION
## Changes

I have added the info icon tool tip to the manufacturer field for the BOM tab


## Screenshots
<img width="839" alt="Screenshot 2024-03-09 at 2 12 34 AM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/147963355/36b8f523-e9fe-445c-b7b1-06c5c11850dc">

<img width="1398" alt="Screenshot 2024-03-09 at 2 12 14 AM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/147963355/c3d454b6-e6bc-438d-8b6e-7da2401eecd1">

<img width="578" alt="Screenshot 2024-03-11 at 10 05 47 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/147963355/ea2e2ea8-dcbf-4abe-8d02-d0bac4fc681b">

<img width="591" alt="Screenshot 2024-03-11 at 10 19 14 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/147963355/96c6cb08-4350-4627-8df5-758f222db68b">


<img width="582" alt="Screenshot 2024-03-11 at 11 30 00 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/147963355/2742b76b-cd9b-4170-b78a-2ab76961cc1b">

