### PR TITLE
Add Design Review notifications and dont necessitate receipts on RR form

### DIFF
--- a/src/backend/src/services/notifications.services.ts
+++ b/src/backend/src/services/notifications.services.ts
@@ -1,5 +1,6 @@
 import prisma from '../prisma/prisma';
 import {
+  DesignReviewWithAttendees,
   TaskWithAssignees,
   endOfDayTomorrow,
   getTeamFromTaskAssignees,
@@ -11,21 +12,13 @@ import { buildDueString } from '../utils/slack.utils';
 import WorkPackagesService from './work-packages.services';
 import { addWeeksToDate } from 'shared';
 import { HttpException } from '../utils/errors.utils';
+import { meetingStartTimePipe } from '../utils/design-reviews.utils';
 
 export default class NotificationsService {
   static async sendDailySlackNotifications() {
     await NotificationsService.sendTaskDeadlineSlackNotifications();
-    const date = new Date();
-    if (date.getDay() === 1) {
-      const nextWeek = addWeeksToDate(date, 1);
-      const ADMIN = process.env.ADMIN_USER_ID;
-      const admin = await prisma.user.findUnique({ where: { userId: ADMIN } });
-      if (!admin) throw new HttpException(404, 'Admin user not found');
-      const organizations = await prisma.organization.findMany();
-      for (const organization of organizations) {
-        await WorkPackagesService.slackMessageUpcomingDeadlines(admin, nextWeek, organization.organizationId);
-      }
-    }
+    await NotificationsService.sendWorkPackageDeadlineSlackNotifications();
+    await NotificationsService.sendDesignReviewSlackNotifications();
   }
 
   /**
@@ -91,6 +84,97 @@ export default class NotificationsService {
       // messageBlock will be empty if there are tasks with no assignees
       if (messageBlock !== '')
         sendMessage(slackId, ':sparkles: :pepe-coop: UPCOMING TASK DEADLINES :pepe-coop: :sparkles: \n\n\n' + messageBlock);
+    });
+  }
+
+  /**
+   * Sends the work package deadline slack notifications for all work packages with a deadline of next week
+   */
+  static async sendWorkPackageDeadlineSlackNotifications() {
+    const date = new Date();
+    if (date.getDay() === 1) {
+      const nextWeek = addWeeksToDate(date, 1);
+      const ADMIN = process.env.ADMIN_USER_ID;
+      const admin = await prisma.user.findUnique({ where: { userId: ADMIN } });
+      if (!admin) throw new HttpException(404, 'Admin user not found');
+      const organizations = await prisma.organization.findMany();
+      for (const organization of organizations) {
+        await WorkPackagesService.slackMessageUpcomingDeadlines(admin, nextWeek, organization.organizationId);
+      }
+    }
+  }
+
+  /**
+   * Sends the design review slack notifications for all design reviews scheduled for today
+   */
+  static async sendDesignReviewSlackNotifications() {
+    const endOfDay = new Date(new Date().setHours(23, 59, 59, 999));
+    const startOfDay = new Date(new Date().setHours(0, 0, 0, 0));
+
+    const designReviews = await prisma.design_Review.findMany({
+      where: {
+        dateScheduled: {
+          lt: endOfDay,
+          gte: startOfDay
+        },
+        status: {
+          not: 'DONE'
+        },
+        dateDeleted: null
+      },
+      include: {
+        requiredMembers: { include: { userSettings: true } },
+        optionalMembers: { include: { userSettings: true } },
+        userCreated: { include: { userSettings: true } },
+        wbsElement: {
+          include: {
+            project: { include: { teams: true } },
+            workPackage: { include: { project: { include: { teams: true } } } }
+          }
+        }
+      }
+    });
+
+    const designReviewTeamMap = new Map<string, DesignReviewWithAttendees[]>();
+
+    designReviews.forEach((designReview) => {
+      const teamSlackIds =
+        designReview.wbsElement.project?.teams.map((team) => team.slackId) ??
+        designReview.wbsElement.workPackage?.project.teams.map((team) => team.slackId) ??
+        [];
+
+      teamSlackIds.forEach((teamSlackId) => {
+        const currentTasks = designReviewTeamMap.get(teamSlackId);
+        if (currentTasks) {
+          currentTasks.push({
+            ...designReview,
+            attendees: designReview.requiredMembers.concat(designReview.optionalMembers).concat(designReview.userCreated)
+          });
+          designReviewTeamMap.set(teamSlackId, currentTasks);
+        } else {
+          designReviewTeamMap.set(teamSlackId, [
+            {
+              ...designReview,
+              attendees: designReview.requiredMembers.concat(designReview.optionalMembers).concat(designReview.userCreated)
+            }
+          ]);
+        }
+      });
+    });
+
+    // send the notifications to each team for their respective design reviews
+    designReviewTeamMap.forEach((designReviews, slackId) => {
+      const messageBlock = designReviews
+        .map((designReview) => {
+          return `${usersToSlackPings(designReview.attendees ?? [])} ${
+            designReview.wbsElement.name
+          } will be having a design review tomorrow at ${meetingStartTimePipe(designReview.meetingTimes)}!`;
+        })
+        .join('\n\n');
+
+      // messageBlock will be empty if there are design reviews with no attendees
+      if (messageBlock !== '')
+        sendMessage(slackId, ':calendar: :clock9: Upcoming Design Reviews! :clock9: :calendar: \n\n\n' + messageBlock);
     });
   }
 }

--- a/src/backend/src/utils/notifications.utils.ts
+++ b/src/backend/src/utils/notifications.utils.ts
@@ -1,4 +1,4 @@
-import { Team, Task as Prisma_Task, WBS_Element } from '@prisma/client';
+import { Team, Task as Prisma_Task, WBS_Element, Design_Review } from '@prisma/client';
 import { UserWithSettings } from './auth.utils';
 import { HttpException } from './errors.utils';
 import { UserWithTeams, getTeamsFromUsers } from './teams.utils';
@@ -7,6 +7,8 @@ export type TaskWithAssignees = Prisma_Task & {
   assignees: UserWithSettings[] | null;
   wbsElement: WBS_Element | null;
 };
+
+export type DesignReviewWithAttendees = Design_Review & { attendees: UserWithSettings[]; wbsElement: WBS_Element };
 
 export const usersToSlackPings = (users: UserWithSettings[]) => {
   // https://api.slack.com/reference/surfaces/formatting#mentioning-users

--- a/src/backend/src/utils/slack.utils.ts
+++ b/src/backend/src/utils/slack.utils.ts
@@ -337,7 +337,7 @@ export const sendDRScheduledSlackNotif = async (
   const { dateScheduled } = designReview;
   const drTime = `${addHours(dateScheduled, 12).toLocaleDateString()} at ${meetingStartTimePipe(designReview.meetingTimes)}`;
   const drSubmitter = `${designReview.userCreated.firstName} ${designReview.userCreated.lastName}`;
-  const zoomLink = designReview.isOnline && `on <${designReview.zoomLink}|Zoom>`;
+  const zoomLink = designReview.isOnline && designReview.zoomLink && `on [Zoom](${designReview.zoomLink})`;
   const location =
     zoomLink && designReview.isInPerson
       ? `in ${designReview.location} and ${zoomLink}`

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementRequestForm.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementRequestForm.tsx
@@ -78,7 +78,6 @@ const schema = yup.object().shape({
       : yup
           .array()
           .required('receipt files required')
-          .min(1, 'At least one Receipt is required')
           .max(7, 'At most 7 Receipts are allowed')
 });
 

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementRequestForm.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementRequestForm.tsx
@@ -75,10 +75,7 @@ const schema = yup.object().shape({
     // in src/frontend/.env and set it to 'enabled'.
     import.meta.env.MODE === 'development' && RECEIPTS_REQUIRED !== 'enabled'
       ? yup.array()
-      : yup
-          .array()
-          .required('receipt files required')
-          .max(7, 'At most 7 Receipts are allowed')
+      : yup.array().required('receipt files required').max(7, 'At most 7 Receipts are allowed')
 });
 
 const ReimbursementRequestForm: React.FC<ReimbursementRequestFormProps> = ({


### PR DESCRIPTION
## Changes

Added a section to the ntoification endpoint that also sounds out notifications for design reviews that are scheduled for that day. 

No longer necessitate one receipt being added to a reimbursement request

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
