### PR TITLE
#2384 Expanding and Collapsing work on the Gantt Chart page

### DIFF
--- a/src/frontend/src/components/SearchBar.tsx
+++ b/src/frontend/src/components/SearchBar.tsx
@@ -13,7 +13,7 @@ interface SearchBarProps {
 const Search = styled('div')(({ theme }) => ({
   position: 'relative',
   borderRadius: theme.shape.borderRadius,
-  backgroundColor: alpha(theme.palette.common.white, 0.15),
+  backgroundColor: theme.palette.background.paper,
   '&:hover': {
     backgroundColor: alpha(theme.palette.common.white, 0.25)
   },

--- a/src/frontend/src/pages/GanttPage/GanttChart.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChart.tsx
@@ -11,8 +11,8 @@ interface GanttChartProps {
   chartEditingState: Array<{ teamName: string; editing: boolean }>;
   setChartEditingState: (array: Array<{ teamName: string; editing: boolean }>) => void;
   saveChanges: (eventChanges: EventChange[]) => void;
-  showWorkPackagesList: { [projectId: string]: boolean };
-  setShowWorkPackagesList: React.Dispatch<React.SetStateAction<{ [projectId: string]: boolean }>>;
+  showWorkPackagesMap: Map<string, boolean>;
+  setShowWorkPackagesMap: React.Dispatch<React.SetStateAction<Map<string, boolean>>>;
 }
 
 const GanttChart = ({
@@ -23,8 +23,8 @@ const GanttChart = ({
   chartEditingState,
   setChartEditingState,
   saveChanges,
-  showWorkPackagesList,
-  setShowWorkPackagesList
+  showWorkPackagesMap,
+  setShowWorkPackagesMap
 }: GanttChartProps) => {
   const theme = useTheme();
 
@@ -51,9 +51,8 @@ const GanttChart = ({
         if (!tasks) return <></>;
 
         // Sorting the work packages of each project based on their start date
-        tasks.map((task) => {
+        tasks.forEach((task) => {
           task.children.sort((a, b) => a.start.getTime() - b.start.getTime());
-          return task;
         });
 
         return (
@@ -93,13 +92,13 @@ const GanttChart = ({
             </Box>
             <Box key={teamName} sx={{ my: 0, width: 'fit-content', pl: 2 }}>
               <GanttChartSection
-                showWorkPackagesList={showWorkPackagesList}
-                setShowWorkPackagesList={setShowWorkPackagesList}
                 tasks={tasks}
                 start={startDate}
                 end={endDate}
                 isEditMode={isEditMode}
                 saveChanges={saveChanges}
+                showWorkPackagesMap={showWorkPackagesMap}
+                setShowWorkPackagesMap={setShowWorkPackagesMap}
               />
             </Box>
           </Box>

--- a/src/frontend/src/pages/GanttPage/GanttChart.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChart.tsx
@@ -1,5 +1,5 @@
 import { Box, Chip, IconButton, Typography, useTheme } from '@mui/material';
-import { EventChange, GanttTask, GanttTaskData } from '../../utils/gantt.utils';
+import { EventChange, GanttTask } from '../../utils/gantt.utils';
 import { Edit } from '@mui/icons-material';
 import GanttChartSection from './GanttChartSection';
 
@@ -11,7 +11,6 @@ interface GanttChartProps {
   chartEditingState: Array<{ teamName: string; editing: boolean }>;
   setChartEditingState: (array: Array<{ teamName: string; editing: boolean }>) => void;
   saveChanges: (eventChanges: EventChange[]) => void;
-  onExpanderClick: (newTask: GanttTaskData, teamName: string) => void;
   showWorkPackagesList: { [projectId: string]: boolean };
   setShowWorkPackagesList: React.Dispatch<React.SetStateAction<{ [projectId: string]: boolean }>>;
 }
@@ -24,7 +23,6 @@ const GanttChart = ({
   chartEditingState,
   setChartEditingState,
   saveChanges,
-  onExpanderClick,
   showWorkPackagesList,
   setShowWorkPackagesList
 }: GanttChartProps) => {
@@ -102,7 +100,6 @@ const GanttChart = ({
                 end={endDate}
                 isEditMode={isEditMode}
                 saveChanges={saveChanges}
-                onExpanderClick={onExpanderClick}
               />
             </Box>
           </Box>

--- a/src/frontend/src/pages/GanttPage/GanttChartComponents/GanttChartFilters.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChartComponents/GanttChartFilters.tsx
@@ -4,6 +4,8 @@
  */
 
 import { Button, Checkbox, Chip, Grid, Typography, useTheme } from '@mui/material';
+import UnfoldMoreIcon from '@mui/icons-material/UnfoldMore';
+import UnfoldLessIcon from '@mui/icons-material/UnfoldLess';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import { ChangeEvent } from 'react';
 
@@ -85,6 +87,7 @@ interface GanttChartFiltersProps {
   }[];
   resetHandler: () => void;
   collapseHandler: () => void;
+  expandHandler: () => void;
 }
 
 const GanttChartFilters = ({
@@ -93,14 +96,14 @@ const GanttChartFilters = ({
   teamHandlers,
   overdueHandler,
   resetHandler,
-  collapseHandler
+  collapseHandler,
+  expandHandler
 }: GanttChartFiltersProps) => {
   const FilterButtons = () => {
     return (
       <Grid item container xs={12} sx={{ justifyContent: 'right', alignItems: 'right' }}>
-        {/* TODO: Expand & Collapse buttons
         <Grid item>
-          <Button onClick={() => {}} startIcon={<UnfoldMoreIcon />}>
+          <Button onClick={expandHandler} startIcon={<UnfoldMoreIcon />}>
             Expand
           </Button>
         </Grid>
@@ -108,7 +111,7 @@ const GanttChartFilters = ({
           <Button onClick={collapseHandler} startIcon={<UnfoldLessIcon />}>
             Collapse
           </Button>
-        </Grid>*/}
+        </Grid>
         <Grid item>
           <Button onClick={resetHandler} startIcon={<RestartAltIcon />}>
             Reset

--- a/src/frontend/src/pages/GanttPage/GanttChartComponents/GanttChartFilters.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChartComponents/GanttChartFilters.tsx
@@ -101,7 +101,7 @@ const GanttChartFilters = ({
 }: GanttChartFiltersProps) => {
   const FilterButtons = () => {
     return (
-      <Grid item container xs={12} sx={{ justifyContent: 'right', alignItems: 'right' }}>
+      <Grid item container xs={12} sx={{ justifyContent: 'center', alignItems: 'right', gap: 4 }}>
         <Grid item>
           <Button onClick={expandHandler} startIcon={<UnfoldMoreIcon />}>
             Expand

--- a/src/frontend/src/pages/GanttPage/GanttChartComponents/GanttChartFiltersButton.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChartComponents/GanttChartFiltersButton.tsx
@@ -18,6 +18,7 @@ interface GanttChartFiltersButtonProps {
   }[];
   resetHandler: () => void;
   collapseHandler: () => void;
+  expandHandler: () => void;
 }
 
 const GanttChartFiltersButton = ({
@@ -26,7 +27,8 @@ const GanttChartFiltersButton = ({
   teamHandlers,
   overdueHandler,
   resetHandler,
-  collapseHandler
+  collapseHandler,
+  expandHandler
 }: GanttChartFiltersButtonProps) => {
   const [anchorFilterEl, setAnchorFilterEl] = useState<HTMLButtonElement | null>(null);
   const handleFilterClick = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -64,6 +66,7 @@ const GanttChartFiltersButton = ({
           overdueHandler={overdueHandler}
           resetHandler={resetHandler}
           collapseHandler={collapseHandler}
+          expandHandler={expandHandler}
         />
       </Popover>
     </>

--- a/src/frontend/src/pages/GanttPage/GanttChartComponents/GanttTaskBar.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChartComponents/GanttTaskBar.tsx
@@ -242,7 +242,7 @@ const GanttTaskBar = ({
             width: width === 0 ? `unset` : `${width}px`,
             border: `1px solid ${isResizing ? theme.palette.text.primary : theme.palette.divider}`,
             borderRadius: '0.25rem',
-            backgroundColor: event.styles ? event.styles.backgroundColor : grey[700],
+            backgroundColor: event.styles ? event.styles.backgroundColor : theme.palette.background.paper,
             cursor: 'pointer',
             gridRow: 1,
             zIndex: 1

--- a/src/frontend/src/pages/GanttPage/GanttChartComponents/GanttToolTip.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChartComponents/GanttToolTip.tsx
@@ -38,12 +38,16 @@ const GanttToolTip: React.FC<GanttToolTipProps> = ({
         </Box>
         <Box sx={{ backgroundColor: theme.palette.background.paper, borderRadius: '0 0 5px 5px', padding: '5px 10px' }}>
           <Box display={'flex'} flexDirection={'row'}>
-            <Typography marginRight={'10px'}>Start: {startDate.toLocaleDateString()}</Typography>
-            <Typography>Project Lead: {fullNamePipe(projectLead)}</Typography>
+            <Typography color={theme.palette.text.primary} marginRight={'10px'}>
+              Start: {startDate.toLocaleDateString()}
+            </Typography>
+            <Typography color={theme.palette.text.primary}>Project Lead: {fullNamePipe(projectLead)}</Typography>
           </Box>
           <Box display={'flex'} flexDirection={'row'}>
-            <Typography marginRight={'10px'}>End: {endDate.toLocaleDateString()}</Typography>
-            <Typography>Project Manager: {fullNamePipe(projectManager)}</Typography>
+            <Typography color={theme.palette.text.primary} marginRight={'10px'}>
+              End: {endDate.toLocaleDateString()}
+            </Typography>
+            <Typography color={theme.palette.text.primary}>Project Manager: {fullNamePipe(projectManager)}</Typography>
           </Box>
         </Box>
       </Box>

--- a/src/frontend/src/pages/GanttPage/GanttChartPage.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChartPage.tsx
@@ -18,8 +18,7 @@ import {
   GanttTask,
   transformProjectToGanttTask,
   getProjectTeamsName,
-  EventChange,
-  GanttTaskData
+  EventChange
 } from '../../utils/gantt.utils';
 import { routes } from '../../utils/routes';
 import { Box } from '@mui/material';
@@ -92,6 +91,8 @@ const GanttChartPage: FC = () => {
       history.push(`${history.location.pathname + buildGanttSearchParams(ganttFilters)}`);
     };
   };
+
+  console.log(teamTypes);
 
   const teamTypeHandlerFn = (teamType: TeamType) => {
     return (event: ChangeEvent<HTMLInputElement>) => {
@@ -265,11 +266,6 @@ const GanttChartPage: FC = () => {
           chartEditingState={chartEditingState}
           setChartEditingState={setChartEditingState}
           saveChanges={saveChanges}
-          onExpanderClick={(newTask: GanttTaskData, teamName: string) => {
-            ganttTasks.forEach((task) => {
-              if (newTask.id === task.id) task = { ...newTask, teamName };
-            });
-          }}
           showWorkPackagesList={showWorkPackagesList}
           setShowWorkPackagesList={setShowWorkPackagesList}
         />

--- a/src/frontend/src/pages/GanttPage/GanttChartSection.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChartSection.tsx
@@ -15,12 +15,8 @@ interface GanttChartSectionProps {
   tasks: GanttTaskData[];
   isEditMode: boolean;
   saveChanges: (eventChanges: EventChange[]) => void;
-  showWorkPackagesList: { [projectId: string]: boolean };
-  setShowWorkPackagesList: React.Dispatch<
-    React.SetStateAction<{
-      [projectId: string]: boolean;
-    }>
-  >;
+  showWorkPackagesMap: Map<string, boolean>;
+  setShowWorkPackagesMap: React.Dispatch<React.SetStateAction<Map<string, boolean>>>;
 }
 
 const GanttChartSection = ({
@@ -29,8 +25,8 @@ const GanttChartSection = ({
   tasks,
   isEditMode,
   saveChanges,
-  showWorkPackagesList,
-  setShowWorkPackagesList
+  showWorkPackagesMap,
+  setShowWorkPackagesMap
 }: GanttChartSectionProps) => {
   const days = eachDayOfInterval({ start, end }).filter((day) => isMonday(day));
   const [eventChanges, setEventChanges] = useState<EventChange[]>([]);
@@ -51,11 +47,8 @@ const GanttChartSection = ({
   const displayEvents = applyChangesToEvents(tasks, eventChanges);
   const projects = displayEvents.filter((event) => !event.project);
 
-  const toggleWorkPackages = (projectId: string) => {
-    setShowWorkPackagesList((prevState) => ({
-      ...prevState,
-      [projectId]: !prevState[projectId]
-    }));
+  const toggleWorkPackages = (projectTask: GanttTaskData) => {
+    setShowWorkPackagesMap((prev) => new Map(prev.set(projectTask.id, !prev.get(projectTask.id))));
   };
 
   return tasks.length > 0 ? (
@@ -72,11 +65,11 @@ const GanttChartSection = ({
                   event={project}
                   isEditMode={isEditMode}
                   createChange={createChange}
-                  onWorkPackageToggle={() => toggleWorkPackages(project.id)}
-                  showWorkPackages={showWorkPackagesList[project.id]}
+                  onWorkPackageToggle={() => toggleWorkPackages(project)}
+                  showWorkPackages={showWorkPackagesMap.get(project.id)}
                 />
               </Box>
-              <Collapse in={showWorkPackagesList[project.id]}>
+              <Collapse in={showWorkPackagesMap.get(project.id)}>
                 {project.children.map((workPackage) => {
                   return (
                     <GanttTaskBar

--- a/src/frontend/src/pages/GanttPage/GanttChartSection.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChartSection.tsx
@@ -15,7 +15,6 @@ interface GanttChartSectionProps {
   tasks: GanttTaskData[];
   isEditMode: boolean;
   saveChanges: (eventChanges: EventChange[]) => void;
-  onExpanderClick: (ganttTasks: GanttTaskData, teamName: string) => void;
   showWorkPackagesList: { [projectId: string]: boolean };
   setShowWorkPackagesList: React.Dispatch<
     React.SetStateAction<{

--- a/src/frontend/src/utils/gantt.utils.ts
+++ b/src/frontend/src/utils/gantt.utils.ts
@@ -35,7 +35,6 @@ export interface GanttTaskData {
   isDisabled?: boolean;
   project?: string;
   dependencies?: string[];
-  hideChildren?: boolean;
   displayOrder?: number;
   onClick?: () => void;
   projectLead?: User;
@@ -79,7 +78,6 @@ export interface GanttFilters {
   showTeamTypes: string[];
   showTeams: string[];
   showOnlyOverdue: boolean;
-  expanded: boolean;
 }
 
 export interface GanttTask extends GanttTaskData {
@@ -134,8 +132,7 @@ export const buildGanttSearchParams = (ganttFilters: GanttFilters): string => {
     ganttFilters.showCars.map((car) => carFormat(car.toString())).join('') +
     ganttFilters.showTeamTypes.map(teamTypeFormat).join('') +
     ganttFilters.showTeams.map(teamFormat).join('') +
-    `&overdue=${ganttFilters.showOnlyOverdue}` +
-    `&expanded=${ganttFilters.expanded}`
+    `&overdue=${ganttFilters.showOnlyOverdue}`
   );
 };
 
@@ -166,7 +163,7 @@ export const getProjectTeamsName = (project: Project): string => {
   return project.teams.length === 0 ? NO_TEAM : project.teams.map((team) => team.teamName).join(', ');
 };
 
-export const transformProjectToGanttTask = (project: Project, expanded: boolean): GanttTask[] => {
+export const transformProjectToGanttTask = (project: Project): GanttTask[] => {
   const teamName = getProjectTeamsName(project);
 
   const projectTask: GanttTask = {
@@ -176,7 +173,6 @@ export const transformProjectToGanttTask = (project: Project, expanded: boolean)
     end: project.endDate || new Date(),
     progress: 100,
     type: 'project',
-    hideChildren: !expanded,
     teamName,
     children: project.workPackages.map((wp) => transformWorkPackageToGanttTask(wp, teamName)),
     onClick: () => {

--- a/src/frontend/src/utils/urls.ts
+++ b/src/frontend/src/utils/urls.ts
@@ -84,7 +84,7 @@ const teamsSetHead = (id: string) => `${teamsById(id)}/set-head`;
 const teamsSetDescription = (id: string) => `${teamsById(id)}/edit-description`;
 const teamsCreate = () => `${teams()}/create`;
 const teamsSetLeads = (id: string) => `${teamsById(id)}/set-leads`;
-const teamTypes = () => `${designReviews()}/teamType/all`;
+const teamTypes = () => `${teams()}/teamType/all`;
 
 /**************** Description Bullet Endpoints ****************/
 const descriptionBullets = () => `${API_URL}/description-bullets`;


### PR DESCRIPTION
## Changes

Individual projects can be expanded and collapsed, and the buttons near the filters expand and collapse all of them. Resetting also collapses all of them 

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #2384
