### PR TITLE
#2141 - Remove page block from Finance Configurator

### DIFF
--- a/src/frontend/src/pages/AdminToolsPage/AdminToolsFinanceConfig.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/AdminToolsFinanceConfig.tsx
@@ -1,11 +1,12 @@
-import { Grid } from '@mui/material';
-import PageBlock from '../../layouts/PageBlock';
+import { Grid, Typography } from '@mui/material';
 import VendorsTable from './FinanceConfig/VendorsTable';
 import AccountCodesTable from './FinanceConfig/AccountCodesTable';
 
 const AdminToolsFinanceConfig: React.FC = () => {
   return (
-    <PageBlock title="Finance Config">
+    <div>
+      <Typography variant="h4">Finance Config</Typography>
+      <br />
       <Grid container spacing="3%">
         <Grid item direction="column" xs={12} md={6}>
           <VendorsTable />
@@ -14,7 +15,7 @@ const AdminToolsFinanceConfig: React.FC = () => {
           <AccountCodesTable />
         </Grid>
       </Grid>
-    </PageBlock>
+    </div>
   );
 };
 

--- a/src/frontend/src/pages/AdminToolsPage/AdminToolsFinanceConfig.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/AdminToolsFinanceConfig.tsx
@@ -1,21 +1,17 @@
-import { Grid, Typography } from '@mui/material';
+import { Grid } from '@mui/material';
 import VendorsTable from './FinanceConfig/VendorsTable';
 import AccountCodesTable from './FinanceConfig/AccountCodesTable';
 
 const AdminToolsFinanceConfig: React.FC = () => {
   return (
-    <div>
-      <Typography variant="h4">Finance Config</Typography>
-      <br />
-      <Grid container spacing="3%">
-        <Grid item direction="column" xs={12} md={6}>
-          <VendorsTable />
-        </Grid>
-        <Grid item direction="column" alignSelf="right" xs={12} md={6}>
-          <AccountCodesTable />
-        </Grid>
+    <Grid container spacing="3%" paddingLeft="5px">
+      <Grid item direction="column" xs={12} md={6}>
+        <VendorsTable />
       </Grid>
-    </div>
+      <Grid item direction="column" alignSelf="right" xs={12} md={6}>
+        <AccountCodesTable />
+      </Grid>
+    </Grid>
   );
 };
 

--- a/src/frontend/src/pages/AdminToolsPage/AdminToolsFinanceConfig.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/AdminToolsFinanceConfig.tsx
@@ -1,17 +1,22 @@
-import { Grid } from '@mui/material';
+import { Box, Grid, Typography } from '@mui/material';
 import VendorsTable from './FinanceConfig/VendorsTable';
 import AccountCodesTable from './FinanceConfig/AccountCodesTable';
 
 const AdminToolsFinanceConfig: React.FC = () => {
   return (
-    <Grid container spacing="3%" paddingLeft="5px">
-      <Grid item direction="column" xs={12} md={6}>
-        <VendorsTable />
+    <Box padding="5px">
+      <Typography marginBottom="15px" variant="h5">
+        Finance Config
+      </Typography>
+      <Grid container spacing="3%">
+        <Grid item direction="column" xs={12} md={6}>
+          <VendorsTable />
+        </Grid>
+        <Grid item direction="column" alignSelf="right" xs={12} md={6}>
+          <AccountCodesTable />
+        </Grid>
       </Grid>
-      <Grid item direction="column" alignSelf="right" xs={12} md={6}>
-        <AccountCodesTable />
-      </Grid>
-    </Grid>
+    </Box>
   );
 };
 


### PR DESCRIPTION
## Changes

Removed the Page Block from the Finance Configurator. Used a Typography component to retain the styling of the title.

## Screenshots

![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/90310958/ef271f36-c9a1-4262-8017-2d089e9e1454)

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #2141 
