### PR TITLE
#2316: Standardize Date View 

### DIFF
--- a/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/DesignReviewDetailPage.tsx
+++ b/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/DesignReviewDetailPage.tsx
@@ -106,11 +106,11 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
   };
 
   const DateField = () => {
-    return <DatePicker value={date} onChange={handleDateChange} sx={Style1} />;
+    return <DatePicker value={date} onChange={handleDateChange} sx={EditableFieldStyle} />;
   };
 
   // styling for the editable fields at the top of the page with light grey backgrounds
-  const Style1 = {
+  const EditableFieldStyle = {
     fontSize: '16px',
     backgroundColor: 'grey',
     borderRadius: 3,
@@ -120,7 +120,7 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
   };
 
   // styling for the non-editable fields at the top of the page with dark backgrounds
-  const Style2 = {
+  const NonEditableFieldStyle = {
     padding: 1.5,
     paddingTop: 1.5,
     paddingBottom: 1.5,
@@ -149,10 +149,10 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
       <DeleteModal />
       <Grid container spacing={3} display={'flex'} paddingBottom={2}>
         <Grid item xs={1}>
-          <Box sx={Style2}>Name</Box>
+          <Box sx={NonEditableFieldStyle}>Name</Box>
         </Grid>
         <Grid item xs={6}>
-          <Box sx={{ ...Style2, textDecoration: 'none' }}>{designReviewNamePipe(designReview)}</Box>
+          <Box sx={{ ...NonEditableFieldStyle, textDecoration: 'none' }}>{designReviewNamePipe(designReview)}</Box>
         </Grid>
         <Grid item xs={2}>
           <DateField />
@@ -166,7 +166,7 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
             onChange={(event: SelectChangeEvent<number>) => setStateTime(Number(event.target.value))}
             size={'small'}
             placeholder={'Start Time'}
-            sx={Style1}
+            sx={EditableFieldStyle}
           >
             {HOURS.map((hour) => {
               return (
@@ -187,7 +187,7 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
             onChange={(event: SelectChangeEvent<number>) => setEndTime(Number(event.target.value))}
             size={'small'}
             placeholder={'End Time'}
-            sx={Style1}
+            sx={EditableFieldStyle}
           >
             {HOURS.map((hour) => {
               return (
@@ -201,10 +201,10 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
         <Grid item xs={12}>
           <Grid container spacing={2}>
             <Grid item xs={2}>
-              <Box sx={Style2}>Required</Box>
+              <Box sx={NonEditableFieldStyle}>Required</Box>
             </Grid>
             <Grid item xs={4}>
-              <Box sx={{ ...Style1, padding: 1 }}>
+              <Box sx={{ ...EditableFieldStyle, padding: 1 }}>
                 <Autocomplete
                   isOptionEqualToValue={(option, value) => option.id === value.id}
                   multiple
@@ -239,10 +239,10 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
               </Box>
             </Grid>
             <Grid item xs={2}>
-              <Box sx={Style2}>Optional</Box>
+              <Box sx={NonEditableFieldStyle}>Optional</Box>
             </Grid>
             <Grid item xs={4}>
-              <Box sx={{ ...Style1, padding: 1 }}>
+              <Box sx={{ ...EditableFieldStyle, padding: 1 }}>
                 <Autocomplete
                   isOptionEqualToValue={(option, value) => option.id === value.id}
                   multiple

--- a/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/DesignReviewDetailPage.tsx
+++ b/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/DesignReviewDetailPage.tsx
@@ -105,6 +105,37 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
     );
   };
 
+  const DateField = () => {
+    return (
+      <div>
+        <DatePicker value={date} onChange={handleDateChange} sx={DetailPageStyles('grey', 'left', 0, '16px', false, true)} />
+      </div>
+    );
+  };
+
+  const DetailPageStyles = (
+    bgColor: string,
+    align: string,
+    padding: number,
+    fontsize: string,
+    underline: boolean,
+    border: boolean
+  ) => {
+    return {
+      padding: padding,
+      paddingTop: padding,
+      paddingBottom: padding,
+      fontSize: fontsize,
+      backgroundColor: bgColor,
+      borderRadius: 3,
+      textAlign: align,
+      textDecoration: underline ? 'underline' : 'none',
+      width: '100%',
+      borderColors: 'grey',
+      border: border ? '2px solid' : 'none'
+    };
+  };
+
   const hasDeletePerms = user.userId === designReview.userCreated.userId || isAdmin(user.role);
 
   return (
@@ -121,35 +152,15 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
       <DeleteModal />
       <Grid container spacing={3} display={'flex'} paddingBottom={2}>
         <Grid item xs={1}>
-          <Box
-            sx={{
-              padding: 1.5,
-              backgroundColor: theme.palette.background.paper,
-              borderRadius: 3,
-              textAlign: 'center',
-              textDecoration: 'underline',
-              fontSize: '1.2em'
-            }}
-          >
-            Name
-          </Box>
+          <Box sx={DetailPageStyles(theme.palette.background.paper, 'center', 1.5, '1.2em', true, false)}>Name</Box>
         </Grid>
         <Grid item xs={6}>
-          <Box
-            sx={{
-              padding: 1.5,
-              fontSize: '1.2em',
-              backgroundColor: 'grey',
-              borderRadius: 3,
-              textAlign: 'center',
-              width: '100%'
-            }}
-          >
+          <Box sx={DetailPageStyles(theme.palette.background.paper, 'center', 1.5, '1.2em', false, false)}>
             {designReviewNamePipe(designReview)}
           </Box>
         </Grid>
         <Grid item xs={2}>
-          <DatePicker value={date} onChange={handleDateChange} />
+          <DateField />
         </Grid>
         <Grid item xs={3} display="flex" gap={3}>
           <Select
@@ -160,7 +171,7 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
             onChange={(event: SelectChangeEvent<number>) => setStateTime(Number(event.target.value))}
             size={'small'}
             placeholder={'Start Time'}
-            sx={{ height: 56, width: '100%', textAlign: 'left' }}
+            sx={DetailPageStyles('grey', 'left', 0, '16px', false, true)}
           >
             {HOURS.map((hour) => {
               return (
@@ -181,7 +192,7 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
             onChange={(event: SelectChangeEvent<number>) => setEndTime(Number(event.target.value))}
             size={'small'}
             placeholder={'End Time'}
-            sx={{ height: 56, width: '100%', textAlign: 'left' }}
+            sx={DetailPageStyles('grey', 'left', 0, '16px', false, true)}
           >
             {HOURS.map((hour) => {
               return (
@@ -195,23 +206,10 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
         <Grid item xs={12}>
           <Grid container spacing={2}>
             <Grid item xs={2}>
-              <Box
-                sx={{
-                  padding: 1,
-                  paddingTop: 1.5,
-                  paddingBottom: 1.5,
-                  fontSize: '1.2em',
-                  backgroundColor: theme.palette.background.paper,
-                  borderRadius: 3,
-                  textAlign: 'center',
-                  textDecoration: 'underline'
-                }}
-              >
-                Required
-              </Box>
+              <Box sx={DetailPageStyles(theme.palette.background.paper, 'center', 1.5, '1.2em', true, false)}>Required</Box>
             </Grid>
             <Grid item xs={4}>
-              <Box sx={{ padding: 1, border: 1, borderColors: 'grey', borderRadius: 3, textAlign: 'center' }}>
+              <Box sx={DetailPageStyles('grey', 'center', 1, '16px', false, true)}>
                 <Autocomplete
                   isOptionEqualToValue={(option, value) => option.id === value.id}
                   multiple
@@ -246,23 +244,10 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
               </Box>
             </Grid>
             <Grid item xs={2}>
-              <Box
-                sx={{
-                  padding: 1,
-                  paddingTop: 1.5,
-                  paddingBottom: 1.5,
-                  backgroundColor: theme.palette.background.paper,
-                  borderRadius: 3,
-                  textAlign: 'center',
-                  textDecoration: 'underline',
-                  fontSize: '1.2em'
-                }}
-              >
-                Optional
-              </Box>
+              <Box sx={DetailPageStyles(theme.palette.background.paper, 'center', 1.5, '1.2em', true, false)}>Optional</Box>
             </Grid>
             <Grid item xs={4}>
-              <Box sx={{ padding: 1, border: 1, borderColors: 'grey', borderRadius: 3, textAlign: 'center' }}>
+              <Box sx={DetailPageStyles('grey', 'center', 1, '16px', false, true)}>
                 <Autocomplete
                   isOptionEqualToValue={(option, value) => option.id === value.id}
                   multiple

--- a/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/DesignReviewDetailPage.tsx
+++ b/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/DesignReviewDetailPage.tsx
@@ -109,6 +109,7 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
     return <DatePicker value={date} onChange={handleDateChange} sx={Style1} />;
   };
 
+  // styling for the editable fields at the top of the page with light grey backgrounds
   const Style1 = {
     fontSize: '16px',
     backgroundColor: 'grey',
@@ -118,6 +119,7 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
     width: '100%'
   };
 
+  // styling for the non-editable fields at the top of the page with dark backgrounds
   const Style2 = {
     padding: 1.5,
     paddingTop: 1.5,

--- a/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/DesignReviewDetailPage.tsx
+++ b/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/DesignReviewDetailPage.tsx
@@ -30,8 +30,6 @@ import { useToast } from '../../../hooks/toasts.hooks';
 import { routes } from '../../../utils/routes';
 import NERModal from '../../../components/NERModal';
 import DeleteIcon from '@mui/icons-material/Delete';
-import { borderRadius, fontSize, textAlign } from '@mui/system';
-import { Style } from '@mui/icons-material';
 
 export interface DesignReviewEditData {
   requiredUserIds: number[];

--- a/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/DesignReviewDetailPage.tsx
+++ b/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/DesignReviewDetailPage.tsx
@@ -30,6 +30,8 @@ import { useToast } from '../../../hooks/toasts.hooks';
 import { routes } from '../../../utils/routes';
 import NERModal from '../../../components/NERModal';
 import DeleteIcon from '@mui/icons-material/Delete';
+import { borderRadius, fontSize, textAlign } from '@mui/system';
+import { Style } from '@mui/icons-material';
 
 export interface DesignReviewEditData {
   requiredUserIds: number[];
@@ -106,34 +108,29 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
   };
 
   const DateField = () => {
-    return (
-      <div>
-        <DatePicker value={date} onChange={handleDateChange} sx={DetailPageStyles('grey', 'left', 0, '16px', false, true)} />
-      </div>
-    );
+    return <DatePicker value={date} onChange={handleDateChange} sx={Style1} />;
   };
 
-  const DetailPageStyles = (
-    bgColor: string,
-    align: string,
-    padding: number,
-    fontsize: string,
-    underline: boolean,
-    border: boolean
-  ) => {
-    return {
-      padding: padding,
-      paddingTop: padding,
-      paddingBottom: padding,
-      fontSize: fontsize,
-      backgroundColor: bgColor,
-      borderRadius: 3,
-      textAlign: align,
-      textDecoration: underline ? 'underline' : 'none',
-      width: '100%',
-      borderColors: 'grey',
-      border: border ? '2px solid' : 'none'
-    };
+  const Style1 = {
+    fontSize: '16px',
+    backgroundColor: 'grey',
+    borderRadius: 3,
+    textAlign: 'left',
+    border: '2px solid',
+    width: '100%'
+  };
+
+  const Style2 = {
+    padding: 1.5,
+    paddingTop: 1.5,
+    paddingBottom: 1.5,
+    fontSize: '1.2em',
+    backgroundColor: theme.palette.background.paper,
+    borderRadius: 3,
+    textAlign: 'center',
+    textDecoration: 'underline',
+    width: '100%',
+    border: 'none'
   };
 
   const hasDeletePerms = user.userId === designReview.userCreated.userId || isAdmin(user.role);
@@ -152,12 +149,10 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
       <DeleteModal />
       <Grid container spacing={3} display={'flex'} paddingBottom={2}>
         <Grid item xs={1}>
-          <Box sx={DetailPageStyles(theme.palette.background.paper, 'center', 1.5, '1.2em', true, false)}>Name</Box>
+          <Box sx={Style2}>Name</Box>
         </Grid>
         <Grid item xs={6}>
-          <Box sx={DetailPageStyles(theme.palette.background.paper, 'center', 1.5, '1.2em', false, false)}>
-            {designReviewNamePipe(designReview)}
-          </Box>
+          <Box sx={{ ...Style2, textDecoration: 'none' }}>{designReviewNamePipe(designReview)}</Box>
         </Grid>
         <Grid item xs={2}>
           <DateField />
@@ -171,7 +166,7 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
             onChange={(event: SelectChangeEvent<number>) => setStateTime(Number(event.target.value))}
             size={'small'}
             placeholder={'Start Time'}
-            sx={DetailPageStyles('grey', 'left', 0, '16px', false, true)}
+            sx={Style1}
           >
             {HOURS.map((hour) => {
               return (
@@ -192,7 +187,7 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
             onChange={(event: SelectChangeEvent<number>) => setEndTime(Number(event.target.value))}
             size={'small'}
             placeholder={'End Time'}
-            sx={DetailPageStyles('grey', 'left', 0, '16px', false, true)}
+            sx={Style1}
           >
             {HOURS.map((hour) => {
               return (
@@ -206,10 +201,10 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
         <Grid item xs={12}>
           <Grid container spacing={2}>
             <Grid item xs={2}>
-              <Box sx={DetailPageStyles(theme.palette.background.paper, 'center', 1.5, '1.2em', true, false)}>Required</Box>
+              <Box sx={Style2}>Required</Box>
             </Grid>
             <Grid item xs={4}>
-              <Box sx={DetailPageStyles('grey', 'center', 1, '16px', false, true)}>
+              <Box sx={{ ...Style1, padding: 1 }}>
                 <Autocomplete
                   isOptionEqualToValue={(option, value) => option.id === value.id}
                   multiple
@@ -244,10 +239,10 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
               </Box>
             </Grid>
             <Grid item xs={2}>
-              <Box sx={DetailPageStyles(theme.palette.background.paper, 'center', 1.5, '1.2em', true, false)}>Optional</Box>
+              <Box sx={Style2}>Optional</Box>
             </Grid>
             <Grid item xs={4}>
-              <Box sx={DetailPageStyles('grey', 'center', 1, '16px', false, true)}>
+              <Box sx={{ ...Style1, padding: 1 }}>
                 <Autocomplete
                   isOptionEqualToValue={(option, value) => option.id === value.id}
                   multiple


### PR DESCRIPTION
…passing in params to objects, and fixed the border problem by making the border slightly bigger

## Changes

implemented requested changes that peyton requested: created a styling object that we pass parameters in to clean up the code. Also, I fixed the border problem by making the border slightly bigger. I had to switch to this new branch because for some reason the git got messed up on my old branch.

## Screenshots
Before:
![image](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/70610902/b16e45dd-549f-48e2-a300-30a3702ae7c3)

Now:
<img width="1710" alt="Screenshot 2024-05-19 at 2 51 45 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/70610902/9d5bfd3c-9f04-41ab-8012-128822ba0441">

Closes #2316
