### PR TITLE
#1247 all work package edits are now marked as active

### DIFF
--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -1,4 +1,4 @@
-import { Prisma, Role, User, WBS_Element, WBS_Element_Status } from '@prisma/client';
+import { Role, User, WBS_Element, WBS_Element_Status } from '@prisma/client';
 import {
   getDay,
   DescriptionBullet,

--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -511,7 +511,8 @@ export default class WorkPackagesService {
           update: {
             name,
             projectLeadId,
-            projectManagerId
+            projectManagerId,
+            status: WBS_Element_Status.ACTIVE // set the status to active if it was not already
           }
         },
         stage,

--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -1,4 +1,4 @@
-import { Role, User, WBS_Element, WBS_Element_Status } from '@prisma/client';
+import { Prisma, Role, User, WBS_Element, WBS_Element_Status } from '@prisma/client';
 import {
   getDay,
   DescriptionBullet,
@@ -499,7 +499,12 @@ export default class WorkPackagesService {
 
     // make the date object but add 12 hours so that the time isn't 00:00 to avoid timezone problems
     const date = new Date(startDate);
-    date.setTime(date.getTime() + 12 * 60 * 60 * 1000);
+
+    // set the status of the wbs element to active if an edit is made to a completed version
+    const status =
+      originalWorkPackage.wbsElement.status === WbsElementStatus.Complete
+        ? WbsElementStatus.Active
+        : originalWorkPackage.wbsElement.status;
 
     // update the work package with the input fields
     const updatedWorkPackage = await prisma.work_Package.update({
@@ -512,7 +517,7 @@ export default class WorkPackagesService {
             name,
             projectLeadId,
             projectManagerId,
-            status: WBS_Element_Status.ACTIVE // set the status to active if it was not already
+            status // set the status to active if it was not already
           }
         },
         stage,

--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -499,6 +499,7 @@ export default class WorkPackagesService {
 
     // make the date object but add 12 hours so that the time isn't 00:00 to avoid timezone problems
     const date = new Date(startDate);
+    date.setTime(date.getTime() + 12 * 60 * 60 * 1000);
 
     // set the status of the wbs element to active if an edit is made to a completed version
     const status =


### PR DESCRIPTION
## Changes

Work package corresponding wbs_elements are now set as active when you edit one

## Test Cases

- **all current tests are passing lmk if I should postman or something**

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1247 
