### PR TITLE
#2247 Added a Get Single TeamType Endpoint

### DIFF
--- a/src/backend/src/controllers/teams.controllers.ts
+++ b/src/backend/src/controllers/teams.controllers.ts
@@ -119,6 +119,18 @@ export default class TeamsController {
     }
   }
 
+  static async getSingleTeamType(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { teamTypeId } = req.params;
+
+      const teamType = await TeamsService.getSingleTeamType(teamTypeId);
+
+      return res.status(200).json(teamType);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
   static async getAllTeamTypes(req: Request, res: Response, next: NextFunction) {
     try {
       const teamTypes = await TeamsService.getAllTeamTypes();

--- a/src/backend/src/routes/teams.routes.ts
+++ b/src/backend/src/routes/teams.routes.ts
@@ -44,6 +44,8 @@ teamsRouter.post('/:teamId/archive');
 
 teamsRouter.get('/teamType/all', TeamsController.getAllTeamTypes);
 
+teamsRouter.get('/teamType/:teamTypeId/single', TeamsController.getSingleTeamType);
+
 teamsRouter.post(
   '/teamType/create',
   nonEmptyString(body('name')),

--- a/src/backend/src/services/teams.services.ts
+++ b/src/backend/src/services/teams.services.ts
@@ -370,6 +370,24 @@ export default class TeamsService {
   }
 
   /**
+   * Gets a team with the given id
+   * @param teamTypeId - id of teamType to retrieve
+   * @returns a teamType
+   * @throws if the team is not found in the db
+   */
+  static async getSingleTeamType(teamTypeId: string): Promise<TeamType> {
+    const teamType = await prisma.teamType.findUnique({
+      where: { teamTypeId }
+    });
+
+    if (!teamType) {
+      throw new NotFoundException('Team Type', teamTypeId);
+    }
+
+    return teamType;
+  }
+
+  /**
    * Gets all the team types in the database
    * @returns all the team types
    */

--- a/src/backend/tests/unmocked/team-type.test.ts
+++ b/src/backend/tests/unmocked/team-type.test.ts
@@ -52,7 +52,6 @@ describe('Team Type Tests', () => {
 
     it('Get a single team type fails', async () => {
       const nonExistingTeamTypeId = 'nonExistingId';
-      await expect(async () => TeamsService.getSingleTeamType(nonExistingTeamTypeId)).rejects.toThrow(NotFoundException);
       await expect(async () => TeamsService.getSingleTeamType(nonExistingTeamTypeId)).rejects.toThrow(
         new NotFoundException('Team Type', nonExistingTeamTypeId)
       );

--- a/src/backend/tests/unmocked/team-type.test.ts
+++ b/src/backend/tests/unmocked/team-type.test.ts
@@ -1,6 +1,6 @@
 import prisma from '../../src/prisma/prisma';
 import TeamsService from '../../src/services/teams.services';
-import { AccessDeniedAdminOnlyException, HttpException } from '../../src/utils/errors.utils';
+import { AccessDeniedAdminOnlyException, HttpException, NotFoundException } from '../../src/utils/errors.utils';
 import { batman, superman, theVisitor } from '../test-data/users.test-data';
 
 describe('Team Type Tests', () => {
@@ -40,6 +40,19 @@ describe('Team Type Tests', () => {
       const teamType2 = await TeamsService.createTeamType(batman, 'teamType2', 'WarningIcon');
       const result = await TeamsService.getAllTeamTypes();
       expect(result).toStrictEqual([teamType1, teamType2]);
+    });
+  });
+
+  describe('Get a single team type', () => {
+    it('Get a single team type works', async () => {
+      const teamType1 = await TeamsService.createTeamType(superman, 'teamType1', 'YouTubeIcon');
+      const result = await TeamsService.getSingleTeamType(teamType1.teamTypeId);
+      expect(result).toStrictEqual(teamType1);
+    });
+
+    it('Get a single team type fails', async () => {
+      const nonExistingTeamTypeId = 'nonExistingId';
+      await expect(async () => TeamsService.getSingleTeamType(nonExistingTeamTypeId)).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/src/backend/tests/unmocked/team-type.test.ts
+++ b/src/backend/tests/unmocked/team-type.test.ts
@@ -53,6 +53,9 @@ describe('Team Type Tests', () => {
     it('Get a single team type fails', async () => {
       const nonExistingTeamTypeId = 'nonExistingId';
       await expect(async () => TeamsService.getSingleTeamType(nonExistingTeamTypeId)).rejects.toThrow(NotFoundException);
+      await expect(async () => TeamsService.getSingleTeamType(nonExistingTeamTypeId)).rejects.toThrow(
+        new NotFoundException('Team Type', nonExistingTeamTypeId)
+      );
     });
   });
 });


### PR DESCRIPTION
## Changes

Added a getSingleTeamType Endpoint where it retrieves a single teamType from the database.

## Screenshots

![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/88903298/faa07e27-aea9-446d-a48c-075b978d3abb)

Exception Handling:
![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/88903298/13d3e828-5e55-47f8-b83e-ba648d9c75d7)


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #2247
