### PR TITLE
#2831 Get organization logo endpoint and tests

### DIFF
--- a/src/backend/src/controllers/organizations.controller.ts
+++ b/src/backend/src/controllers/organizations.controller.ts
@@ -65,4 +65,13 @@ export default class OrganizationsController {
       return next(error);
     }
   }
+
+  static async getOrganizationLogoImage(req: Request, res: Response, next: NextFunction) {
+    try {
+      const logoImageId = await OrganizationsService.getLogoImage(req.organization.organizationId);
+      res.status(200).json(logoImageId);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
 }

--- a/src/backend/src/routes/organizations.routes.ts
+++ b/src/backend/src/routes/organizations.routes.ts
@@ -19,4 +19,5 @@ organizationRouter.post(
 
 organizationRouter.get('/images', OrganizationsController.getOrganizationImages);
 organizationRouter.post('/logo/update', upload.single('logo'), OrganizationsController.setLogoImage);
+organizationRouter.get('/logo', OrganizationsController.getOrganizationLogoImage);
 export default organizationRouter;

--- a/src/backend/src/services/organizations.services.ts
+++ b/src/backend/src/services/organizations.services.ts
@@ -1,7 +1,7 @@
 import { Organization, User } from '@prisma/client';
 import { LinkCreateArgs, isAdmin } from 'shared';
 import prisma from '../prisma/prisma';
-import { AccessDeniedAdminOnlyException, NotFoundException } from '../utils/errors.utils';
+import { AccessDeniedAdminOnlyException, HttpException, NotFoundException } from '../utils/errors.utils';
 import { userHasPermission } from '../utils/users.utils';
 import { createUsefulLinks } from '../utils/organizations.utils';
 import { linkTransformer } from '../transformers/links.transformer';
@@ -159,5 +159,26 @@ export default class OrganizationsService {
     });
 
     return updatedOrg;
+  }
+
+  /**
+   * Gets the logo image of the organization
+   * @param organizationId the id of the organization
+   * @returns the id of the image
+   */
+  static async getLogoImage(organizationId: string): Promise<string> {
+    const organization = await prisma.organization.findUnique({
+      where: { organizationId }
+    });
+
+    if (!organization) {
+      throw new NotFoundException('Organization', organizationId);
+    }
+
+    if (!organization.logoImageId) {
+      throw new HttpException(404, `Organization ${organizationId} does not have a logo image`);
+    }
+
+    return organization.logoImageId;
   }
 }

--- a/src/backend/tests/unmocked/organization.test.ts
+++ b/src/backend/tests/unmocked/organization.test.ts
@@ -228,4 +228,31 @@ describe('Team Type Tests', () => {
       expect(updatedOrganization?.logoImageId).toBe('uploaded-image2.png');
     });
   });
+
+  describe('Get Organization Logo', () => {
+    it('Fails if an organization does not exist', async () => {
+      await expect(async () => await OrganizationsService.getLogoImage('1')).rejects.toThrow(
+        new NotFoundException('Organization', '1')
+      );
+    });
+
+    it('Fails if the organization does not have a logo image', async () => {
+      await expect(async () => await OrganizationsService.getLogoImage(orgId)).rejects.toThrow(
+        new HttpException(404, `Organization ${orgId} does not have a logo image`)
+      );
+    });
+
+    it('Succeeds and gets the image', async () => {
+      const testBatman = await createTestUser(batmanAppAdmin, orgId);
+      await OrganizationsService.setLogoImage(
+        { originalname: 'image1.png' } as Express.Multer.File,
+        testBatman,
+        organization
+      );
+      const image = await OrganizationsService.getLogoImage(orgId);
+
+      expect(image).not.toBeNull();
+      expect(image).toBe('uploaded-image1.png');
+    });
+  });
 });


### PR DESCRIPTION
## Changes

Added endpoint to retrieve the ID of the logo image for an organization
Added tests for endpoint

## Notes

Due to the uploadFile function not working locally, postman screenshots were preformed with that function replaced with {id: "Test Logo Id"}

## Test Cases

- Fails if the organization does not exist
- Fails if the organization does not have a logo image yet
- Returns id of image if organization has a logo image

## Screenshots

Calling logo before uploading an image errors:
<img width="1370" alt="NoLogoImage" src="https://github.com/user-attachments/assets/51c45c15-1ec1-4c25-b779-2fbac039ef0b">

Update logo with:
<img width="1367" alt="UpdateLogo" src="https://github.com/user-attachments/assets/2e6163e3-16b1-4373-bd1e-87d702efa149">

Get logo image id with endpoint:
<img width="1374" alt="ReturnsLogoId" src="https://github.com/user-attachments/assets/c974febd-7071-4214-9147-b59119dfd3aa">

Closes #2831
