### PR TITLE
Allow Design Reviews to be edited before being finalized

### DIFF
--- a/src/backend/src/routes/design-reviews.routes.ts
+++ b/src/backend/src/routes/design-reviews.routes.ts
@@ -38,7 +38,7 @@ designReviewsRouter.post(
   body('isInPerson').isBoolean(),
   nonEmptyString(body('zoomLink')).isURL().optional(),
   nonEmptyString(body('location')).optional(),
-  nonEmptyString(body('docTemplateLink')).isURL().optional(),
+  nonEmptyString(body('docTemplateLink')).optional(),
   isDesignReviewStatus(body('status')),
   body('attendees').isArray(),
   nonEmptyString(body('attendees.*')),

--- a/src/frontend/src/pages/CalendarPage/CalendarPage.tsx
+++ b/src/frontend/src/pages/CalendarPage/CalendarPage.tsx
@@ -96,8 +96,7 @@ const CalendarPage = () => {
   const paddingArrayStart = [...Array<number>(calendarPaddingDays(displayMonthYear)).keys()]
     .map(
       (day) =>
-        daysInMonth(new Date(displayMonthYear.getFullYear(), displayMonthYear.getMonth() - 1, displayMonthYear.getDate())) -
-        day
+        daysInMonth(new Date(displayMonthYear.getFullYear(), displayMonthYear.getMonth(), displayMonthYear.getDate())) - day
     )
     .reverse();
   const paddingArrayEnd = [

--- a/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/AvailabilityScheduleView.tsx
+++ b/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/AvailabilityScheduleView.tsx
@@ -18,6 +18,7 @@ interface AvailabilityScheduleViewProps {
   existingMeetingData: Map<number, string>;
   setCurrentAvailableUsers: (val: User[]) => void;
   setCurrentUnavailableUsers: (val: User[]) => void;
+  onSelectedTimeslotChanged: (val: number | null) => void;
   dateRangeTitle: string;
 }
 
@@ -28,7 +29,8 @@ const AvailabilityScheduleView: React.FC<AvailabilityScheduleViewProps> = ({
   existingMeetingData,
   setCurrentAvailableUsers,
   setCurrentUnavailableUsers,
-  dateRangeTitle
+  dateRangeTitle,
+  onSelectedTimeslotChanged
 }) => {
   const totalUsers = usersToAvailabilities.size;
   const [selectedTimeslot, setSelectedTimeslot] = useState<number | null>(null);
@@ -43,6 +45,8 @@ const AvailabilityScheduleView: React.FC<AvailabilityScheduleViewProps> = ({
       setCurrentAvailableUsers(availableUsers.get(index) || []);
       setCurrentUnavailableUsers(unavailableUsers.get(index) || []);
     }
+
+    onSelectedTimeslotChanged(index);
   };
 
   const handleOnMouseOver = (index: number) => {

--- a/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/DesignReviewDetailPage.tsx
+++ b/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/DesignReviewDetailPage.tsx
@@ -227,6 +227,7 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
             displayEmpty
             renderValue={(value) => meetingStartTimePipe([value])}
             value={endTime}
+            disabled={true}
             onChange={(event: SelectChangeEvent<number>) => setEndTime(Number(event.target.value))}
             size={'small'}
             placeholder={'End Time'}

--- a/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/DesignReviewDetailPage.tsx
+++ b/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/DesignReviewDetailPage.tsx
@@ -21,8 +21,8 @@ import { useState } from 'react';
 import CheckBoxIcon from '@mui/icons-material/CheckBox';
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
 import { DatePicker } from '@mui/x-date-pickers';
-import { DesignReview, isAdmin } from 'shared';
-import { useAllDesignReviews, useDeleteDesignReview } from '../../../hooks/design-reviews.hooks';
+import { DesignReview, DesignReviewStatus, isAdmin } from 'shared';
+import { useAllDesignReviews, useDeleteDesignReview, useEditDesignReview } from '../../../hooks/design-reviews.hooks';
 import { designReviewNamePipe, meetingStartTimePipe } from '../../../utils/pipes';
 import { HOURS } from '../../../utils/design-review.utils';
 import { useHistory } from 'react-router-dom';
@@ -42,6 +42,13 @@ interface DesignReviewDetailPageProps {
   designReview: DesignReview;
 }
 
+export interface FinalizeReviewInformation {
+  docTemplateLink: string;
+  zoomLink?: string;
+  location?: string;
+  meetingType: string[];
+}
+
 const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designReview }) => {
   const theme = useTheme();
   const [requiredUsers, setRequiredUsers] = useState(designReview.requiredMembers.map(userToAutocompleteOption));
@@ -52,6 +59,7 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [startTime, setStateTime] = useState(designReview.meetingTimes[0] % 12);
   const [endTime, setEndTime] = useState((designReview.meetingTimes[designReview.meetingTimes.length - 1] % 12) + 1);
+  const { mutateAsync: editDesignReview } = useEditDesignReview(designReview.designReviewId);
 
   const { isLoading: allUsersIsLoading, isError: allUsersIsError, error: allUsersError, data: allUsers } = useAllUsers();
   const {
@@ -69,7 +77,7 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
   if (allDesignReviewsIsError) return <ErrorPage message={allDesignReviewsError?.message} />;
   if (allUsersIsLoading || !allUsers || allDesignReviewsIsLoading || !allDesignReviews) return <LoadingIndicator />;
 
-  const users = allUsers.filter((user) => user.scheduleSettings).map(userToAutocompleteOption);
+  const users = allUsers.map(userToAutocompleteOption);
 
   const handleDateChange = (newDate: Date | null) => {
     if (newDate) {
@@ -79,13 +87,42 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
     }
   };
 
-  const handleDelete = () => {
+  const handleDelete = async () => {
     try {
-      deleteDesignReview();
+      await deleteDesignReview();
       history.push(routes.CALENDAR);
     } catch (e: unknown) {
       if (e instanceof Error) {
         toast.error(e.message, 3000);
+      }
+    }
+  };
+
+  const handleEdit = async (data?: FinalizeReviewInformation) => {
+    const day = date.getDay();
+    const adjustedDay = day === 0 ? 6 : day - 1;
+    const times: number[] = [];
+    for (let i = adjustedDay * 12 + startTime; i < adjustedDay * 12 + endTime; i++) {
+      times.push(i);
+    }
+    try {
+      const payload = {
+        ...data,
+        dateScheduled: date,
+        teamTypeId: designReview.teamType.teamTypeId,
+        requiredMembersIds: requiredUsers.map((user) => user.id),
+        optionalMembersIds: optionalUsers.map((user) => user.id),
+        isOnline: data?.meetingType.includes('virtual') ?? false,
+        isInPerson: data?.meetingType.includes('inPerson') ?? false,
+        status: data ? DesignReviewStatus.SCHEDULED : designReview.status,
+        attendees: [],
+        meetingTimes: times
+      };
+      await editDesignReview(payload);
+      history.push(routes.CALENDAR);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        toast.error(error.message);
       }
     }
   };
@@ -128,7 +165,6 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
     backgroundColor: theme.palette.background.paper,
     borderRadius: 3,
     textAlign: 'center',
-    textDecoration: 'underline',
     width: '100%',
     border: 'none'
   };
@@ -280,16 +316,18 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
         </Grid>
       </Grid>
       <AvailabilityView
-        editPayload={{
-          requiredUserIds: requiredUsers.map((option) => option.id),
-          optionalUserIds: optionalUsers.map((option) => option.id),
-          selectedDate: date,
-          startTime,
-          endTime
-        }}
+        handleEdit={handleEdit}
         designReview={designReview}
         allDesignReviews={allDesignReviews}
         allUsers={allUsers}
+        selectedDate={date}
+        setSelectDate={setDate}
+        requiredUserIds={requiredUsers.map((user) => user.id)}
+        optionalUserIds={optionalUsers.map((user) => user.id)}
+        startTime={startTime}
+        endTime={endTime}
+        setStartTime={setStateTime}
+        setEndTime={setEndTime}
       />
     </PageLayout>
   );

--- a/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/DesignReviewDetailPage.tsx
+++ b/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/DesignReviewDetailPage.tsx
@@ -22,7 +22,12 @@ import CheckBoxIcon from '@mui/icons-material/CheckBox';
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
 import { DatePicker } from '@mui/x-date-pickers';
 import { DesignReview, DesignReviewStatus, isAdmin } from 'shared';
-import { useAllDesignReviews, useDeleteDesignReview, useEditDesignReview } from '../../../hooks/design-reviews.hooks';
+import {
+  EditDesignReviewPayload,
+  useAllDesignReviews,
+  useDeleteDesignReview,
+  useEditDesignReview
+} from '../../../hooks/design-reviews.hooks';
 import { designReviewNamePipe, meetingStartTimePipe } from '../../../utils/pipes';
 import { HOURS } from '../../../utils/design-review.utils';
 import { useHistory } from 'react-router-dom';
@@ -106,8 +111,7 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
       times.push(i);
     }
     try {
-      const payload = {
-        ...data,
+      const payload: EditDesignReviewPayload = {
         dateScheduled: date,
         teamTypeId: designReview.teamType.teamTypeId,
         requiredMembersIds: requiredUsers.map((user) => user.id),
@@ -116,7 +120,10 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
         isInPerson: data?.meetingType.includes('inPerson') ?? false,
         status: data ? DesignReviewStatus.SCHEDULED : designReview.status,
         attendees: [],
-        meetingTimes: times
+        meetingTimes: times,
+        docTemplateLink: data?.docTemplateLink ?? designReview.docTemplateLink,
+        zoomLink: data?.zoomLink ?? designReview.zoomLink,
+        location: data?.location ?? designReview.location
       };
       await editDesignReview(payload);
       history.push(routes.CALENDAR);

--- a/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/FinalizeDesignReviewDetailsModal.tsx
+++ b/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/FinalizeDesignReviewDetailsModal.tsx
@@ -1,17 +1,13 @@
 import { Box, Grid, Link, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material';
 import { useState } from 'react';
-import { DesignReview, DesignReviewStatus, wbsPipe } from 'shared';
+import { DesignReview, wbsPipe } from 'shared';
 import { meetingStartTimePipe } from '../../../utils/pipes';
-import { DesignReviewEditData } from './DesignReviewDetailPage';
 import NERFormModal from '../../../components/NERFormModal';
 import ReactHookTextField from '../../../components/ReactHookTextField';
 import { useForm } from 'react-hook-form';
-import { useToast } from '../../../hooks/toasts.hooks';
-import { useEditDesignReview } from '../../../hooks/design-reviews.hooks';
 import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { useHistory } from 'react-router-dom';
-import { routes } from '../../../utils/routes';
+import { FinalizeReviewInformation } from './DesignReviewDetailPage';
 
 const schema = yup.object().shape({
   zoomLink: yup
@@ -26,8 +22,10 @@ interface FinalizeDesignReviewProps {
   open: boolean;
   setOpen: (val: boolean) => void;
   designReview: DesignReview;
-  editData: DesignReviewEditData;
   conflictingDesignReviews: DesignReview[];
+  startTime: number;
+  selectedDate: Date;
+  finalizeDesignReview: (data: FinalizeReviewInformation) => void;
 }
 
 const FinalizeDesignReviewDetailsModal = ({
@@ -35,20 +33,16 @@ const FinalizeDesignReviewDetailsModal = ({
   setOpen,
   designReview,
   conflictingDesignReviews,
-  editData
+  finalizeDesignReview,
+  startTime,
+  selectedDate
 }: FinalizeDesignReviewProps) => {
-  const toast = useToast();
-  const history = useHistory();
-  const { mutateAsync } = useEditDesignReview(designReview.designReviewId);
   const [meetingType, setMeetingType] = useState<string[]>([]);
-
-  const { selectedDate } = editData;
 
   const title = `Finalize Design Review for ${designReview.wbsName}`;
 
   const designReviewConflicts = conflictingDesignReviews.map(
-    (designReview) =>
-      `${wbsPipe(designReview.wbsNum)} - ${designReview.wbsName} at ${meetingStartTimePipe([editData.startTime])}`
+    (designReview) => `${wbsPipe(designReview.wbsNum)} - ${designReview.wbsName} at ${meetingStartTimePipe([startTime])}`
   );
 
   const handleMeetingTypeChange = (_event: any, newMeetingType: string[]) => {
@@ -56,32 +50,7 @@ const FinalizeDesignReviewDetailsModal = ({
   };
 
   const onSubmit = async (data: { docTemplateLink: string; zoomLink?: string; location?: string }) => {
-    const day = editData.selectedDate.getDay();
-    const adjustedDay = day === 0 ? 6 : day - 1;
-    const times: number[] = [];
-    for (let i = adjustedDay * 12 + editData.startTime; i < adjustedDay * 12 + editData.endTime; i++) {
-      times.push(i);
-    }
-    try {
-      const payload = {
-        ...data,
-        dateScheduled: editData.selectedDate,
-        teamTypeId: designReview.teamType.teamTypeId,
-        requiredMembersIds: editData.requiredUserIds,
-        optionalMembersIds: editData.optionalUserIds,
-        isOnline: meetingType.includes('virtual'),
-        isInPerson: meetingType.includes('inPerson'),
-        status: DesignReviewStatus.SCHEDULED,
-        attendees: [],
-        meetingTimes: times
-      };
-      await mutateAsync(payload);
-      history.push(routes.CALENDAR);
-    } catch (error: unknown) {
-      if (error instanceof Error) {
-        toast.error(error.message);
-      }
-    }
+    finalizeDesignReview({ ...data, meetingType });
     setOpen(false);
   };
 
@@ -113,7 +82,7 @@ const FinalizeDesignReviewDetailsModal = ({
       <Box style={{ display: 'flex', marginBottom: 20 }}>
         <Typography style={{ fontSize: '1.2em', marginRight: 90 }}>Meeting Time:</Typography>
         <Typography style={{ fontSize: '1.2em' }}>{`${meetingStartTimePipe([
-          editData.startTime
+          startTime
         ])} - ${selectedDate.toDateString()}`}</Typography>
       </Box>
       <Box style={{ display: 'flex', marginBottom: 20 }}>

--- a/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/UserAvailabilitesView.tsx
+++ b/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/UserAvailabilitesView.tsx
@@ -7,7 +7,7 @@ import NERFailButton from '../../../components/NERFailButton';
 import NERSuccessButton from '../../../components/NERSuccessButton';
 import { useState } from 'react';
 import FinalizeDesignReviewDetailsModal from './FinalizeDesignReviewDetailsModal';
-import { DesignReviewEditData } from './DesignReviewDetailPage';
+import { FinalizeReviewInformation } from './DesignReviewDetailPage';
 
 interface UserAvailabilitiesProps {
   currentAvailableUsers: User[];
@@ -15,7 +15,9 @@ interface UserAvailabilitiesProps {
   usersToAvailabilities: Map<User, number[]>;
   designReview: DesignReview;
   conflictingDesignReviews: DesignReview[];
-  editPayload: DesignReviewEditData;
+  selectedDate: Date;
+  startTime: number;
+  handleEdit: (data?: FinalizeReviewInformation) => void;
 }
 
 const UserAvailabilites: React.FC<UserAvailabilitiesProps> = ({
@@ -24,7 +26,9 @@ const UserAvailabilites: React.FC<UserAvailabilitiesProps> = ({
   usersToAvailabilities,
   designReview,
   conflictingDesignReviews,
-  editPayload
+  handleEdit,
+  selectedDate,
+  startTime
 }) => {
   const theme = useTheme();
   const [showFinalizeDesignReviewDetailsModal, setShowFinalizeDesignReviewDetailsModal] = useState(false);
@@ -111,10 +115,13 @@ const UserAvailabilites: React.FC<UserAvailabilitiesProps> = ({
           }}
         >
           <NERFailButton>Cancel</NERFailButton>
+          <NERSuccessButton variant="contained" type="submit" sx={{ mx: 1 }} onClick={() => handleEdit()}>
+            Save
+          </NERSuccessButton>
           <NERSuccessButton
             variant="contained"
             type="submit"
-            sx={{ mx: 1 }}
+            sx={{ mr: 1 }}
             onClick={() => setShowFinalizeDesignReviewDetailsModal(true)}
           >
             Finalize
@@ -124,7 +131,9 @@ const UserAvailabilites: React.FC<UserAvailabilitiesProps> = ({
             setOpen={setShowFinalizeDesignReviewDetailsModal}
             conflictingDesignReviews={conflictingDesignReviews}
             designReview={designReview}
-            editData={editPayload}
+            finalizeDesignReview={handleEdit}
+            selectedDate={selectedDate}
+            startTime={startTime}
           />
         </Box>
       </Box>

--- a/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/UserAvailabilitesView.tsx
+++ b/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/UserAvailabilitesView.tsx
@@ -1,6 +1,6 @@
 import { Typography } from '@mui/material';
 import { Box, useTheme } from '@mui/system';
-import { DesignReview, User } from 'shared';
+import { DesignReview, DesignReviewStatus, User } from 'shared';
 import { HeatmapColors } from '../../../utils/design-review.utils';
 import { fullNamePipe } from '../../../utils/pipes';
 import NERFailButton from '../../../components/NERFailButton';
@@ -8,6 +8,8 @@ import NERSuccessButton from '../../../components/NERSuccessButton';
 import { useState } from 'react';
 import FinalizeDesignReviewDetailsModal from './FinalizeDesignReviewDetailsModal';
 import { FinalizeReviewInformation } from './DesignReviewDetailPage';
+import { useHistory } from 'react-router-dom';
+import { routes } from '../../../utils/routes';
 
 interface UserAvailabilitiesProps {
   currentAvailableUsers: User[];
@@ -31,8 +33,13 @@ const UserAvailabilites: React.FC<UserAvailabilitiesProps> = ({
   startTime
 }) => {
   const theme = useTheme();
+  const history = useHistory();
   const [showFinalizeDesignReviewDetailsModal, setShowFinalizeDesignReviewDetailsModal] = useState(false);
   const totalUsers = usersToAvailabilities.size;
+
+  const handleCancel = () => {
+    history.push(routes.CALENDAR);
+  };
 
   return (
     <Box
@@ -114,11 +121,14 @@ const UserAvailabilites: React.FC<UserAvailabilitiesProps> = ({
             overflow: 'auto'
           }}
         >
-          <NERFailButton>Cancel</NERFailButton>
+          <NERFailButton onClick={handleCancel}>Cancel</NERFailButton>
           <NERSuccessButton variant="contained" type="submit" sx={{ mx: 1 }} onClick={() => handleEdit()}>
             Save
           </NERSuccessButton>
           <NERSuccessButton
+            disabled={
+              designReview.status === DesignReviewStatus.DONE || designReview.status === DesignReviewStatus.SCHEDULED
+            }
             variant="contained"
             type="submit"
             sx={{ mr: 1 }}

--- a/src/frontend/src/pages/CalendarPage/DesignReviewSummaryModal.tsx
+++ b/src/frontend/src/pages/CalendarPage/DesignReviewSummaryModal.tsx
@@ -15,6 +15,7 @@ import { useDeleteDesignReview } from '../../hooks/design-reviews.hooks';
 import { designReviewStatusColor, designReviewStatusPipe } from '../../utils/design-review.utils';
 import NERSuccessButton from '../../components/NERSuccessButton';
 import { DesignReviewAvailabilityInfo } from './DesignReviewAvailabilityInfo';
+import { CheckCircle } from '@mui/icons-material';
 
 interface DRCSummaryModalProps {
   open: boolean;
@@ -74,16 +75,30 @@ const DRCSummaryModal: React.FC<DRCSummaryModalProps> = ({ open, onHide, designR
     >
       <Box minWidth="550px">
         <DeleteModal />
-        {isDesignReviewCreator && (
-          <Box position="absolute" right="52px" top="12px">
-            <IconButton onClick={() => setShowDeleteModal(true)}>
-              <DeleteIcon />
-            </IconButton>
-            <IconButton component={RouterLink} to={`${routes.CALENDAR}/${designReview.designReviewId}`}>
-              <EditIcon />
-            </IconButton>
-          </Box>
-        )}
+        <Box position="absolute" right="52px" top="12px">
+          {isDesignReviewCreator && (
+            <>
+              <IconButton onClick={() => setShowDeleteModal(true)}>
+                <DeleteIcon />
+              </IconButton>
+              <IconButton component={RouterLink} to={`${routes.CALENDAR}/${designReview.designReviewId}`}>
+                <EditIcon />
+              </IconButton>
+            </>
+          )}
+          <IconButton
+            component={RouterLink}
+            to={`${routes.SETTINGS_PREFERENCES}?drId=${designReview.designReviewId}`}
+            disabled={
+              !designReview.requiredMembers
+                .concat(designReview.optionalMembers)
+                .some((attendee) => attendee.userId === user.userId) || isScheduled
+            }
+          >
+            <CheckCircle />
+          </IconButton>
+        </Box>
+
         <Box>
           <Box display={'flex'} alignItems={'center'}>
             <Typography flexGrow={1} variant="h4">

--- a/src/frontend/src/pages/CalendarPage/DesignReviewSummaryModal.tsx
+++ b/src/frontend/src/pages/CalendarPage/DesignReviewSummaryModal.tsx
@@ -79,11 +79,9 @@ const DRCSummaryModal: React.FC<DRCSummaryModalProps> = ({ open, onHide, designR
             <IconButton onClick={() => setShowDeleteModal(true)}>
               <DeleteIcon />
             </IconButton>
-            {isScheduled && (
-              <IconButton component={RouterLink} to={`${routes.CALENDAR}/${designReview.designReviewId}`}>
-                <EditIcon />
-              </IconButton>
-            )}
+            <IconButton component={RouterLink} to={`${routes.CALENDAR}/${designReview.designReviewId}`}>
+              <EditIcon />
+            </IconButton>
           </Box>
         )}
         <Box>

--- a/src/frontend/src/utils/design-review.utils.ts
+++ b/src/frontend/src/utils/design-review.utils.ts
@@ -7,13 +7,13 @@ export const EnumToArray = (en: { [key: number]: string | number }) => {
 export const NOON_IN_MINUTES = 720;
 
 export enum DAY_NAMES {
+  Sunday,
   Monday,
   Tuesday,
   Wednesday,
   Thursday,
   Friday,
-  Saturday,
-  Sunday
+  Saturday
 }
 
 export enum MONTH_NAMES {

--- a/src/frontend/src/utils/pipes.ts
+++ b/src/frontend/src/utils/pipes.ts
@@ -186,7 +186,7 @@ export const displayEnum = (enumString: string) => {
 export const meetingStartTimePipe = (times: number[]) => {
   const time = (times[0] % 12) + 10;
 
-  return time <= 12 ? time + 'am' : time - 12 + 'pm';
+  return time === 12 ? time + 'pm' : time < 12 ? time + 'am' : time - 12 + 'pm';
 };
 
 // takes in a Date and returns it as a string in the form mm/dd/yy

--- a/src/frontend/src/utils/routes.ts
+++ b/src/frontend/src/utils/routes.ts
@@ -41,7 +41,7 @@ const CHANGE_REQUESTS_OVERVIEW = CHANGE_REQUESTS + `/overview`;
 /****************** Settings Section  *********************/
 const SETTINGS = `/settings`;
 const SETTINGS_DETAILS = '/details';
-const SETTINGS_PREFERENCES = '/preferences';
+const SETTINGS_PREFERENCES = SETTINGS + '/preferences';
 
 /**************** Admin Tools Setion ****************/
 const ADMIN_TOOLS = `/admin-tools`;


### PR DESCRIPTION
## Changes

Changed the weird inversion of prop drilling to be top down which allowed for the date, starttime and end time to be edited along with the required users and everything else. 

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
