### PR TITLE
#2496 change delete work package view to ner form modal

### DIFF
--- a/src/frontend/src/pages/WorkPackageDetailPage/DeleteWorkPackageModalContainer/DeleteWorkPackageView.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/DeleteWorkPackageModalContainer/DeleteWorkPackageView.tsx
@@ -34,7 +34,8 @@ const DeleteWorkPackageView: React.FC<DeleteWorkPackageViewProps> = ({ workPacka
   } = useForm({
     resolver: yupResolver(schema),
     defaultValues: {
-      wbsNum: ''
+      wbsNum: '',
+      name: ''
     },
     mode: 'onChange'
   });

--- a/src/frontend/src/pages/WorkPackageDetailPage/DeleteWorkPackageModalContainer/DeleteWorkPackageView.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/DeleteWorkPackageModalContainer/DeleteWorkPackageView.tsx
@@ -30,7 +30,7 @@ const DeleteWorkPackageView: React.FC<DeleteWorkPackageViewProps> = ({ workPacka
     handleSubmit,
     control,
     reset,
-    formState: { errors, isValid }
+    formState: { errors }
   } = useForm({
     resolver: yupResolver(schema),
     defaultValues: {

--- a/src/frontend/src/pages/WorkPackageDetailPage/DeleteWorkPackageModalContainer/DeleteWorkPackageView.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/DeleteWorkPackageModalContainer/DeleteWorkPackageView.tsx
@@ -33,7 +33,7 @@ const DeleteWorkPackageView: React.FC<DeleteWorkPackageViewProps> = ({ workPacka
     handleSubmit,
     control,
     reset,
-    formState: { errors }
+    formState: { errors, isValid }
   } = useForm({
     resolver: yupResolver(schema),
     defaultValues: {
@@ -56,8 +56,8 @@ const DeleteWorkPackageView: React.FC<DeleteWorkPackageViewProps> = ({ workPacka
       handleUseFormSubmit={handleSubmit}
       onFormSubmit={onSubmitWrapper}
       formId="delete-wp-form"
+      disabled={!isValid}
       showCloseButton
-      disabled={errors.wbsNum !== undefined}
     >
       <Typography sx={{ marginBottom: '1rem' }}>
         Are you sure you want to delete work package #{wbsPipe(workPackage)}?

--- a/src/frontend/src/pages/WorkPackageDetailPage/DeleteWorkPackageModalContainer/DeleteWorkPackageView.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/DeleteWorkPackageModalContainer/DeleteWorkPackageView.tsx
@@ -50,6 +50,7 @@ const DeleteWorkPackageView: React.FC<DeleteWorkPackageViewProps> = ({ workPacka
       onHide={onHide}
       title={`Delete Work Package #${wbsPipe(workPackage)}`}
       reset={() => reset({ wbsNum: '' })}
+      submitText="Delete"
       handleUseFormSubmit={handleSubmit}
       onFormSubmit={onSubmitWrapper}
       formId="delete-wp-form"
@@ -58,7 +59,7 @@ const DeleteWorkPackageView: React.FC<DeleteWorkPackageViewProps> = ({ workPacka
       <Typography sx={{ marginBottom: '1rem' }}>
         Are you sure you want to delete Work Package #{wbsPipe(workPackage)}?
       </Typography>
-      <Typography sx={{ fontWeight: 'bold' }}>This action cannot be undone!</Typography>
+      <Typography sx={{ fontWeight: 'bold' }}>This action cannot be undone!!!</Typography>
       <FormControl>
         <FormLabel sx={{ marginTop: '1rem', marginBottom: '1rem' }}>
           To confirm deletion, please type in the WBS number of this Work Package.

--- a/src/frontend/src/pages/WorkPackageDetailPage/DeleteWorkPackageModalContainer/DeleteWorkPackageView.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/DeleteWorkPackageModalContainer/DeleteWorkPackageView.tsx
@@ -4,23 +4,12 @@
  */
 
 import { WbsNumber, wbsPipe } from 'shared';
-import {
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  FormControl,
-  FormLabel,
-  IconButton,
-  Typography
-} from '@mui/material';
+import { FormControl, FormLabel, Typography } from '@mui/material';
+import NERFormModal from '../../../components/NERFormModal';
 import { useForm } from 'react-hook-form';
-import NERSuccessButton from '../../../components/NERSuccessButton';
-import NERFailButton from '../../../components/NERFailButton';
 import ReactHookTextField from '../../../components/ReactHookTextField';
 import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
-import CloseIcon from '@mui/icons-material/Close';
 import { DeleteWorkPackageInputs } from './DeleteWorkPackage';
 
 interface DeleteWorkPackageViewProps {
@@ -40,11 +29,13 @@ const DeleteWorkPackageView: React.FC<DeleteWorkPackageViewProps> = ({ workPacka
   const {
     handleSubmit,
     control,
+    reset,
     formState: { errors, isValid }
   } = useForm({
     resolver: yupResolver(schema),
     defaultValues: {
-      wbsNum: ''
+      wbsNum: '',
+      name: ''
     },
     mode: 'onChange'
   });
@@ -54,70 +45,34 @@ const DeleteWorkPackageView: React.FC<DeleteWorkPackageViewProps> = ({ workPacka
   };
 
   return (
-    <Dialog open={modalShow} onClose={onHide}>
-      <DialogTitle
-        className="font-weight-bold"
-        sx={{
-          '&.MuiDialogTitle-root': {
-            padding: '1rem 1.5rem 0'
-          }
-        }}
-      >{`Delete Work Package #${wbsPipe(workPackage)}`}</DialogTitle>
-      <IconButton
-        aria-label="close"
-        onClick={onHide}
-        sx={{
-          position: 'absolute',
-          right: 8,
-          top: 8,
-          color: (theme) => theme.palette.grey[500]
-        }}
-      >
-        <CloseIcon />
-      </IconButton>
-      <DialogContent
-        sx={{
-          '&.MuiDialogContent-root': {
-            padding: '1rem 1.5rem'
-          }
-        }}
-      >
-        <Typography sx={{ marginBottom: '1rem' }}>
-          Are you sure you want to delete Work Package #{wbsPipe(workPackage)}?
-        </Typography>
-        <Typography sx={{ fontWeight: 'bold' }}>This action cannot be undone!</Typography>
-        <form
-          id="delete-wp-form"
-          onSubmit={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            handleSubmit(onSubmitWrapper)(e);
-          }}
-        >
-          <FormControl>
-            <FormLabel sx={{ marginTop: '1rem', marginBottom: '1rem' }}>
-              To confirm deletion, please type in the WBS number of this Work Package.
-            </FormLabel>
-            <ReactHookTextField
-              control={control}
-              name="wbsNum"
-              errorMessage={errors.wbsNum}
-              placeholder="Enter Work Package WBS # here"
-              sx={{ width: 1 }}
-              type="string"
-            />
-          </FormControl>
-        </form>
-      </DialogContent>
-      <DialogActions>
-        <NERSuccessButton variant="contained" sx={{ mx: 1 }} onClick={onHide}>
-          Cancel
-        </NERSuccessButton>
-        <NERFailButton variant="contained" type="submit" form="delete-wp-form" sx={{ mx: 1 }} disabled={!isValid}>
-          Delete
-        </NERFailButton>
-      </DialogActions>
-    </Dialog>
+    <NERFormModal
+      open={modalShow}
+      onHide={onHide}
+      title={`Delete Work Package #${wbsPipe(workPackage)}`}
+      reset={() => reset({ wbsNum: '' })}
+      handleUseFormSubmit={handleSubmit}
+      onFormSubmit={onSubmitWrapper}
+      formId="delete-wp-form"
+      showCloseButton
+    >
+      <Typography sx={{ marginBottom: '1rem' }}>
+        Are you sure you want to delete Work Package #{wbsPipe(workPackage)}?
+      </Typography>
+      <Typography sx={{ fontWeight: 'bold' }}>This action cannot be undone!</Typography>
+      <FormControl>
+        <FormLabel sx={{ marginTop: '1rem', marginBottom: '1rem' }}>
+          To confirm deletion, please type in the WBS number of this Work Package.
+        </FormLabel>
+        <ReactHookTextField
+          control={control}
+          name="wbsNum"
+          errorMessage={errors.wbsNum}
+          placeholder="Enter Work Package WBS # here"
+          sx={{ width: 1 }}
+          type="string"
+        />
+      </FormControl>
+    </NERFormModal>
   );
 };
 

--- a/src/frontend/src/pages/WorkPackageDetailPage/DeleteWorkPackageModalContainer/DeleteWorkPackageView.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/DeleteWorkPackageModalContainer/DeleteWorkPackageView.tsx
@@ -58,7 +58,7 @@ const DeleteWorkPackageView: React.FC<DeleteWorkPackageViewProps> = ({ workPacka
       <Typography sx={{ marginBottom: '1rem' }}>
         Are you sure you want to delete Work Package #{wbsPipe(workPackage)}?
       </Typography>
-      <Typography sx={{ fontWeight: 'bold' }}>This action cannot be undone!!!</Typography>
+      <Typography sx={{ fontWeight: 'bold' }}>This action cannot be undone!!</Typography>
       <FormControl>
         <FormLabel sx={{ marginTop: '1rem', marginBottom: '1rem' }}>
           To confirm deletion, please type in the WBS number of this Work Package.

--- a/src/frontend/src/pages/WorkPackageDetailPage/DeleteWorkPackageModalContainer/DeleteWorkPackageView.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/DeleteWorkPackageModalContainer/DeleteWorkPackageView.tsx
@@ -34,8 +34,7 @@ const DeleteWorkPackageView: React.FC<DeleteWorkPackageViewProps> = ({ workPacka
   } = useForm({
     resolver: yupResolver(schema),
     defaultValues: {
-      wbsNum: '',
-      name: ''
+      wbsNum: ''
     },
     mode: 'onChange'
   });

--- a/src/frontend/src/pages/WorkPackageDetailPage/DeleteWorkPackageModalContainer/DeleteWorkPackageView.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/DeleteWorkPackageModalContainer/DeleteWorkPackageView.tsx
@@ -23,7 +23,10 @@ const DeleteWorkPackageView: React.FC<DeleteWorkPackageViewProps> = ({ workPacka
   const workPackageWbsTester = (wbsNum: string | undefined) => wbsNum !== undefined && wbsNum === wbsPipe(workPackage);
 
   const schema = yup.object().shape({
-    wbsNum: yup.string().required().test('wp-wbs-test', 'Work Package WBS Number does not match', workPackageWbsTester)
+    wbsNum: yup
+      .string()
+      .required('WBS number is required')
+      .test('wp-wbs-test', 'Work Package WBS Number does not match', workPackageWbsTester)
   });
 
   const {
@@ -54,20 +57,21 @@ const DeleteWorkPackageView: React.FC<DeleteWorkPackageViewProps> = ({ workPacka
       onFormSubmit={onSubmitWrapper}
       formId="delete-wp-form"
       showCloseButton
+      disabled={errors.wbsNum !== undefined}
     >
       <Typography sx={{ marginBottom: '1rem' }}>
-        Are you sure you want to delete Work Package #{wbsPipe(workPackage)}?
+        Are you sure you want to delete work package #{wbsPipe(workPackage)}?
       </Typography>
-      <Typography sx={{ fontWeight: 'bold' }}>This action cannot be undone!!</Typography>
+      <Typography sx={{ fontWeight: 'bold' }}>This action cannot be undone!</Typography>
       <FormControl>
         <FormLabel sx={{ marginTop: '1rem', marginBottom: '1rem' }}>
-          To confirm deletion, please type in the WBS number of this Work Package.
+          To confirm deletion, please type in the WBS number of this work package.
         </FormLabel>
         <ReactHookTextField
           control={control}
           name="wbsNum"
           errorMessage={errors.wbsNum}
-          placeholder="Enter Work Package WBS # here"
+          placeholder="Enter work package WBS # here"
           sx={{ width: 1 }}
           type="string"
         />


### PR DESCRIPTION
## Changes

Changed the Dialog component on the DeleteWorkPackageView to a NERFormModal.

## Test Cases
testing to make sure the functionality still works - i.e. that when you delete a work package, it does, in fact, delete it.
Before deleting WP 0.5.1:
<img width="1710" alt="Screenshot 2024-05-30 at 3 50 04 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/70610902/f4dc7e87-f701-4c07-9623-0b8d3c46bbc9">
Process of actually deleting WP 0.5.1:
<img width="1710" alt="Screenshot 2024-05-30 at 3 50 34 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/70610902/1b5ebb35-21a3-4d5f-a9d5-1db4c1da2fd6">
After deleting WP 0.5.1:
<img width="1710" alt="Screenshot 2024-05-30 at 3 51 07 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/70610902/8a7b379f-32f7-429f-bdb7-5e38fa0107f3">

second test - making sure that you can't delete a WP unless you enter in the proper name:
what shows up when you try to click the delete button without entering anything into the WBSnum field:
<img width="594" alt="Screenshot 2024-05-30 at 3 52 31 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/70610902/6da16e95-6c6b-462d-861b-952dd850290c">
what shows up when you try to click the delete button after entering the wrong WBSnum into the WBSnum fields:
<img width="583" alt="Screenshot 2024-05-30 at 3 53 35 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/70610902/957b179b-c831-4d21-81da-1849bbcedf5a">


## Screenshots
Full-sized window:
before:
<img width="1710" alt="Screenshot 2024-05-30 at 3 56 31 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/70610902/1030c9cb-0336-4e34-a6e5-8eccf59c018a">

after:
<img width="1710" alt="Screenshot 2024-05-30 at 3 55 12 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/70610902/99883a74-702b-474d-bf55-c9ecd5328914">


Smallest possible window:
before (you are able to scroll to see the full message):
<img width="492" alt="Screenshot 2024-05-30 at 3 57 09 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/70610902/2fa32d94-2c02-47ce-88d4-1adf4b1d0756">


after (you are able to scroll):
<img width="495" alt="Screenshot 2024-05-30 at 3 55 50 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/70610902/4308ffbc-eae7-4450-b875-4b7b4b33682b">

Closes #2496
