### PR TITLE
#2630 added distinction between project and work package proposed changes

### DIFF
--- a/src/frontend/src/pages/ChangeRequestDetailPage/DiffSection/DiffPanel.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/DiffSection/DiffPanel.tsx
@@ -6,7 +6,8 @@ import {
   PotentialChangeType,
   changeBulletDetailText,
   getPotentialChangeBackground,
-  ProposedChangeValue
+  ProposedChangeValue,
+  workPackageProposedChangesToPreview
 } from '../../../utils/diff-page.utils';
 import { labelPipe } from '../../../utils/pipes';
 
@@ -24,11 +25,18 @@ const DiffPanel: React.FC<ProjectDiffPanelProps> = ({
   const theme = useTheme();
 
   const changeBullets: ChangeBullet[][] = [[{ label: 'Proposed Changes', detail: 'None' }]];
+  const workPackagePreviews =
+    projectProposedChanges?.workPackageProposedChanges.map(workPackageProposedChangesToPreview) ?? [];
   for (const projectKey in projectProposedChanges) {
     if (projectProposedChanges.hasOwnProperty(projectKey)) {
       if (projectKey === 'workPackageProposedChanges') {
-        for (const workPackage of projectProposedChanges.workPackageProposedChanges) {
-          const wpChangeBullets: ChangeBullet[] = [{ label: 'Work Package Proposed Changes', detail: 'None' }];
+        workPackagePreviews.forEach((workPackage, idx) => {
+          const wpChangeBullets: ChangeBullet[] = [
+            {
+              label: `Work Package Proposed Changes ${workPackagePreviews.length > 1 ? '#' + (idx + 1) : ''}`,
+              detail: 'None'
+            }
+          ];
           for (let workPackageKey in workPackage) {
             if (workPackage.hasOwnProperty(workPackageKey)) {
               if (workPackageKey === 'duration') {
@@ -53,7 +61,7 @@ const DiffPanel: React.FC<ProjectDiffPanelProps> = ({
             }
           }
           changeBullets.push(wpChangeBullets);
-        }
+        });
       } else {
         changeBullets[0].push({
           label: projectKey,
@@ -99,7 +107,7 @@ const DiffPanel: React.FC<ProjectDiffPanelProps> = ({
     } else if (Array.isArray(detailText) && detailText.length > 0) {
       if (typeof detailText[0] === 'string') {
         return (
-          <List sx={{ listStyleType: 'disc', pl: 4 }}>
+          <List sx={{ listStyleType: 'disc', pl: 6 }}>
             {(detailText as string[]).map((bullet) => {
               const url = bullet.includes('http') ? bullet.split(': ')[1] : undefined;
               return (
@@ -135,7 +143,9 @@ const DiffPanel: React.FC<ProjectDiffPanelProps> = ({
 
               return potentialChangeType === PotentialChangeType.SAME ? (
                 <Typography>
-                  {labelPipe(changeBullet.label)}: {renderDetailText(detailText)}
+                  <Box pl={2}>
+                    {labelPipe(changeBullet.label)}: {renderDetailText(detailText)}
+                  </Box>
                 </Typography>
               ) : (
                 <Box
@@ -150,6 +160,7 @@ const DiffPanel: React.FC<ProjectDiffPanelProps> = ({
                       borderRadius: '5px',
                       width: 'fit-content'
                     }}
+                    pl={2}
                     component="span"
                     display="inline"
                   >


### PR DESCRIPTION
## Changes

Added indentation for everything but the section labels

## Screenshots

_If you made UI changes you must post a screenshot of the whole page for each change in 1) a normal sized window and 2) the smallest possible window_

_If you did any manual testing (e.g., with Postman), put screenshots of the http request and before and after of the db_

_If none of this applies, you can delete this section_

<img width="1440" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/114596410/567318c7-d455-41bc-b096-0b0d3a2f3b88">
<img width="1440" alt="image" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/114596410/db1f88a2-6994-4aa6-b4ea-85d525fb8b09">


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #2630
