### PR TITLE
#feature/cr delete wp

### DIFF
--- a/src/backend/src/controllers/work-packages.controllers.ts
+++ b/src/backend/src/controllers/work-packages.controllers.ts
@@ -117,8 +117,9 @@ export default class WorkPackagesController {
     try {
       const user = await getCurrentUser(res);
       const wbsNum = validateWBS(req.params.wbsNum);
+      const { crId } = req.body;
 
-      await WorkPackagesService.deleteWorkPackage(user, wbsNum);
+      await WorkPackagesService.deleteWorkPackage(user, wbsNum, crId);
       return res.status(200).json({ message: `Successfully deleted work package #${req.params.wbsNum}` });
     } catch (error: unknown) {
       next(error);

--- a/src/backend/src/routes/work-packages.routes.ts
+++ b/src/backend/src/routes/work-packages.routes.ts
@@ -56,7 +56,7 @@ workPackagesRouter.post(
   validateInputs,
   WorkPackagesController.editWorkPackage
 );
-workPackagesRouter.delete('/:wbsNum/delete', WorkPackagesController.deleteWorkPackage);
+workPackagesRouter.delete('/:wbsNum/delete', intMinZero(body('crId')), WorkPackagesController.deleteWorkPackage);
 workPackagesRouter.get('/:wbsNum/blocking', WorkPackagesController.getBlockingWorkPackages);
 workPackagesRouter.post(
   '/slack-upcoming-deadlines',

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -417,7 +417,8 @@ export default class ProjectsService {
 
     await Promise.all(
       workPackages.map(
-        async (workPackage) => await WorkPackagesService.deleteWorkPackage(user, wbsNumOf(workPackage.wbsElement))
+        async (workPackage) =>
+          await WorkPackagesService.deleteWorkPackage(user, wbsNumOf(workPackage.wbsElement), workPackage.workPackageId)
       )
     );
 

--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -556,6 +556,9 @@ export default class WorkPackagesService {
     if (!workPackage) throw new NotFoundException('Work Package', wbsPipe(wbsNum));
     if (workPackage.wbsElement.dateDeleted) throw new DeletedException('Work Package', wbsPipe(wbsNum));
 
+    // call the correct createChangeRequest function
+    
+
     const { wbsElementId, workPackageId } = workPackage;
 
     const dateDeleted = new Date();

--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -556,11 +556,18 @@ export default class WorkPackagesService {
     if (!workPackage) throw new NotFoundException('Work Package', wbsPipe(wbsNum));
     if (workPackage.wbsElement.dateDeleted) throw new DeletedException('Work Package', wbsPipe(wbsNum));
 
+    const { wbsElementId, workPackageId } = workPackage;
+
     await validateChangeRequestAccepted(crId);
 
-    
-
-    const { wbsElementId, workPackageId } = workPackage;
+    await prisma.change.create({
+      data: {
+        changeRequestId: crId,
+        implementerId: submitter.userId,
+        wbsElementId,
+        detail: 'Work Package Deleted'
+      }
+    });
 
     const dateDeleted = new Date();
     const deletedByUserId = submitter.userId;

--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -531,8 +531,9 @@ export default class WorkPackagesService {
    * Deletes the Work Package
    * @param submitter The user who deleted the work package
    * @param wbsNum The work package number to be deleted
+   * @param crId The id of the change request to be implemented by this deletion
    */
-  static async deleteWorkPackage(submitter: User, wbsNum: WbsNumber): Promise<void> {
+  static async deleteWorkPackage(submitter: User, wbsNum: WbsNumber, crId: number): Promise<void> {
     // Verify submitter is allowed to delete work packages
     if (!isAdmin(submitter.role)) throw new AccessDeniedAdminOnlyException('delete work packages');
 

--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -556,7 +556,8 @@ export default class WorkPackagesService {
     if (!workPackage) throw new NotFoundException('Work Package', wbsPipe(wbsNum));
     if (workPackage.wbsElement.dateDeleted) throw new DeletedException('Work Package', wbsPipe(wbsNum));
 
-    // call the correct createChangeRequest function
+    await validateChangeRequestAccepted(crId);
+
     
 
     const { wbsElementId, workPackageId } = workPackage;

--- a/src/backend/tests/mocked/work-packages.test.ts
+++ b/src/backend/tests/mocked/work-packages.test.ts
@@ -222,23 +222,23 @@ describe('Work Packages', () => {
     const wbsNum: WbsNumber = { carNumber: 1, projectNumber: 2, workPackageNumber: 3 };
 
     test('User does not have submit permission', async () => {
-      await expect(() => WorkPackageService.deleteWorkPackage(wonderwoman, wbsNum)).rejects.toThrow(
-        new AccessDeniedAdminOnlyException('delete work packages')
-      );
+      await expect(() =>
+        WorkPackageService.deleteWorkPackage(wonderwoman, wbsNum, wbsNum.workPackageNumber)
+      ).rejects.toThrow(new AccessDeniedAdminOnlyException('delete work packages'));
     });
 
     test('Work package does not exist', async () => {
       vi.spyOn(prisma.work_Package, 'findFirst').mockResolvedValue(null);
-      await expect(() => WorkPackageService.deleteWorkPackage(batman, wbsNum)).rejects.toThrow(
+      await expect(() => WorkPackageService.deleteWorkPackage(batman, wbsNum, wbsNum.workPackageNumber)).rejects.toThrow(
         new NotFoundException('Work Package', '1.2.3')
       );
       expect(prisma.work_Package.findFirst).toHaveBeenCalledTimes(1);
     });
 
     test('Work package wbs has invalid work package number', async () => {
-      await expect(() => WorkPackageService.deleteWorkPackage(batman, { ...wbsNum, workPackageNumber: 0 })).rejects.toThrow(
-        new HttpException(400, '1.2.0 is not a valid work package WBS!')
-      );
+      await expect(() =>
+        WorkPackageService.deleteWorkPackage(batman, { ...wbsNum, workPackageNumber: 0 }, 0)
+      ).rejects.toThrow(new HttpException(400, '1.2.0 is not a valid work package WBS!'));
     });
 
     test('Work package already deleted', async () => {
@@ -247,7 +247,7 @@ describe('Work Packages', () => {
         wbsElement: { dateDeleted: new Date() }
       } as any);
 
-      await expect(() => WorkPackageService.deleteWorkPackage(batman, wbsNum)).rejects.toThrow(
+      await expect(() => WorkPackageService.deleteWorkPackage(batman, wbsNum, wbsNum.workPackageNumber)).rejects.toThrow(
         new DeletedException('Work Package', '1.2.3')
       );
 
@@ -258,7 +258,7 @@ describe('Work Packages', () => {
       vi.spyOn(prisma.work_Package, 'findFirst').mockResolvedValue({ ...prismaWorkPackage1, wbsElement: {} } as any);
       vi.spyOn(prisma.work_Package, 'update').mockResolvedValue(prismaWorkPackage1);
 
-      await WorkPackageService.deleteWorkPackage(batman, wbsNum);
+      await WorkPackageService.deleteWorkPackage(batman, wbsNum, wbsNum.workPackageNumber);
 
       expect(prisma.work_Package.findFirst).toHaveBeenCalledTimes(1);
       expect(prisma.work_Package.update).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Changes

- **work-packages.routes.ts** delete route takes in a CR ID
- work-packages.controllers.ts delete method gets CR ID from request body and passes that into the service function
- work-packages.services.ts delete method takes in CR ID, makes a Change on the CR corresponding to the given CR ID (which states that the WP is deleted), then soft deletes the WP

## Notes

- I think I did everything this ticket wants me to do, unless I missed something

## Test Cases

- yarn test:frontend works

## To Do

- Fix failing yarn test:backend checks by merging the 'feature/multitenancy' branch into my branch
- Fix other errors as necessary
- Fix merge conflicts
- Manually test to make sure FinishLine still works

## Checklist

- [X] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [X] Screenshots of UI changes (see Screenshots section)
- [X] Remove any non-applicable sections of this template
- [X] Assign the PR to yourself
- [X] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [X] PR is linked to the ticket (fill in the closes line below)

Closes #1587 
