### PR TITLE
#2121 moving create unit functionality to admin tools

### DIFF
--- a/src/frontend/src/pages/AdminToolsPage/AdminToolsBOMConfig.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/AdminToolsBOMConfig.tsx
@@ -6,7 +6,7 @@ import UnitTable from './BOMConfig/UnitTable';
 
 const AdminToolsBOMConfig: React.FC = () => {
   return (
-    <PageBlock title="Bill of Materials Config">
+    <PageBlock title="Bill of Material Config">
       <Grid container spacing="3%">
         <Grid item direction="column" xs={12} md={6}>
           <ManufacturerTable />

--- a/src/frontend/src/pages/AdminToolsPage/AdminToolsBOMConfig.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/AdminToolsBOMConfig.tsx
@@ -6,7 +6,7 @@ import UnitTable from './BOMConfig/UnitTable';
 
 const AdminToolsBOMConfig: React.FC = () => {
   return (
-    <PageBlock title="Bill of Material Config">
+    <PageBlock title="Bill of Materials Config">
       <Grid container spacing="3%">
         <Grid item direction="column" xs={12} md={6}>
           <ManufacturerTable />

--- a/src/frontend/src/pages/AdminToolsPage/AdminToolsBOMConfig.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/AdminToolsBOMConfig.tsx
@@ -14,7 +14,7 @@ const AdminToolsBOMConfig: React.FC = () => {
         <Grid item direction="column" alignSelf="right" xs={12} md={6}>
           <MaterialTypeTable />
         </Grid>
-        <Grid item direction="column" xs={12} md={6}>
+        <Grid item direction="column" xs={11} md={6}>
           <UnitTable />
         </Grid>
       </Grid>

--- a/src/frontend/src/pages/AdminToolsPage/AdminToolsBOMConfig.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/AdminToolsBOMConfig.tsx
@@ -2,6 +2,7 @@ import { Grid } from '@mui/material';
 import PageBlock from '../../layouts/PageBlock';
 import ManufacturerTable from './BOMConfig/ManufacturerTable';
 import MaterialTypeTable from './BOMConfig/MaterialTypeTable';
+import UnitTable from './BOMConfig/UnitTable';
 
 const AdminToolsBOMConfig: React.FC = () => {
   return (
@@ -12,6 +13,9 @@ const AdminToolsBOMConfig: React.FC = () => {
         </Grid>
         <Grid item direction="column" alignSelf="right" xs={12} md={6}>
           <MaterialTypeTable />
+        </Grid>
+        <Grid item direction="column" xs={12} md={6}>
+          <UnitTable />
         </Grid>
       </Grid>
     </PageBlock>

--- a/src/frontend/src/pages/AdminToolsPage/AdminToolsBOMConfig.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/AdminToolsBOMConfig.tsx
@@ -14,7 +14,7 @@ const AdminToolsBOMConfig: React.FC = () => {
         <Grid item direction="column" alignSelf="right" xs={12} md={6}>
           <MaterialTypeTable />
         </Grid>
-        <Grid item direction="column" xs={11} md={6}>
+        <Grid item direction="column" xs={12} md={6}>
           <UnitTable />
         </Grid>
       </Grid>

--- a/src/frontend/src/pages/AdminToolsPage/BOMConfig/CreateUnitFormModal.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/BOMConfig/CreateUnitFormModal.tsx
@@ -10,7 +10,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { useCreateUnit } from '../../../hooks/bom.hooks';
 
 const schema = yup.object().shape({
-  name: yup.string().required('Vendor Name is Required')
+  name: yup.string().required('Unit Name is Required')
 });
 
 interface CreateUnitTypeModalProps {

--- a/src/frontend/src/pages/AdminToolsPage/BOMConfig/CreateUnitFormModal.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/BOMConfig/CreateUnitFormModal.tsx
@@ -10,7 +10,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { useCreateUnit } from '../../../hooks/bom.hooks';
 
 const schema = yup.object().shape({
-  name: yup.string().required('Unit Name is required')
+  name: yup.string().required('Unit Name is Required')
 });
 
 interface CreateUnitTypeModalProps {

--- a/src/frontend/src/pages/AdminToolsPage/BOMConfig/CreateUnitFormModal.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/BOMConfig/CreateUnitFormModal.tsx
@@ -13,12 +13,12 @@ const schema = yup.object().shape({
   name: yup.string().required('Vendor Name is Required')
 });
 
-interface CreateUnitModalProps {
+interface CreateUnitTypeModalProps {
   showModal: boolean;
   handleClose: () => void;
 }
 
-const CreateUnitModal: React.FC<CreateUnitModalProps> = ({ showModal, handleClose }) => {
+const CreateUnitModal: React.FC<CreateUnitTypeModalProps> = ({ showModal, handleClose }) => {
   const toast = useToast();
   const { isLoading, isError, error, mutateAsync } = useCreateUnit();
 

--- a/src/frontend/src/pages/AdminToolsPage/BOMConfig/CreateUnitFormModal.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/BOMConfig/CreateUnitFormModal.tsx
@@ -1,0 +1,71 @@
+import { useForm } from 'react-hook-form';
+import NERFormModal from '../../../components/NERFormModal';
+import { FormControl, FormLabel, FormHelperText } from '@mui/material';
+import ReactHookTextField from '../../../components/ReactHookTextField';
+import { useToast } from '../../../hooks/toasts.hooks';
+import ErrorPage from '../../ErrorPage';
+import LoadingIndicator from '../../../components/LoadingIndicator';
+import * as yup from 'yup';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { useCreateUnit } from '../../../hooks/bom.hooks';
+
+const schema = yup.object().shape({
+  name: yup.string().required('Vendor Name is Required')
+});
+
+interface CreateUnitModalProps {
+  showModal: boolean;
+  handleClose: () => void;
+}
+
+const CreateUnitModal: React.FC<CreateUnitModalProps> = ({ showModal, handleClose }) => {
+  const toast = useToast();
+  const { isLoading, isError, error, mutateAsync } = useCreateUnit();
+
+  const onSubmit = async (data: { name: string }) => {
+    try {
+      await mutateAsync(data);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        toast.error(error.message);
+      }
+    }
+    handleClose();
+  };
+
+  const {
+    handleSubmit,
+    control,
+    reset,
+    formState: { errors }
+  } = useForm({
+    resolver: yupResolver(schema),
+    defaultValues: {
+      name: ''
+    }
+  });
+
+  if (isError) return <ErrorPage message={error?.message} />;
+  if (isLoading) return <LoadingIndicator />;
+
+  return (
+    <NERFormModal
+      open={showModal}
+      onHide={handleClose}
+      title="New Unit"
+      reset={() => reset({ name: '' })}
+      handleUseFormSubmit={handleSubmit}
+      onFormSubmit={onSubmit}
+      formId="new-unit"
+      showCloseButton
+    >
+      <FormControl>
+        <FormLabel>Unit Name</FormLabel>
+        <ReactHookTextField name="name" control={control} sx={{ width: 1 }} />
+        <FormHelperText error>{errors.name?.message}</FormHelperText>
+      </FormControl>
+    </NERFormModal>
+  );
+};
+
+export default CreateUnitModal;

--- a/src/frontend/src/pages/AdminToolsPage/BOMConfig/CreateUnitFormModal.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/BOMConfig/CreateUnitFormModal.tsx
@@ -10,7 +10,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { useCreateUnit } from '../../../hooks/bom.hooks';
 
 const schema = yup.object().shape({
-  name: yup.string().required('Unit Name is Required')
+  name: yup.string().required('Unit Name is required')
 });
 
 interface CreateUnitTypeModalProps {

--- a/src/frontend/src/pages/AdminToolsPage/BOMConfig/UnitTable.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/BOMConfig/UnitTable.tsx
@@ -26,7 +26,7 @@ const UnitTypeTable: React.FC = () => {
 
   const unitTypesTableRows = unitTypes.map((unitType) => (
     <TableRow>
-      <TableCell align="left" sx={{ border: '2px solid black' }}>
+      <TableCell align="right" sx={{ border: '2px solid black' }}>
         {unitType.name}
       </TableCell>
     </TableRow>

--- a/src/frontend/src/pages/AdminToolsPage/BOMConfig/UnitTable.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/BOMConfig/UnitTable.tsx
@@ -1,0 +1,53 @@
+import { TableRow, TableCell, Typography, Box } from '@mui/material';
+import LoadingIndicator from '../../../components/LoadingIndicator';
+// import { datePipe } from '../../../utils/pipes';
+import ErrorPage from '../../ErrorPage';
+import { NERButton } from '../../../components/NERButton';
+import { useState } from 'react';
+import AdminToolTable from '../AdminToolTable';
+import { useGetAllUnits } from '../../../hooks/bom.hooks';
+import CreateUnitFormModal from './CreateUnitFormModal';
+
+const UnitTable: React.FC = () => {
+  const {
+    data: unitTypes,
+    isLoading: unitTypesIsLoading,
+    isError: unitTypesIsError,
+    error: unitTypesError
+  } = useGetAllUnits();
+  const [createModalShow, setCreateModalShow] = useState<boolean>(false);
+
+  if (!unitTypes || unitTypesIsLoading) {
+    return <LoadingIndicator />;
+  }
+  if (unitTypesIsError) {
+    return <ErrorPage message={unitTypesError?.message} />;
+  }
+
+  const unitTypesTableRows = unitTypes.map((unitType) => (
+    <TableRow>
+      <TableCell align="left" sx={{ border: '2px solid black' }}></TableCell>
+      <TableCell sx={{ border: '2px solid black' }}>{unitType.name}</TableCell>
+    </TableRow>
+  ));
+
+  return (
+    <Box>
+      <CreateUnitFormModal showModal={createModalShow} handleClose={() => setCreateModalShow(false)} />
+      <Typography variant="subtitle1">Registered Units</Typography>
+      <AdminToolTable columns={[{ name: 'Date Registered' }, { name: 'Unit' }]} rows={unitTypesTableRows} />
+      <Box sx={{ display: 'flex', justifyContent: 'right', marginTop: '10px' }}>
+        <NERButton
+          variant="contained"
+          onClick={() => {
+            setCreateModalShow(true);
+          }}
+        >
+          New Unit
+        </NERButton>
+      </Box>
+    </Box>
+  );
+};
+
+export default UnitTable;

--- a/src/frontend/src/pages/AdminToolsPage/BOMConfig/UnitTable.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/BOMConfig/UnitTable.tsx
@@ -8,7 +8,7 @@ import AdminToolTable from '../AdminToolTable';
 import { useGetAllUnits } from '../../../hooks/bom.hooks';
 import CreateUnitFormModal from './CreateUnitFormModal';
 
-const UnitTable: React.FC = () => {
+const UnitTypeTable: React.FC = () => {
   const {
     data: unitTypes,
     isLoading: unitTypesIsLoading,
@@ -50,4 +50,4 @@ const UnitTable: React.FC = () => {
   );
 };
 
-export default UnitTable;
+export default UnitTypeTable;

--- a/src/frontend/src/pages/AdminToolsPage/BOMConfig/UnitTable.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/BOMConfig/UnitTable.tsx
@@ -26,7 +26,7 @@ const UnitTypeTable: React.FC = () => {
 
   const unitTypesTableRows = unitTypes.map((unitType) => (
     <TableRow>
-      <TableCell align="right" sx={{ border: '2px solid black' }}>
+      <TableCell align="left" sx={{ border: '2px solid black' }}>
         {unitType.name}
       </TableCell>
     </TableRow>

--- a/src/frontend/src/pages/AdminToolsPage/BOMConfig/UnitTable.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/BOMConfig/UnitTable.tsx
@@ -26,8 +26,9 @@ const UnitTypeTable: React.FC = () => {
 
   const unitTypesTableRows = unitTypes.map((unitType) => (
     <TableRow>
-      <TableCell align="left" sx={{ border: '2px solid black' }}></TableCell>
-      <TableCell sx={{ border: '2px solid black' }}>{unitType.name}</TableCell>
+      <TableCell align="left" sx={{ border: '2px solid black' }}>
+        {unitType.name}
+      </TableCell>
     </TableRow>
   ));
 
@@ -35,7 +36,7 @@ const UnitTypeTable: React.FC = () => {
     <Box>
       <CreateUnitFormModal showModal={createModalShow} handleClose={() => setCreateModalShow(false)} />
       <Typography variant="subtitle1">Registered Units</Typography>
-      <AdminToolTable columns={[{ name: 'Date Registered' }, { name: 'Unit' }]} rows={unitTypesTableRows} />
+      <AdminToolTable columns={[{ name: 'Unit' }]} rows={unitTypesTableRows} />
       <Box sx={{ display: 'flex', justifyContent: 'right', marginTop: '10px' }}>
         <NERButton
           variant="contained"

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialForm.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialForm.tsx
@@ -5,7 +5,6 @@ import * as yup from 'yup';
 import LoadingIndicator from '../../../../../components/LoadingIndicator';
 import {
   useCreateManufacturer,
-  useCreateUnit,
   useGetAllManufacturers,
   useGetAllMaterialTypes,
   useGetAllUnits
@@ -92,7 +91,6 @@ const MaterialForm: React.FC<MaterialFormProps> = ({ submitText, onSubmit, defau
     resolver: yupResolver(schema)
   });
 
-  const { mutateAsync: createUnit, isLoading: isLoadingCreateUnit } = useCreateUnit();
   const { mutateAsync: createManufacturer, isLoading: isLoadingCreateManufacturer } = useCreateManufacturer();
 
   const {
@@ -123,7 +121,6 @@ const MaterialForm: React.FC<MaterialFormProps> = ({ submitText, onSubmit, defau
     !materialTypes ||
     !units ||
     !manufactuers ||
-    isLoadingCreateUnit ||
     isLoadingCreateManufacturer
   ) {
     return <LoadingIndicator />;
@@ -133,17 +130,6 @@ const MaterialForm: React.FC<MaterialFormProps> = ({ submitText, onSubmit, defau
     const price = Math.round(data.price * 100);
     const subtotal = parseFloat((data.quantity * price).toFixed(2));
     onSubmit({ ...data, subtotal: subtotal, price: price, quantity: new Decimal(data.quantity) });
-  };
-
-  const createUnitWrapper = async (unitName: string): Promise<void> => {
-    try {
-      const createdUnit = await createUnit({ name: unitName });
-      setValue('unitName', createdUnit.name);
-    } catch (error: unknown) {
-      if (error instanceof Error) {
-        console.error(error.message);
-      }
-    }
   };
 
   const createManufacturerWrapper = async (manufacturerName: string): Promise<void> => {
@@ -171,7 +157,6 @@ const MaterialForm: React.FC<MaterialFormProps> = ({ submitText, onSubmit, defau
       errors={errors}
       open={open}
       watch={watch}
-      createUnit={createUnitWrapper}
       createManufacturer={createManufacturerWrapper}
       setValue={setValue}
     />

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialForm.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialForm.tsx
@@ -105,7 +105,7 @@ const MaterialForm: React.FC<MaterialFormProps> = ({ submitText, onSubmit, defau
   const {
     data: manufactuers,
     isLoading: isLoadingManufactuers,
-    isError: manufacturersIsError
+    isError: manufacturersIsError,
     error: manufacturersError
   } = useGetAllManufacturers();
 

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialForm.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialForm.tsx
@@ -105,7 +105,7 @@ const MaterialForm: React.FC<MaterialFormProps> = ({ submitText, onSubmit, defau
   const {
     data: manufactuers,
     isLoading: isLoadingManufactuers,
-    isError: manufacturersIsError,
+    isError: manufacturersIsError
     error: manufacturersError
   } = useGetAllManufacturers();
 

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
@@ -185,7 +185,7 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
                 control={control}
                 errorMessage={errors.quantity}
                 placeholder="Enter Quantity"
-                type="number"
+                type="numbers"
               />
             </FormControl>
             <FormControl fullWidth>

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
@@ -20,7 +20,6 @@ export interface MaterialFormViewProps {
   assemblies: Assembly[];
   open: boolean;
   watch: UseFormWatch<MaterialFormInput>;
-  createUnit: (name: string) => void;
   createManufacturer: (name: string) => void;
   setValue: UseFormSetValue<MaterialFormInput>;
 }
@@ -38,7 +37,6 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
   assemblies,
   open,
   watch,
-  createUnit,
   createManufacturer,
   setValue
 }) => {
@@ -204,24 +202,12 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
                     error={!!errors.unitName}
                     helperText={errors.unitName?.message}
                     value={field.value || ''}
-                    onChange={(event) => {
-                      const selectedValue = event.target.value;
-                      if (selectedValue === 'createUnit') {
-                        const unitName = prompt('Enter Unit Name');
-                        if (unitName) {
-                          createUnit(unitName);
-                        }
-                      } else {
-                        field.onChange(event);
-                      }
-                    }}
                   >
                     {allUnits.map((unit) => (
                       <MenuItem key={unit.name} value={unit.name}>
                         {unit.name}
                       </MenuItem>
                     ))}
-                    <MenuItem value="createUnit">+ Create Unit</MenuItem>
                   </TextField>
                 )}
               />

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
@@ -185,7 +185,7 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
                 control={control}
                 errorMessage={errors.quantity}
                 placeholder="Enter Quantity"
-                type="numbers"
+                type="number"
               />
             </FormControl>
             <FormControl fullWidth>


### PR DESCRIPTION
## Changes

Added the ability to create a new unit to the admin tools page under the Build of Materials Config section. Also removed the create unit functionality from the dropdown of the units select on the material form.

## Screenshots

<img width="1728" alt="Screenshot 2024-03-13 at 16 38 27" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/90429900/cd40146e-06b7-41c5-9e88-a1d1d54f55b1">
<img width="500" alt="Screenshot 2024-03-13 at 16 38 55" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/90429900/e352a8d8-1ba1-40c1-ba8b-e2fc9ba7feff">
<img width="1728" alt="Screenshot 2024-03-13 at 16 39 21" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/90429900/ffcceacc-c892-414f-a835-1babe77f9ba5">
<img width="501" alt="Screenshot 2024-03-13 at 16 39 55" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/90429900/1b480664-9297-4f15-95ed-3af5cd847e4d">


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #2121 
