### PR TITLE
#2432: deleted if statement that caused duplicate tab

### DIFF
--- a/src/frontend/src/pages/FinancePage/RefundsSection.tsx
+++ b/src/frontend/src/pages/FinancePage/RefundsSection.tsx
@@ -139,7 +139,6 @@ const Refunds = ({ userReimbursementRequests, allReimbursementRequests }: Refund
 
   const tabs = [{ label: 'My Refunds', value: 0 }];
   if (canViewAllReimbursementRequests) tabs.push({ label: 'All Club Refunds', value: 1 });
-  if (user.isFinance) tabs.push({ label: 'All Club Refunds', value: 1 });
 
   return (
     <Box sx={{ bgcolor: theme.palette.background.paper, width: '100%', borderRadius: '8px 8px 8px 8px', boxShadow: 1 }}>


### PR DESCRIPTION
## Changes

deleted an if statement that double checked if the user isFinance therefore adding another tab
"canViewAllReimbursementRequests" already checks if the user is finance or an admin

## Screenshots

<img width="1460" alt="Screenshot 2024-05-23 at 1 28 36 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/147569744/2a37ff96-aa98-4e8d-9aa5-50b2282a20e7">
^^ as Milburn Pennybags

## Checklist

- [x] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [ ] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #2432
