### PR TITLE
#2399: changed the color of the cancel button on the create work pack…

### DIFF
--- a/src/frontend/src/pages/WorkPackageForm/WorkPackageFormView.tsx
+++ b/src/frontend/src/pages/WorkPackageForm/WorkPackageFormView.tsx
@@ -9,7 +9,6 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { Box, TextField, Autocomplete, FormControl, Typography, Tooltip } from '@mui/material';
 import { useState } from 'react';
 import WorkPackageFormDetails from './WorkPackageFormDetails';
-import NERFailButton from '../../components/NERFailButton';
 import NERSuccessButton from '../../components/NERSuccessButton';
 import PageLayout from '../../components/PageLayout';
 import { useToast } from '../../hooks/toasts.hooks';
@@ -198,9 +197,9 @@ const WorkPackageFormView: React.FC<WorkPackageFormViewProps> = ({
               </Box>
             )}
             <Box>
-              <NERFailButton variant="contained" onClick={exitActiveMode} sx={{ mx: 1 }}>
+              <NERButton variant="contained" onClick={exitActiveMode} sx={{ mx: 1 }}>
                 Cancel
-              </NERFailButton>
+              </NERButton>
               <NERSuccessButton variant="contained" type="submit" sx={{ mx: 1 }} disabled={!changeRequestInputExists}>
                 Submit
               </NERSuccessButton>


### PR DESCRIPTION
…age form

## Changes

Updated the color of the cancel button on the create work package form to be the same as the other buttons on that page

## Screenshots


![Screenshot 2024-05-25 222033](https://github.com/Northeastern-Electric-Racing/FinishLine/assets/147948058/5050dc19-e218-4655-a836-5aceb586ba9a)

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes # 2399
