### PR TITLE
#1789 - Disabled 'Actions' button for guest roles.

### DIFF
--- a/src/frontend/src/components/ActionsMenu.tsx
+++ b/src/frontend/src/components/ActionsMenu.tsx
@@ -3,6 +3,8 @@ import { ReactElement, useState } from 'react';
 import { NERButton } from './NERButton';
 import { ArrowDropDown } from '@mui/icons-material';
 import { Divider, ListItemIcon, Menu, MenuItem } from '@mui/material';
+import { isGuest } from 'shared';
+import { useCurrentUser } from '../hooks/users.hooks';
 
 export type ButtonInfo = {
   title: string;
@@ -29,12 +31,14 @@ const ActionsMenu: React.FC<ActionsMenuProps> = ({ buttons, title = 'Actions' })
   };
 
   const dropdownOpen = Boolean(anchorEl);
+  const user = useCurrentUser();
 
   return (
     <Box>
       <NERButton
         endIcon={<ArrowDropDown style={{ fontSize: 28 }} />}
         variant="contained"
+        disabled={isGuest(user.role)}
         id="reimbursement-request-actions-dropdown"
         onClick={handleClick}
       >


### PR DESCRIPTION
## Changes

If a user is a guest, then the 'Actions' button when viewing a change request is disabled. Follows the method done for other similar buttons.

## Screenshots

Full Screen
<img width="1424" alt="Screenshot 2024-04-02 at 10 35 10 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/54627422/e7fbf440-219d-48a5-ad15-6d3282136e4e">

Smallest Window
<img width="582" alt="Screenshot 2024-04-02 at 10 35 22 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/54627422/d372e891-9087-4188-8ae7-0d2adebe39c8">

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1789
