### PR TITLE
#2685 created useHistoryState hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@types/react-dom": "17.0.1"
   },
   "dependencies": {
+    "react-hook-form-persist": "^3.0.0",
     "typescript": "^4.1.5"
   },
   "devDependencies": {

--- a/src/frontend/src/hooks/misc.hooks.ts
+++ b/src/frontend/src/hooks/misc.hooks.ts
@@ -34,11 +34,3 @@ export const useHistoryState = <T>(key: string, initialValue: T): [T, (t: T) => 
   }
   return [rawState, setState];
 };
-
-export const usePersistForm = <T>(value: T, localStorageKey: string) => {
-  useEffect(() => {
-    localStorage.setItem(localStorageKey, JSON.stringify(value));
-  }, [value, localStorageKey]);
-
-  return;
-};

--- a/src/frontend/src/hooks/misc.hooks.ts
+++ b/src/frontend/src/hooks/misc.hooks.ts
@@ -6,6 +6,8 @@
 import { useQuery } from 'react-query';
 import { VersionObject } from '../utils/types';
 import { getReleaseInfo } from '../apis/misc.api';
+import { useHistory } from "react-router-dom";
+import { useState } from 'react';
 
 export const useGetVersionNumber = () => {
   return useQuery<VersionObject, Error>(['version'], async () => {
@@ -13,3 +15,23 @@ export const useGetVersionNumber = () => {
     return data;
   });
 };
+
+
+export const useHistoryState = <T>(key: string, initialValue: T): [T, (t: T) => void] => {
+  const history = useHistory();
+  const [rawState, rawSetState] = useState<T>(() => {
+    const value = (history.location.state as any)?.[key];
+    return value ?? initialValue;
+  });
+  function setState(value: T) {
+    history.replace({
+      ...history.location,
+      state: {
+        ...(history.location.state as object),
+        [key]: value,
+      },
+    });
+    rawSetState(value);
+  }
+  return [rawState, setState];
+}

--- a/src/frontend/src/hooks/misc.hooks.ts
+++ b/src/frontend/src/hooks/misc.hooks.ts
@@ -6,8 +6,8 @@
 import { useQuery } from 'react-query';
 import { VersionObject } from '../utils/types';
 import { getReleaseInfo } from '../apis/misc.api';
-import { useHistory } from "react-router-dom";
-import { useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import { useState, useEffect } from 'react';
 
 export const useGetVersionNumber = () => {
   return useQuery<VersionObject, Error>(['version'], async () => {
@@ -15,7 +15,6 @@ export const useGetVersionNumber = () => {
     return data;
   });
 };
-
 
 export const useHistoryState = <T>(key: string, initialValue: T): [T, (t: T) => void] => {
   const history = useHistory();
@@ -28,10 +27,18 @@ export const useHistoryState = <T>(key: string, initialValue: T): [T, (t: T) => 
       ...history.location,
       state: {
         ...(history.location.state as object),
-        [key]: value,
-      },
+        [key]: value
+      }
     });
     rawSetState(value);
   }
   return [rawState, setState];
-}
+};
+
+export const usePersistForm = <T>(value: T, localStorageKey: string) => {
+  useEffect(() => {
+    localStorage.setItem(localStorageKey, JSON.stringify(value));
+  }, [value, localStorageKey]);
+
+  return;
+};

--- a/src/frontend/src/hooks/misc.hooks.ts
+++ b/src/frontend/src/hooks/misc.hooks.ts
@@ -7,7 +7,7 @@ import { useQuery } from 'react-query';
 import { VersionObject } from '../utils/types';
 import { getReleaseInfo } from '../apis/misc.api';
 import { useHistory } from 'react-router-dom';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 
 export const useGetVersionNumber = () => {
   return useQuery<VersionObject, Error>(['version'], async () => {

--- a/src/frontend/src/pages/AdminToolsPage/TeamConfig/CreateTeamTypeFormModal.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/TeamConfig/CreateTeamTypeFormModal.tsx
@@ -51,7 +51,7 @@ const CreateTeamTypeModal: React.FC<CreateTeamTypeModalProps> = ({ showModal, ha
     }
   });
 
-  useFormPersist('storageKey', {
+  useFormPersist('createTeamTypeForm', {
     watch,
     setValue
   });

--- a/src/frontend/src/pages/AdminToolsPage/TeamConfig/CreateTeamTypeFormModal.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/TeamConfig/CreateTeamTypeFormModal.tsx
@@ -9,6 +9,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { Box } from '@mui/system';
 import HelpIcon from '@mui/icons-material/Help';
 import { CreateTeamTypePayload, useCreateTeamType } from '../../../hooks/design-reviews.hooks';
+import useFormPersist from 'react-hook-form-persist';
 
 const schema = yup.object().shape({
   name: yup.string().required('Material Type is Required'),
@@ -39,13 +40,20 @@ const CreateTeamTypeModal: React.FC<CreateTeamTypeModalProps> = ({ showModal, ha
     handleSubmit,
     control,
     reset,
-    formState: { errors }
+    formState: { errors },
+    watch,
+    setValue
   } = useForm({
     resolver: yupResolver(schema),
     defaultValues: {
       name: '',
       iconName: ''
     }
+  });
+
+  useFormPersist('storageKey', {
+    watch,
+    setValue
   });
 
   if (isLoading) return <LoadingIndicator />;

--- a/src/frontend/src/pages/AdminToolsPage/TeamConfig/CreateTeamTypeFormModal.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/TeamConfig/CreateTeamTypeFormModal.tsx
@@ -10,6 +10,7 @@ import { Box } from '@mui/system';
 import HelpIcon from '@mui/icons-material/Help';
 import { CreateTeamTypePayload, useCreateTeamType } from '../../../hooks/design-reviews.hooks';
 import useFormPersist from 'react-hook-form-persist';
+import { FormStorageKey } from '../../../utils/form';
 
 const schema = yup.object().shape({
   name: yup.string().required('Material Type is Required'),
@@ -51,7 +52,7 @@ const CreateTeamTypeModal: React.FC<CreateTeamTypeModalProps> = ({ showModal, ha
     }
   });
 
-  useFormPersist('createTeamTypeForm', {
+  useFormPersist(FormStorageKey.CREATE_TEAM_TYPE, {
     watch,
     setValue
   });

--- a/src/frontend/src/pages/AdminToolsPage/TeamConfig/TeamTypeTable.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/TeamConfig/TeamTypeTable.tsx
@@ -2,7 +2,6 @@ import { TableRow, TableCell, Box, Typography, Icon } from '@mui/material';
 import LoadingIndicator from '../../../components/LoadingIndicator';
 import ErrorPage from '../../ErrorPage';
 import { NERButton } from '../../../components/NERButton';
-import { useState } from 'react';
 import AdminToolTable from '../AdminToolTable';
 import CreateTeamTypeModal from './CreateTeamTypeFormModal';
 import { useAllTeamTypes } from '../../../hooks/design-reviews.hooks';
@@ -15,7 +14,7 @@ const TeamTypeTable: React.FC = () => {
     isError: teamTypesIsError,
     error: teamTypesError
   } = useAllTeamTypes();
-  const [createModalShow, setCreateModalShow] = useHistoryState<boolean>("", false);
+  const [createModalShow, setCreateModalShow] = useHistoryState<boolean>('', false);
 
   if (!teamTypes || teamTypesIsLoading) {
     return <LoadingIndicator />;

--- a/src/frontend/src/pages/AdminToolsPage/TeamConfig/TeamTypeTable.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/TeamConfig/TeamTypeTable.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 import AdminToolTable from '../AdminToolTable';
 import CreateTeamTypeModal from './CreateTeamTypeFormModal';
 import { useAllTeamTypes } from '../../../hooks/design-reviews.hooks';
+import { useHistoryState } from '../../../hooks/misc.hooks';
 
 const TeamTypeTable: React.FC = () => {
   const {
@@ -14,7 +15,7 @@ const TeamTypeTable: React.FC = () => {
     isError: teamTypesIsError,
     error: teamTypesError
   } = useAllTeamTypes();
-  const [createModalShow, setCreateModalShow] = useState<boolean>(false);
+  const [createModalShow, setCreateModalShow] = useHistoryState<boolean>("", false);
 
   if (!teamTypes || teamTypesIsLoading) {
     return <LoadingIndicator />;

--- a/src/frontend/src/utils/form.ts
+++ b/src/frontend/src/utils/form.ts
@@ -86,3 +86,7 @@ export const generateUUID = () => {
     return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16);
   });
 };
+
+export enum FormStorageKey {
+  CREATE_TEAM_TYPE = 'CREATE_TEAM_TYPE'
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10225,6 +10225,7 @@ __metadata:
     eslint-config-react-app: ^7.0.1
     eslint-plugin-prettier: ^4.2.1
     prettier: ^2.0.5
+    react-hook-form-persist: ^3.0.0
     rimraf: ^3.0.2
     ts-node: ^10.9.1
     typescript: ^4.1.5
@@ -17188,6 +17189,16 @@ __metadata:
   peerDependencies:
     react: ">=16.3.0"
   checksum: a4998479dab7fc1c2799eddefb1870a9d881b5f71cfdf97979a9882e42f4bb50402d55335f308f461e735e01a06f46b16cc7b4e6bcb22c7a4a6f85a753c5c106
+  languageName: node
+  linkType: hard
+
+"react-hook-form-persist@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "react-hook-form-persist@npm:3.0.0"
+  peerDependencies:
+    react: ">= 16.3"
+    react-hook-form: ">= 6"
+  checksum: de90d45cb8ac49c636df78da96284e5f915894a639b06b95c1ce1d7da7bbd04305a52411b90693007376417dac3fd9bd3ed114dedbbae32fb15c2a588e870260
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Changes

- Created useHistoryState Hook

## Notes

- I implemented it for create new team type to test it out. When navigating back to the page, the modal stays open but the all the text inside dissaepars. I tried to do something similar for each field in the modal like using the useHistoryState hook but it ended up refreshing the page every time I typed something into the text field.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #2685
