### PR TITLE
2326 drc debugs set team teamtype endpoint

### DIFF
--- a/src/backend/src/controllers/teams.controllers.ts
+++ b/src/backend/src/controllers/teams.controllers.ts
@@ -131,9 +131,10 @@ export default class TeamsController {
   static async setTeamType(req: Request, res: Response, next: NextFunction) {
     try {
       const { teamTypeId } = req.body;
+      const { teamId } = req.params;
       const submitter = await getCurrentUser(res);
 
-      const updateTeamType = await TeamsService.setTeamType(submitter, req.params.teamId, teamTypeId);
+      const updateTeamType = await TeamsService.setTeamType(submitter, teamId, teamTypeId);
 
       return res.status(200).json(updateTeamType);
     } catch (error: unknown) {

--- a/src/backend/src/controllers/teams.controllers.ts
+++ b/src/backend/src/controllers/teams.controllers.ts
@@ -127,4 +127,19 @@ export default class TeamsController {
       next(error);
     }
   }
+
+  static async setTeamType(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { teamTypeId } = req.body;
+      const submitter = await getCurrentUser(res);
+
+      // update the team with the input fields
+      const updateTeamType = await TeamsService.setTeamType(submitter, req.params.teamId, teamTypeId);
+
+      // return the updated team
+      return res.status(200).json(updateTeamType);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
 }

--- a/src/backend/src/controllers/teams.controllers.ts
+++ b/src/backend/src/controllers/teams.controllers.ts
@@ -134,9 +134,9 @@ export default class TeamsController {
       const { teamId } = req.params;
       const submitter = await getCurrentUser(res);
 
-      const updateTeamType = await TeamsService.setTeamType(submitter, teamId, teamTypeId);
+      const updatedTeam = await TeamsService.setTeamType(submitter, teamId, teamTypeId);
 
-      return res.status(200).json(updateTeamType);
+      return res.status(200).json(updatedTeam);
     } catch (error: unknown) {
       next(error);
     }

--- a/src/backend/src/controllers/teams.controllers.ts
+++ b/src/backend/src/controllers/teams.controllers.ts
@@ -133,10 +133,8 @@ export default class TeamsController {
       const { teamTypeId } = req.body;
       const submitter = await getCurrentUser(res);
 
-      // update the team with the input fields
       const updateTeamType = await TeamsService.setTeamType(submitter, req.params.teamId, teamTypeId);
 
-      // return the updated team
       return res.status(200).json(updateTeamType);
     } catch (error: unknown) {
       next(error);

--- a/src/backend/src/prisma-query-args/teams.query-args.ts
+++ b/src/backend/src/prisma-query-args/teams.query-args.ts
@@ -6,6 +6,7 @@ const teamQueryArgs = Prisma.validator<Prisma.TeamArgs>()({
     head: true,
     leads: true,
     userArchived: true,
+    teamType: true,
     projects: {
       where: {
         wbsElement: {

--- a/src/backend/src/prisma/migrations/20240411015314_added_team_type_to_team/migration.sql
+++ b/src/backend/src/prisma/migrations/20240411015314_added_team_type_to_team/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Team" ADD COLUMN     "teamTypeId" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "Team" ADD CONSTRAINT "Team_teamTypeId_fkey" FOREIGN KEY ("teamTypeId") REFERENCES "TeamType"("teamTypeId") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/src/backend/src/prisma/schema.prisma
+++ b/src/backend/src/prisma/schema.prisma
@@ -146,6 +146,8 @@ model Team {
   userArchived           User?                      @relation(name: "userArchived", fields: [userArchivedId], references: [userId])
   meetings               Meeting[]
   proposedProjectChanges Project_Proposed_Changes[] @relation(name: "proposedProjectTeams")
+  teamType               TeamType?                  @relation(fields: [teamTypeId], references: [teamTypeId])
+  teamTypeId             String?
 }
 
 model Session {
@@ -617,6 +619,7 @@ model TeamType {
   name           String          @unique
   iconName       String
   Design_Reviews Design_Review[]
+  Team           Team[]
 }
 
 model Design_Review {

--- a/src/backend/src/prisma/seed.ts
+++ b/src/backend/src/prisma/seed.ts
@@ -1156,9 +1156,9 @@ const performSeed: () => Promise<void> = async () => {
     assembly1.assemblyId
   );
 
-  const teamType1 = await TeamsService.createTeamType(batman, 'team 1', 'YouTubeIcon');
-  const teamType2 = await TeamsService.createTeamType(thomasEmrax, 'team 2', 'InstagramIcon');
-  const teamType3 = await TeamsService.createTeamType(cyborg, 'team 3', 'SettingsIcon');
+  const teamType1 = await TeamsService.createTeamType(batman, 'Mechanical', 'YouTubeIcon');
+  const teamType2 = await TeamsService.createTeamType(thomasEmrax, 'Software', 'InstagramIcon');
+  const teamType3 = await TeamsService.createTeamType(cyborg, 'Electrical', 'SettingsIcon');
 
   // Need to do this because the design review cannot be scheduled for a past day
   const nextDay = new Date();

--- a/src/backend/src/routes/teams.routes.ts
+++ b/src/backend/src/routes/teams.routes.ts
@@ -53,7 +53,7 @@ teamsRouter.post(
 );
 
 teamsRouter.post(
-  'teams/:teamId/set-team-type',
+  '/:teamId/set-team-type',
   nonEmptyString(body('teamTypeId')),
   validateInputs,
   TeamsController.setTeamType

--- a/src/backend/src/routes/teams.routes.ts
+++ b/src/backend/src/routes/teams.routes.ts
@@ -54,10 +54,8 @@ teamsRouter.post(
 
 teamsRouter.post(
   'teams/:teamId/set-team-type',
-  body('teamType').isArray(),
-  nonEmptyString(body('teamType.*.teamTypeId')),
-  nonEmptyString(body(''))
-  nonEmptyString(body('name.*.iconName'))
+  nonEmptyString(body('teamTypeId')),
+  validateInputs,
   TeamsController.setTeamType
 );
 export default teamsRouter;

--- a/src/backend/src/routes/teams.routes.ts
+++ b/src/backend/src/routes/teams.routes.ts
@@ -51,4 +51,13 @@ teamsRouter.post(
   validateInputs,
   TeamsController.createTeamType
 );
+
+teamsRouter.post(
+  'teams/:teamId/set-team-type',
+  body('teamType').isArray(),
+  nonEmptyString(body('teamType.*.teamTypeId')),
+  nonEmptyString(body(''))
+  nonEmptyString(body('name.*.iconName'))
+  TeamsController.setTeamType
+);
 export default teamsRouter;

--- a/src/backend/src/routes/teams.routes.ts
+++ b/src/backend/src/routes/teams.routes.ts
@@ -52,10 +52,5 @@ teamsRouter.post(
   TeamsController.createTeamType
 );
 
-teamsRouter.post(
-  '/:teamId/set-team-type',
-  nonEmptyString(body('teamTypeId')),
-  validateInputs,
-  TeamsController.setTeamType
-);
+teamsRouter.post('/:teamId/set-team-type', nonEmptyString(body('teamTypeId')), validateInputs, TeamsController.setTeamType);
 export default teamsRouter;

--- a/src/backend/src/services/teams.services.ts
+++ b/src/backend/src/services/teams.services.ts
@@ -372,4 +372,30 @@ export default class TeamsService {
     const teamTypes = await prisma.teamType.findMany();
     return teamTypes;
   }
+
+  static async setTeamType(submitter: User, teamId: string, teamTypeId: string): Promise<Team> {
+    if (!isAdmin(submitter.role)) {
+      throw new AccessDeniedAdminOnlyException('set a team type');
+    }
+
+    const teamType = await prisma.teamType.findFirst({
+      where: { teamTypeId }
+    });
+
+    if (teamType) {
+      throw new HttpException(400, 'Cannot create a teamType with a name that already exists');
+    }
+
+    const updatedTeam = await prisma.team.update({
+      where: {
+        teamId
+      },
+      data: {
+        teamType,
+        teamTypeId
+      },
+      ...teamQueryArgs
+    })
+    return teamTransformer(updatedTeam);
+  }
 }

--- a/src/backend/src/services/teams.services.ts
+++ b/src/backend/src/services/teams.services.ts
@@ -382,6 +382,15 @@ export default class TeamsService {
       where: { teamTypeId }
     });
 
+    const team = await prisma.team.findUnique({
+      where: { teamId },
+      ...teamQueryArgs
+    });
+
+    if (!team) {
+      throw new NotFoundException('Team', teamId);
+    }
+
     if (!teamType) {
       throw new HttpException(400, 'Team type with the given ID does not exist');
     }

--- a/src/backend/src/services/teams.services.ts
+++ b/src/backend/src/services/teams.services.ts
@@ -382,20 +382,19 @@ export default class TeamsService {
       where: { teamTypeId }
     });
 
-    if (teamType) {
-      throw new HttpException(400, 'Cannot create a teamType with a name that already exists');
+    if (!teamType) {
+      throw new HttpException(400, 'Team type with the given ID does not exist');
     }
 
-    const updatedTeam = await prisma.team.update({
-      where: {
-        teamId
-      },
+    const updateTeam = await prisma.team.update({
+      where: { teamId },
       data: {
-        teamType,
-        teamTypeId
+        teamType: {
+          connect: { teamTypeId }
+        }
       },
       ...teamQueryArgs
-    })
-    return teamTransformer(updatedTeam);
+    });
+    return teamTransformer(updateTeam);
   }
 }

--- a/src/backend/src/services/teams.services.ts
+++ b/src/backend/src/services/teams.services.ts
@@ -382,6 +382,10 @@ export default class TeamsService {
       where: { teamTypeId }
     });
 
+    if (!teamType) {
+      throw new NotFoundException('Team Type', teamTypeId);
+    }
+
     const team = await prisma.team.findUnique({
       where: { teamId },
       ...teamQueryArgs
@@ -389,10 +393,6 @@ export default class TeamsService {
 
     if (!team) {
       throw new NotFoundException('Team', teamId);
-    }
-
-    if (!teamType) {
-      throw new HttpException(400, 'Team type with the given ID does not exist');
     }
 
     const updateTeam = await prisma.team.update({

--- a/src/backend/src/services/teams.services.ts
+++ b/src/backend/src/services/teams.services.ts
@@ -373,6 +373,13 @@ export default class TeamsService {
     return teamTypes;
   }
 
+  /**
+   * Sets the teamType for a team
+   * @param submitter the user who is setting the team type
+   * @param teamId id of the team
+   * @param teamTypeId id of the teamType
+   * @returns the updated team with teamType
+   */
   static async setTeamType(submitter: User, teamId: string, teamTypeId: string): Promise<Team> {
     if (!isAdmin(submitter.role)) {
       throw new AccessDeniedAdminOnlyException('set a team type');
@@ -395,7 +402,7 @@ export default class TeamsService {
       throw new NotFoundException('Team', teamId);
     }
 
-    const updateTeam = await prisma.team.update({
+    const updatedTeam = await prisma.team.update({
       where: { teamId },
       data: {
         teamType: {
@@ -404,6 +411,6 @@ export default class TeamsService {
       },
       ...teamQueryArgs
     });
-    return teamTransformer(updateTeam);
+    return teamTransformer(updatedTeam);
   }
 }

--- a/src/backend/src/transformers/teams.transformer.ts
+++ b/src/backend/src/transformers/teams.transformer.ts
@@ -21,7 +21,8 @@ const teamTransformer = (team: Prisma.TeamGetPayload<typeof teamQueryArgs>): Tea
     })),
     leads: team.leads.map(userTransformer),
     userArchived: team.userArchived ? userTransformer(team.userArchived) : undefined,
-    dateArchived: team.dateArchived ?? undefined
+    dateArchived: team.dateArchived ?? undefined,
+    teamType: team.teamType ?? undefined
   };
 };
 

--- a/src/backend/tests/mocked/teams.test.ts
+++ b/src/backend/tests/mocked/teams.test.ts
@@ -375,7 +375,8 @@ describe('Teams', () => {
         userArchivedId: 2,
         userArchived: superman,
         dateArchived,
-        projects: []
+        projects: [],
+        teamType: undefined
       };
 
       vi.spyOn(prisma.team, 'update').mockResolvedValue(justiceLeagueUpdates);

--- a/src/backend/tests/test-data/teams.test-data.ts
+++ b/src/backend/tests/test-data/teams.test-data.ts
@@ -22,6 +22,7 @@ export const prismaTeam1: Prisma.TeamGetPayload<typeof teamQueryArgs> = {
   dateArchived: new Date('12/15/1985'),
   userArchived: wonderwoman,
   userArchivedId: 3,
+  teamType: null,
   teamTypeId: null
 };
 
@@ -38,6 +39,7 @@ export const primsaTeam2: Prisma.TeamGetPayload<typeof teamQueryArgs> = {
   dateArchived: new Date('12/02/2002'),
   userArchived: null,
   userArchivedId: null,
+  teamType: null,
   teamTypeId: null
 };
 
@@ -65,5 +67,6 @@ export const justiceLeague: Prisma.TeamGetPayload<typeof teamQueryArgs> = {
   dateArchived: null,
   userArchived: null,
   userArchivedId: null,
+  teamType: null,
   teamTypeId: null
 };

--- a/src/backend/tests/test-data/teams.test-data.ts
+++ b/src/backend/tests/test-data/teams.test-data.ts
@@ -21,7 +21,8 @@ export const prismaTeam1: Prisma.TeamGetPayload<typeof teamQueryArgs> = {
   leads: [wonderwoman, alfred],
   dateArchived: new Date('12/15/1985'),
   userArchived: wonderwoman,
-  userArchivedId: 3
+  userArchivedId: 3,
+  teamTypeId: null
 };
 
 export const primsaTeam2: Prisma.TeamGetPayload<typeof teamQueryArgs> = {
@@ -36,7 +37,8 @@ export const primsaTeam2: Prisma.TeamGetPayload<typeof teamQueryArgs> = {
   leads: [],
   dateArchived: new Date('12/02/2002'),
   userArchived: null,
-  userArchivedId: null
+  userArchivedId: null,
+  teamTypeId: null
 };
 
 export const sharedTeam1: SharedTeam = {
@@ -62,5 +64,6 @@ export const justiceLeague: Prisma.TeamGetPayload<typeof teamQueryArgs> = {
   leads: [wonderwoman],
   dateArchived: null,
   userArchived: null,
-  userArchivedId: null
+  userArchivedId: null,
+  teamTypeId: null
 };

--- a/src/shared/src/types/team-types.ts
+++ b/src/shared/src/types/team-types.ts
@@ -3,6 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
+import { TeamType } from './design-review-types';
 import { ProjectPreview } from './project-types';
 import { User } from './user-types';
 
@@ -17,6 +18,7 @@ export interface Team {
   leads: User[];
   userArchived?: User;
   dateArchived?: Date;
+  teamType?: TeamType;
 }
 
 export type TeamPreview = Pick<Team, 'teamId' | 'teamName' | 'members' | 'head' | 'leads'>;


### PR DESCRIPTION
## Changes

Created a setTeamType endpoint, where the admin can set a team type for each team in its project. 

## Screenshots

This adds the teamType to a Team:
![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/88903298/efc52bb4-7d4d-4521-80ee-3ddb7ff75f87)

The added teamType in prisma studio:
![Screenshot 2024-04-13 162903](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/88903298/0e00b355-d2aa-467b-8d2d-16a940af59e2)

Testing for exceptions:

Wrong teamTypeId
![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/88903298/297a567c-7801-4616-948b-f65354c61eb5)

Wrong Team
![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/88903298/cb46baa1-eeb5-4895-87c5-f0ce28c4dfb9)

Wrong user (not admin)
![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/88903298/0ef218df-5258-42b1-bbd3-1896ee2cfd1b)


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #2326 
