### PR TITLE
Remove Finance Team ID from slack utils

### DIFF
--- a/src/backend/src/utils/slack.utils.ts
+++ b/src/backend/src/utils/slack.utils.ts
@@ -108,12 +108,8 @@ export const sendReimbursementRequestCreatedNotification = async (requestId: str
   const link = `https://finishlinebyner.com/finance/reimbursement-requests/${requestId}`;
   const linkButtonText = 'View Reimbursement Request';
 
-  if (!process.env.FINANCE_TEAM_ID) {
-    throw new HttpException(500, 'FINANCE_TEAM_ID not in env');
-  }
-
-  const financeTeam = await prisma.team.findUnique({
-    where: { teamId: process.env.FINANCE_TEAM_ID }
+  const financeTeam = await prisma.team.findFirst({
+    where: { financeTeam: true }
   });
 
   if (!financeTeam) throw new HttpException(500, 'Finance team does not exist!');


### PR DESCRIPTION
## Changes

Fixed an issue where when you submit a reimbursement request it does not send out the slack notification because its trying to use the old finance team id. 


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
