### PR TITLE
#2764 Create set logo endpoint

### DIFF
--- a/src/backend/src/controllers/organizations.controller.ts
+++ b/src/backend/src/controllers/organizations.controller.ts
@@ -55,11 +55,10 @@ export default class OrganizationsController {
 
   static async setLogoImage(req: Request, res: Response, next: NextFunction) {
     try {
-      const logoFile = req.file || null;
-      if (!logoFile) {
+      if (!req.file) {
         throw new HttpException(400, 'Invalid or undefined image data');
       }
-      const updatedOrg = await OrganizationsService.setLogoImage(logoFile, req.currentUser, req.organization);
+      const updatedOrg = await OrganizationsService.setLogoImage(req.file, req.currentUser, req.organization);
 
       return res.status(200).json(updatedOrg);
     } catch (error: unknown) {

--- a/src/backend/src/controllers/organizations.controller.ts
+++ b/src/backend/src/controllers/organizations.controller.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Request, Response } from 'express';
 import OrganizationsService from '../services/organizations.services';
+import { HttpException } from '../utils/errors.utils';
 
 export default class OrganizationsController {
   static async setUsefulLinks(req: Request, res: Response, next: NextFunction) {
@@ -49,6 +50,20 @@ export default class OrganizationsController {
       res.status(200).json(images);
     } catch (error: unknown) {
       next(error);
+    }
+  }
+
+  static async setLogoImage(req: Request, res: Response, next: NextFunction) {
+    try {
+      const logoFile = req.file || null;
+      if (!logoFile) {
+        throw new HttpException(400, 'Invalid or undefined image data');
+      }
+      const updatedOrg = await OrganizationsService.setLogoImage(logoFile, req.currentUser, req.organization);
+
+      return res.status(200).json(updatedOrg);
+    } catch (error: unknown) {
+      return next(error);
     }
   }
 }

--- a/src/backend/src/routes/organizations.routes.ts
+++ b/src/backend/src/routes/organizations.routes.ts
@@ -18,4 +18,5 @@ organizationRouter.post(
 );
 
 organizationRouter.get('/images', OrganizationsController.getOrganizationImages);
+organizationRouter.post('/logo/update', upload.single('logo'), OrganizationsController.setLogoImage);
 export default organizationRouter;

--- a/src/backend/src/services/organizations.services.ts
+++ b/src/backend/src/services/organizations.services.ts
@@ -151,13 +151,13 @@ export default class OrganizationsService {
 
     const logoImageData = await uploadFile(logoImage);
 
-    const newOrg = await prisma.organization.update({
+    const updatedOrg = await prisma.organization.update({
       where: { organizationId: organization.organizationId },
       data: {
         logoImageId: logoImageData.id
       }
     });
 
-    return newOrg;
+    return updatedOrg;
   }
 }

--- a/src/backend/src/services/organizations.services.ts
+++ b/src/backend/src/services/organizations.services.ts
@@ -131,4 +131,33 @@ export default class OrganizationsService {
       exploreAsGuestImage: organization.exploreAsGuestImageId
     };
   }
+
+  /**
+   * Sets the logo for an organization, User must be admin
+   * @param logoImage the image which will be uploaded and have its id stored in the org
+   * @param submitter the user submitting the logo
+   * @param organization the organization who's logo is being set
+   * @returns the updated organization
+   * @throws if the user is not an admin
+   */
+  static async setLogoImage(
+    logoImage: Express.Multer.File,
+    submitter: User,
+    organization: Organization
+  ): Promise<Organization> {
+    if (!(await userHasPermission(submitter.userId, organization.organizationId, isAdmin))) {
+      throw new AccessDeniedAdminOnlyException('update logo');
+    }
+
+    const logoImageData = await uploadFile(logoImage);
+
+    const newOrg = await prisma.organization.update({
+      where: { organizationId: organization.organizationId },
+      data: {
+        logoImageId: logoImageData.id
+      }
+    });
+
+    return newOrg;
+  }
 }


### PR DESCRIPTION
## Changes

Added a setLogo endpoint to "/organizations/images/update" that lets an admin user update the logo for the organization.

## Notes

Could not manually test uploadFile() function with postman, so manual override was used for this function in screenshots

## Test Cases

Case A: fails if user is not an admin
Case B: updates logo if no previous logo exists
Case C: updates a previously existing logo

## Screenshots

Successful Postman Response (await uploadFile() was replaced with {id: "123"})
<img width="1363" alt="logoUploadSuccess" src="https://github.com/user-attachments/assets/4ca2cf2a-c8bb-4a74-87d5-1838e99a75b0">

Error Postman Response if no image is supplied
<img width="1373" alt="logoUploadError" src="https://github.com/user-attachments/assets/ed75e948-1e95-45f9-9b6a-b8bcbf0871d2">

Closes #2764
