### PR TITLE
#2312 DR Mark Complete Button Hooked Up

### DIFF
--- a/src/frontend/src/apis/design-reviews.api.ts
+++ b/src/frontend/src/apis/design-reviews.api.ts
@@ -4,7 +4,7 @@
  */
 import { CreateTeamTypePayload, EditDesignReviewPayload } from '../hooks/design-reviews.hooks';
 import axios from '../utils/axios';
-import { DesignReview } from 'shared';
+import { DesignReview, DesignReviewStatus } from 'shared';
 import { apiUrls } from '../utils/urls';
 import { CreateDesignReviewsPayload } from '../hooks/design-reviews.hooks';
 import { designReviewTransformer } from './transformers/design-reviews.tranformers';
@@ -72,4 +72,10 @@ export const deleteDesignReview = async (id: string) => {
 
 export const markUserConfirmed = async (id: string, payload: { availability: number[] }) => {
   return axios.post<DesignReview>(apiUrls.designReviewMarkUserConfirmed(id), payload);
+};
+
+export const setDesignReviewStatus = async (id: string, payload: { status: DesignReviewStatus }) => {
+  return axios.post<DesignReview>(apiUrls.designReviewSetStatus(id), payload, {
+    transformResponse: (data) => designReviewTransformer(JSON.parse(data))
+  });
 };

--- a/src/frontend/src/hooks/design-reviews.hooks.ts
+++ b/src/frontend/src/hooks/design-reviews.hooks.ts
@@ -12,7 +12,8 @@ import {
   getAllTeamTypes,
   getSingleDesignReview,
   markUserConfirmed,
-  createTeamType
+  createTeamType,
+  setDesignReviewStatus
 } from '../apis/design-reviews.api';
 import { useCurrentUser } from './users.hooks';
 
@@ -175,6 +176,22 @@ export const useMarkUserConfirmed = (id: string) => {
       onSuccess: () => {
         queryClient.invalidateQueries(['design-reviews']);
         queryClient.invalidateQueries(['users', user.userId, 'schedule-settings']);
+      }
+    }
+  );
+};
+
+export const useSetDesignReviewStatus = (id: string) => {
+  const queryClient = useQueryClient();
+  return useMutation<DesignReview, Error, { status: DesignReviewStatus }>(
+    ['design-reviews', id],
+    async (payload: { status: DesignReviewStatus }) => {
+      const { data } = await setDesignReviewStatus(id, payload);
+      return data;
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(['design-reviews', id]);
       }
     }
   );

--- a/src/frontend/src/pages/CalendarPage/CalendarComponents/CalendarDayCard.tsx
+++ b/src/frontend/src/pages/CalendarPage/CalendarComponents/CalendarDayCard.tsx
@@ -48,6 +48,7 @@ const CalendarDayCard: React.FC<CalendarDayCardProps> = ({ cardDate, events, tea
 
   const EventCard = ({ event }: { event: DesignReview }) => {
     const [isSummaryModalOpen, setIsSummaryModalOpen] = useState(false);
+    const [markedStatus, setMarkedStatus] = useState(event.status);
     const name = event.wbsName;
 
     return (
@@ -57,11 +58,13 @@ const CalendarDayCard: React.FC<CalendarDayCardProps> = ({ cardDate, events, tea
           onHide={() => setIsSummaryModalOpen(false)}
           designReview={event}
           teamTypes={teamTypes}
+          markedStatus={markedStatus}
+          setMarkedStatus={setMarkedStatus}
         />
         <Box marginLeft={0.5} marginBottom={0.5} onClick={() => setIsSummaryModalOpen(true)} sx={{ cursor: 'pointer' }}>
           <Card
             sx={{
-              backgroundColor: designReviewStatusColor(event.status),
+              backgroundColor: designReviewStatusColor(markedStatus),
               borderRadius: 1,
               width: '100%',
               minHeight: 20,
@@ -83,6 +86,7 @@ const CalendarDayCard: React.FC<CalendarDayCardProps> = ({ cardDate, events, tea
 
   const ExtraEventNote = ({ event }: { event: DesignReview }) => {
     const [isSummaryModalOpen, setIsSummaryModalOpen] = useState(false);
+    const [markedStatus, setMarkedStatus] = useState(event.status);
 
     return (
       <>
@@ -91,6 +95,8 @@ const CalendarDayCard: React.FC<CalendarDayCardProps> = ({ cardDate, events, tea
           onHide={() => setIsSummaryModalOpen(false)}
           designReview={event}
           teamTypes={teamTypes}
+          markedStatus={markedStatus}
+          setMarkedStatus={setMarkedStatus}
         />
         <Link
           style={{ cursor: 'pointer' }}

--- a/src/frontend/src/pages/CalendarPage/CalendarPage.tsx
+++ b/src/frontend/src/pages/CalendarPage/CalendarPage.tsx
@@ -129,6 +129,8 @@ const CalendarPage = () => {
           }}
           designReview={unconfirmedDesignReview as DesignReview}
           teamTypes={allTeamTypes}
+          markedStatus={DesignReviewStatus.UNCONFIRMED}
+          setMarkedStatus={() => {}}
         />
       )}
       <PageLayout

--- a/src/frontend/src/pages/CalendarPage/CalendarPage.tsx
+++ b/src/frontend/src/pages/CalendarPage/CalendarPage.tsx
@@ -129,8 +129,6 @@ const CalendarPage = () => {
           }}
           designReview={unconfirmedDesignReview as DesignReview}
           teamTypes={allTeamTypes}
-          markedStatus={DesignReviewStatus.UNCONFIRMED}
-          setMarkedStatus={() => {}}
         />
       )}
       <PageLayout

--- a/src/frontend/src/pages/CalendarPage/DesignReviewSummaryModal.tsx
+++ b/src/frontend/src/pages/CalendarPage/DesignReviewSummaryModal.tsx
@@ -22,9 +22,18 @@ interface DRCSummaryModalProps {
   onHide: () => void;
   designReview: DesignReview;
   teamTypes: TeamType[];
+  markedStatus: DesignReviewStatus;
+  setMarkedStatus: (_: DesignReviewStatus) => void;
 }
 
-const DRCSummaryModal: React.FC<DRCSummaryModalProps> = ({ open, onHide, designReview, teamTypes }) => {
+const DRCSummaryModal: React.FC<DRCSummaryModalProps> = ({
+  open,
+  onHide,
+  designReview,
+  teamTypes,
+  markedStatus,
+  setMarkedStatus
+}: DRCSummaryModalProps) => {
   const user = useCurrentUser();
   const toast = useToast();
   const history = useHistory();
@@ -108,10 +117,10 @@ const DRCSummaryModal: React.FC<DRCSummaryModalProps> = ({ open, onHide, designR
             </Typography>
             <Chip
               size="small"
-              label={designReviewStatusPipe(designReview.status)}
+              label={designReviewStatusPipe(markedStatus)}
               variant="filled"
               sx={{
-                backgroundColor: designReviewStatusColor(designReview.status),
+                backgroundColor: designReviewStatusColor(markedStatus),
                 fontSize: 14,
                 color: 'white',
                 width: 150,
@@ -119,7 +128,14 @@ const DRCSummaryModal: React.FC<DRCSummaryModalProps> = ({ open, onHide, designR
               }}
             />
           </Box>
-          {isScheduled && <DesignReviewSummaryModalDetails designReview={designReview} teamTypes={teamTypes} />}
+          {isScheduled && (
+            <DesignReviewSummaryModalDetails
+              designReview={designReview}
+              teamTypes={teamTypes}
+              markedStatus={markedStatus}
+              setMarkedStatus={setMarkedStatus}
+            />
+          )}
           {designReview.status === DesignReviewStatus.CONFIRMED && (
             <Box>
               <DesignReviewSummaryModalAttendees designReview={designReview} />

--- a/src/frontend/src/pages/CalendarPage/DesignReviewSummaryModal.tsx
+++ b/src/frontend/src/pages/CalendarPage/DesignReviewSummaryModal.tsx
@@ -22,8 +22,8 @@ interface DRCSummaryModalProps {
   onHide: () => void;
   designReview: DesignReview;
   teamTypes: TeamType[];
-  markedStatus: DesignReviewStatus;
-  setMarkedStatus: (_: DesignReviewStatus) => void;
+  markedStatus?: DesignReviewStatus;
+  setMarkedStatus?: (_: DesignReviewStatus) => void;
 }
 
 const DRCSummaryModal: React.FC<DRCSummaryModalProps> = ({
@@ -31,8 +31,8 @@ const DRCSummaryModal: React.FC<DRCSummaryModalProps> = ({
   onHide,
   designReview,
   teamTypes,
-  markedStatus,
-  setMarkedStatus
+  markedStatus = DesignReviewStatus.UNCONFIRMED,
+  setMarkedStatus = () => {}
 }: DRCSummaryModalProps) => {
   const user = useCurrentUser();
   const toast = useToast();

--- a/src/frontend/src/pages/CalendarPage/SummaryComponents/DesignReviewSummaryModalDetails.tsx
+++ b/src/frontend/src/pages/CalendarPage/SummaryComponents/DesignReviewSummaryModalDetails.tsx
@@ -16,10 +16,16 @@ import { useSetDesignReviewStatus } from '../../../hooks/design-reviews.hooks';
 interface DesignReviewSummaryModalDetailsProps {
   designReview: DesignReview;
   teamTypes: TeamType[];
+  markedStatus: DesignReviewStatus;
+  setMarkedStatus: (_: DesignReviewStatus) => void;
 }
 
-const DesignReviewSummaryModalDetails: React.FC<DesignReviewSummaryModalDetailsProps> = ({ designReview, teamTypes }) => {
-  const [markCompleteChecked, setMarkCompleteChecked] = useState<boolean>(designReview.status === DesignReviewStatus.DONE);
+const DesignReviewSummaryModalDetails: React.FC<DesignReviewSummaryModalDetailsProps> = ({
+  designReview,
+  teamTypes,
+  markedStatus,
+  setMarkedStatus
+}) => {
   const [showStageGateModal, setShowStageGateModal] = useState<boolean>(false);
   const [showDelayModal, setShowDelayModal] = useState<boolean>(false);
   const [showMarkCompleteModal, setShowMarkCompleteModal] = useState<boolean>(false);
@@ -36,7 +42,7 @@ const DesignReviewSummaryModalDetails: React.FC<DesignReviewSummaryModalDetailsP
         submitText="Yes"
         onSubmit={async () => {
           await mutateAsync({ status: DesignReviewStatus.DONE });
-          setMarkCompleteChecked(true);
+          setMarkedStatus(DesignReviewStatus.DONE);
           setShowMarkCompleteModal(false);
         }}
       >
@@ -55,7 +61,7 @@ const DesignReviewSummaryModalDetails: React.FC<DesignReviewSummaryModalDetailsP
         submitText="Yes"
         onSubmit={async () => {
           await mutateAsync({ status: DesignReviewStatus.SCHEDULED });
-          setMarkCompleteChecked(false);
+          setMarkedStatus(DesignReviewStatus.SCHEDULED);
           setShowUnmarkCompleteModal(false);
         }}
       >
@@ -93,14 +99,15 @@ const DesignReviewSummaryModalDetails: React.FC<DesignReviewSummaryModalDetailsP
                 </Typography>
               </Link>
             </Box>
+
             <FormControlLabel
               label="Mark Design Review as complete"
               control={
                 <Checkbox
-                  checked={markCompleteChecked}
-                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                    if (event.target.checked) setShowMarkCompleteModal(true);
-                    else setShowUnmarkCompleteModal(true);
+                  checked={markedStatus === DesignReviewStatus.DONE}
+                  onChange={() => {
+                    if (markedStatus === DesignReviewStatus.DONE) setShowUnmarkCompleteModal(true);
+                    else setShowMarkCompleteModal(true);
                   }}
                   sx={{
                     color: 'inherit',
@@ -117,7 +124,7 @@ const DesignReviewSummaryModalDetails: React.FC<DesignReviewSummaryModalDetailsP
                 <Typography fontSize={18}>{designReview.zoomLink ? 'Zoom Link' : 'No Zoom'}</Typography>
               </Link>
             </Box>
-            {markCompleteChecked && (
+            {markedStatus === DesignReviewStatus.DONE && (
               <DesignReviewSummaryModalButtons
                 designReview={designReview}
                 handleStageGateClick={() => setShowStageGateModal(true)}

--- a/src/frontend/src/pages/CalendarPage/SummaryComponents/DesignReviewSummaryModalDetails.tsx
+++ b/src/frontend/src/pages/CalendarPage/SummaryComponents/DesignReviewSummaryModalDetails.tsx
@@ -41,9 +41,9 @@ const DesignReviewSummaryModalDetails: React.FC<DesignReviewSummaryModalDetailsP
         cancelText="No"
         submitText="Yes"
         onSubmit={async () => {
+          setShowMarkCompleteModal(false);
           await mutateAsync({ status: DesignReviewStatus.DONE });
           setMarkedStatus(DesignReviewStatus.DONE);
-          setShowMarkCompleteModal(false);
         }}
       >
         <Typography>Are you sure you want to mark this design review as complete?</Typography>
@@ -60,9 +60,9 @@ const DesignReviewSummaryModalDetails: React.FC<DesignReviewSummaryModalDetailsP
         cancelText="No"
         submitText="Yes"
         onSubmit={async () => {
+          setShowUnmarkCompleteModal(false);
           await mutateAsync({ status: DesignReviewStatus.SCHEDULED });
           setMarkedStatus(DesignReviewStatus.SCHEDULED);
-          setShowUnmarkCompleteModal(false);
         }}
       >
         <Typography>

--- a/src/frontend/src/pages/CalendarPage/SummaryComponents/DesignReviewSummaryModalDetails.tsx
+++ b/src/frontend/src/pages/CalendarPage/SummaryComponents/DesignReviewSummaryModalDetails.tsx
@@ -1,5 +1,5 @@
 import { Box, Checkbox, FormControlLabel, Link, Typography } from '@mui/material';
-import { DesignReview, TeamType } from 'shared';
+import { DesignReview, DesignReviewStatus, TeamType } from 'shared';
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
 import DescriptionIcon from '@mui/icons-material/Description';
@@ -10,6 +10,8 @@ import { useState } from 'react';
 import StageGateWorkPackageModalContainer from '../../WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModalContainer';
 import { DesignReviewDelayModal } from './DesignReviewDelayModal';
 import DesignReviewSummaryModalButtons from './DesignReviewSummaryModalButtons';
+import NERModal from '../../../components/NERModal';
+import { useSetDesignReviewStatus } from '../../../hooks/design-reviews.hooks';
 
 interface DesignReviewSummaryModalDetailsProps {
   designReview: DesignReview;
@@ -17,67 +19,118 @@ interface DesignReviewSummaryModalDetailsProps {
 }
 
 const DesignReviewSummaryModalDetails: React.FC<DesignReviewSummaryModalDetailsProps> = ({ designReview, teamTypes }) => {
-  const [checked, setChecked] = useState<boolean>(false);
+  const [markCompleteChecked, setMarkCompleteChecked] = useState<boolean>(designReview.status === DesignReviewStatus.DONE);
   const [showStageGateModal, setShowStageGateModal] = useState<boolean>(false);
   const [showDelayModal, setShowDelayModal] = useState<boolean>(false);
+  const [showMarkCompleteModal, setShowMarkCompleteModal] = useState<boolean>(false);
+  const [showUnmarkCompleteModal, setShowUnmarkCompleteModal] = useState<boolean>(false);
+  const { mutateAsync } = useSetDesignReviewStatus(designReview.designReviewId);
+
+  const MarkCompleteModal: React.FC = () => {
+    return (
+      <NERModal
+        open={showMarkCompleteModal}
+        title="Mark Design Review Complete"
+        onHide={() => setShowMarkCompleteModal(false)}
+        cancelText="No"
+        submitText="Yes"
+        onSubmit={async () => {
+          await mutateAsync({ status: DesignReviewStatus.DONE });
+          setMarkCompleteChecked(true);
+          setShowMarkCompleteModal(false);
+        }}
+      >
+        <Typography>Are you sure you want to mark this design review as complete?</Typography>
+      </NERModal>
+    );
+  };
+
+  const UnmarkCompleteModal: React.FC = () => {
+    return (
+      <NERModal
+        open={showUnmarkCompleteModal}
+        title="Mark Design Review as Not Complete"
+        onHide={() => setShowUnmarkCompleteModal(false)}
+        cancelText="No"
+        submitText="Yes"
+        onSubmit={async () => {
+          await mutateAsync({ status: DesignReviewStatus.SCHEDULED });
+          setMarkCompleteChecked(false);
+          setShowUnmarkCompleteModal(false);
+        }}
+      >
+        <Typography>
+          Are you sure you want to mark this design review as <b>not</b> complete?
+        </Typography>
+      </NERModal>
+    );
+  };
 
   return (
-    <Box display="flex" flexDirection={'column'} paddingBottom={2} rowGap={2} marginTop="20px">
-      <StageGateWorkPackageModalContainer
-        wbsNum={designReview.wbsNum}
-        modalShow={showStageGateModal}
-        handleClose={() => setShowStageGateModal(false)}
-        hideStatus
-      />
-      <DesignReviewDelayModal open={showDelayModal} onHide={() => setShowDelayModal(false)} designReview={designReview} />
-      <Box display="flex" gap={3} paddingRight={'10px'}>
-        <DesignReviewPill icon={<AccessTimeIcon />} displayText={meetingStartTimePipe(designReview.meetingTimes)} />
-        <DesignReviewPill icon={<LocationOnIcon />} displayText={designReview.location ? designReview.location : 'Online'} />
-      </Box>
-      <Box rowGap={2} display="flex" flexDirection={'column'}>
-        <Box display="flex" gap={8} alignItems={'center'}>
-          <Box display="flex" gap={1} alignItems={'center'}>
-            <DescriptionIcon />
-            <Link target="_blank" href={designReview.docTemplateLink ?? ''} paddingLeft="4px">
-              <Typography fontSize={18}>
-                {designReview.docTemplateLink ? 'Question Document' : 'No Question Document'}
-              </Typography>
-            </Link>
-          </Box>
-          <FormControlLabel
-            label="Mark Design Review as Complete"
-            control={
-              <Checkbox
-                checked={checked}
-                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                  setChecked(event.target.checked);
-                }}
-                sx={{
-                  color: 'inherit',
-                  '&.Mui-checked': { color: 'inherit' }
-                }}
-              />
-            }
+    <>
+      <Box display="flex" flexDirection={'column'} paddingBottom={2} rowGap={2} marginTop="20px">
+        <StageGateWorkPackageModalContainer
+          wbsNum={designReview.wbsNum}
+          modalShow={showStageGateModal}
+          handleClose={() => setShowStageGateModal(false)}
+          hideStatus
+        />
+        <DesignReviewDelayModal open={showDelayModal} onHide={() => setShowDelayModal(false)} designReview={designReview} />
+        <Box display="flex" gap={3} paddingRight={'10px'}>
+          <DesignReviewPill icon={<AccessTimeIcon />} displayText={meetingStartTimePipe(designReview.meetingTimes)} />
+          <DesignReviewPill
+            icon={<LocationOnIcon />}
+            displayText={designReview.location ? designReview.location : 'Online'}
           />
         </Box>
-        <Box display="flex" gap={16} alignItems={'center'}>
-          <Box display="flex" gap={1} alignItems={'center'}>
-            <VideocamIcon />
-            <Link target="_blank" href={designReview.zoomLink ?? ''} paddingLeft="4px">
-              <Typography fontSize={18}>{designReview.zoomLink ? 'Zoom Link' : 'No Zoom'}</Typography>
-            </Link>
-          </Box>
-          {checked && (
-            <DesignReviewSummaryModalButtons
-              designReview={designReview}
-              handleStageGateClick={() => setShowStageGateModal(true)}
-              handleDelayClick={() => setShowDelayModal(true)}
-              teamTypes={teamTypes}
+        <Box rowGap={2} display="flex" flexDirection={'column'}>
+          <Box display="flex" gap={8} alignItems={'center'}>
+            <Box display="flex" gap={1} alignItems={'center'}>
+              <DescriptionIcon />
+              <Link target="_blank" href={designReview.docTemplateLink ?? ''} paddingLeft="4px">
+                <Typography fontSize={18}>
+                  {designReview.docTemplateLink ? 'Question Document' : 'No Question Document'}
+                </Typography>
+              </Link>
+            </Box>
+            <FormControlLabel
+              label="Mark Design Review as complete"
+              control={
+                <Checkbox
+                  checked={markCompleteChecked}
+                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                    if (event.target.checked) setShowMarkCompleteModal(true);
+                    else setShowUnmarkCompleteModal(true);
+                  }}
+                  sx={{
+                    color: 'inherit',
+                    '&.Mui-checked': { color: 'inherit' }
+                  }}
+                />
+              }
             />
-          )}
+          </Box>
+          <Box display="flex" gap={16} alignItems={'center'}>
+            <Box display="flex" gap={1} alignItems={'center'}>
+              <VideocamIcon />
+              <Link target="_blank" href={designReview.zoomLink ?? ''} paddingLeft="4px">
+                <Typography fontSize={18}>{designReview.zoomLink ? 'Zoom Link' : 'No Zoom'}</Typography>
+              </Link>
+            </Box>
+            {markCompleteChecked && (
+              <DesignReviewSummaryModalButtons
+                designReview={designReview}
+                handleStageGateClick={() => setShowStageGateModal(true)}
+                handleDelayClick={() => setShowDelayModal(true)}
+                teamTypes={teamTypes}
+              />
+            )}
+          </Box>
         </Box>
       </Box>
-    </Box>
+      <MarkCompleteModal />
+      <UnmarkCompleteModal />
+    </>
   );
 };
 

--- a/src/frontend/src/utils/urls.ts
+++ b/src/frontend/src/utils/urls.ts
@@ -154,6 +154,7 @@ const designReviewsEdit = (designReviewId: string) => `${designReviews()}/${desi
 const designReviewById = (id: string) => `${designReviews()}/${id}`;
 const designReviewDelete = (id: string) => `${designReviewById(id)}/delete`;
 const designReviewMarkUserConfirmed = (id: string) => `${designReviewById(id)}/confirm-schedule`;
+const designReviewSetStatus = (id: string) => `${designReviewById(id)}/set-status`;
 
 /******************* Work Package Template Endpoints ********************/
 
@@ -300,6 +301,7 @@ export const apiUrls = {
   designReviewsEdit,
   designReviewMarkUserConfirmed,
   designReviewDelete,
+  designReviewSetStatus,
 
   workPackageTemplates,
   workPackageTemplatesById,


### PR DESCRIPTION
## Changes
The mark complete checkbox now sets the design review status to complete when checked and scheduled when unchecked

## Screenshots

### Mark Complete Confirmation Modal
<img width="683" alt="image" src="https://github.com/user-attachments/assets/4ac289f5-f877-4eae-8215-23ab08adcbb8">

### Unmark Complete
<img width="644" alt="image" src="https://github.com/user-attachments/assets/62bfe0fc-c841-4128-bb1e-8272c391f15d">

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #2312
