### PR TITLE
Deny reimbursement request ping financeteam- slack

### DIFF
--- a/src/backend/tests/reimbursement-requests.test.ts
+++ b/src/backend/tests/reimbursement-requests.test.ts
@@ -625,7 +625,7 @@ describe('Reimbursement Requests', () => {
         ReimbursementRequestService.approveReimbursementRequest(prismaGiveMeMyMoney2.reimbursementRequestId, alfred)
       ).rejects.toThrow(new HttpException(400, 'This reimbursement request has already been approved'));
     });
-    test('Approve Reimbursment Request success', async () => {
+    test('Approve  Request success', async () => {
       vi.spyOn(prisma.team, 'findUnique').mockResolvedValue(primsaTeam2);
       vi.spyOn(prisma.reimbursement_Request, 'findUnique').mockResolvedValue(prismaGiveMeMyMoney3);
       vi.spyOn(prisma.reimbursement_Status, 'create').mockResolvedValue(prismaReimbursementStatus);

--- a/src/frontend/src/apis/finance.api.ts
+++ b/src/frontend/src/apis/finance.api.ts
@@ -56,7 +56,7 @@ export const markReimbursementRequestAsDelivered = (id: string) => {
 };
 
 /**
- * Edits a reimbursment request
+ * Edits a  request
  *
  * @param id the id of the reimbursement request to edit
  * @param formData the data to edit the reimbursement request with


### PR DESCRIPTION
## Changes

Changed the deny reimbursement request endpoint to ping the user slack ID to the slack ID of the finance team

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #2278
