### PR TITLE
#2808: Added work package util function to get overdue WPs

### DIFF
--- a/src/frontend/src/utils/work-package.utils.ts
+++ b/src/frontend/src/utils/work-package.utils.ts
@@ -1,4 +1,4 @@
-import { WbsElement, wbsPipe } from 'shared';
+import { WbsElement, WbsElementStatus, wbsPipe, WorkPackage } from 'shared';
 import { WPFormType } from './form';
 
 export const getTitleFromFormType = (formType: WPFormType, wbsElement: WbsElement): string => {
@@ -10,4 +10,24 @@ export const getTitleFromFormType = (formType: WPFormType, wbsElement: WbsElemen
     default:
       return `${wbsPipe(wbsElement.wbsNum)} - ${wbsElement.name}`;
   }
+};
+
+/**
+ * Given a list of work packages, return the work packages that are overdue.
+ * @param wpList a list of work packages.
+ * @returns a list of work packages that are overdue.
+ */
+export const getOverdueWorkPackages = (wpList : WorkPackage[]) : WorkPackage[] => {
+  const overdueWorkPackages : WorkPackage[] = [];
+
+  for(let i = 0; i < wpList.length ; i++){
+    const curr = wpList[i];
+
+    // if the work package is anything but complete and the end date is before today, it is overdue.
+    if(curr.status !== WbsElementStatus.Complete && curr.endDate < new Date()){
+      overdueWorkPackages.push(curr);
+    }
+  }
+
+  return overdueWorkPackages;
 };

--- a/src/frontend/src/utils/work-package.utils.ts
+++ b/src/frontend/src/utils/work-package.utils.ts
@@ -18,16 +18,5 @@ export const getTitleFromFormType = (formType: WPFormType, wbsElement: WbsElemen
  * @returns a list of work packages that are overdue.
  */
 export const getOverdueWorkPackages = (wpList: WorkPackage[]): WorkPackage[] => {
-  const overdueWorkPackages: WorkPackage[] = [];
-
-  for (let i = 0; i < wpList.length; i++) {
-    const curr = wpList[i];
-
-    // if the work package is anything but complete and the end date is before today, it is overdue.
-    if (curr.status !== WbsElementStatus.Complete && curr.endDate < new Date()) {
-      overdueWorkPackages.push(curr);
-    }
-  }
-
-  return overdueWorkPackages;
+  return wpList.filter((wp) => wp.status !== WbsElementStatus.Complete && wp.endDate < new Date());
 };

--- a/src/frontend/src/utils/work-package.utils.ts
+++ b/src/frontend/src/utils/work-package.utils.ts
@@ -17,14 +17,14 @@ export const getTitleFromFormType = (formType: WPFormType, wbsElement: WbsElemen
  * @param wpList a list of work packages.
  * @returns a list of work packages that are overdue.
  */
-export const getOverdueWorkPackages = (wpList : WorkPackage[]) : WorkPackage[] => {
-  const overdueWorkPackages : WorkPackage[] = [];
+export const getOverdueWorkPackages = (wpList: WorkPackage[]): WorkPackage[] => {
+  const overdueWorkPackages: WorkPackage[] = [];
 
-  for(let i = 0; i < wpList.length ; i++){
+  for (let i = 0; i < wpList.length; i++) {
     const curr = wpList[i];
 
     // if the work package is anything but complete and the end date is before today, it is overdue.
-    if(curr.status !== WbsElementStatus.Complete && curr.endDate < new Date()){
+    if (curr.status !== WbsElementStatus.Complete && curr.endDate < new Date()) {
       overdueWorkPackages.push(curr);
     }
   }


### PR DESCRIPTION
## Changes

- Added a function in work-package.utils.ts that takes in an array of work packages and returns an array of overdue work packages.

## Notes

- Function consists of a loop that pushes each work package is not complete and has a due date prior to current date to return array.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #2808
