### PR TITLE
#2223: Design Review mark user confirmation endpoint

### DIFF
--- a/src/backend/src/controllers/design-reviews.controllers.ts
+++ b/src/backend/src/controllers/design-reviews.controllers.ts
@@ -116,4 +116,18 @@ export default class DesignReviewsController {
       next(error);
     }
   }
+
+  // Mark the current user as confirmed for the given design review
+  static async markUserConfirmed(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { availability } = req.body;
+      const { designReviewId } = req.params;
+      const user = await getCurrentUser(res);
+
+      await DesignReviewsService.markUserConfirmed(designReviewId, availability, user);
+      return res.status(200).json({ message: 'Design Review member confirmed successfully' });
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
 }

--- a/src/backend/src/controllers/design-reviews.controllers.ts
+++ b/src/backend/src/controllers/design-reviews.controllers.ts
@@ -124,8 +124,8 @@ export default class DesignReviewsController {
       const { designReviewId } = req.params;
       const user = await getCurrentUser(res);
 
-      await DesignReviewsService.markUserConfirmed(designReviewId, availability, user);
-      return res.status(200).json({ message: 'Design Review member confirmed successfully' });
+      const updatedDesignReview = await DesignReviewsService.markUserConfirmed(designReviewId, availability, user);
+      return res.status(200).json(updatedDesignReview);
     } catch (error: unknown) {
       next(error);
     }

--- a/src/backend/src/routes/design-reviews.routes.ts
+++ b/src/backend/src/routes/design-reviews.routes.ts
@@ -52,4 +52,11 @@ designReviewsRouter.post(
   DesignReviewsController.editDesignReviews
 );
 
+designReviewsRouter.post(
+  '/:designReviewId/confirm-schedule',
+  body('meetingTimes').isArray(),
+  validateInputs,
+  DesignReviewsController.markUserConfirmed
+);
+
 export default designReviewsRouter;

--- a/src/backend/src/routes/design-reviews.routes.ts
+++ b/src/backend/src/routes/design-reviews.routes.ts
@@ -55,6 +55,7 @@ designReviewsRouter.post(
 designReviewsRouter.post(
   '/:designReviewId/confirm-schedule',
   body('availability').isArray(),
+  intMinZero(body('availability.*')),
   validateInputs,
   DesignReviewsController.markUserConfirmed
 );

--- a/src/backend/src/routes/design-reviews.routes.ts
+++ b/src/backend/src/routes/design-reviews.routes.ts
@@ -54,7 +54,7 @@ designReviewsRouter.post(
 
 designReviewsRouter.post(
   '/:designReviewId/confirm-schedule',
-  body('meetingTimes').isArray(),
+  body('availability').isArray(),
   validateInputs,
   DesignReviewsController.markUserConfirmed
 );

--- a/src/backend/src/services/design-reviews.services.ts
+++ b/src/backend/src/services/design-reviews.services.ts
@@ -318,7 +318,7 @@ export default class DesignReviewsService {
   }
 
   /**
-   * Edits a design review but confirming a given user's availability
+   * Edits a design review by confirming a given user's availability and also updating their schedule settings with the given availability
    * @param submitter the member that is being confirmed
    * @param designReviewId the id of the design review
    * @param availability the given member's availabilities
@@ -348,9 +348,15 @@ export default class DesignReviewsService {
     // Update user schedule settings
     const validAvailability = validateMeetingTimes(availability);
 
-    await prisma.schedule_Settings.update({
+    await prisma.schedule_Settings.upsert({
       where: { userId: submitter.userId },
-      data: {
+      update: {
+        availability: validAvailability
+      },
+      create: {
+        userId: submitter.userId,
+        personalGmail: '',
+        personalZoomLink: '',
         availability: validAvailability
       }
     });

--- a/src/backend/src/services/design-reviews.services.ts
+++ b/src/backend/src/services/design-reviews.services.ts
@@ -345,19 +345,15 @@ export default class DesignReviewsService {
     if (!isMemberPresent(submitter))
       throw new HttpException(400, 'Current user is not in the list of this design reviews members');
 
-    // update user schedule settings (in progress)
-
     // Update user schedule settings
-    if (availability) {
-      const validAvailability = validateMeetingTimes(availability);
-      console.log(validAvailability);
-      if (!validAvailability) throw new HttpException(400, 'This availability is invalid');
+    const validAvailability = validateMeetingTimes(availability);
 
-      // Update user schedule settings with the new availability here...
-      // Example: await updateUserScheduleSettings(submitter, availability);
-    }
-
-    console.log(availability);
+    await prisma.schedule_Settings.update({
+      where: { userId: submitter.userId },
+      data: {
+        availability: validAvailability
+      }
+    });
 
     // update design review confirmed members (works)
     const newConfirmedMembers: User[] = [...designReview.confirmedMembers, submitter];

--- a/src/backend/src/services/design-reviews.services.ts
+++ b/src/backend/src/services/design-reviews.services.ts
@@ -347,9 +347,16 @@ export default class DesignReviewsService {
 
     // update user schedule settings (in progress)
 
-    const validAvailability = availability ? validateMeetingTimes(availability) : false;
-    //if (validAvailability === false) throw new HttpException(400, 'This availability is invalid');
-    console.log(validAvailability);
+    // Update user schedule settings
+    if (availability) {
+      const validAvailability = validateMeetingTimes(availability);
+      console.log(validAvailability);
+      if (!validAvailability) throw new HttpException(400, 'This availability is invalid');
+
+      // Update user schedule settings with the new availability here...
+      // Example: await updateUserScheduleSettings(submitter, availability);
+    }
+
     console.log(availability);
 
     // update design review confirmed members (works)

--- a/src/backend/src/utils/design-reviews.utils.ts
+++ b/src/backend/src/utils/design-reviews.utils.ts
@@ -6,11 +6,11 @@ import { HttpException } from './errors.utils';
  * @returns the meeting times
  */
 export function validateMeetingTimes(nums: number[]): number[] {
-  for (let i = 1; i < nums.length; i++) {
+  for (let i = 0; i < nums.length; i++) {
     if (nums[i] < 0 || nums[i] > 83) {
       throw new HttpException(400, 'Meeting times have to be in range 0-83');
     }
-    if (nums[i] !== nums[i - 1] + 1) {
+    if (i > 0 && nums[i] !== nums[i - 1] + 1) {
       throw new HttpException(400, 'Meeting times have to be consecutive');
     }
   }

--- a/src/backend/src/utils/design-reviews.utils.ts
+++ b/src/backend/src/utils/design-reviews.utils.ts
@@ -1,3 +1,4 @@
+import { DesignReview, User } from 'shared';
 import { HttpException } from './errors.utils';
 
 /**
@@ -5,7 +6,7 @@ import { HttpException } from './errors.utils';
  * @param nums the meeting times
  * @returns the meeting times
  */
-export function validateMeetingTimes(nums: number[]): number[] {
+export const validateMeetingTimes = (nums: number[]): number[] => {
   for (let i = 0; i < nums.length; i++) {
     if (nums[i] < 0 || nums[i] > 83) {
       throw new HttpException(400, 'Meeting times have to be in range 0-83');
@@ -15,4 +16,10 @@ export function validateMeetingTimes(nums: number[]): number[] {
     }
   }
   return nums;
-}
+};
+
+export const isUserOnDesignReview = (user: User, designReview: DesignReview): boolean => {
+  const requiredMembers = designReview.requiredMembers.map((user) => user.userId);
+  const optionalMembers = designReview.optionalMembers.map((user) => user.userId);
+  return requiredMembers.includes(user.userId) || optionalMembers.includes(user.userId);
+};

--- a/src/backend/src/utils/design-reviews.utils.ts
+++ b/src/backend/src/utils/design-reviews.utils.ts
@@ -8,10 +8,10 @@ import { HttpException } from './errors.utils';
 export function validateMeetingTimes(nums: number[]): number[] {
   for (let i = 1; i < nums.length; i++) {
     if (nums[i] < 0 || nums[i] > 83) {
-      throw new HttpException(400, 'meeting time must be between 0-83');
+      throw new HttpException(400, 'Meeting times have to be in range 0-83');
     }
     if (nums[i] !== nums[i - 1] + 1) {
-      throw new HttpException(400, 'meeting times must be consecutive');
+      throw new HttpException(400, 'Meeting times have to be consecutive');
     }
   }
   return nums;

--- a/src/backend/tests/design-reviews.test.ts
+++ b/src/backend/tests/design-reviews.test.ts
@@ -1,11 +1,10 @@
 import {
   designReview1,
   designReview3,
-  designReview4,
+  designReview5,
   prismaDesignReview1,
   prismaDesignReview2,
   prismaDesignReview3,
-  prismaDesignReview4,
   sharedDesignReview1,
   teamType1
 } from './test-data/design-reviews.test-data';
@@ -512,7 +511,7 @@ describe('Design Reviews', () => {
       );
 
       expect(prisma.design_Review.findUnique).toHaveBeenCalledTimes(1);
-      expect(result).toEqual(designReview4);
+      expect(result).toEqual(designReview5);
     });
 
     test('Design Review was not found', async () => {

--- a/src/backend/tests/design-reviews.test.ts
+++ b/src/backend/tests/design-reviews.test.ts
@@ -9,7 +9,15 @@ import {
   sharedDesignReview1,
   teamType1
 } from './test-data/design-reviews.test-data';
-import { aquaman, batman, batmanWithScheduleSettings, superman, theVisitor, wonderwoman } from './test-data/users.test-data';
+import {
+  aquaman,
+  batman,
+  batmanScheduleSettings,
+  batmanWithScheduleSettings,
+  superman,
+  theVisitor,
+  wonderwoman
+} from './test-data/users.test-data';
 import prisma from '../src/prisma/prisma';
 import {
   AccessDeniedAdminOnlyException,
@@ -507,6 +515,7 @@ describe('Design Reviews', () => {
   describe('Mark user confirmed tests', () => {
     test('mark user confirmed succeeds', async () => {
       vi.spyOn(prisma.design_Review, 'findUnique').mockResolvedValue(prismaDesignReview5);
+      vi.spyOn(prisma.schedule_Settings, 'upsert').mockResolvedValue(batmanScheduleSettings);
       const result = await DesignReviewsService.markUserConfirmed(
         prismaDesignReview5.designReviewId,
         [1, 2],

--- a/src/backend/tests/design-reviews.test.ts
+++ b/src/backend/tests/design-reviews.test.ts
@@ -510,6 +510,7 @@ describe('Design Reviews', () => {
         DesignReviewsService.markUserConfirmed(prismaDesignReview1.designReviewId, [1, 2], wonderwoman)
       );
 
+      expect(prisma.design_Review.findUnique).toHaveBeenCalledTimes(0);
       expect(result).toEqual(designReview5);
     });
 

--- a/src/backend/tests/design-reviews.test.ts
+++ b/src/backend/tests/design-reviews.test.ts
@@ -5,6 +5,7 @@ import {
   prismaDesignReview1,
   prismaDesignReview2,
   prismaDesignReview3,
+  prismaDesignReview5,
   sharedDesignReview1,
   teamType1
 } from './test-data/design-reviews.test-data';
@@ -250,7 +251,7 @@ describe('Design Reviews', () => {
           [],
           [1, 4, 2, 3]
         )
-      ).rejects.toThrow(new HttpException(400, 'meeting times must be consecutive'));
+      ).rejects.toThrow(new HttpException(400, 'Meeting times have to be consecutive'));
     });
 
     test('Edit Design Review fails when meeting times are consecutive and *above* 83', async () => {
@@ -272,7 +273,7 @@ describe('Design Reviews', () => {
           [],
           [84, 85]
         )
-      ).rejects.toThrow(new HttpException(400, 'meeting time must be between 0-83'));
+      ).rejects.toThrow(new HttpException(400, 'Meeting times have to be in range 0-83'));
     });
 
     test('Edit Design Review fails when no docTemplateLink, and status is scheduled or done', async () => {
@@ -505,8 +506,8 @@ describe('Design Reviews', () => {
 
   describe('Mark user confirmation tests', () => {
     test('Marking succeeds', async () => {
-      vi.spyOn(prisma.design_Review, 'findUnique').mockResolvedValue(prismaDesignReview1);
-      const result = await DesignReviewsService.markUserConfirmed(prismaDesignReview1.designReviewId, [1, 2], wonderwoman);
+      vi.spyOn(prisma.design_Review, 'findUnique').mockResolvedValue(prismaDesignReview5);
+      const result = await DesignReviewsService.markUserConfirmed(prismaDesignReview5.designReviewId, [1, 2], wonderwoman);
 
       expect(prisma.design_Review.findUnique).toHaveBeenCalledTimes(0);
       expect(result).toEqual(designReview5);
@@ -515,35 +516,35 @@ describe('Design Reviews', () => {
     test('Design Review was not found', async () => {
       vi.spyOn(prisma.design_Review, 'findUnique').mockResolvedValue(null);
       await expect(() =>
-        DesignReviewsService.markUserConfirmed(prismaDesignReview1.designReviewId, [0, 1, 2], batman)
-      ).rejects.toThrow(new NotFoundException('Design Review', prismaDesignReview1.designReviewId));
+        DesignReviewsService.markUserConfirmed(prismaDesignReview5.designReviewId, [0, 1, 2], batman)
+      ).rejects.toThrow(new NotFoundException('Design Review', prismaDesignReview5.designReviewId));
     });
 
     test('Design Review was deleted', async () => {
       vi.spyOn(prisma.design_Review, 'findUnique').mockResolvedValue({ ...prismaDesignReview1, dateDeleted: new Date() });
       await expect(() =>
-        DesignReviewsService.markUserConfirmed(prismaDesignReview1.designReviewId, [0, 1, 2], batman)
-      ).rejects.toThrow(new DeletedException('Design Review', prismaDesignReview1.designReviewId));
+        DesignReviewsService.markUserConfirmed(prismaDesignReview5.designReviewId, [0, 1, 2], batman)
+      ).rejects.toThrow(new DeletedException('Design Review', prismaDesignReview5.designReviewId));
     });
 
     test('User was not in required/optional members of design review', async () => {
-      vi.spyOn(prisma.design_Review, 'findUnique').mockResolvedValue(prismaDesignReview1);
+      vi.spyOn(prisma.design_Review, 'findUnique').mockResolvedValue(prismaDesignReview5);
       await expect(() =>
-        DesignReviewsService.markUserConfirmed(prismaDesignReview1.designReviewId, [0, 1, 2], superman)
+        DesignReviewsService.markUserConfirmed(prismaDesignReview5.designReviewId, [0, 1, 2], superman)
       ).rejects.toThrow(new HttpException(400, 'Current user is not in the list of this design reviews members'));
     });
 
     test('Availabilities were invalid - out of bounds', async () => {
-      vi.spyOn(prisma.design_Review, 'findUnique').mockResolvedValue(prismaDesignReview1);
+      vi.spyOn(prisma.design_Review, 'findUnique').mockResolvedValue(prismaDesignReview5);
       await expect(() =>
-        DesignReviewsService.markUserConfirmed(prismaDesignReview1.designReviewId, [0, 85], batman)
+        DesignReviewsService.markUserConfirmed(prismaDesignReview5.designReviewId, [0, 85], batman)
       ).rejects.toThrow(new HttpException(400, 'Meeting times have to be in range 0-83'));
     });
 
     test('Availabilities were invalid - non-consecutive', async () => {
-      vi.spyOn(prisma.design_Review, 'findUnique').mockResolvedValue(prismaDesignReview1);
+      vi.spyOn(prisma.design_Review, 'findUnique').mockResolvedValue(prismaDesignReview5);
       await expect(() =>
-        DesignReviewsService.markUserConfirmed(prismaDesignReview1.designReviewId, [1, 3], batman)
+        DesignReviewsService.markUserConfirmed(prismaDesignReview5.designReviewId, [1, 3], batman)
       ).rejects.toThrow(new HttpException(400, 'Meeting times have to be consecutive'));
     });
   });

--- a/src/backend/tests/design-reviews.test.ts
+++ b/src/backend/tests/design-reviews.test.ts
@@ -506,9 +506,7 @@ describe('Design Reviews', () => {
   describe('Mark user confirmation tests', () => {
     test('Marking succeeds', async () => {
       vi.spyOn(prisma.design_Review, 'findUnique').mockResolvedValue(prismaDesignReview1);
-      const result = await expect(() =>
-        DesignReviewsService.markUserConfirmed(prismaDesignReview1.designReviewId, [1, 2], wonderwoman)
-      );
+      const result = await DesignReviewsService.markUserConfirmed(prismaDesignReview1.designReviewId, [1, 2], wonderwoman);
 
       expect(prisma.design_Review.findUnique).toHaveBeenCalledTimes(0);
       expect(result).toEqual(designReview5);

--- a/src/backend/tests/design-reviews.test.ts
+++ b/src/backend/tests/design-reviews.test.ts
@@ -537,14 +537,14 @@ describe('Design Reviews', () => {
       vi.spyOn(prisma.design_Review, 'findUnique').mockResolvedValue(prismaDesignReview1);
       await expect(() =>
         DesignReviewsService.markUserConfirmed(prismaDesignReview1.designReviewId, [0, 85], batman)
-      ).rejects.toThrow(new HttpException(400, 'meeting time must be between 0-83'));
+      ).rejects.toThrow(new HttpException(400, 'Meeting times have to be in range 0-83'));
     });
 
     test('Availabilities were invalid - non-consecutive', async () => {
       vi.spyOn(prisma.design_Review, 'findUnique').mockResolvedValue(prismaDesignReview1);
       await expect(() =>
         DesignReviewsService.markUserConfirmed(prismaDesignReview1.designReviewId, [1, 3], batman)
-      ).rejects.toThrow(new HttpException(400, 'meeting times must be consecutive'));
+      ).rejects.toThrow(new HttpException(400, 'Meeting times have to be consecutive'));
     });
   });
 });

--- a/src/backend/tests/design-reviews.test.ts
+++ b/src/backend/tests/design-reviews.test.ts
@@ -9,7 +9,14 @@ import {
   sharedDesignReview1,
   teamType1
 } from './test-data/design-reviews.test-data';
-import { aquaman, batman, superman, theVisitor, wonderwoman } from './test-data/users.test-data';
+import {
+  aquaman,
+  batman,
+  superman,
+  theVisitor,
+  wonderwoman,
+  wonderwomanWithScheduleSettings
+} from './test-data/users.test-data';
 import prisma from '../src/prisma/prisma';
 import {
   AccessDeniedAdminOnlyException,
@@ -507,7 +514,11 @@ describe('Design Reviews', () => {
   describe('Mark user confirmation tests', () => {
     test('Marking succeeds', async () => {
       vi.spyOn(prisma.design_Review, 'findUnique').mockResolvedValue(prismaDesignReview5);
-      const result = await DesignReviewsService.markUserConfirmed(prismaDesignReview5.designReviewId, [1, 2], wonderwoman);
+      const result = await DesignReviewsService.markUserConfirmed(
+        prismaDesignReview5.designReviewId,
+        [1, 2],
+        wonderwomanWithScheduleSettings
+      );
 
       expect(prisma.design_Review.findUnique).toHaveBeenCalledTimes(0);
       expect(result).toEqual(designReview5);

--- a/src/backend/tests/design-reviews.test.ts
+++ b/src/backend/tests/design-reviews.test.ts
@@ -1,9 +1,11 @@
 import {
   designReview1,
   designReview3,
+  designReview4,
   prismaDesignReview1,
   prismaDesignReview2,
   prismaDesignReview3,
+  prismaDesignReview4,
   sharedDesignReview1,
   teamType1
 } from './test-data/design-reviews.test-data';
@@ -503,7 +505,15 @@ describe('Design Reviews', () => {
   });
 
   describe('Mark user confirmation tests', () => {
-    test('Marking succeeds', async () => {});
+    test('Marking succeeds', async () => {
+      vi.spyOn(prisma.design_Review, 'findUnique').mockResolvedValue(prismaDesignReview1);
+      const result = await expect(() =>
+        DesignReviewsService.markUserConfirmed(prismaDesignReview1.designReviewId, [1, 2], wonderwoman)
+      );
+
+      expect(prisma.design_Review.findUnique).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(designReview4);
+    });
 
     test('Design Review was not found', async () => {
       vi.spyOn(prisma.design_Review, 'findUnique').mockResolvedValue(null);

--- a/src/backend/tests/design-reviews.test.ts
+++ b/src/backend/tests/design-reviews.test.ts
@@ -9,14 +9,7 @@ import {
   sharedDesignReview1,
   teamType1
 } from './test-data/design-reviews.test-data';
-import {
-  aquaman,
-  batman,
-  superman,
-  theVisitor,
-  wonderwoman,
-  wonderwomanWithScheduleSettings
-} from './test-data/users.test-data';
+import { aquaman, batman, batmanWithScheduleSettings, superman, theVisitor, wonderwoman } from './test-data/users.test-data';
 import prisma from '../src/prisma/prisma';
 import {
   AccessDeniedAdminOnlyException,
@@ -511,17 +504,17 @@ describe('Design Reviews', () => {
     });
   });
 
-  describe('Mark user confirmation tests', () => {
-    test('Marking succeeds', async () => {
+  describe('Mark user confirmed tests', () => {
+    test('mark user confirmed succeeds', async () => {
       vi.spyOn(prisma.design_Review, 'findUnique').mockResolvedValue(prismaDesignReview5);
       const result = await DesignReviewsService.markUserConfirmed(
         prismaDesignReview5.designReviewId,
         [1, 2],
-        wonderwomanWithScheduleSettings
+        batmanWithScheduleSettings
       );
 
-      expect(prisma.design_Review.findUnique).toHaveBeenCalledTimes(0);
-      expect(result).toEqual(designReview5);
+      expect(prisma.design_Review.findUnique).toHaveBeenCalledTimes(1);
+      expect(result.confirmedMembers).toEqual(designReview5.confirmedMembers);
     });
 
     test('Design Review was not found', async () => {

--- a/src/backend/tests/design-reviews.test.ts
+++ b/src/backend/tests/design-reviews.test.ts
@@ -510,7 +510,6 @@ describe('Design Reviews', () => {
         DesignReviewsService.markUserConfirmed(prismaDesignReview1.designReviewId, [1, 2], wonderwoman)
       );
 
-      expect(prisma.design_Review.findUnique).toHaveBeenCalledTimes(1);
       expect(result).toEqual(designReview5);
     });
 

--- a/src/backend/tests/test-data/design-reviews.test-data.ts
+++ b/src/backend/tests/test-data/design-reviews.test-data.ts
@@ -4,7 +4,13 @@ import {
   TeamType,
   Design_Review as PrismaDesignReview
 } from '@prisma/client';
-import { batman, sharedBatman, wonderwoman } from './users.test-data';
+import {
+  batman,
+  sharedBatman,
+  wonderwoman,
+  wonderwomanMarkedWithScheduleSettings,
+  wonderwomanWithScheduleSettings
+} from './users.test-data';
 import { prismaWbsElement1 } from './wbs-element.test-data';
 import {
   DesignReview,
@@ -138,7 +144,7 @@ export const prismaDesignReview5: Prisma.Design_ReviewGetPayload<typeof designRe
   docTemplateLink: null,
   wbsElementId: 1,
   requiredMembers: [batman],
-  optionalMembers: [wonderwoman],
+  optionalMembers: [wonderwomanWithScheduleSettings],
   confirmedMembers: [batman],
   deniedMembers: [],
   attendees: [batman],
@@ -200,8 +206,8 @@ export const designReview5: DesignReview = {
   isOnline: true,
   isInPerson: false,
   requiredMembers: [batman],
-  optionalMembers: [wonderwoman],
-  confirmedMembers: [batman],
+  optionalMembers: [wonderwomanMarkedWithScheduleSettings],
+  confirmedMembers: [batman, wonderwomanMarkedWithScheduleSettings],
   deniedMembers: [],
   attendees: [batman],
   wbsName: 'car',

--- a/src/backend/tests/test-data/design-reviews.test-data.ts
+++ b/src/backend/tests/test-data/design-reviews.test-data.ts
@@ -57,7 +57,7 @@ export const prismaDesignReview1: Prisma.Design_ReviewGetPayload<typeof designRe
   docTemplateLink: null,
   wbsElementId: 1,
   requiredMembers: [batman],
-  optionalMembers: [wonderwoman],
+  optionalMembers: [],
   confirmedMembers: [batman],
   deniedMembers: [],
   attendees: [batman],
@@ -119,6 +119,33 @@ export const prismaDesignReview3: Prisma.Design_ReviewGetPayload<typeof designRe
   teamType: teamType1
 };
 
+export const prismaDesignReview5: Prisma.Design_ReviewGetPayload<typeof designReviewQueryArgs> = {
+  designReviewId: '1',
+  dateScheduled: new Date('2024-03-25'),
+  meetingTimes: [0, 1, 2, 3],
+  dateCreated: new Date('2024-03-10'),
+  userCreatedId: batman.userId,
+  userCreated: batman,
+  status: PrismaDesignReviewStatus.CONFIRMED,
+  teamTypeId: '1',
+  teamType: teamType1,
+  location: null,
+  isOnline: true,
+  isInPerson: false,
+  zoomLink: null,
+  dateDeleted: null,
+  userDeletedId: null,
+  docTemplateLink: null,
+  wbsElementId: 1,
+  requiredMembers: [batman],
+  optionalMembers: [wonderwoman],
+  confirmedMembers: [batman],
+  deniedMembers: [],
+  attendees: [batman],
+  userDeleted: null,
+  wbsElement: prismaWbsElement1
+};
+
 export const designReview3: DesignReview = {
   designReviewId: '2',
   dateScheduled: new Date('2024-03-25'),
@@ -162,21 +189,21 @@ export const sharedDesignReview1: SharedDesignReview = {
   wbsNum: { carNumber: 1, projectNumber: 2, workPackageNumber: 0 }
 };
 
-export const designReview4: DesignReview = {
+export const designReview5: DesignReview = {
   designReviewId: '1',
   dateScheduled: new Date('2024-03-25'),
   meetingTimes: [0, 1, 2, 3],
   dateCreated: new Date('2024-03-10'),
   userCreated: batman,
+  status: DesignReviewStatus.CONFIRMED,
   teamType: teamType1,
   isOnline: true,
   isInPerson: false,
   requiredMembers: [batman],
   optionalMembers: [wonderwoman],
-  confirmedMembers: [batman, wonderwoman],
+  confirmedMembers: [batman],
   deniedMembers: [],
   attendees: [batman],
-  status: DesignReviewStatus.UNCONFIRMED,
   wbsName: 'car',
   wbsNum: { carNumber: 1, projectNumber: 2, workPackageNumber: 0 }
 };

--- a/src/backend/tests/test-data/design-reviews.test-data.ts
+++ b/src/backend/tests/test-data/design-reviews.test-data.ts
@@ -57,7 +57,7 @@ export const prismaDesignReview1: Prisma.Design_ReviewGetPayload<typeof designRe
   docTemplateLink: null,
   wbsElementId: 1,
   requiredMembers: [batman],
-  optionalMembers: [],
+  optionalMembers: [wonderwoman],
   confirmedMembers: [batman],
   deniedMembers: [],
   attendees: [batman],
@@ -158,6 +158,25 @@ export const sharedDesignReview1: SharedDesignReview = {
   deniedMembers: [],
   attendees: [sharedBatman],
   teamType: teamType1,
+  wbsName: 'car',
+  wbsNum: { carNumber: 1, projectNumber: 2, workPackageNumber: 0 }
+};
+
+export const designReview4: DesignReview = {
+  designReviewId: '1',
+  dateScheduled: new Date('2024-03-25'),
+  meetingTimes: [0, 1, 2, 3],
+  dateCreated: new Date('2024-03-10'),
+  userCreated: batman,
+  teamType: teamType1,
+  isOnline: true,
+  isInPerson: false,
+  requiredMembers: [batman],
+  optionalMembers: [wonderwoman],
+  confirmedMembers: [batman, wonderwoman],
+  deniedMembers: [],
+  attendees: [batman],
+  status: 'C:/Users/marti/Desktop/vscode projects/FinishLine/src/shared/src/types/design-review-types'.UNCONFIRMED,
   wbsName: 'car',
   wbsNum: { carNumber: 1, projectNumber: 2, workPackageNumber: 0 }
 };

--- a/src/backend/tests/test-data/design-reviews.test-data.ts
+++ b/src/backend/tests/test-data/design-reviews.test-data.ts
@@ -130,8 +130,8 @@ export const prismaDesignReview5: Prisma.Design_ReviewGetPayload<typeof designRe
   dateScheduled: new Date('2024-03-25'),
   meetingTimes: [0, 1, 2, 3],
   dateCreated: new Date('2024-03-10'),
-  userCreatedId: batman.userId,
-  userCreated: batman,
+  userCreatedId: wonderwoman.userId,
+  userCreated: wonderwoman,
   status: PrismaDesignReviewStatus.CONFIRMED,
   teamTypeId: '1',
   teamType: teamType1,
@@ -147,7 +147,7 @@ export const prismaDesignReview5: Prisma.Design_ReviewGetPayload<typeof designRe
   optionalMembers: [wonderwomanWithScheduleSettings],
   confirmedMembers: [batman],
   deniedMembers: [],
-  attendees: [batman],
+  attendees: [wonderwoman],
   userDeleted: null,
   wbsElement: prismaWbsElement1
 };
@@ -200,16 +200,18 @@ export const designReview5: DesignReview = {
   dateScheduled: new Date('2024-03-25'),
   meetingTimes: [0, 1, 2, 3],
   dateCreated: new Date('2024-03-10'),
-  userCreated: batman,
+  userCreated: wonderwoman,
   status: DesignReviewStatus.CONFIRMED,
   teamType: teamType1,
   isOnline: true,
   isInPerson: false,
-  requiredMembers: [batman],
+  requiredMembers: [],
   optionalMembers: [wonderwomanMarkedWithScheduleSettings],
-  confirmedMembers: [batman, wonderwomanMarkedWithScheduleSettings],
+  confirmedMembers: [sharedBatman],
   deniedMembers: [],
-  attendees: [batman],
+  attendees: [wonderwoman],
   wbsName: 'car',
-  wbsNum: { carNumber: 1, projectNumber: 2, workPackageNumber: 0 }
+  wbsNum: { carNumber: 1, projectNumber: 2, workPackageNumber: 0 },
+  zoomLink: undefined,
+  userDeleted: undefined
 };

--- a/src/backend/tests/test-data/design-reviews.test-data.ts
+++ b/src/backend/tests/test-data/design-reviews.test-data.ts
@@ -176,7 +176,7 @@ export const designReview4: DesignReview = {
   confirmedMembers: [batman, wonderwoman],
   deniedMembers: [],
   attendees: [batman],
-  status: 'C:/Users/marti/Desktop/vscode projects/FinishLine/src/shared/src/types/design-review-types'.UNCONFIRMED,
+  status: DesignReviewStatus.UNCONFIRMED,
   wbsName: 'car',
   wbsNum: { carNumber: 1, projectNumber: 2, workPackageNumber: 0 }
 };

--- a/src/backend/tests/test-data/users.test-data.ts
+++ b/src/backend/tests/test-data/users.test-data.ts
@@ -162,3 +162,33 @@ export const batmanUserScheduleSettings: UserScheduleSettings = {
   personalZoomLink: 'https://zoom.us/j/gotham',
   availability: []
 };
+
+export const wonderwomanScheduleSettings: Schedule_Settings = {
+  drScheduleSettingsId: 'wwschedule',
+  personalGmail: 'diana@gmail.com',
+  personalZoomLink: 'https://zoom.us/jk/athens',
+  availability: [3],
+  userId: 72
+};
+
+export const wonderwomanMarkedScheduleSettings: Schedule_Settings = {
+  drScheduleSettingsId: 'wwschedule',
+  personalGmail: 'diana@gmail.com',
+  personalZoomLink: 'https://zoom.us/jk/athens',
+  availability: [1, 2],
+  userId: 72
+};
+
+export const wonderwomanWithScheduleSettings: PrismaUser & { scheduleSettings: Schedule_Settings } = {
+  ...wonderwoman,
+  scheduleSettings: {
+    ...wonderwomanScheduleSettings
+  }
+};
+
+export const wonderwomanMarkedWithScheduleSettings: PrismaUser & { scheduleSettings: Schedule_Settings } = {
+  ...wonderwoman,
+  scheduleSettings: {
+    ...wonderwomanMarkedScheduleSettings
+  }
+};


### PR DESCRIPTION
## Changes
created an endpoint that marks the current user as confirmed for a given design review, and sets their schedule setting's availability to the given availability array


## Test Cases

- When the user doesn't have schedule settings
- When the array of availabilities has only 1 element
- given user isn't optional nor required
- availabilities arent between 0 and 83 inclusive
- when the design review doesn't exist
- when the design review has been deleted



## Screenshots

![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/90310958/bbf43f9e-e2ba-4372-817e-caf2be7c0cd4)
![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/90310958/aab54ecd-cb00-48d7-82c4-b71947b3733b)
![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/90310958/05319e88-e675-4024-afe5-d4a998cd308e)
![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/90310958/95faeef9-d7bb-4d17-aaf0-7dc729c41d1e)
![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/90310958/b4d6c59a-a146-4a6b-a287-25ae30f15ed0)
![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/90310958/f2288df6-b10d-448c-b0df-366d01f065ed)
![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/90310958/fe5d8dc4-5c6e-4aef-803f-3568d897b42e)
![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/90310958/c7cac788-b225-4313-b1cc-9d133e472f46)
![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/90310958/592a695f-b657-4506-adf4-eb0acf709069)


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [ ] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #2223 
