### PR TITLE
#1587: added everything from previous wrong branch (made off of develop)

### DIFF
--- a/src/backend/src/controllers/projects.controllers.ts
+++ b/src/backend/src/controllers/projects.controllers.ts
@@ -102,10 +102,15 @@ export default class ProjectsController {
     try {
       const user: User = await getCurrentUser(res);
       const wbsNumber: WbsNumber = validateWBS(req.params.wbsNum);
-      const { crId } = req.body;
+      const { changeRequestIdentifier } = req.body;
       const organizationId = getOrganizationId(req.headers);
 
-      const deletedProject: Project = await ProjectsService.deleteProject(user, wbsNumber, crId, organizationId);
+      const deletedProject: Project = await ProjectsService.deleteProject(
+        user,
+        wbsNumber,
+        changeRequestIdentifier,
+        organizationId
+      );
       res.status(200).json(deletedProject);
     } catch (error: unknown) {
       next(error);

--- a/src/backend/src/controllers/projects.controllers.ts
+++ b/src/backend/src/controllers/projects.controllers.ts
@@ -111,6 +111,7 @@ export default class ProjectsController {
         changeRequestIdentifier,
         organizationId
       );
+      
       res.status(200).json(deletedProject);
     } catch (error: unknown) {
       next(error);

--- a/src/backend/src/controllers/projects.controllers.ts
+++ b/src/backend/src/controllers/projects.controllers.ts
@@ -111,7 +111,7 @@ export default class ProjectsController {
         changeRequestIdentifier,
         organizationId
       );
-      
+
       res.status(200).json(deletedProject);
     } catch (error: unknown) {
       next(error);

--- a/src/backend/src/controllers/projects.controllers.ts
+++ b/src/backend/src/controllers/projects.controllers.ts
@@ -102,10 +102,10 @@ export default class ProjectsController {
     try {
       const user: User = await getCurrentUser(res);
       const wbsNumber: WbsNumber = validateWBS(req.params.wbsNum);
-      const { identifier } = req.body;
+      const { crId } = req.body;
       const organizationId = getOrganizationId(req.headers);
 
-      const deletedProject: Project = await ProjectsService.deleteProject(user, wbsNumber, identifier, organizationId);
+      const deletedProject: Project = await ProjectsService.deleteProject(user, wbsNumber, crId, organizationId);
       res.status(200).json(deletedProject);
     } catch (error: unknown) {
       next(error);

--- a/src/backend/src/controllers/projects.controllers.ts
+++ b/src/backend/src/controllers/projects.controllers.ts
@@ -102,9 +102,10 @@ export default class ProjectsController {
     try {
       const user: User = await getCurrentUser(res);
       const wbsNumber: WbsNumber = validateWBS(req.params.wbsNum);
+      const { identifier } = req.body;
       const organizationId = getOrganizationId(req.headers);
 
-      const deletedProject: Project = await ProjectsService.deleteProject(user, wbsNumber, organizationId);
+      const deletedProject: Project = await ProjectsService.deleteProject(user, wbsNumber, identifier, organizationId);
       res.status(200).json(deletedProject);
     } catch (error: unknown) {
       next(error);

--- a/src/backend/src/controllers/work-packages.controllers.ts
+++ b/src/backend/src/controllers/work-packages.controllers.ts
@@ -111,9 +111,10 @@ export default class WorkPackagesController {
     try {
       const user = await getCurrentUser(res);
       const wbsNum = validateWBS(req.params.wbsNum);
+      const { identifier } = req.body;
       const organizationId = getOrganizationId(req.headers);
 
-      await WorkPackagesService.deleteWorkPackage(user, wbsNum, organizationId);
+      await WorkPackagesService.deleteWorkPackage(user, wbsNum, identifier, organizationId);
       res.status(200).json({ message: `Successfully deleted work package #${req.params.wbsNum}` });
     } catch (error: unknown) {
       next(error);

--- a/src/backend/src/controllers/work-packages.controllers.ts
+++ b/src/backend/src/controllers/work-packages.controllers.ts
@@ -111,10 +111,10 @@ export default class WorkPackagesController {
     try {
       const user = await getCurrentUser(res);
       const wbsNum = validateWBS(req.params.wbsNum);
-      const { crId } = req.body;
+      const { changeRequestIdentifier } = req.body;
       const organizationId = getOrganizationId(req.headers);
 
-      await WorkPackagesService.deleteWorkPackage(user, wbsNum, crId, organizationId);
+      await WorkPackagesService.deleteWorkPackage(user, wbsNum, changeRequestIdentifier, organizationId);
       res.status(200).json({ message: `Successfully deleted work package #${req.params.wbsNum}` });
     } catch (error: unknown) {
       next(error);

--- a/src/backend/src/controllers/work-packages.controllers.ts
+++ b/src/backend/src/controllers/work-packages.controllers.ts
@@ -111,10 +111,10 @@ export default class WorkPackagesController {
     try {
       const user = await getCurrentUser(res);
       const wbsNum = validateWBS(req.params.wbsNum);
-      const { identifier } = req.body;
+      const { crId } = req.body;
       const organizationId = getOrganizationId(req.headers);
 
-      await WorkPackagesService.deleteWorkPackage(user, wbsNum, identifier, organizationId);
+      await WorkPackagesService.deleteWorkPackage(user, wbsNum, crId, organizationId);
       res.status(200).json({ message: `Successfully deleted work package #${req.params.wbsNum}` });
     } catch (error: unknown) {
       next(error);

--- a/src/backend/src/routes/projects.routes.ts
+++ b/src/backend/src/routes/projects.routes.ts
@@ -53,7 +53,7 @@ projectRouter.post(
 
 projectRouter.get('/:wbsNum', ProjectsController.getSingleProject);
 projectRouter.post('/:wbsNum/set-team', nonEmptyString(body('teamId')), validateInputs, ProjectsController.setProjectTeam);
-projectRouter.delete('/:wbsNum/delete', nonEmptyString(body('identifier')), ProjectsController.deleteProject);
+projectRouter.delete('/:wbsNum/delete', nonEmptyString(body('changeRequestIdentifier')), ProjectsController.deleteProject);
 projectRouter.post('/:wbsNum/favorite', ProjectsController.toggleFavorite);
 
 /**************** BOM Section ****************/

--- a/src/backend/src/routes/projects.routes.ts
+++ b/src/backend/src/routes/projects.routes.ts
@@ -53,7 +53,7 @@ projectRouter.post(
 
 projectRouter.get('/:wbsNum', ProjectsController.getSingleProject);
 projectRouter.post('/:wbsNum/set-team', nonEmptyString(body('teamId')), validateInputs, ProjectsController.setProjectTeam);
-projectRouter.delete('/:wbsNum/delete', ProjectsController.deleteProject);
+projectRouter.delete('/:wbsNum/delete', nonEmptyString(body('identifier')), ProjectsController.deleteProject);
 projectRouter.post('/:wbsNum/favorite', ProjectsController.toggleFavorite);
 
 /**************** BOM Section ****************/

--- a/src/backend/src/routes/projects.routes.ts
+++ b/src/backend/src/routes/projects.routes.ts
@@ -53,7 +53,12 @@ projectRouter.post(
 
 projectRouter.get('/:wbsNum', ProjectsController.getSingleProject);
 projectRouter.post('/:wbsNum/set-team', nonEmptyString(body('teamId')), validateInputs, ProjectsController.setProjectTeam);
-projectRouter.delete('/:wbsNum/delete', nonEmptyString(body('changeRequestIdentifier')), ProjectsController.deleteProject);
+projectRouter.delete(
+  '/:wbsNum/delete',
+  intMinZero(body('changeRequestIdentifier')),
+  validateInputs,
+  ProjectsController.deleteProject
+);
 projectRouter.post('/:wbsNum/favorite', ProjectsController.toggleFavorite);
 
 /**************** BOM Section ****************/

--- a/src/backend/src/routes/work-packages.routes.ts
+++ b/src/backend/src/routes/work-packages.routes.ts
@@ -53,7 +53,8 @@ workPackagesRouter.post(
 );
 workPackagesRouter.delete(
   '/:wbsNum/delete',
-  nonEmptyString(body('changeRequestIdentifier')),
+  intMinZero(body('changeRequestIdentifier')),
+  validateInputs,
   WorkPackagesController.deleteWorkPackage
 );
 workPackagesRouter.get('/:wbsNum/blocking', WorkPackagesController.getBlockingWorkPackages);

--- a/src/backend/src/routes/work-packages.routes.ts
+++ b/src/backend/src/routes/work-packages.routes.ts
@@ -51,7 +51,7 @@ workPackagesRouter.post(
   validateInputs,
   WorkPackagesController.editWorkPackage
 );
-workPackagesRouter.delete('/:wbsNum/delete', WorkPackagesController.deleteWorkPackage);
+workPackagesRouter.delete('/:wbsNum/delete', nonEmptyString(body('identifier')), WorkPackagesController.deleteWorkPackage);
 workPackagesRouter.get('/:wbsNum/blocking', WorkPackagesController.getBlockingWorkPackages);
 workPackagesRouter.post(
   '/slack-upcoming-deadlines',

--- a/src/backend/src/routes/work-packages.routes.ts
+++ b/src/backend/src/routes/work-packages.routes.ts
@@ -51,7 +51,11 @@ workPackagesRouter.post(
   validateInputs,
   WorkPackagesController.editWorkPackage
 );
-workPackagesRouter.delete('/:wbsNum/delete', nonEmptyString(body('identifier')), WorkPackagesController.deleteWorkPackage);
+workPackagesRouter.delete(
+  '/:wbsNum/delete',
+  nonEmptyString(body('changeRequestIdentifier')),
+  WorkPackagesController.deleteWorkPackage
+);
 workPackagesRouter.get('/:wbsNum/blocking', WorkPackagesController.getBlockingWorkPackages);
 workPackagesRouter.post(
   '/slack-upcoming-deadlines',

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -347,19 +347,14 @@ export default class ProjectsService {
    * Delete the the project in the database along with all its dependencies.
    * @param user the user who is trying to delete the project
    * @param wbsNumber the wbsNumber of the project
-   * @param identifier the id for the change request whose changes are to be
+   * @param crId the id for the change request whose changes are to be
    * implemented by the deletions of each work package in this project
    * @param organizationId the id of the organization the user is currently in
    * @throws if the wbs number does not correspond to a project, the user trying to
    * delete the project is not admin/app-admin, or the project is not found.
    * @returns the project that is deleted.
    */
-  static async deleteProject(
-    user: User,
-    wbsNumber: WbsNumber,
-    identifier: number,
-    organizationId: string
-  ): Promise<Project> {
+  static async deleteProject(user: User, wbsNumber: WbsNumber, crId: string, organizationId: string): Promise<Project> {
     if (!(await userHasPermission(user.userId, organizationId, isAdmin))) {
       throw new AccessDeniedAdminOnlyException('delete projects');
     }
@@ -413,7 +408,7 @@ export default class ProjectsService {
     await Promise.all(
       workPackages.map(
         async (workPackage) =>
-          await WorkPackagesService.deleteWorkPackage(user, wbsNumOf(workPackage.wbsElement), identifier, organizationId)
+          await WorkPackagesService.deleteWorkPackage(user, wbsNumOf(workPackage.wbsElement), crId, organizationId)
       )
     );
 

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -391,16 +391,14 @@ export default class ProjectsService {
     });
 
     await Promise.all(
-      workPackages.map(
-        async (workPackage) => {
-          await WorkPackagesService.deleteWorkPackage(
-            user,
-            wbsNumOf(workPackage.wbsElement),
-            changeRequestIdentifier,
-            organizationId
-          )
-        }
-      )
+      workPackages.map(async (workPackage) => {
+        await WorkPackagesService.deleteWorkPackage(
+          user,
+          wbsNumOf(workPackage.wbsElement),
+          changeRequestIdentifier,
+          organizationId
+        );
+      })
     );
 
     const dateDeleted: Date = new Date();

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -364,6 +364,18 @@ export default class ProjectsService {
       throw new AccessDeniedAdminOnlyException('delete projects');
     }
 
+    const changeRequest = await prisma.change_Request.findUnique({
+      where: {
+        uniqueChangeRequest: {
+          identifier: Number.parseInt(changeRequestIdentifier),
+          organizationId
+        }
+      }
+    });
+
+    // throw error if changeRequest is null
+    await validateChangeRequestAccepted(changeRequest!.crId);
+
     const project = await ProjectsService.getSingleProjectWithQueryArgs(wbsNumber, organizationId);
 
     const { projectId, wbsElementId } = project;

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -354,7 +354,12 @@ export default class ProjectsService {
    * delete the project is not admin/app-admin, or the project is not found.
    * @returns the project that is deleted.
    */
-  static async deleteProject(user: User, wbsNumber: WbsNumber, changeRequestIdentifier: string, organizationId: string): Promise<Project> {
+  static async deleteProject(
+    user: User,
+    wbsNumber: WbsNumber,
+    changeRequestIdentifier: string,
+    organizationId: string
+  ): Promise<Project> {
     if (!(await userHasPermission(user.userId, organizationId, isAdmin))) {
       throw new AccessDeniedAdminOnlyException('delete projects');
     }
@@ -408,7 +413,12 @@ export default class ProjectsService {
     await Promise.all(
       workPackages.map(
         async (workPackage) =>
-          await WorkPackagesService.deleteWorkPackage(user, wbsNumOf(workPackage.wbsElement), changeRequestIdentifier, organizationId)
+          await WorkPackagesService.deleteWorkPackage(
+            user,
+            wbsNumOf(workPackage.wbsElement),
+            changeRequestIdentifier,
+            organizationId
+          )
       )
     );
 

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -364,7 +364,6 @@ export default class ProjectsService {
       throw new AccessDeniedAdminOnlyException('delete projects');
     }
 
-    // REVISED CODE
     const changeRequest = await prisma.change_Request.findUnique({
       where: {
         uniqueChangeRequest: {
@@ -374,11 +373,10 @@ export default class ProjectsService {
       }
     });
 
-    if(changeRequest == null) {
+    if (changeRequest == null) {
       throw new DeletedException('Change Request', changeRequestIdentifier);
     }
     await validateChangeRequestAccepted(changeRequest.crId);
-    // ****************
 
     const project = await ProjectsService.getSingleProjectWithQueryArgs(wbsNumber, organizationId);
 

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -347,12 +347,19 @@ export default class ProjectsService {
    * Delete the the project in the database along with all its dependencies.
    * @param user the user who is trying to delete the project
    * @param wbsNumber the wbsNumber of the project
+   * @param identifier the id for the change request whose changes are to be
+   * implemented by the deletions of each work package in this project
    * @param organizationId the id of the organization the user is currently in
    * @throws if the wbs number does not correspond to a project, the user trying to
    * delete the project is not admin/app-admin, or the project is not found.
    * @returns the project that is deleted.
    */
-  static async deleteProject(user: User, wbsNumber: WbsNumber, organizationId: string): Promise<Project> {
+  static async deleteProject(
+    user: User,
+    wbsNumber: WbsNumber,
+    identifier: number,
+    organizationId: string
+  ): Promise<Project> {
     if (!(await userHasPermission(user.userId, organizationId, isAdmin))) {
       throw new AccessDeniedAdminOnlyException('delete projects');
     }
@@ -406,7 +413,7 @@ export default class ProjectsService {
     await Promise.all(
       workPackages.map(
         async (workPackage) =>
-          await WorkPackagesService.deleteWorkPackage(user, wbsNumOf(workPackage.wbsElement), organizationId)
+          await WorkPackagesService.deleteWorkPackage(user, wbsNumOf(workPackage.wbsElement), identifier, organizationId)
       )
     );
 

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -364,6 +364,7 @@ export default class ProjectsService {
       throw new AccessDeniedAdminOnlyException('delete projects');
     }
 
+    // REVISED CODE
     const changeRequest = await prisma.change_Request.findUnique({
       where: {
         uniqueChangeRequest: {
@@ -373,8 +374,11 @@ export default class ProjectsService {
       }
     });
 
-    // throw error if changeRequest is null
-    await validateChangeRequestAccepted(changeRequest!.crId);
+    if(changeRequest == null) {
+      throw new DeletedException('Change Request', changeRequestIdentifier);
+    }
+    await validateChangeRequestAccepted(changeRequest.crId);
+    // ****************
 
     const project = await ProjectsService.getSingleProjectWithQueryArgs(wbsNumber, organizationId);
 

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -392,12 +392,16 @@ export default class ProjectsService {
 
     await Promise.all(
       workPackages.map(async (workPackage) => {
-        await WorkPackagesService.deleteWorkPackage(
-          user,
-          wbsNumOf(workPackage.wbsElement),
-          changeRequestIdentifier,
-          organizationId
-        );
+        try {
+          await WorkPackagesService.deleteWorkPackage(
+            user,
+            wbsNumOf(workPackage.wbsElement),
+            changeRequestIdentifier,
+            organizationId
+          );
+        } catch (error) {
+          // do nothing
+        }
       })
     );
 

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -373,9 +373,14 @@ export default class ProjectsService {
       }
     });
 
-    if (changeRequest == null) {
+    if (!changeRequest) {
+      throw new NotFoundException('Change Request', changeRequestIdentifier);
+    }
+
+    if (changeRequest.dateDeleted) {
       throw new DeletedException('Change Request', changeRequestIdentifier);
     }
+
     await validateChangeRequestAccepted(changeRequest.crId);
 
     const project = await ProjectsService.getSingleProjectWithQueryArgs(wbsNumber, organizationId);

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -347,14 +347,14 @@ export default class ProjectsService {
    * Delete the the project in the database along with all its dependencies.
    * @param user the user who is trying to delete the project
    * @param wbsNumber the wbsNumber of the project
-   * @param crId the id for the change request whose changes are to be
+   * @param changeRequestIdentifier the id for the change request whose changes are to be
    * implemented by the deletions of each work package in this project
    * @param organizationId the id of the organization the user is currently in
    * @throws if the wbs number does not correspond to a project, the user trying to
    * delete the project is not admin/app-admin, or the project is not found.
    * @returns the project that is deleted.
    */
-  static async deleteProject(user: User, wbsNumber: WbsNumber, crId: string, organizationId: string): Promise<Project> {
+  static async deleteProject(user: User, wbsNumber: WbsNumber, changeRequestIdentifier: string, organizationId: string): Promise<Project> {
     if (!(await userHasPermission(user.userId, organizationId, isAdmin))) {
       throw new AccessDeniedAdminOnlyException('delete projects');
     }
@@ -408,7 +408,7 @@ export default class ProjectsService {
     await Promise.all(
       workPackages.map(
         async (workPackage) =>
-          await WorkPackagesService.deleteWorkPackage(user, wbsNumOf(workPackage.wbsElement), crId, organizationId)
+          await WorkPackagesService.deleteWorkPackage(user, wbsNumOf(workPackage.wbsElement), changeRequestIdentifier, organizationId)
       )
     );
 

--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -444,7 +444,6 @@ export default class WorkPackagesService {
 
     const { wbsElementId, id: workPackageId } = workPackage;
 
-    // REVISED CODE
     const changeRequest = await prisma.change_Request.findUnique({
       where: {
         uniqueChangeRequest: {
@@ -459,7 +458,6 @@ export default class WorkPackagesService {
     }
 
     await validateChangeRequestAccepted(changeRequest.crId);
-    // ***********
 
     await prisma.change.create({
       data: {

--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -444,15 +444,22 @@ export default class WorkPackagesService {
 
     const { wbsElementId, id: workPackageId } = workPackage;
 
-    // change this to match what is in projects.services
-    const changeRequest = await prisma.change_Request.findFirst({
+    // REVISED CODE
+    const changeRequest = await prisma.change_Request.findUnique({
       where: {
-        identifier: Number.parseInt(changeRequestIdentifier)
+        uniqueChangeRequest: {
+          identifier: Number.parseInt(changeRequestIdentifier),
+          organizationId
+        }
       }
     });
 
-    // throw error if changeRequest is null by checking in an if statement
-    await validateChangeRequestAccepted(changeRequest!.crId);
+    if (changeRequest == null) {
+      throw new DeletedException('Change Request', changeRequestIdentifier);
+    }
+
+    await validateChangeRequestAccepted(changeRequest.crId);
+    // ***********
 
     await prisma.change.create({
       data: {

--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -426,16 +426,11 @@ export default class WorkPackagesService {
    * Deletes the Work Package
    * @param submitter The user who deleted the work package
    * @param wbsNum The work package number to be deleted
-   * @param identifer The id of the change request whose change is
+   * @param crId The id of the change request whose change is
    * to be implemented by this deletion
    * @param organizationId The organization id that the user is in
    */
-  static async deleteWorkPackage(
-    submitter: User,
-    wbsNum: WbsNumber,
-    identifier: number,
-    organizationId: string
-  ): Promise<void> {
+  static async deleteWorkPackage(submitter: User, wbsNum: WbsNumber, crId: string, organizationId: string): Promise<void> {
     // Verify submitter is allowed to delete work packages
     if (!(await userHasPermission(submitter.userId, organizationId, isAdmin)))
       throw new AccessDeniedAdminOnlyException('delete work packages');
@@ -444,11 +439,11 @@ export default class WorkPackagesService {
 
     const { wbsElementId, id: workPackageId } = workPackage;
 
-    await validateChangeRequestAccepted(identifier.toString());
+    await validateChangeRequestAccepted(crId);
 
     await prisma.change.create({
       data: {
-        changeRequestId: identifier.toString(),
+        changeRequestId: crId,
         implementerId: submitter.userId,
         wbsElementId,
         detail: 'Work Package Deleted'

--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -480,17 +480,6 @@ export default class WorkPackagesService {
         // Soft delete the given wp's wbs by setting crs to denied and soft deleting tasks
         wbsElement: {
           update: {
-            changeRequests: {
-              updateMany: {
-                where: {
-                  wbsElementId
-                },
-                data: {
-                  accepted: false,
-                  dateReviewed: dateDeleted
-                }
-              }
-            },
             tasks: {
               updateMany: {
                 where: {

--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -444,12 +444,14 @@ export default class WorkPackagesService {
 
     const { wbsElementId, id: workPackageId } = workPackage;
 
+    // change this to match what is in projects.services
     const changeRequest = await prisma.change_Request.findFirst({
       where: {
         identifier: Number.parseInt(changeRequestIdentifier)
       }
     });
 
+    // throw error if changeRequest is null by checking in an if statement
     await validateChangeRequestAccepted(changeRequest!.crId);
 
     await prisma.change.create({

--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -453,7 +453,11 @@ export default class WorkPackagesService {
       }
     });
 
-    if (changeRequest == null) {
+    if (!changeRequest) {
+      throw new NotFoundException('Change Request', changeRequestIdentifier);
+    }
+
+    if (changeRequest.dateDeleted) {
       throw new DeletedException('Change Request', changeRequestIdentifier);
     }
 


### PR DESCRIPTION
## Changes

- work-packages.routes.ts delete route takes in a CR ID (the identifier field of a CR)
- work-packages.controllers.ts delete method gets CR ID from request body and passes that into the service function
- work-packages.services.ts delete method takes in CR ID, makes a Change on the CR corresponding to the given CR ID (which states that the WP is deleted), then soft deletes the WP
- the same changes as above were made in projects.routes.ts delete, projects.controllers.ts delete, and projects.services.ts
- change requests in a work package are no longer deleted after the work package is deleted

## Screenshots

# Calling Delete Work Package Endpoint

Endpoint Call on Postman:

<img width="550" alt="Screen Shot 2024-08-12 at 11 56 11 PM" src="https://github.com/user-attachments/assets/ecd1c5f0-a1c5-4b7c-8b58-092eae2eda21">

Results in Prisma Studio:

<img width="1216" alt="Screen Shot 2024-08-12 at 11 56 16 PM" src="https://github.com/user-attachments/assets/50cf3167-00d6-45d9-a8be-5f70951ff61d">
<img width="1267" alt="Screen Shot 2024-08-12 at 11 56 48 PM" src="https://github.com/user-attachments/assets/0b479de8-b930-4ca2-8bed-55fc10754572">

# Calling Delete Project Endpoint - CASE 1 (Deleting a project with three non-deleted work packages)

Endpoint Call on Postman:

<img width="557" alt="Screen Shot 2024-08-13 at 12 05 41 AM" src="https://github.com/user-attachments/assets/f2c54199-4390-476f-b7bb-743b73bdbd34">

Results in Prisma Studio:

<img width="1232" alt="Screen Shot 2024-08-13 at 12 17 36 PM" src="https://github.com/user-attachments/assets/368fec8c-2458-4977-9346-f00820697668">
<img width="1439" alt="Screen Shot 2024-08-13 at 12 18 01 PM" src="https://github.com/user-attachments/assets/03008ca9-5c2e-44e9-8008-d1bffc085454">

# Calling Delete Project Endpoint - CASE 2 (Deleting a project with two work packages, one of which has already been deleted)

Before Endpoint Call:
<img width="1427" alt="Screen Shot 2024-08-13 at 12 35 30 PM" src="https://github.com/user-attachments/assets/3f89b3b6-5c85-4bc2-bfc2-b5d3da4335b5">
<img width="1440" alt="Screen Shot 2024-08-13 at 12 35 51 PM" src="https://github.com/user-attachments/assets/42fbe3db-0f33-4a34-b4a0-d5cf8db42fa1">

Endpoint Call on Postman:
<img width="547" alt="Screen Shot 2024-08-13 at 12 38 45 PM" src="https://github.com/user-attachments/assets/b5735fb6-a70f-4156-9382-41b5efffb2ac">

Results in Prisma Studio:
<img width="1107" alt="Screen Shot 2024-08-13 at 12 38 55 PM" src="https://github.com/user-attachments/assets/57186fd5-8afc-4704-9d4e-62b0d162266c">
<img width="1440" alt="Screen Shot 2024-08-13 at 12 39 26 PM" src="https://github.com/user-attachments/assets/8f6aba15-1ade-492d-9585-c142c07fad2d">

**Note: I also tested a case where the project had no work packages and everything worked fine**

## Test Cases

- yarn test:frontend passes all tests
- yarn test:backend passes all tests
- FinishLine starts up and functions properly

## Checklist

- [X] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [X] Screenshots of UI changes (see Screenshots section)
- [X] Remove any non-applicable sections of this template
- [X] Assign the PR to yourself
- [X] No `yarn.lock` changes (unless dependencies have changed)
- [X] Request reviewers & ping on Slack
- [X] PR is linked to the ticket (fill in the closes line below)

Closes #1587 
