### PR TITLE
changed the color of the cancel button on the create work package form

### DIFF
--- a/src/frontend/src/pages/WorkPackageForm/WorkPackageFormView.tsx
+++ b/src/frontend/src/pages/WorkPackageForm/WorkPackageFormView.tsx
@@ -9,7 +9,6 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { Box, TextField, Autocomplete, FormControl, Typography, Tooltip } from '@mui/material';
 import { useState } from 'react';
 import WorkPackageFormDetails from './WorkPackageFormDetails';
-import NERFailButton from '../../components/NERFailButton';
 import NERSuccessButton from '../../components/NERSuccessButton';
 import PageLayout from '../../components/PageLayout';
 import ReactHookEditableList from '../../components/ReactHookEditableList';
@@ -216,9 +215,9 @@ const WorkPackageFormView: React.FC<WorkPackageFormViewProps> = ({
               </Box>
             )}
             <Box>
-              <NERFailButton variant="contained" onClick={exitActiveMode} sx={{ mx: 1 }}>
+              <NERButton variant="contained" onClick={exitActiveMode} sx={{ mx: 1 }}>
                 Cancel
-              </NERFailButton>
+              </NERButton>
               <NERSuccessButton variant="contained" type="submit" sx={{ mx: 1 }} disabled={!changeRequestInputExists}>
                 Submit
               </NERSuccessButton>


### PR DESCRIPTION
## Changes

I changed the cancel button on the create work package form to be the same color as the create 
change request button

## Notes

## Test Cases

- Case A
- Edge case
- ...

## Screenshots

![Screenshot 2024-05-25 222033](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/147948058/d85048f8-31f5-4f1e-bc44-3518e468c7ca)

_If you made UI changes you must post a screenshot of the whole page for each change in 1) a normal sized window and 2) the smallest possible window_

_If you did any manual testing (e.g., with Postman), put screenshots of the http request and before and after of the db_

_If none of this applies, you can delete this section_

## To Do

_Any remaining things that need to get done_

- [ ] item 1
- [ ] ...

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
