### PR TITLE
#2806 created getUpcomingWorkPackages util

### DIFF
--- a/src/frontend/src/utils/work-package.utils.ts
+++ b/src/frontend/src/utils/work-package.utils.ts
@@ -16,5 +16,5 @@ export const getUpcomingWorkPackages = (workPackages: WorkPackage[]): WorkPackag
   const currentTime = new Date();
   const twoWeeks = new Date();
   twoWeeks.setDate(currentTime.getDate() + 14);
-  return workPackages.filter(({ startDate }) => currentTime <= startDate && startDate <= twoWeeks);
+  return workPackages.filter(({ startDate }) => currentTime < startDate && startDate <= twoWeeks);
 };

--- a/src/frontend/src/utils/work-package.utils.ts
+++ b/src/frontend/src/utils/work-package.utils.ts
@@ -1,4 +1,4 @@
-import { WbsElement, wbsPipe } from 'shared';
+import { WbsElement, wbsPipe, WorkPackage } from 'shared';
 import { WPFormType } from './form';
 
 export const getTitleFromFormType = (formType: WPFormType, wbsElement: WbsElement): string => {
@@ -11,3 +11,10 @@ export const getTitleFromFormType = (formType: WPFormType, wbsElement: WbsElemen
       return `${wbsPipe(wbsElement.wbsNum)} - ${wbsElement.name}`;
   }
 };
+
+export const getUpcomingWorkPackages = (workPackages: WorkPackage[]): WorkPackage[] => {
+  const currentTime = new Date();
+  const twoWeeks = new Date();
+  twoWeeks.setDate(currentTime.getDate() + 14);
+  return workPackages.filter(({startDate}) => currentTime <= startDate && startDate <= twoWeeks);
+}

--- a/src/frontend/src/utils/work-package.utils.ts
+++ b/src/frontend/src/utils/work-package.utils.ts
@@ -16,5 +16,5 @@ export const getUpcomingWorkPackages = (workPackages: WorkPackage[]): WorkPackag
   const currentTime = new Date();
   const twoWeeks = new Date();
   twoWeeks.setDate(currentTime.getDate() + 14);
-  return workPackages.filter(({startDate}) => currentTime <= startDate && startDate <= twoWeeks);
-}
+  return workPackages.filter(({ startDate }) => currentTime <= startDate && startDate <= twoWeeks);
+};

--- a/src/frontend/src/utils/work-package.utils.ts
+++ b/src/frontend/src/utils/work-package.utils.ts
@@ -1,4 +1,3 @@
-import { WbsElement, wbsPipe, WorkPackage } from 'shared';
 import { WbsElement, WbsElementStatus, wbsPipe, WorkPackage } from 'shared';
 import { WPFormType } from './form';
 
@@ -13,12 +12,18 @@ export const getTitleFromFormType = (formType: WPFormType, wbsElement: WbsElemen
   }
 };
 
-export const getUpcomingWorkPackages = (workPackages: WorkPackage[]): WorkPackage[] => {
+/**
+ * Given a list of work packages, return work packages with a start date within the next 2 weeks of the current day
+ * @param wpList a list of work packages.
+ * @returns a list of work packages with a start date within the next 2 weeks of the current day
+ */
+export const getUpcomingWorkPackages = (wpList: WorkPackage[]): WorkPackage[] => {
   const currentTime = new Date();
   const twoWeeks = new Date();
   twoWeeks.setDate(currentTime.getDate() + 14);
-  return workPackages.filter(({ startDate }) => currentTime < startDate && startDate <= twoWeeks);
-  
+  return wpList.filter(({ startDate }) => currentTime < startDate && startDate <= twoWeeks);
+};
+
 /**
  * Given a list of work packages, return the work packages that are overdue.
  * @param wpList a list of work packages.


### PR DESCRIPTION
## Changes

Added a function in work-package utils that, when given an array of work packages, returns upcoming work packages (start date within 2 weeks).

## Notes
- Used a filter that kept work packages whose startDate value was between the current date and 2 weeks after the current date, inclusive.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #2806 
