### PR TITLE
#2493 change DeleteProjectView to NERFormModal

### DIFF
--- a/src/frontend/src/pages/ProjectDetailPage/DeleteProjectView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/DeleteProjectView.tsx
@@ -4,23 +4,11 @@
  */
 
 import { WbsNumber, wbsPipe } from 'shared';
-import {
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  FormControl,
-  FormLabel,
-  IconButton,
-  Typography
-} from '@mui/material';
+import { FormControl, FormLabel, Typography } from '@mui/material';
 import { useForm } from 'react-hook-form';
-import NERSuccessButton from '../../components/NERSuccessButton';
 import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
-import NERFailButton from '../../components/NERFailButton';
 import ReactHookTextField from '../../components/ReactHookTextField';
-import CloseIcon from '@mui/icons-material/Close';
 import { DeleteProjectInputs } from './DeleteProject';
 import NERFormModal from '../../components/NERFormModal';
 

--- a/src/frontend/src/pages/ProjectDetailPage/DeleteProjectView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/DeleteProjectView.tsx
@@ -34,7 +34,10 @@ const DeleteProjectView: React.FC<DeleteProjectViewProps> = ({ project, modalSho
   const projectWbsNumTester = (wbsNum: string | undefined) => wbsNum !== undefined && wbsNum === wbsPipe(project);
 
   const schema = yup.object().shape({
-    wbsNum: yup.string().required().test('project-wbs-test', 'Project WBS does not match', projectWbsNumTester)
+    wbsNum: yup
+      .string()
+      .required('Project WBS is required')
+      .test('project-wbs-test', 'Project WBS does not match', projectWbsNumTester)
   });
 
   const {

--- a/src/frontend/src/pages/ProjectDetailPage/DeleteProjectView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/DeleteProjectView.tsx
@@ -22,6 +22,7 @@ import NERFailButton from '../../components/NERFailButton';
 import ReactHookTextField from '../../components/ReactHookTextField';
 import CloseIcon from '@mui/icons-material/Close';
 import { DeleteProjectInputs } from './DeleteProject';
+import NERFormModal from '../../components/NERFormModal';
 
 interface DeleteProjectViewProps {
   project: WbsNumber;
@@ -43,6 +44,7 @@ const DeleteProjectView: React.FC<DeleteProjectViewProps> = ({ project, modalSho
   const {
     handleSubmit,
     control,
+    reset,
     formState: { errors, isValid }
   } = useForm({
     resolver: yupResolver(schema),
@@ -57,68 +59,34 @@ const DeleteProjectView: React.FC<DeleteProjectViewProps> = ({ project, modalSho
   };
 
   return (
-    <Dialog open={modalShow} onClose={onHide}>
-      <DialogTitle
-        className="font-weight-bold"
-        sx={{
-          '&.MuiDialogTitle-root': {
-            padding: '1rem 1.5rem 0'
-          }
-        }}
-      >{`Delete Project #${wbsPipe(project)}`}</DialogTitle>
-      <IconButton
-        aria-label="close"
-        onClick={onHide}
-        sx={{
-          position: 'absolute',
-          right: 8,
-          top: 8,
-          color: (theme) => theme.palette.grey[500]
-        }}
-      >
-        <CloseIcon />
-      </IconButton>
-      <DialogContent
-        sx={{
-          '&.MuiDialogContent-root': {
-            padding: '1rem 1.5rem'
-          }
-        }}
-      >
-        <Typography sx={{ marginBottom: '1rem' }}>Are you sure you want to delete Project #{wbsPipe(project)}?</Typography>
-        <Typography sx={{ fontWeight: 'bold' }}>This action cannot be undone!</Typography>
-        <form
-          id="delete-project-form"
-          onSubmit={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            handleSubmit(onSubmitWrapper)(e);
-          }}
-        >
-          <FormControl>
-            <FormLabel sx={{ marginTop: '1rem', marginBottom: '1rem' }}>
-              To confirm deletion, please type in the WBS number of this Project.
-            </FormLabel>
-            <ReactHookTextField
-              control={control}
-              name="wbsNum"
-              errorMessage={errors.wbsNum}
-              placeholder="Enter Project WBS here"
-              sx={{ width: 1 }}
-              type="string"
-            />
-          </FormControl>
-        </form>
-      </DialogContent>
-      <DialogActions>
-        <NERSuccessButton variant="contained" sx={{ mx: 1 }} onClick={onHide}>
-          Cancel
-        </NERSuccessButton>
-        <NERFailButton variant="contained" type="submit" form="delete-project-form" sx={{ mx: 1 }} disabled={!isValid}>
-          Delete
-        </NERFailButton>
-      </DialogActions>
-    </Dialog>
+    <NERFormModal
+      open={modalShow}
+      onHide={onHide}
+      title={`Delete Project #${wbsPipe(project)}`}
+      reset={() => reset({ wbsNum: '' })}
+      submitText="Delete"
+      handleUseFormSubmit={handleSubmit}
+      onFormSubmit={onSubmitWrapper}
+      formId="delete-wp-form"
+      disabled={!isValid}
+      showCloseButton
+    >
+      <Typography sx={{ marginBottom: '1rem' }}>Are you sure you want to delete Project #{wbsPipe(project)}?</Typography>
+      <Typography sx={{ fontWeight: 'bold' }}>This action cannot be undone!</Typography>
+      <FormControl>
+        <FormLabel sx={{ marginTop: '1rem', marginBottom: '1rem' }}>
+          To confirm deletion, please type in the WBS number of this Project.
+        </FormLabel>
+        <ReactHookTextField
+          control={control}
+          name="wbsNum"
+          errorMessage={errors.wbsNum}
+          placeholder="Enter Project WBS here"
+          sx={{ width: 1 }}
+          type="string"
+        />
+      </FormControl>
+    </NERFormModal>
   );
 };
 


### PR DESCRIPTION
## Changes
Changed the dialog component of the delete project view to an NERFormModal. Also adjusted the yup schema to have a custom required message.

## Screenshots:
Before changes:
What the dialog looks like as soon as the user opens the form in a full sized window
<img width="544" alt="Screenshot 2024-06-13 at 9 37 15 AM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/70610902/47a97f88-b953-411f-88cd-751fa51e7dad">



After changes:
As soon as you open the Delete form view (the delete button is greyed out because the wbsNum field is required:
<img width="536" alt="Screenshot 2024-06-13 at 9 30 41 AM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/70610902/37be28d8-cb13-4f34-bebe-84424fd395cd">
If the user inputs the wrong WBSNum (the delete button is greyed out because the wbsNum must be correct):
<img width="537" alt="Screenshot 2024-06-13 at 9 31 45 AM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/70610902/f420012b-1bc1-4f89-ae29-961f280b1365">
If the user deletes their input in the WBSNum field (custom error message shows and the delete button is still greyed out):
<img width="538" alt="Screenshot 2024-06-13 at 9 33 04 AM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/70610902/95321fb0-51e5-4837-a3a9-a3dc93d182cf">
When the user inputs the correct wbsNum (the delete button is not greyed out):
<img width="538" alt="Screenshot 2024-06-13 at 9 33 21 AM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/70610902/81a8335f-85dc-4b64-89a2-fd9efb446fa2">
view of projects page after deleting project 0.5.0 - the project doesn't show anymore, so the functionality of the deleteworkpackageview still works. 
<img width="1710" alt="Screenshot 2024-06-13 at 9 34 16 AM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/70610902/197c3b57-eba7-4d86-82c5-f550472d0073">
NERFormModal in smallest possible window size (the user is able to use the scroll bar to see the full form)
<img width="491" alt="Screenshot 2024-06-13 at 9 36 04 AM" src="https://github.com/Northeastern-Electric-Racing/FinishLine/assets/70610902/2f83fbc2-b578-485c-a78c-d8d063108023">
Closes #2493
