### PR TITLE
#2724 set images endpoint for organization

### DIFF
--- a/src/backend/src/controllers/organizations.controller.ts
+++ b/src/backend/src/controllers/organizations.controller.ts
@@ -17,6 +17,19 @@ export default class OrganizationsController {
     }
   }
 
+  static async setImages(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { images } = req.body;
+      const submitter = await getCurrentUser(res);
+      const organizationId = getOrganizationId(req.headers);
+
+      const newImages = await OrganizationsService.setImages(images, submitter, organizationId);
+      res.status(200).json(newImages);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
   static async getAllUsefulLinks(req: Request, res: Response, next: NextFunction) {
     try {
       const organizationId = getOrganizationId(req.headers);

--- a/src/backend/src/controllers/organizations.controller.ts
+++ b/src/backend/src/controllers/organizations.controller.ts
@@ -19,18 +19,29 @@ export default class OrganizationsController {
 
   static async setImages(req: Request, res: Response, next: NextFunction) {
     try {
-      const files = req.files as Express.Multer.File[];
+      const { applyInterestImage = [], exploreAsGuestImage = [] } = req.files as {
+        applyInterestImage?: Express.Multer.File[];
+        exploreAsGuestImage?: Express.Multer.File[];
+      };
+
+      const applyInterestFile = applyInterestImage[0] || null;
+      const exploreAsGuestFile = exploreAsGuestImage[0] || null;
+
       const submitter = await getCurrentUser(res);
       const organizationId = getOrganizationId(req.headers);
 
-      const newImages = await OrganizationsService.setImages(files, submitter, organizationId);
+      const newImages = await OrganizationsService.setImages(
+        applyInterestFile,
+        exploreAsGuestFile,
+        submitter,
+        organizationId
+      );
 
       res.status(200).json(newImages);
     } catch (error: unknown) {
       next(error);
     }
   }
-
   static async getAllUsefulLinks(req: Request, res: Response, next: NextFunction) {
     try {
       const organizationId = getOrganizationId(req.headers);

--- a/src/backend/src/controllers/organizations.controller.ts
+++ b/src/backend/src/controllers/organizations.controller.ts
@@ -19,11 +19,12 @@ export default class OrganizationsController {
 
   static async setImages(req: Request, res: Response, next: NextFunction) {
     try {
-      const { images } = req.body;
+      const files = req.files as Express.Multer.File[];
       const submitter = await getCurrentUser(res);
       const organizationId = getOrganizationId(req.headers);
 
-      const newImages = await OrganizationsService.setImages(images, submitter, organizationId);
+      const newImages = await OrganizationsService.setImages(files, submitter, organizationId);
+
       res.status(200).json(newImages);
     } catch (error: unknown) {
       next(error);

--- a/src/backend/src/prisma/migrations/20240722214357_added_images_to_organization/migration.sql
+++ b/src/backend/src/prisma/migrations/20240722214357_added_images_to_organization/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Organization" ADD COLUMN     "exploreAsGuestImage" TEXT,
+ADD COLUMN     "interestedinApplyingImage" TEXT;

--- a/src/backend/src/prisma/migrations/20240722214357_added_images_to_organization/migration.sql
+++ b/src/backend/src/prisma/migrations/20240722214357_added_images_to_organization/migration.sql
@@ -1,3 +1,0 @@
--- AlterTable
-ALTER TABLE "Organization" ADD COLUMN     "exploreAsGuestImage" TEXT,
-ADD COLUMN     "interestedinApplyingImage" TEXT;

--- a/src/backend/src/prisma/migrations/20240726002259_added_images_to_organization/migration.sql
+++ b/src/backend/src/prisma/migrations/20240726002259_added_images_to_organization/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[applyInterestImageId]` on the table `Organization` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[exploreAsGuestImageId]` on the table `Organization` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "Organization" ADD COLUMN     "applyInterestImageId" TEXT,
+ADD COLUMN     "exploreAsGuestImageId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Organization_applyInterestImageId_key" ON "Organization"("applyInterestImageId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Organization_exploreAsGuestImageId_key" ON "Organization"("exploreAsGuestImageId");

--- a/src/backend/src/prisma/schema.prisma
+++ b/src/backend/src/prisma/schema.prisma
@@ -842,18 +842,20 @@ model Car {
 }
 
 model Organization {
-  organizationId String    @id @default(uuid())
-  name           String
-  dateCreated    DateTime  @default(now())
-  userCreatedId  String
-  userCreated    User      @relation(fields: [userCreatedId], references: [userId], name: "organizationCreator")
-  dateDeleted    DateTime?
-  userDeletedId  String?
-  userDeleted    User?     @relation(fields: [userDeletedId], references: [userId], name: "organizationDeleter")
-  treasurerId    String?
-  treasurer      User?     @relation(name: "treasurer", fields: [treasurerId], references: [userId])
-  advisor        User?     @relation(name: "advisor", fields: [advisorId], references: [userId])
-  advisorId      String?
+  organizationId            String    @id @default(uuid())
+  name                      String
+  dateCreated               DateTime  @default(now())
+  userCreatedId             String
+  userCreated               User      @relation(fields: [userCreatedId], references: [userId], name: "organizationCreator")
+  dateDeleted               DateTime?
+  userDeletedId             String?
+  userDeleted               User?     @relation(fields: [userDeletedId], references: [userId], name: "organizationDeleter")
+  treasurerId               String?
+  treasurer                 User?     @relation(name: "treasurer", fields: [treasurerId], references: [userId])
+  advisor                   User?     @relation(name: "advisor", fields: [advisorId], references: [userId])
+  advisorId                 String?
+  interestedinApplyingImage String?   @unique
+  exploreAsGuestImage       String?   @unique
 
   // Relation references
   wbsElements            WBS_Element[]

--- a/src/backend/src/prisma/schema.prisma
+++ b/src/backend/src/prisma/schema.prisma
@@ -842,20 +842,20 @@ model Car {
 }
 
 model Organization {
-  organizationId            String    @id @default(uuid())
-  name                      String
-  dateCreated               DateTime  @default(now())
-  userCreatedId             String
-  userCreated               User      @relation(fields: [userCreatedId], references: [userId], name: "organizationCreator")
-  dateDeleted               DateTime?
-  userDeletedId             String?
-  userDeleted               User?     @relation(fields: [userDeletedId], references: [userId], name: "organizationDeleter")
-  treasurerId               String?
-  treasurer                 User?     @relation(name: "treasurer", fields: [treasurerId], references: [userId])
-  advisor                   User?     @relation(name: "advisor", fields: [advisorId], references: [userId])
-  advisorId                 String?
-  interestedinApplyingImage String?   @unique
-  exploreAsGuestImage       String?   @unique
+  organizationId        String    @id @default(uuid())
+  name                  String
+  dateCreated           DateTime  @default(now())
+  userCreatedId         String
+  userCreated           User      @relation(fields: [userCreatedId], references: [userId], name: "organizationCreator")
+  dateDeleted           DateTime?
+  userDeletedId         String?
+  userDeleted           User?     @relation(fields: [userDeletedId], references: [userId], name: "organizationDeleter")
+  treasurerId           String?
+  treasurer             User?     @relation(name: "treasurer", fields: [treasurerId], references: [userId])
+  advisor               User?     @relation(name: "advisor", fields: [advisorId], references: [userId])
+  advisorId             String?
+  applyInterestImageId  String?   @unique
+  exploreAsGuestImageId String?   @unique
 
   // Relation references
   wbsElements            WBS_Element[]

--- a/src/backend/src/routes/organizations.routes.ts
+++ b/src/backend/src/routes/organizations.routes.ts
@@ -8,6 +8,13 @@ const upload = multer({ limits: { fileSize: 30000000 }, storage: memoryStorage()
 
 organizationRouter.post('/useful-links/set', ...linkValidators, validateInputs, OrganizationsController.setUsefulLinks);
 organizationRouter.get('/useful-links', OrganizationsController.getAllUsefulLinks);
-organizationRouter.post('/images/update', upload.array('image'), OrganizationsController.setImages);
+organizationRouter.post(
+  '/images/update',
+  upload.fields([
+    { name: 'applyInterestImage', maxCount: 1 },
+    { name: 'exploreAsGuestImage', maxCount: 1 }
+  ]),
+  OrganizationsController.setImages
+);
 
 export default organizationRouter;

--- a/src/backend/src/routes/organizations.routes.ts
+++ b/src/backend/src/routes/organizations.routes.ts
@@ -1,10 +1,13 @@
 import express from 'express';
 import { linkValidators, validateInputs } from '../utils/validation.utils';
 import OrganizationsController from '../controllers/organizations.controller';
+import multer, { memoryStorage } from 'multer';
 
 const organizationRouter = express.Router();
+const upload = multer({ limits: { fileSize: 30000000 }, storage: memoryStorage() });
 
 organizationRouter.post('/useful-links/set', ...linkValidators, validateInputs, OrganizationsController.setUsefulLinks);
 organizationRouter.get('/useful-links', OrganizationsController.getAllUsefulLinks);
+organizationRouter.post('/images/update', upload.array('image'), OrganizationsController.setImages);
 
 export default organizationRouter;

--- a/src/backend/src/services/organizations.service.ts
+++ b/src/backend/src/services/organizations.service.ts
@@ -63,17 +63,23 @@ export default class OrganizationsService {
    * @param organizationId the organization which the images will be set up
    * @param images the images which are being set
    */
-  static async setImages(images: Express.Multer.File[], submitter: User, organizationId: string) {
+  static async setImages(
+    applyInterestImage: Express.Multer.File,
+    exploreAsGuestImage: Express.Multer.File,
+    submitter: User,
+    organizationId: string
+  ) {
     if (!(await userHasPermission(submitter.userId, organizationId, isAdmin)))
       throw new AccessDeniedAdminOnlyException('update images');
 
-    const imageData = await Promise.all(images.map((file: Express.Multer.File) => uploadFile(file)));
+    const applyInterestImageData = uploadFile(applyInterestImage);
+    const exploreAsGuestImageData = uploadFile(exploreAsGuestImage);
 
     const newImages = await prisma.organization.update({
       where: { organizationId },
       data: {
-        interestedinApplyingImage: imageData[0].id,
-        exploreAsGuestImage: imageData[1].id
+        applyInterestImageId: (await applyInterestImageData).id,
+        exploreAsGuestImageId: (await exploreAsGuestImageData).id
       }
     });
 

--- a/src/backend/src/services/organizations.service.ts
+++ b/src/backend/src/services/organizations.service.ts
@@ -57,6 +57,12 @@ export default class OrganizationsService {
     return newLinks;
   }
 
+  /**
+   * sets an organizations images
+   * @param submitter the user who is setting the images
+   * @param organizationId the organization which the images will be set up
+   * @param images the images which are being set
+   */
   static async setImages(images: Express.Multer.File[], submitter: User, organizationId: string) {
     if (!(await userHasPermission(submitter.userId, organizationId, isAdmin)))
       throw new AccessDeniedAdminOnlyException('update images');

--- a/src/backend/src/services/organizations.service.ts
+++ b/src/backend/src/services/organizations.service.ts
@@ -4,16 +4,13 @@ import prisma from '../prisma/prisma';
 import {
   AccessDeniedAdminOnlyException,
   AccessDeniedGuestException,
-  DeletedException,
   HttpException,
-  InvalidOrganizationException,
   NotFoundException
 } from '../utils/errors.utils';
 import { userHasPermission } from '../utils/users.utils';
 import { createUsefulLinks } from '../utils/organizations.utils';
 import { linkTransformer } from '../transformers/links.transformer';
 import { getLinkQueryArgs } from '../prisma-query-args/links.query-args';
-import { isUserLeadOrHeadOfFinanceTeam } from '../utils/reimbursement-requests.utils';
 import { uploadFile } from '../utils/google-integration.utils';
 
 export default class OrganizationsService {

--- a/src/backend/src/services/organizations.service.ts
+++ b/src/backend/src/services/organizations.service.ts
@@ -1,12 +1,7 @@
 import { User } from '@prisma/client';
-import { LinkCreateArgs, isAdmin, isGuest } from 'shared';
+import { LinkCreateArgs, isAdmin } from 'shared';
 import prisma from '../prisma/prisma';
-import {
-  AccessDeniedAdminOnlyException,
-  AccessDeniedGuestException,
-  HttpException,
-  NotFoundException
-} from '../utils/errors.utils';
+import { AccessDeniedAdminOnlyException, HttpException, NotFoundException } from '../utils/errors.utils';
 import { userHasPermission } from '../utils/users.utils';
 import { createUsefulLinks } from '../utils/organizations.utils';
 import { linkTransformer } from '../transformers/links.transformer';
@@ -63,8 +58,8 @@ export default class OrganizationsService {
   }
 
   static async setImages(images: Express.Multer.File[], submitter: User, organizationId: string) {
-    if (await userHasPermission(submitter.userId, organizationId, isGuest))
-      throw new AccessDeniedGuestException('Guests cannot upload receipts');
+    if (!(await userHasPermission(submitter.userId, organizationId, isAdmin)))
+      throw new AccessDeniedAdminOnlyException('update images');
 
     const imageData = await Promise.all(images.map((file: Express.Multer.File) => uploadFile(file)));
 

--- a/src/backend/tests/unmocked/organization.test.ts
+++ b/src/backend/tests/unmocked/organization.test.ts
@@ -5,7 +5,6 @@ import { batmanAppAdmin, wonderwomanGuest } from '../test-data/users.test-data';
 import { createTestLinkType, createTestOrganization, createTestUser, resetUsers } from '../test-utils';
 import prisma from '../../src/prisma/prisma';
 import { testLink1 } from '../test-data/organizations.test-data';
-import { uploadFile } from '../../src/utils/google-integration.utils';
 
 describe('Team Type Tests', () => {
   let orgId: string;

--- a/src/backend/tests/unmocked/organization.test.ts
+++ b/src/backend/tests/unmocked/organization.test.ts
@@ -6,10 +6,10 @@ import { createTestLinkType, createTestOrganization, createTestUser, resetUsers 
 import prisma from '../../src/prisma/prisma';
 import { testLink1 } from '../test-data/organizations.test-data';
 import { uploadFile } from '../../src/utils/google-integration.utils';
+import { Mock, vi } from 'vitest';
 
-// Mock uploadFile function from google-integration.utils
-jest.mock('../../src/utils/google-integration.utils', () => ({
-  uploadFile: jest.fn()
+vi.mock('../../src/utils/google-integration.utils', () => ({
+  uploadFile: vi.fn()
 }));
 
 describe('Team Type Tests', () => {
@@ -25,15 +25,15 @@ describe('Team Type Tests', () => {
 
   describe('Set Images', () => {
     it('Fails if user is not an admin', async () => {
-      await expect(
-        OrganizationsService.setImages([], await createTestUser(wonderwomanGuest, orgId), orgId)
-      ).rejects.toThrow(new AccessDeniedAdminOnlyException('update images'));
+      await expect(OrganizationsService.setImages([], await createTestUser(wonderwomanGuest, orgId), orgId)).rejects.toThrow(
+        new AccessDeniedAdminOnlyException('update images')
+      );
     });
 
     it('Fails if an organization does not exist', async () => {
-      await expect(
-        OrganizationsService.setImages([], await createTestUser(batmanAppAdmin, orgId), '1')
-      ).rejects.toThrow(new HttpException(400, `Organization with id: 1 not found!`));
+      await expect(OrganizationsService.setImages([], await createTestUser(batmanAppAdmin, orgId), '1')).rejects.toThrow(
+        new HttpException(400, `Organization with id: 1 not found!`)
+      );
     });
 
     it('Succeeds and updates all the images', async () => {
@@ -43,8 +43,7 @@ describe('Team Type Tests', () => {
         { originalname: 'image2.png', buffer: Buffer.from('') }
       ] as Express.Multer.File[];
 
-      // Mock the uploadFile function to return simulated file IDs
-      (uploadFile as jest.Mock).mockImplementation((file) => {
+      (uploadFile as Mock).mockImplementation((file) => {
         return Promise.resolve({ id: `uploaded-${file.originalname}` });
       });
 

--- a/src/backend/tests/unmocked/organization.test.ts
+++ b/src/backend/tests/unmocked/organization.test.ts
@@ -38,10 +38,8 @@ describe('Team Type Tests', () => {
 
     it('Succeeds and updates all the images', async () => {
       const testBatman = await createTestUser(batmanAppAdmin, orgId);
-      const testFiles = [
-        { originalname: 'image1.png', buffer: Buffer.from('') },
-        { originalname: 'image2.png', buffer: Buffer.from('') }
-      ] as Express.Multer.File[];
+      const testFiles = [{ originalname: 'image1.png' }, { originalname: 'image2.png' }] as Express.Multer.File[];
+      const newFiles = [{ originalname: 'image1.png' }, { originalname: 'image3.png' }] as Express.Multer.File[];
 
       (uploadFile as Mock).mockImplementation((file) => {
         return Promise.resolve({ id: `uploaded-${file.originalname}` });
@@ -56,8 +54,18 @@ describe('Team Type Tests', () => {
       });
 
       expect(organization).not.toBeNull();
-      expect(organization!.interestedinApplyingImage).toMatch(/^uploaded-image1\.png$/);
-      expect(organization!.exploreAsGuestImage).toMatch(/^uploaded-image2\.png$/);
+      expect(organization?.interestedinApplyingImage).toBe('uploaded-image1.png');
+      expect(organization?.exploreAsGuestImage).toBe('uploaded-image2.png');
+
+      await OrganizationsService.setImages(newFiles, testBatman, orgId);
+
+      const updatedOrganization = await prisma.organization.findUnique({
+        where: {
+          organizationId: orgId
+        }
+      });
+
+      expect(updatedOrganization?.exploreAsGuestImage).toBe('uploaded-image3.png');
     });
   });
 

--- a/src/backend/tests/unmocked/organization.test.ts
+++ b/src/backend/tests/unmocked/organization.test.ts
@@ -7,10 +7,6 @@ import prisma from '../../src/prisma/prisma';
 import { testLink1 } from '../test-data/organizations.test-data';
 import { uploadFile } from '../../src/utils/google-integration.utils';
 
-jest.mock('../../src/utils/uploadFile', () => ({
-  uploadFile: jest.fn()
-}));
-
 describe('Team Type Tests', () => {
   let orgId: string;
   beforeEach(async () => {
@@ -41,10 +37,6 @@ describe('Team Type Tests', () => {
         { originalname: 'image2.png', buffer: Buffer.from('') }
       ] as Express.Multer.File[];
 
-      (uploadFile as jest.Mock).mockImplementation((file) => {
-        return Promise.resolve({ id: `uploaded-${file.originalname}` });
-      });
-
       await OrganizationsService.setImages(testFiles, testBatman, orgId);
 
       const organization = await prisma.organization.findUnique({
@@ -54,8 +46,8 @@ describe('Team Type Tests', () => {
       });
 
       expect(organization).not.toBeNull();
-      expect(organization!.interestedinApplyingImage).toBe('uploaded-image1.png');
-      expect(organization!.exploreAsGuestImage).toBe('uploaded-image2.png');
+      expect(organization!.interestedinApplyingImage).toBeTruthy();
+      expect(organization!.exploreAsGuestImage).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
## Changes

Migration: Added 2 more image fields to organization

- Added route with file upload
- Added controller
- Added service method to upload new data and update organization

## Screenshots
<img width="1304" alt="Screenshot 2024-07-23 at 11 57 36 AM" src="https://github.com/user-attachments/assets/f9096c71-3788-47a2-b49b-e10a2c073b51">

New images after setting other images above
<img width="1305" alt="Screenshot 2024-07-24 at 11 02 28 AM" src="https://github.com/user-attachments/assets/f2deb08c-b943-4ef5-ad79-e1f302293769">


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #2714)
