### PR TITLE
Display Blocked By Changes

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -26,6 +26,7 @@
     "google-auth-library": "^8.1.1",
     "pdf-lib": "^1.17.1",
     "react": "18.2.0",
+    "react-archer": "^4.4.0",
     "react-dom": "^18.2.0",
     "react-draggable": "^4.4.6",
     "react-google-charts": "^4.0.0",

--- a/src/frontend/src/components/NERAutocomplete.tsx
+++ b/src/frontend/src/components/NERAutocomplete.tsx
@@ -26,6 +26,7 @@ interface NERAutocompleteProps {
   listboxProps?: HTMLAttributes<HTMLUListElement>;
   filterSelectedOptions?: boolean;
   errorMessage?: FieldError;
+  required?: boolean;
 }
 
 const NERAutocomplete: React.FC<NERAutocompleteProps> = ({
@@ -38,7 +39,8 @@ const NERAutocomplete: React.FC<NERAutocompleteProps> = ({
   value,
   listboxProps,
   filterSelectedOptions,
-  errorMessage
+  errorMessage,
+  required = true
 }) => {
   const theme = useTheme();
 
@@ -59,7 +61,7 @@ const NERAutocomplete: React.FC<NERAutocompleteProps> = ({
           sx: { height: '56px' }
         }}
         placeholder={placeholder}
-        required
+        required={required}
       />
     );
   };

--- a/src/frontend/src/pages/GanttPage/GanttChartComponents/GanttTaskBar/GanttTaskBar.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChartComponents/GanttTaskBar/GanttTaskBar.tsx
@@ -8,7 +8,7 @@ import { dateToString, getMonday } from '../../../../utils/datetime.utils';
 import GanttTaskBarEdit from './GanttTaskBarEdit';
 import GanttTaskBarView from './GanttTaskBarView';
 import { WorkPackage } from 'shared';
-import { ArcherContainer, ArcherContainerRef } from 'react-archer';
+import { ArcherContainer } from 'react-archer';
 import { useRef } from 'react';
 import { ArcherContainerHandle } from 'react-archer/lib/ArcherContainer/ArcherContainer.types';
 

--- a/src/frontend/src/pages/GanttPage/GanttChartComponents/GanttTaskBar/GanttTaskBar.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChartComponents/GanttTaskBar/GanttTaskBar.tsx
@@ -58,7 +58,7 @@ const GanttTaskBar = ({
     createChange(change);
     setTimeout(() => {
       if (archerRef.current) {
-        archerRef.current?.refreshScreen();
+        archerRef.current.refreshScreen();
       }
     }, 100); // wait for the change to be added to the state and the DOM to update
   };

--- a/src/frontend/src/pages/GanttPage/GanttChartComponents/GanttTaskBar/GanttTaskBar.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChartComponents/GanttTaskBar/GanttTaskBar.tsx
@@ -8,6 +8,9 @@ import { dateToString, getMonday } from '../../../../utils/datetime.utils';
 import GanttTaskBarEdit from './GanttTaskBarEdit';
 import GanttTaskBarView from './GanttTaskBarView';
 import { WorkPackage } from 'shared';
+import { ArcherContainer, ArcherContainerRef } from 'react-archer';
+import { useRef } from 'react';
+import { ArcherContainerHandle } from 'react-archer/lib/ArcherContainer/ArcherContainer.types';
 
 const GanttTaskBar = ({
   days,
@@ -35,6 +38,7 @@ const GanttTaskBar = ({
   getNewWorkPackageNumber: (projectId: string) => number;
 }) => {
   const isProject = !task.projectId;
+  const archerRef = useRef<ArcherContainerHandle>(null);
 
   const getStartCol = (start: Date) => {
     const startCol = days.findIndex((day) => dateToString(day) === dateToString(getMonday(start))) + 1;
@@ -50,35 +54,46 @@ const GanttTaskBar = ({
     return endCol;
   };
 
+  const handleChange = (change: GanttChange) => {
+    createChange(change);
+    setTimeout(() => {
+      if (archerRef.current) {
+        archerRef.current?.refreshScreen();
+      }
+    }, 100); // wait for the change to be added to the state and the DOM to update
+  };
+
   return (
-    <div id={`gantt-task-${task.id}`}>
-      {isEditMode ? (
-        <GanttTaskBarEdit
-          days={days}
-          task={task}
-          createChange={createChange}
-          getStartCol={getStartCol}
-          getEndCol={getEndCol}
-          isProject={isProject}
-          addWorkPackage={addWorkPackage}
-          getNewWorkPackageNumber={getNewWorkPackageNumber}
-        />
-      ) : (
-        <GanttTaskBarView
-          days={days}
-          task={task}
-          getStartCol={getStartCol}
-          getEndCol={getEndCol}
-          isProject={isProject}
-          handleOnMouseOver={handleOnMouseOver}
-          handleOnMouseLeave={handleOnMouseLeave}
-          onWorkPackageToggle={onWorkPackageToggle}
-          showWorkPackages={showWorkPackages}
-          highlightedChange={highlightedChange}
-          getNewWorkPackageNumber={getNewWorkPackageNumber}
-        />
-      )}
-    </div>
+    <ArcherContainer ref={archerRef} strokeColor="#ef4545">
+      <div id={`gantt-task-${task.id}`}>
+        {isEditMode ? (
+          <GanttTaskBarEdit
+            days={days}
+            task={task}
+            createChange={handleChange}
+            getStartCol={getStartCol}
+            getEndCol={getEndCol}
+            isProject={isProject}
+            addWorkPackage={addWorkPackage}
+            getNewWorkPackageNumber={getNewWorkPackageNumber}
+          />
+        ) : (
+          <GanttTaskBarView
+            days={days}
+            task={task}
+            getStartCol={getStartCol}
+            getEndCol={getEndCol}
+            isProject={isProject}
+            handleOnMouseOver={handleOnMouseOver}
+            handleOnMouseLeave={handleOnMouseLeave}
+            onWorkPackageToggle={onWorkPackageToggle}
+            showWorkPackages={showWorkPackages}
+            highlightedChange={highlightedChange}
+            getNewWorkPackageNumber={getNewWorkPackageNumber}
+          />
+        )}
+      </div>
+    </ArcherContainer>
   );
 };
 

--- a/src/frontend/src/pages/GanttPage/GanttChartComponents/GanttTaskBar/GanttTaskBarDisplay.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChartComponents/GanttTaskBar/GanttTaskBarDisplay.tsx
@@ -88,7 +88,6 @@ const GanttTaskBarDisplay = ({
   };
 
   const highlightedChangeBoxStyles = (highlightedChange: RequestEventChange): CSSProperties => {
-    console.log('highlightedChange', highlightedChange);
     return {
       paddingTop: '2px',
       paddingLeft: '5px',

--- a/src/frontend/src/pages/GanttPage/GanttChartComponents/GanttTaskBar/GanttTaskBarDisplay.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChartComponents/GanttTaskBar/GanttTaskBarDisplay.tsx
@@ -18,6 +18,7 @@ import {
   webKitBoxStyles
 } from './GanttTaskBarDisplayStyles';
 import { CSSProperties } from 'react';
+import { ArcherElement } from 'react-archer';
 
 interface GanttTaskBarDisplayProps {
   days: Date[];
@@ -104,18 +105,30 @@ const GanttTaskBarDisplay = ({
   };
 
   return (
-    <Box style={ganttTaskBarContainerStyles()}>
+    <div id={task.teamName + wbsPipe(task)} style={ganttTaskBarContainerStyles()}>
       <Box sx={ganttTaskBarBackgroundStyles(days.length)}>
-        <div
-          style={ganttTaskBarHoverDetectionBoxStyles}
-          onMouseOver={(e) => handleOnMouseOver(e, task)}
-          onMouseLeave={handleOnMouseLeave}
-          onClick={() => history.push(`${routes.PROJECTS}/${task.id}`)}
+        <ArcherElement
+          id={task.teamName + wbsPipe(task)}
+          relations={task.blocking.map((blocking) => {
+            return {
+              targetId: task.teamName + wbsPipe(blocking),
+              targetAnchor: 'left',
+              sourceAnchor: 'right',
+              style: { strokeDasharray: '5,5', noCurves: true, endMarker: false }
+            };
+          })}
         >
-          <Box sx={webKitBoxContainerStyles()}>
-            <Box sx={webKitBoxStyles()} />
-          </Box>
-        </div>
+          <div
+            style={ganttTaskBarHoverDetectionBoxStyles}
+            onMouseOver={(e) => handleOnMouseOver(e, task)}
+            onMouseLeave={handleOnMouseLeave}
+            onClick={() => history.push(`${routes.PROJECTS}/${task.id}`)}
+          >
+            <Box sx={webKitBoxContainerStyles()}>
+              <Box sx={webKitBoxStyles()} />
+            </Box>
+          </div>
+        </ArcherElement>
         <div
           style={ganttTaskBarDetailsBoxStyles}
           onMouseOver={(e) => handleOnMouseOver(e, task)}
@@ -163,7 +176,7 @@ const GanttTaskBarDisplay = ({
           </div>
         )}
       </Box>
-    </Box>
+    </div>
   );
 };
 

--- a/src/frontend/src/pages/GanttPage/GanttChartComponents/GanttTaskBar/GanttTaskBarEditView.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChartComponents/GanttTaskBar/GanttTaskBarEditView.tsx
@@ -3,7 +3,7 @@ import useId from '@mui/material/utils/useId';
 import { useTheme } from '@mui/system';
 import { CSSProperties, DragEvent, MouseEvent, useEffect, useState } from 'react';
 import useMeasure from 'react-use-measure';
-import { addDaysToDate, WbsElementStatus, WorkPackage, WorkPackageStage } from 'shared';
+import { addDaysToDate, WbsElementStatus, wbsPipe, WorkPackage, WorkPackageStage } from 'shared';
 import {
   GanttChange,
   GanttTask,
@@ -19,6 +19,7 @@ import {
   webKitBoxContainerStyles,
   webKitBoxStyles
 } from './GanttTaskBarDisplayStyles';
+import { ArcherElement } from 'react-archer';
 
 interface GanttTaskBarEditProps {
   days: Date[];
@@ -207,19 +208,31 @@ export const GanttTaskBarEditView = ({
           ))}
       </Box>
       <Box sx={ganttTaskBarBackgroundStyles(days.length)}>
-        <div ref={measureRef} style={taskBarDisplayStyles}>
-          <Box sx={webKitBoxContainerStyles()}>
-            <Box draggable={!isProject} onDrag={onDragStart} onDragEnd={onDragEnd} sx={webKitBoxStyles()}>
-              <Box sx={{ display: 'flex', flexDirection: 'row' }}>
-                <Typography variant="body1" sx={taskNameContainerStyles(task)}>
-                  {task.name}
-                </Typography>
+        <ArcherElement
+          id={task.teamName + wbsPipe(task)}
+          relations={task.blocking.map((blocking) => {
+            return {
+              targetId: task.teamName + wbsPipe(blocking),
+              targetAnchor: 'left',
+              sourceAnchor: 'right',
+              style: { strokeDasharray: '5,5', noCurves: true, endMarker: false}
+            };
+          })}
+        >
+          <div ref={measureRef} style={taskBarDisplayStyles}>
+            <Box sx={webKitBoxContainerStyles()}>
+              <Box draggable={!isProject} onDrag={onDragStart} onDragEnd={onDragEnd} sx={webKitBoxStyles()}>
+                <Box sx={{ display: 'flex', flexDirection: 'row' }}>
+                  <Typography variant="body1" sx={taskNameContainerStyles(task)}>
+                    {task.name}
+                  </Typography>
+                </Box>
               </Box>
-            </Box>
 
-            <Box sx={hoverContainerBoxStyles} onMouseDown={isProject ? undefined : handleMouseDown} />
-          </Box>
-        </div>
+              <Box sx={hoverContainerBoxStyles} onMouseDown={isProject ? undefined : handleMouseDown} />
+            </Box>
+          </div>
+        </ArcherElement>
         {isProject && (
           <Chip
             label={'+'}

--- a/src/frontend/src/pages/GanttPage/GanttChartComponents/GanttTaskBar/GanttTaskBarEditView.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChartComponents/GanttTaskBar/GanttTaskBarEditView.tsx
@@ -215,7 +215,7 @@ export const GanttTaskBarEditView = ({
               targetId: task.teamName + wbsPipe(blocking),
               targetAnchor: 'left',
               sourceAnchor: 'right',
-              style: { strokeDasharray: '5,5', noCurves: true, endMarker: false}
+              style: { strokeDasharray: '5,5', noCurves: true, endMarker: false }
             };
           })}
         >

--- a/src/frontend/src/pages/GanttPage/GanttChartComponents/GanttTaskBar/GanttTaskBarView.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChartComponents/GanttTaskBar/GanttTaskBarView.tsx
@@ -5,7 +5,6 @@ import {
   isHighlightedChangeOnWbsProject
 } from '../../../../utils/gantt.utils';
 import { Collapse } from '@mui/material';
-
 import GanttTaskBar from './GanttTaskBar';
 import BlockedGanttTaskView from './BlockedTaskBarView';
 import { wbsPipe } from 'shared';

--- a/src/frontend/src/pages/GanttPage/GanttChartTeamSection.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChartTeamSection.tsx
@@ -59,7 +59,6 @@ const GanttChartTeamSection = ({
 
   useEffect(() => {
     if (!IsProjectPreviewsEqual(projectsState, deeplyCopiedProjects.concat(addedProjects))) {
-      console.log('Projects state changed');
       setProjectsState([...deeplyCopiedProjects, ...addedProjects]);
     }
   }, [addedProjects, projectsState, deeplyCopiedProjects]);

--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackagePage.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackagePage.tsx
@@ -30,8 +30,6 @@ const WorkPackagePage: React.FC<WorkPackagePageProps> = ({ wbsNum }) => {
     return <EditWorkPackageForm wbsNum={wbsNum} workPackageName={data?.name} setPageMode={setEditMode} />;
   }
 
-  console.log(data.startDate);
-
   return (
     <WorkPackageViewContainer
       workPackage={data}

--- a/src/frontend/src/pages/WorkPackageForm/WorkPackageFormDetails.tsx
+++ b/src/frontend/src/pages/WorkPackageForm/WorkPackageFormDetails.tsx
@@ -145,6 +145,7 @@ const WorkPackageFormDetails: React.FC<Props> = ({
                 size="small"
                 placeholder="Select a Project Lead"
                 value={userToOption(usersForLead.find((user) => user.userId.toString() === lead))}
+                required={false}
               />
             </Grid>
             <Grid item xs={12} md={6}>
@@ -157,6 +158,7 @@ const WorkPackageFormDetails: React.FC<Props> = ({
                 size="small"
                 placeholder="Select a Project Manager"
                 value={userToOption(usersForManager.find((user) => user.userId.toString() === manager))}
+                required={false}
               />
             </Grid>
           </>

--- a/src/frontend/src/utils/gantt.utils.ts
+++ b/src/frontend/src/utils/gantt.utils.ts
@@ -196,20 +196,21 @@ export const applyChangesToWBSElement = (
   if (isWorkPackage(wbsElement.wbsNum)) {
     // If its a work package were gonna loop through and see if we need to apply changes
     const workPackage = wbsElement as WorkPackage;
-    ganttChanges.forEach((change) => {
+    for (const change of ganttChanges) {
       if (wbsPipe(change.element.wbsNum) === wbsPipe(wbsElement.wbsNum)) {
         // If the change is for this work package then were gonna apply it
-        if (change.type === 'change-end-date') {
+        if (change.type === 'create-work-package') {
+          break; // We dont want to apply the changes to a new work package because the changes get tracked already when the user edit the created work package
+        } else if (change.type === 'change-end-date') {
           workPackage.endDate = change.newEnd;
         } else if (change.type === 'shift-by-days') {
-          const newStartDate = dayjs(workPackage.startDate).add(change.days, 'day').toDate();
-          workPackage.startDate = newStartDate;
+          workPackage.startDate = dayjs(workPackage.startDate).add(change.days, 'day').toDate();
           workPackage.endDate = dayjs(workPackage.endDate).add(change.days, 'day').toDate();
         }
 
         applyChangesToBlockedBy(workPackage, parentProject.workPackages, change); // Apply the changes to all of the blocked work packages
       }
-    });
+    }
   }
 
   if (isProject(wbsElement.wbsNum)) {
@@ -282,7 +283,6 @@ export const filterGanttProjects = (
 
   deepCopy = deepCopy.filter((project) => getProjectEndDate(project).getFullYear() !== 1969); // Filter out projects with no end date
 
-  console.log(deepCopy, team.teamName);
   return deepCopy;
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10379,6 +10379,7 @@ __metadata:
     msw: ^0.44.2
     pdf-lib: ^1.17.1
     react: 18.2.0
+    react-archer: ^4.4.0
     react-dom: ^18.2.0
     react-draggable: ^4.4.6
     react-google-charts: ^4.0.0
@@ -16983,6 +16984,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-archer@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "react-archer@npm:4.4.0"
+  dependencies:
+    react-fast-compare: ^2.0.4
+    resize-observer-polyfill: 1.5.0
+  peerDependencies:
+    "@types/react": ^16.8.8 || ^17 || ^18
+    prop-types: ^15.6.2
+    react: ^16.9.0 || ^17 || ^18
+  checksum: 2f675499d9af5a06911332e432af24280b38715151078a3a75b6dd7790f6756c19647928e3f67cda3b21526c6dda2729bedb17e40d1f21835a1b4873c362c6c4
+  languageName: node
+  linkType: hard
+
 "react-dev-utils@npm:^11.0.3":
   version: 11.0.4
   resolution: "react-dev-utils@npm:11.0.4"
@@ -17055,6 +17070,13 @@ __metadata:
   version: 6.0.11
   resolution: "react-error-overlay@npm:6.0.11"
   checksum: ce7b44c38fadba9cedd7c095cf39192e632daeccf1d0747292ed524f17dcb056d16bc197ddee5723f9dd888f0b9b19c3b486c430319e30504289b9296f2d2c42
+  languageName: node
+  linkType: hard
+
+"react-fast-compare@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "react-fast-compare@npm:2.0.4"
+  checksum: 06046595f90a4e3e3a56f40a8078c00aa71bdb064ddb98343f577f546aa22e888831fd45f009c93b34707cc842b4c637737e956fd13d6f80607ee92fb9cf9a1c
   languageName: node
   linkType: hard
 
@@ -17691,6 +17713,13 @@ __metadata:
   version: 0.1.2
   resolution: "reserved-words@npm:0.1.2"
   checksum: 72e80f71dcde1e2d697e102473ad6d597e1659118836092c63cc4db68a64857f07f509176d239c8675b24f7f03574336bf202a780cc1adb39574e2884d1fd1fa
+  languageName: node
+  linkType: hard
+
+"resize-observer-polyfill@npm:1.5.0":
+  version: 1.5.0
+  resolution: "resize-observer-polyfill@npm:1.5.0"
+  checksum: ecc6aab5d4f967f1b76cee0748c1967c8b6b5d8c4393764ca3b788dbd15c0f846326c4ebff9f4f39aba45fea8016cd42bb95e28e8fab1d14349e173790c58133
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Changes

Uses react-archer https://github.com/pierpo/react-archer to draw the arrows
Add relations to the blocking gantt task to all of its blocked by
Works with both edit and viewing the gantt tasks

## Screenshots
<img width="1476" alt="Screenshot 2024-06-06 at 7 33 08 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/113635669/ce01b82d-3982-47e0-9774-4c6a6a311893">

<img width="1495" alt="Screenshot 2024-06-06 at 7 33 17 PM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/113635669/810f3086-41db-40f6-818a-2427e3e1f33e">

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
