### PR TITLE
#2702: Created createFaq Endpoint

### DIFF
--- a/src/backend/src/controllers/recruitment.controllers.ts
+++ b/src/backend/src/controllers/recruitment.controllers.ts
@@ -26,4 +26,17 @@ export default class RecruitmentController {
       next(error);
     }
   }
+
+  static async createFaq(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { question, answer } = req.body;
+      const submitter = await getCurrentUser(res);
+      const organizationId = getOrganizationId(req.headers);
+
+      const faq = await RecruitmentServices.createFaq(submitter, question, answer, organizationId);
+      res.status(200).json(faq);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
 }

--- a/src/backend/src/prisma/seed.ts
+++ b/src/backend/src/prisma/seed.ts
@@ -32,6 +32,7 @@ import { transformDate } from '../utils/datetime.utils';
 import { writeFileSync } from 'fs';
 import WorkPackageTemplatesService from '../services/work-package-template.services';
 import OrganizationsService from '../services/organizations.service';
+import RecruitmentServices from '../services/recruitment.services';
 
 const prisma = new PrismaClient();
 
@@ -1957,6 +1958,25 @@ const performSeed: () => Promise<void> = async () => {
       url: 'https://docs.google.com'
     }
   ]);
+
+  await RecruitmentServices.createFaq(
+    batman,
+    'Who is the Chief Software Engineer?',
+    'Peyton McKee',
+    organizationId
+  );
+  await RecruitmentServices.createFaq(
+    batman,
+    'When was FinishLine created?',
+    'FinishLine was created in 2019',
+    organizationId
+  );
+  await RecruitmentServices.createFaq(
+    batman,
+    'How many developers are working on FinishLine?',
+    '178 as of 2024',
+    organizationId
+  );
 };
 
 performSeed()

--- a/src/backend/src/prisma/seed.ts
+++ b/src/backend/src/prisma/seed.ts
@@ -1959,12 +1959,7 @@ const performSeed: () => Promise<void> = async () => {
     }
   ]);
 
-  await RecruitmentServices.createFaq(
-    batman,
-    'Who is the Chief Software Engineer?',
-    'Peyton McKee',
-    organizationId
-  );
+  await RecruitmentServices.createFaq(batman, 'Who is the Chief Software Engineer?', 'Peyton McKee', organizationId);
   await RecruitmentServices.createFaq(
     batman,
     'When was FinishLine created?',

--- a/src/backend/src/routes/recruitment.routes.ts
+++ b/src/backend/src/routes/recruitment.routes.ts
@@ -14,6 +14,14 @@ recruitmentRouter.post(
   RecruitmentController.createMilestone
 );
 
+recruitmentRouter.post(
+  '/faq/create',
+  nonEmptyString(body('question')),
+  nonEmptyString(body('answer')),
+  validateInputs,
+  RecruitmentController.createFaq
+);
+
 recruitmentRouter.get('/milestones', RecruitmentController.getAllMilestones);
 
 export default recruitmentRouter;

--- a/src/backend/src/services/recruitment.services.ts
+++ b/src/backend/src/services/recruitment.services.ts
@@ -70,12 +70,7 @@ export default class RecruitmentServices {
    * @param organizationId the organization Id of the FAQ
    * @returns A newly created FAQ
    */
-  static async createFaq(
-    submitter: User,
-    question: string,
-    answer: string,
-    organizationId: string
-  ) {
+  static async createFaq(submitter: User, question: string, answer: string, organizationId: string) {
     const organization = await prisma.organization.findUnique({
       where: { organizationId }
     });

--- a/src/backend/src/services/recruitment.services.ts
+++ b/src/backend/src/services/recruitment.services.ts
@@ -1,7 +1,7 @@
 import { User } from '@prisma/client';
 import { isAdmin } from 'shared';
 import prisma from '../prisma/prisma';
-import { AccessDeniedAdminOnlyException, HttpException } from '../utils/errors.utils';
+import { AccessDeniedAdminOnlyException, HttpException, NotFoundException } from '../utils/errors.utils';
 import { userHasPermission } from '../utils/users.utils';
 
 export default class RecruitmentServices {
@@ -76,7 +76,7 @@ export default class RecruitmentServices {
     });
 
     if (!organization) {
-      throw new HttpException(400, `Organization with id ${organizationId} doesn't exist`);
+      throw new NotFoundException('Organization', organizationId);
     }
 
     if (!(await userHasPermission(submitter.userId, organizationId, isAdmin)))

--- a/src/backend/src/services/recruitment.services.ts
+++ b/src/backend/src/services/recruitment.services.ts
@@ -61,4 +61,41 @@ export default class RecruitmentServices {
 
     return allMilestones;
   }
+
+  /**
+   * Creates a new FAQ in the given organization Id
+   * @param submitter a user who is making this request
+   * @param question question to be displayed by the FAQ
+   * @param answer answer to the question of the FAQ
+   * @param organizationId the organization Id of the FAQ
+   * @returns A newly created FAQ
+   */
+  static async createFaq(
+    submitter: User,
+    question: string,
+    answer: string,
+    organizationId: string
+  ) {
+    const organization = await prisma.organization.findUnique({
+      where: { organizationId }
+    });
+
+    if (!organization) {
+      throw new HttpException(400, `Organization with id ${organizationId} doesn't exist`);
+    }
+
+    if (!(await userHasPermission(submitter.userId, organizationId, isAdmin)))
+      throw new AccessDeniedAdminOnlyException('create an faq');
+
+    const faq = await prisma.frequentlyAskedQuestion.create({
+      data: {
+        question,
+        answer,
+        organizationId,
+        userCreatedId: submitter.userId
+      }
+    });
+
+    return faq;
+  }
 }

--- a/src/backend/src/utils/errors.utils.ts
+++ b/src/backend/src/utils/errors.utils.ts
@@ -136,4 +136,5 @@ export type ExceptionObjectNames =
   | 'Work Package Template'
   | 'Description Bullet Type'
   | 'Organization'
-  | 'Car';
+  | 'Car'
+    'Faq';

--- a/src/backend/src/utils/errors.utils.ts
+++ b/src/backend/src/utils/errors.utils.ts
@@ -136,5 +136,5 @@ export type ExceptionObjectNames =
   | 'Work Package Template'
   | 'Description Bullet Type'
   | 'Organization'
-  | 'Car'
-    'Faq';
+  | 'Faq'
+  | 'Car';

--- a/src/backend/tests/test-utils.ts
+++ b/src/backend/tests/test-utils.ts
@@ -114,6 +114,7 @@ export const resetUsers = async () => {
   await prisma.team_Type.deleteMany();
   await prisma.wBS_Element.deleteMany();
   await prisma.milestone.deleteMany();
+  await prisma.frequentlyAskedQuestion.deleteMany();
   await prisma.organization.deleteMany();
   await prisma.user.deleteMany();
 };

--- a/src/backend/tests/unmocked/recruitment.test.ts
+++ b/src/backend/tests/unmocked/recruitment.test.ts
@@ -1,6 +1,6 @@
 import RecruitmentServices from '../../src/services/recruitment.services';
 import { AccessDeniedAdminOnlyException, HttpException } from '../../src/utils/errors.utils';
-import { batmanAppAdmin, wonderwomanGuest, supermanAdmin } from '../test-data/users.test-data';
+import { batmanAppAdmin, wonderwomanGuest, supermanAdmin, member } from '../test-data/users.test-data';
 import { createTestOrganization, createTestUser, resetUsers } from '../test-utils';
 
 describe('Recruitment Tests', () => {
@@ -86,6 +86,33 @@ describe('Recruitment Tests', () => {
       );
       const result = await RecruitmentServices.getAllMilestones(orgId);
       expect(result).toStrictEqual([milestone1, milestone2]);
+    });
+  });
+
+  describe('Create FAQ', () => {
+    it('Fails if user is not an admin', async () => {
+      await expect(
+        async () => await RecruitmentServices.createFaq(await createTestUser(member, orgId), 'question', 'answer', orgId)
+      ).rejects.toThrow(new AccessDeniedAdminOnlyException('create an faq'));
+    });
+
+    it('Fails if organization doesn`t exist', async () => {
+      await expect(
+        async () =>
+          await RecruitmentServices.createFaq(await createTestUser(batmanAppAdmin, orgId), 'question', 'answer', '5')
+      ).rejects.toThrow(new HttpException(400, `Organization with id 5 doesn't exist`));
+    });
+
+    it('Succeeds and creates an FAQ', async () => {
+      const result = await RecruitmentServices.createFaq(
+        await createTestUser(batmanAppAdmin, orgId),
+        'question',
+        'answer',
+        orgId
+      );
+
+      expect(result.question).toEqual('question');
+      expect(result.answer).toEqual('answer');
     });
   });
 });

--- a/src/backend/tests/unmocked/recruitment.test.ts
+++ b/src/backend/tests/unmocked/recruitment.test.ts
@@ -1,5 +1,5 @@
 import RecruitmentServices from '../../src/services/recruitment.services';
-import { AccessDeniedAdminOnlyException, HttpException } from '../../src/utils/errors.utils';
+import { AccessDeniedAdminOnlyException, HttpException, NotFoundException } from '../../src/utils/errors.utils';
 import { batmanAppAdmin, wonderwomanGuest, supermanAdmin, member } from '../test-data/users.test-data';
 import { createTestOrganization, createTestUser, resetUsers } from '../test-utils';
 
@@ -100,7 +100,7 @@ describe('Recruitment Tests', () => {
       await expect(
         async () =>
           await RecruitmentServices.createFaq(await createTestUser(batmanAppAdmin, orgId), 'question', 'answer', '5')
-      ).rejects.toThrow(new HttpException(400, `Organization with id 5 doesn't exist`));
+      ).rejects.toThrow(new NotFoundException('Organization', `5`));
     });
 
     it('Succeeds and creates an FAQ', async () => {


### PR DESCRIPTION
## Changes

Created a create FAQ endpoint

Added unit tests (not 100% if they are correct though)

## Notes

Confused on how to go about Postman testing so I left out those screenshots for now

## Screenshots

**Postman test where user is not an admin**
<img width="1728" alt="Screenshot 2024-08-07 at 14 43 47" src="https://github.com/user-attachments/assets/beeb4f64-57f5-45ef-8a3f-e6b4bde63f3b">

**Postman test where organizationId is invalid**
<img width="1728" alt="Screenshot 2024-08-08 at 13 53 29" src="https://github.com/user-attachments/assets/461ecd29-f11d-4a11-9409-68f5fc0ba8e7">

**Postman test where createFaq endpoint succeeds**
<img width="1728" alt="Screenshot 2024-08-07 at 14 46 16" src="https://github.com/user-attachments/assets/5e8f33d3-8dd9-468b-bdef-2949c1ef3ea9">



## To Do

- [x] Postman testing

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #2702 
