### PR TITLE
Fix schema relation name, correct edit wp route

### DIFF
--- a/src/backend/src/prisma/migrations/20240425034912_auto_implementing_crs/migration.sql
+++ b/src/backend/src/prisma/migrations/20240425034912_auto_implementing_crs/migration.sql
@@ -1,6 +1,3 @@
--- DropForeignKey
-ALTER TABLE "_blockedBy" DROP CONSTRAINT "_blockedBy_B_fkey";
-
 -- AlterTable
 ALTER TABLE "Description_Bullet" ADD COLUMN     "projectProposedChangesFeaturesId" TEXT,
 ADD COLUMN     "projectProposedChangesGoalsId" TEXT,
@@ -10,9 +7,6 @@ ADD COLUMN     "wpProposedChangesExpectedActivitiesId" TEXT;
 
 -- AlterTable
 ALTER TABLE "Scope_CR" ADD COLUMN     "wbsProposedChangesId" TEXT;
-
--- AlterTable
-ALTER TABLE "_blockedBy" ALTER COLUMN "B" SET DATA TYPE TEXT;
 
 -- CreateTable
 CREATE TABLE "LinkInfo" (
@@ -61,6 +55,12 @@ CREATE TABLE "Work_Package_Proposed_Changes" (
 );
 
 -- CreateTable
+CREATE TABLE "_proposedBlockedBy" (
+    "A" INTEGER NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
 CREATE TABLE "_proposedProjectTeams" (
     "A" TEXT NOT NULL,
     "B" TEXT NOT NULL
@@ -74,6 +74,12 @@ CREATE UNIQUE INDEX "Project_Proposed_Changes_wbsProposedChangesId_key" ON "Proj
 
 -- CreateIndex
 CREATE UNIQUE INDEX "Work_Package_Proposed_Changes_wbsProposedChangesId_key" ON "Work_Package_Proposed_Changes"("wbsProposedChangesId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_proposedBlockedBy_AB_unique" ON "_proposedBlockedBy"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_proposedBlockedBy_B_index" ON "_proposedBlockedBy"("B");
 
 -- CreateIndex
 CREATE UNIQUE INDEX "_proposedProjectTeams_AB_unique" ON "_proposedProjectTeams"("A", "B");
@@ -118,7 +124,10 @@ ALTER TABLE "Project_Proposed_Changes" ADD CONSTRAINT "Project_Proposed_Changes_
 ALTER TABLE "Work_Package_Proposed_Changes" ADD CONSTRAINT "Work_Package_Proposed_Changes_wbsProposedChangesId_fkey" FOREIGN KEY ("wbsProposedChangesId") REFERENCES "Wbs_Proposed_Changes"("wbsProposedChangesId") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "_blockedBy" ADD CONSTRAINT "_blockedBy_B_fkey" FOREIGN KEY ("B") REFERENCES "Work_Package_Proposed_Changes"("workPackageProposedChangesId") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "_proposedBlockedBy" ADD CONSTRAINT "_proposedBlockedBy_A_fkey" FOREIGN KEY ("A") REFERENCES "WBS_Element"("wbsElementId") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_proposedBlockedBy" ADD CONSTRAINT "_proposedBlockedBy_B_fkey" FOREIGN KEY ("B") REFERENCES "Work_Package_Proposed_Changes"("workPackageProposedChangesId") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "_proposedProjectTeams" ADD CONSTRAINT "_proposedProjectTeams_A_fkey" FOREIGN KEY ("A") REFERENCES "Project_Proposed_Changes"("projectProposedChangesId") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/backend/src/prisma/schema.prisma
+++ b/src/backend/src/prisma/schema.prisma
@@ -292,7 +292,7 @@ model WBS_Element {
   materials                   Material[]
   reimbursementProductReasons Reimbursement_Product_Reason[]
   designReviews               Design_Review[]
-  proposedBlockedByChanges    Work_Package_Proposed_Changes[] @relation(name: "blockedBy")
+  proposedBlockedByChanges    Work_Package_Proposed_Changes[] @relation(name: "proposedBlockedBy")
 
   @@unique([carNumber, projectNumber, workPackageNumber], name: "wbsNumber")
 }
@@ -705,7 +705,7 @@ model Work_Package_Proposed_Changes {
   workPackageProposedChangesId String               @id @default(uuid())
   startDate                    DateTime             @db.Date
   duration                     Int
-  blockedBy                    WBS_Element[]        @relation(name: "blockedBy")
+  blockedBy                    WBS_Element[]        @relation(name: "proposedBlockedBy")
   expectedActivities           Description_Bullet[] @relation(name: "workPackageExpectedActivities")
   deliverables                 Description_Bullet[] @relation(name: "workPackageDeliverables")
   stage                        Work_Package_Stage?

--- a/src/backend/src/routes/work-packages.routes.ts
+++ b/src/backend/src/routes/work-packages.routes.ts
@@ -39,7 +39,7 @@ workPackagesRouter.post(
   intMinZero(body('workPackageId')),
   intMinZero(body('crId')),
   nonEmptyString(body('name')),
-  body('startDate').isDate(),
+  isDate(body('startDate')),
   intMinZero(body('duration')),
   isWorkPackageStageOrNone(body('stage')),
   intMinZero(body('blockedBy.*.carNumber')),


### PR DESCRIPTION
## Changes

Two bugs were happening. When you created or edited a wp and tried to add a blocked by it would error because we make blockedByInfo have the same relation name 'blockedBy' as regular blockedBy, so prisma was getting upset. Also updated the edit work package route so that it actually works

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
