### PR TITLE
#2311-reversed-workpackage-dropdown

### DIFF
--- a/src/frontend/src/pages/CalendarPage/DesignReviewCreateModal.tsx
+++ b/src/frontend/src/pages/CalendarPage/DesignReviewCreateModal.tsx
@@ -127,21 +127,16 @@ export const DesignReviewCreateModal: React.FC<DesignReviewCreateModalProps> = (
 
   const memberOptions = users.map(userToAutocompleteOption);
 
-  const wbsDropdownOptionsSorted: { label: string; id: string }[] = [];
   const wbsDropdownOptions: { label: string; id: string }[] = [];
 
   allWorkPackages.forEach((workPackage: WorkPackage) => {
-    wbsDropdownOptionsSorted.push({
+    wbsDropdownOptions.push({
       label: `${wbsNamePipe(workPackage)}`,
       id: wbsPipe(workPackage.wbsNum)
     });
   });
 
-  wbsDropdownOptionsSorted.sort((wp1, wp2) => wbsNumComparator(wp1.id, wp2.id));
-
-  for (let i = wbsDropdownOptionsSorted.length - 1; i >= 0; i--) {
-    wbsDropdownOptions.push(wbsDropdownOptionsSorted[i]);
-  }
+  wbsDropdownOptions.sort((wp1, wp2) => wbsNumComparator(wp2.id, wp1.id));
 
   return (
     <NERFormModal

--- a/src/frontend/src/pages/CalendarPage/DesignReviewCreateModal.tsx
+++ b/src/frontend/src/pages/CalendarPage/DesignReviewCreateModal.tsx
@@ -127,16 +127,21 @@ export const DesignReviewCreateModal: React.FC<DesignReviewCreateModalProps> = (
 
   const memberOptions = users.map(userToAutocompleteOption);
 
+  const wbsDropdownOptionsSorted: { label: string; id: string }[] = [];
   const wbsDropdownOptions: { label: string; id: string }[] = [];
 
   allWorkPackages.forEach((workPackage: WorkPackage) => {
-    wbsDropdownOptions.push({
+    wbsDropdownOptionsSorted.push({
       label: `${wbsNamePipe(workPackage)}`,
       id: wbsPipe(workPackage.wbsNum)
     });
   });
 
-  wbsDropdownOptions.sort((wp1, wp2) => wbsNumComparator(wp1.id, wp2.id));
+  wbsDropdownOptionsSorted.sort((wp1, wp2) => wbsNumComparator(wp1.id, wp2.id));
+
+  for (let i = wbsDropdownOptionsSorted.length - 1; i >= 0; i--) {
+    wbsDropdownOptions.push(wbsDropdownOptionsSorted[i]);
+  }
 
   return (
     <NERFormModal


### PR DESCRIPTION
## Changes

Reversed the order of the dropdown menu.

## Screenshots

![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/148027431/dc128008-bc7c-4bd8-8e0d-11398989af3d)

![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/148027431/3f56ed30-5191-472b-8e1b-985673d5bcbe)


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #2311 
