### PR TITLE
#2084 delete unit column

### DIFF
--- a/src/backend/src/controllers/projects.controllers.ts
+++ b/src/backend/src/controllers/projects.controllers.ts
@@ -246,8 +246,8 @@ export default class ProjectsController {
   static async deleteUnit(req: Request, res: Response, next: NextFunction) {
     try {
       const user: User = await getCurrentUser(res);
-      const { unitName } = req.params;
-      const deletedUnit = await ProjectsService.deleteUnit(user, unitName);
+      const { unitId } = req.params;
+      const deletedUnit = await ProjectsService.deleteUnit(user, unitId);
       res.status(200).json(deletedUnit);
     } catch (error: unknown) {
       next(error);

--- a/src/frontend/src/apis/bom.api.ts
+++ b/src/frontend/src/apis/bom.api.ts
@@ -56,6 +56,11 @@ export const createUnit = async (name: string) => {
   const { data } = await axios.post(apiUrls.bomCreateUnit(), { name });
   return data;
 };
+
+export const deleteUnit = async (id: string) => {
+  return axios.delete(apiUrls.bomDeleteUnit(id));
+};
+
 /**
  * Requests all the units from the backend.
  * @returns All the units

--- a/src/frontend/src/apis/bom.api.ts
+++ b/src/frontend/src/apis/bom.api.ts
@@ -57,6 +57,11 @@ export const createUnit = async (name: string) => {
   return data;
 };
 
+/**
+ * Soft deletes a unit.
+ * @param unitId
+ * @returns
+ */
 export const deleteUnit = async (id: string) => {
   return axios.delete(apiUrls.bomDeleteUnit(id));
 };

--- a/src/frontend/src/hooks/bom.hooks.ts
+++ b/src/frontend/src/hooks/bom.hooks.ts
@@ -8,6 +8,7 @@ import {
   createMaterialType,
   createUnit,
   deleteSingleMaterial,
+  deleteUnit,
   editMaterial,
   getAllManufacturers,
   getAllMaterialTypes,
@@ -47,6 +48,22 @@ export const useGetAllUnits = () => {
     const data = await getAllUnits();
     return data;
   });
+};
+
+export const useDeleteUnit = (id: string) => {
+  const queryClient = useQueryClient();
+  return useMutation<Unit, Error>(
+    ['units', 'delete'],
+    async () => {
+      const { data } = await deleteUnit(id);
+      return data;
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(['units']);
+      }
+    }
+  );
 };
 
 /**

--- a/src/frontend/src/hooks/bom.hooks.ts
+++ b/src/frontend/src/hooks/bom.hooks.ts
@@ -64,7 +64,7 @@ export const useDeleteUnit = () => {
     },
     {
       onSuccess: () => {
-        queryClient.invalidateQueries(['units', 'materials']);
+        queryClient.invalidateQueries(['materials', 'units']);
       }
     }
   );

--- a/src/frontend/src/hooks/bom.hooks.ts
+++ b/src/frontend/src/hooks/bom.hooks.ts
@@ -50,17 +50,21 @@ export const useGetAllUnits = () => {
   });
 };
 
-export const useDeleteUnit = (id: string) => {
+/**
+ * Custom react hook to delete a unit
+ */
+
+export const useDeleteUnit = () => {
   const queryClient = useQueryClient();
-  return useMutation<Unit, Error>(
+  return useMutation<Unit, Error, string>(
     ['units', 'delete'],
-    async () => {
+    async (id: string) => {
       const { data } = await deleteUnit(id);
       return data;
     },
     {
       onSuccess: () => {
-        queryClient.invalidateQueries(['units']);
+        queryClient.invalidateQueries(['units', 'materials']);
       }
     }
   );

--- a/src/frontend/src/pages/AdminToolsPage/AdminToolsBOMConfig.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/AdminToolsBOMConfig.tsx
@@ -6,7 +6,7 @@ import { Box } from '@mui/system';
 
 const AdminToolsBOMConfig: React.FC = () => {
   return (
-    <Box>
+    <Box paddingBottom="4">
       <Typography variant="h5" gutterBottom borderBottom={1} color="#ef4345" borderColor={'white'}>
         Bill of Materials Config
       </Typography>

--- a/src/frontend/src/pages/AdminToolsPage/AdminToolsBOMConfig.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/AdminToolsBOMConfig.tsx
@@ -6,7 +6,7 @@ import { Box } from '@mui/system';
 
 const AdminToolsBOMConfig: React.FC = () => {
   return (
-    <Box paddingBottom="4">
+    <Box paddingBottom={4}>
       <Typography variant="h5" gutterBottom borderBottom={1} color="#ef4345" borderColor={'white'}>
         Bill of Materials Config
       </Typography>

--- a/src/frontend/src/pages/AdminToolsPage/BOMConfig/UnitTable.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/BOMConfig/UnitTable.tsx
@@ -1,11 +1,14 @@
-import { TableRow, TableCell, Box } from '@mui/material';
+import { TableRow, TableCell, Box, IconButton } from '@mui/material';
 import LoadingIndicator from '../../../components/LoadingIndicator';
 import ErrorPage from '../../ErrorPage';
 import { NERButton } from '../../../components/NERButton';
 import { useState } from 'react';
 import AdminToolTable from '../AdminToolTable';
-import { useGetAllUnits } from '../../../hooks/bom.hooks';
+import { useGetAllUnits, useDeleteUnit } from '../../../hooks/bom.hooks';
 import CreateUnitFormModal from './CreateUnitFormModal';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { Unit } from 'shared';
+import { useToast } from '../../../hooks/toasts.hooks';
 
 const UnitTypeTable: React.FC = () => {
   const {
@@ -15,6 +18,7 @@ const UnitTypeTable: React.FC = () => {
     error: unitTypesError
   } = useGetAllUnits();
   const [createModalShow, setCreateModalShow] = useState<boolean>(false);
+  const toast = useToast();
 
   if (!unitTypes || unitTypesIsLoading) {
     return <LoadingIndicator />;
@@ -23,10 +27,31 @@ const UnitTypeTable: React.FC = () => {
     return <ErrorPage message={unitTypesError?.message} />;
   }
 
+  const handleDeleteUnit = (unit: Unit) => {
+    try {
+      useDeleteUnit(unit.name);
+    } catch (e: unknown) {
+      if (e instanceof Error) {
+        toast.error(e.message, 3000);
+      }
+    }
+  };
+
   const unitTypesTableRows = unitTypes.map((unitType) => (
     <TableRow>
       <TableCell align="left" sx={{ border: '2px solid black' }}>
         {unitType.name}
+      </TableCell>
+      <TableCell align="center" sx={{ width: 10, border: '2px solid black' }}>
+        <IconButton
+          type="button"
+          sx={{
+            mx: 1
+          }}
+          onClick={handleDeleteUnit}
+        >
+          <DeleteIcon />
+        </IconButton>
       </TableCell>
     </TableRow>
   ));

--- a/src/frontend/src/pages/AdminToolsPage/BOMConfig/UnitTable.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/BOMConfig/UnitTable.tsx
@@ -7,7 +7,6 @@ import AdminToolTable from '../AdminToolTable';
 import { useGetAllUnits, useDeleteUnit } from '../../../hooks/bom.hooks';
 import CreateUnitFormModal from './CreateUnitFormModal';
 import DeleteIcon from '@mui/icons-material/Delete';
-import { Unit } from 'shared';
 import { useToast } from '../../../hooks/toasts.hooks';
 
 const UnitTypeTable: React.FC = () => {

--- a/src/frontend/src/pages/AdminToolsPage/BOMConfig/UnitTable.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/BOMConfig/UnitTable.tsx
@@ -19,6 +19,7 @@ const UnitTypeTable: React.FC = () => {
   } = useGetAllUnits();
   const [createModalShow, setCreateModalShow] = useState<boolean>(false);
   const toast = useToast();
+  const { mutateAsync: deleteUnit } = useDeleteUnit();
 
   if (!unitTypes || unitTypesIsLoading) {
     return <LoadingIndicator />;
@@ -27,9 +28,9 @@ const UnitTypeTable: React.FC = () => {
     return <ErrorPage message={unitTypesError?.message} />;
   }
 
-  const handleDeleteUnit = (unit: Unit) => {
+  const handleDeleteUnit = (id: string) => {
     try {
-      useDeleteUnit(unit.name);
+      deleteUnit(id);
     } catch (e: unknown) {
       if (e instanceof Error) {
         toast.error(e.message, 3000);
@@ -48,7 +49,7 @@ const UnitTypeTable: React.FC = () => {
           sx={{
             mx: 1
           }}
-          onClick={handleDeleteUnit}
+          onClick={() => handleDeleteUnit(unitType.name)}
         >
           <DeleteIcon />
         </IconButton>

--- a/src/frontend/src/pages/AdminToolsPage/BOMConfig/UnitTable.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/BOMConfig/UnitTable.tsx
@@ -59,7 +59,7 @@ const UnitTypeTable: React.FC = () => {
   return (
     <Box>
       <CreateUnitFormModal showModal={createModalShow} handleClose={() => setCreateModalShow(false)} />
-      <AdminToolTable columns={[{ name: 'Unit' }]} rows={unitTypesTableRows} />
+      <AdminToolTable columns={[{ name: 'Unit' }, { name: '' }]} rows={unitTypesTableRows} />
       <Box sx={{ display: 'flex', justifyContent: 'right', marginTop: '10px' }}>
         <NERButton
           variant="contained"

--- a/src/frontend/src/utils/urls.ts
+++ b/src/frontend/src/utils/urls.ts
@@ -129,7 +129,9 @@ const bomCreateAssembly = (wbsNum: WbsNumber) => `${assemblyEndpoints()}/${wbsPi
 const bomAssignAssembly = (materialId: string) => `${materialEndpoints()}/${materialId}/assign-assembly`;
 const bomCreateManufacturer = () => `${bomEndpoints()}/manufacturer/create`;
 const bomCreateMaterialType = () => `${bomEndpoints()}/material-type/create`;
-const bomCreateUnit = () => `${bomEndpoints()}/units/create`;
+const bomCreateUnit = () => `${bomGetAllUnits()}/create`;
+const bomUnitById = (id: string) => `${bomGetAllUnits()}/${id}`;
+const bomDeleteUnit = (id: string) => `${bomUnitById(id)}/delete`;
 
 /************** Design Review Endpoints *******************************/
 const designReviews = () => `${API_URL}/design-reviews`;
@@ -245,6 +247,8 @@ export const apiUrls = {
   bomCreateManufacturer,
   bomCreateMaterialType,
   bomCreateUnit,
+  bomUnitById,
+  bomDeleteUnit,
 
   designReviews,
   designReviewsCreate,


### PR DESCRIPTION
## Changes

Added a column of trash can icons in the unit table in admin tools that allow for deleting a unit. 

## Notes

- there is an error occurring and I'm not sure where it's coming from

## Screenshots
<img width="1702" alt="Screenshot 2024-03-29 at 4 21 08 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/147773632/0b64cbbc-5253-4dc1-aeb2-112790a5ec6a">
<img width="379" alt="Screenshot 2024-03-29 at 4 21 26 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/147773632/e9cadd43-5659-4251-a415-27e91c500866">

## To Do

- [ ] fix delete functionality  - figure out the error with handleDeleteUnit

## Checklist

- [X] All commits are tagged with the ticket number
- [X] All code follows repository-configured prettier formatting
- [X] No merge conflicts
- [X] Screenshots of UI changes (see Screenshots section)
- [X] Remove any non-applicable sections of this template
- [X] Assign the PR to yourself
- [X] No `yarn.lock` changes (unless dependencies have changed)
- [X] Request reviewers & ping on Slack
- [X] PR is linked to the ticket (fill in the closes line below)

Closes #2084 
