### PR TITLE
Design review test passes for all dates

### DIFF
--- a/src/backend/tests/design-reviews.test.ts
+++ b/src/backend/tests/design-reviews.test.ts
@@ -419,10 +419,13 @@ describe('Design Reviews', () => {
       vi.spyOn(prisma.teamType, 'findFirst').mockResolvedValue(teamType1);
       vi.spyOn(prisma.wBS_Element, 'findUnique').mockResolvedValue(prismaWbsElement1);
       vi.spyOn(prisma.design_Review, 'create').mockResolvedValue(prismaDesignReview1);
+      
+      const newDate = new Date();
+      newDate.setDate(newDate.getDate() + 1); 
 
       const res = await DesignReviewsService.createDesignReview(
         batman,
-        new Date('2024-03-25'),
+        newDate,
         '1',
         [],
         [],

--- a/src/backend/tests/design-reviews.test.ts
+++ b/src/backend/tests/design-reviews.test.ts
@@ -419,9 +419,10 @@ describe('Design Reviews', () => {
       vi.spyOn(prisma.teamType, 'findFirst').mockResolvedValue(teamType1);
       vi.spyOn(prisma.wBS_Element, 'findUnique').mockResolvedValue(prismaWbsElement1);
       vi.spyOn(prisma.design_Review, 'create').mockResolvedValue(prismaDesignReview1);
-      
+
+      // the date for the design review is always in the future
       const newDate = new Date();
-      newDate.setDate(newDate.getDate() + 1); 
+      newDate.setDate(newDate.getDate() + 1);
 
       const res = await DesignReviewsService.createDesignReview(
         batman,


### PR DESCRIPTION
## Changes
Design review test will fail right now because the date it has been set for is in the past. I made it so that the date it is set for is always a future date so this no longer happens
