### PR TITLE
#2710: Created acceptance page for PNM

### DIFF
--- a/src/frontend/src/pages/AcceptedPage/AcceptedPage.tsx
+++ b/src/frontend/src/pages/AcceptedPage/AcceptedPage.tsx
@@ -1,4 +1,4 @@
-import { Typography, Box } from '@mui/material';
+import { Typography, Box, Grid } from '@mui/material';
 import PageLayout from '../../components/PageLayout';
 import { AuthenticatedUser } from 'shared';
 import LoadingIndicator from '../../components/LoadingIndicator';
@@ -19,30 +19,62 @@ const AcceptedPage = ({ user }: AcceptedPageProps) => {
   return (
     <PageLayout title="Accepted" hidePageTitle>
       <Box sx={{ mt: 6, ml: 4 }}>
-        <Typography variant="h3" marginLeft="auto" sx={{ marginTop: 2, textAlign: 'center', pt: 3, padding: 0 }}>
+        <Typography variant="h2" marginLeft="auto" sx={{ marginTop: 2, textAlign: 'center', pt: 3, padding: 0 }}>
           Congratulations, {user.firstName}!
         </Typography>
-        <Typography variant="h4" marginLeft="auto" sx={{ marginTop: 2, textAlign: 'center', pt: 1, padding: 0 }}>
+        <Typography
+          variant="h3"
+          marginLeft="auto"
+          sx={{ marginTop: 2, textAlign: 'center', pt: 1, padding: 0, fontWeight: 1 }}
+        >
           We are so excited to welcome you to Northeastern Electric Racing!
         </Typography>
       </Box>
-      <Box />
-      <Box sx={{ mt: 4, ml: 2 }}>
-        <Typography variant="body1" marginLeft="auto" sx={{ marginTop: 50, textAlign: 'center', pt: 3, padding: 0 }}>
+      <Box
+        component="img"
+        src={'../NER-Logo-App-Icon.png'}
+        sx={{
+          width: '25%',
+          height: '25%',
+          display: 'block',
+          marginLeft: 'auto',
+          marginRight: 'auto',
+          marginTop: 2
+        }}
+      />
+      <Box sx={{ mt: 2, ml: 2 }}>
+        <Typography
+          variant="h6"
+          marginLeft="auto"
+          sx={{ marginTop: 5, textAlign: 'center', pt: 3, padding: 0, fontFamily: 'oswald', fontWeight: 1 }}
+        >
           Before you get started on the [subteam name] subteam, all new members will have to complete general and
           subteam-specific onboarding. Please accept this offer within 5 days to start onboarding.
         </Typography>
-        <Typography variant="body1" marginLeft="auto" sx={{ textAlign: 'center', pt: 3, padding: 0 }}>
+        <Typography
+          variant="h6"
+          marginLeft="auto"
+          sx={{ marginTop: 1, textAlign: 'center', pt: 3, padding: 0, fontFamily: 'oswald', fontWeight: 1 }}
+        >
           We can't wait to see you around and all that you'll accomplish!
         </Typography>
       </Box>
-      <Box sx={{ mt: 15, ml: 2 }}>
-        <NERButton sx={{ mt: '20px', float: 'left' }} variant="contained">
-          Accept
-        </NERButton>
-        <NERButton sx={{ mt: '20px', float: 'right' }} variant="contained">
-          Reject
-        </NERButton>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          mt: 7,
+          width: '100%'
+        }}
+      >
+        <Grid container justifyContent="center" spacing={8} sx={{ maxWidth: '300px' }}>
+          <Grid item>
+            <NERButton variant="contained">Accept</NERButton>
+          </Grid>
+          <Grid item>
+            <NERButton variant="contained">Reject</NERButton>
+          </Grid>
+        </Grid>
       </Box>
     </PageLayout>
   );

--- a/src/frontend/src/pages/AcceptedPage/AcceptedPage.tsx
+++ b/src/frontend/src/pages/AcceptedPage/AcceptedPage.tsx
@@ -50,7 +50,7 @@ const AcceptedPage = ({ user }: AcceptedPageProps) => {
           marginLeft="auto"
           sx={{ marginTop: 2, textAlign: 'center', pt: 3, padding: 0, fontFamily: 'oswald', fontWeight: 1, fontSize: 25 }}
         >
-          Before you get started on the  subteam, all new members will have to complete general and subteam-specific
+          Before you get started on the subteam, all new members will have to complete general and subteam-specific
           onboarding. Please accept this offer within 5 days to start onboarding.
         </Typography>
         <Typography
@@ -71,10 +71,14 @@ const AcceptedPage = ({ user }: AcceptedPageProps) => {
       >
         <Grid container justifyContent="center" spacing={8} sx={{ maxWidth: '500px' }}>
           <Grid item>
-            <NERButton variant="contained" sx={{fontSize: 20}}>Accept</NERButton>
+            <NERButton variant="contained" sx={{ fontSize: 20 }}>
+              Accept
+            </NERButton>
           </Grid>
           <Grid item>
-            <NERButton variant="contained" sx={{fontSize: 20}}>Reject</NERButton>
+            <NERButton variant="contained" sx={{ fontSize: 20 }}>
+              Reject
+            </NERButton>
           </Grid>
         </Grid>
       </Box>

--- a/src/frontend/src/pages/AcceptedPage/AcceptedPage.tsx
+++ b/src/frontend/src/pages/AcceptedPage/AcceptedPage.tsx
@@ -5,14 +5,13 @@ import LoadingIndicator from '../../components/LoadingIndicator';
 import ErrorPage from '../ErrorPage';
 import { useSingleUserSettings } from '../../hooks/users.hooks';
 import { NERButton } from '../../components/NERButton';
-import { fontSize } from '@mui/system';
 
 interface AcceptedPageProps {
   user: AuthenticatedUser;
-  // team: TeamType;
+  team: TeamType;
 }
 
-const AcceptedPage = ({ user }: AcceptedPageProps) => {
+const AcceptedPage = ({ user, team }: AcceptedPageProps) => {
   const { isLoading, isError, error, data: userSettingsData } = useSingleUserSettings(user.userId);
 
   if (isLoading || !userSettingsData) return <LoadingIndicator />;
@@ -50,7 +49,7 @@ const AcceptedPage = ({ user }: AcceptedPageProps) => {
           marginLeft="auto"
           sx={{ marginTop: 2, textAlign: 'center', pt: 3, padding: 0, fontFamily: 'oswald', fontWeight: 1, fontSize: 25 }}
         >
-          Before you get started on the subteam, all new members will have to complete general and subteam-specific
+          Before you get started on the {team.name}, all new members will have to complete general and subteam-specific
           onboarding. Please accept this offer within 5 days to start onboarding.
         </Typography>
         <Typography

--- a/src/frontend/src/pages/AcceptedPage/AcceptedPage.tsx
+++ b/src/frontend/src/pages/AcceptedPage/AcceptedPage.tsx
@@ -1,13 +1,15 @@
 import { Typography, Box, Grid } from '@mui/material';
 import PageLayout from '../../components/PageLayout';
-import { AuthenticatedUser } from 'shared';
+import { AuthenticatedUser, TeamType } from 'shared';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import ErrorPage from '../ErrorPage';
 import { useSingleUserSettings } from '../../hooks/users.hooks';
 import { NERButton } from '../../components/NERButton';
+import { fontSize } from '@mui/system';
 
 interface AcceptedPageProps {
   user: AuthenticatedUser;
+  // team: TeamType;
 }
 
 const AcceptedPage = ({ user }: AcceptedPageProps) => {
@@ -39,22 +41,22 @@ const AcceptedPage = ({ user }: AcceptedPageProps) => {
           display: 'block',
           marginLeft: 'auto',
           marginRight: 'auto',
-          marginTop: 2
+          marginTop: 4
         }}
       />
       <Box sx={{ mt: 2, ml: 2 }}>
         <Typography
           variant="h6"
           marginLeft="auto"
-          sx={{ marginTop: 5, textAlign: 'center', pt: 3, padding: 0, fontFamily: 'oswald', fontWeight: 1 }}
+          sx={{ marginTop: 2, textAlign: 'center', pt: 3, padding: 0, fontFamily: 'oswald', fontWeight: 1, fontSize: 25 }}
         >
-          Before you get started on the [subteam name] subteam, all new members will have to complete general and
-          subteam-specific onboarding. Please accept this offer within 5 days to start onboarding.
+          Before you get started on the  subteam, all new members will have to complete general and subteam-specific
+          onboarding. Please accept this offer within 5 days to start onboarding.
         </Typography>
         <Typography
           variant="h6"
           marginLeft="auto"
-          sx={{ marginTop: 1, textAlign: 'center', pt: 3, padding: 0, fontFamily: 'oswald', fontWeight: 1 }}
+          sx={{ marginTop: 1, textAlign: 'center', pt: 3, padding: 0, fontFamily: 'oswald', fontWeight: 1, fontSize: 25 }}
         >
           We can't wait to see you around and all that you'll accomplish!
         </Typography>
@@ -67,12 +69,12 @@ const AcceptedPage = ({ user }: AcceptedPageProps) => {
           width: '100%'
         }}
       >
-        <Grid container justifyContent="center" spacing={8} sx={{ maxWidth: '300px' }}>
+        <Grid container justifyContent="center" spacing={8} sx={{ maxWidth: '500px' }}>
           <Grid item>
-            <NERButton variant="contained">Accept</NERButton>
+            <NERButton variant="contained" sx={{fontSize: 20}}>Accept</NERButton>
           </Grid>
           <Grid item>
-            <NERButton variant="contained">Reject</NERButton>
+            <NERButton variant="contained" sx={{fontSize: 20}}>Reject</NERButton>
           </Grid>
         </Grid>
       </Box>

--- a/src/frontend/src/pages/AcceptedPage/AcceptedPage.tsx
+++ b/src/frontend/src/pages/AcceptedPage/AcceptedPage.tsx
@@ -1,0 +1,50 @@
+import { Typography, Box } from '@mui/material';
+import PageLayout from '../../components/PageLayout';
+import { AuthenticatedUser } from 'shared';
+import LoadingIndicator from '../../components/LoadingIndicator';
+import ErrorPage from '../ErrorPage';
+import { useSingleUserSettings } from '../../hooks/users.hooks';
+import { NERButton } from '../../components/NERButton';
+
+interface AcceptedPageProps {
+  user: AuthenticatedUser;
+}
+
+const AcceptedPage = ({ user }: AcceptedPageProps) => {
+  const { isLoading, isError, error, data: userSettingsData } = useSingleUserSettings(user.userId);
+
+  if (isLoading || !userSettingsData) return <LoadingIndicator />;
+  if (isError) return <ErrorPage error={error} message={error.message} />;
+
+  return (
+    <PageLayout title="Accepted" hidePageTitle>
+      <Box sx={{ mt: 6, ml: 4 }}>
+        <Typography variant="h3" marginLeft="auto" sx={{ marginTop: 2, textAlign: 'center', pt: 3, padding: 0 }}>
+          Congratulations, {user.firstName}!
+        </Typography>
+        <Typography variant="h4" marginLeft="auto" sx={{ marginTop: 2, textAlign: 'center', pt: 1, padding: 0 }}>
+          We are so excited to welcome you to Northeastern Electric Racing!
+        </Typography>
+      </Box>
+      <Box />
+      <Box sx={{ mt: 4, ml: 2 }}>
+        <Typography variant="body1" marginLeft="auto" sx={{ marginTop: 50, textAlign: 'center', pt: 3, padding: 0 }}>
+          Before you get started on the [subteam name] subteam, all new members will have to complete general and
+          subteam-specific onboarding. Please accept this offer within 5 days to start onboarding.
+        </Typography>
+        <Typography variant="body1" marginLeft="auto" sx={{ textAlign: 'center', pt: 3, padding: 0 }}>
+          We can't wait to see you around and all that you'll accomplish!
+        </Typography>
+      </Box>
+      <Box sx={{ mt: 15, ml: 2 }}>
+        <NERButton sx={{ mt: '20px', float: 'left' }} variant="contained">
+          Accept
+        </NERButton>
+        <NERButton sx={{ mt: '20px', float: 'right' }} variant="contained">
+          Reject
+        </NERButton>
+      </Box>
+    </PageLayout>
+  );
+};
+export default AcceptedPage;


### PR DESCRIPTION
## Changes

Created frontend part of the acceptance page for PNM's.

## Notes

- FinishLine image changes size based on screen size
- Top bar with user's name is still missing
- Currently there is no route to this page and no way to check if a user can have permission to access this page.

## Screenshots
<img width="1366" alt="Screenshot 2024-09-11 at 12 33 23" src="https://github.com/user-attachments/assets/b9dfdd7c-a979-49f6-a5af-002db6c49457">

<img width="526" alt="Screenshot 2024-09-11 at 12 33 44" src="https://github.com/user-attachments/assets/df0f1de4-c3a2-4fc6-a263-981e4d645642">


## To Do

- [x] Fix button spacing
- [x] Implement Electric Racing image in the center of the page

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #2710
