### PR TITLE
2803 added change requests overview to homepage and refactoed logic i…

### DIFF
--- a/src/frontend/src/components/ChangeRequestRow.tsx
+++ b/src/frontend/src/components/ChangeRequestRow.tsx
@@ -12,9 +12,10 @@ interface ChangeRequestRowProps {
   title: string;
   changeRequests: ChangeRequest[];
   noChangeRequestsMessage: string;
+  flexWrap?: string;
 }
 
-const ChangeRequestRow: React.FC<ChangeRequestRowProps> = ({ title, changeRequests, noChangeRequestsMessage }) => {
+const ChangeRequestRow: React.FC<ChangeRequestRowProps> = ({ title, changeRequests, noChangeRequestsMessage, flexWrap }) => {
   const theme = useTheme();
 
   return (
@@ -28,7 +29,7 @@ const ChangeRequestRow: React.FC<ChangeRequestRowProps> = ({ title, changeReques
             sx={{
               display: 'flex',
               flexDirection: 'row',
-              flexWrap: 'wrap',
+              flexWrap: flexWrap ? flexWrap : 'wrap',
               overflow: 'auto',
               justifyContent: 'flex-start',
               '&::-webkit-scrollbar': {

--- a/src/frontend/src/pages/ChangeRequestsPage/ChangeRequestsOverview.tsx
+++ b/src/frontend/src/pages/ChangeRequestsPage/ChangeRequestsOverview.tsx
@@ -6,12 +6,12 @@
 import { useAllChangeRequests } from '../../hooks/change-requests.hooks';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import ErrorPage from '../ErrorPage';
-import { isLeadership, isHead, ChangeRequest, Project, WorkPackage, equalsWbsNumber } from 'shared';
+import { isLeadership, isHead } from 'shared';
 import { useAllProjects } from '../../hooks/projects.hooks';
 import { useAllWorkPackages } from '../../hooks/work-packages.hooks';
 import { useCurrentUser } from '../../hooks/users.hooks';
-import { makeTeamList } from '../../utils/teams.utils';
 import ChangeRequestRow from '../../components/ChangeRequestRow';
+import { getCRsApproved, getCRsToReview, getCRsUnreviewed } from '../../utils/change-request.utils';
 
 const ChangeRequestsOverview: React.FC = () => {
   const user = useCurrentUser();
@@ -29,53 +29,9 @@ const ChangeRequestsOverview: React.FC = () => {
   if (projectIsError) return <ErrorPage message={projectError?.message} />;
   if (wpIsError) return <ErrorPage message={wpError?.message} />;
 
-  // projects whose change requests the user would have to review
-  const myProjects = projects.filter((project: Project) => {
-    const projectMemberIds = project.teams.flatMap((team) => makeTeamList(team)).map((user) => user.userId);
-    return (
-      projectMemberIds.includes(user.userId) ||
-      (project.lead && project.lead.userId === user.userId) ||
-      (project.manager && project.manager.userId === user.userId)
-    );
-  });
-
-  // work packages whose change requests the user would have to review
-  const myWorkPackages = workPackages.filter(
-    (wp: WorkPackage) =>
-      (wp.lead ? wp.lead.userId === user.userId : false) || (wp.manager ? wp.manager.userId === user.userId : false)
-  );
-
-  // all of the wbs numbers (in x.x.x string format) corresponding to projects and work packages
-  // whose change requests the user would have to review
-  const myWbsNumbers = myProjects
-    .map((project: Project) => project.wbsNum)
-    .concat(myWorkPackages.map((wp: WorkPackage) => wp.wbsNum));
-
-  const currentDate = new Date();
-
-  const crToReview = changeRequests
-    .filter(
-      (cr) =>
-        !cr.dateReviewed &&
-        cr.submitter.userId !== user.userId &&
-        (myWbsNumbers.some((wbsNum) => equalsWbsNumber(wbsNum, cr.wbsNum)) ||
-          cr.requestedReviewers.map((user) => user.userId).includes(user.userId))
-    )
-    .sort((a, b) => b.dateSubmitted.getTime() - a.dateSubmitted.getTime());
-
-  const crUnreviewed = changeRequests
-    .filter((cr: ChangeRequest) => !cr.dateReviewed && cr.submitter.userId === user.userId)
-    .sort((a, b) => b.dateSubmitted.getTime() - a.dateSubmitted.getTime());
-
-  const crApproved = changeRequests
-    .filter(
-      (cr: ChangeRequest) =>
-        cr.dateReviewed &&
-        cr.accepted &&
-        cr.submitter.userId === user.userId &&
-        currentDate.getTime() - cr.dateReviewed.getTime() <= 1000 * 60 * 60 * 24 * 5
-    )
-    .sort((a, b) => (a.dateReviewed && b.dateReviewed ? b.dateReviewed.getTime() - a.dateReviewed.getTime() : 0));
+  const crToReview = getCRsToReview(projects, workPackages, user, changeRequests);
+  const crUnreviewed = getCRsUnreviewed(user, changeRequests);
+  const crApproved = getCRsApproved(user, changeRequests);
 
   return (
     <>

--- a/src/frontend/src/pages/HomePage/MemberHomePage.tsx
+++ b/src/frontend/src/pages/HomePage/MemberHomePage.tsx
@@ -13,6 +13,7 @@ import LoadingIndicator from '../../components/LoadingIndicator';
 import ErrorPage from '../ErrorPage';
 import PageLayout from '../../components/PageLayout';
 import { AuthenticatedUser } from 'shared';
+import UnreviewedChangeRequests from './components/UnreviewedChangeRequests';
 
 interface MemberHomePageProps {
   user: AuthenticatedUser;
@@ -29,6 +30,7 @@ const MemberHomePage = ({ user }: MemberHomePageProps) => {
       <Typography variant="h3" marginLeft="auto" sx={{ marginTop: 2, textAlign: 'center', pt: 3, padding: 0 }}>
         Welcome, {user.firstName}!
       </Typography>
+      <UnreviewedChangeRequests />
       <OverdueWorkPackageAlerts />
       <UsefulLinks />
       <UpcomingDeadlines />

--- a/src/frontend/src/pages/HomePage/components/UnreviewedChangeRequests.tsx
+++ b/src/frontend/src/pages/HomePage/components/UnreviewedChangeRequests.tsx
@@ -6,7 +6,6 @@ import { useCurrentUser } from '../../../hooks/users.hooks';
 import { useAllChangeRequests } from '../../../hooks/change-requests.hooks';
 import { useAllProjects } from '../../../hooks/projects.hooks';
 import { getCRsToReview } from '../../../utils/change-request.utils';
-import Box from '@mui/material/Box';
 import ChangeRequestRow from '../../../components/ChangeRequestRow';
 
 const UnreviewedChangeRequests: React.FC = () => {
@@ -25,18 +24,12 @@ const UnreviewedChangeRequests: React.FC = () => {
 
   return (
     <PageBlock>
-      <Box sx={{ flexWrap: 'nowrap' }}>
-        <ChangeRequestRow
-          title="My Unreviewed Change Requests"
-          changeRequests={crsToReview}
-          noChangeRequestsMessage="No unreviewed change requests"
-        />
-        <style>{`
-          [data-testid='My Unreviewed Change RequestscrRow'] {
-            flex-wrap: nowrap !important;
-          }
-        `}</style>
-      </Box>
+      <ChangeRequestRow
+        title="My Unreviewed Change Requests"
+        changeRequests={crsToReview}
+        noChangeRequestsMessage="No unreviewed change requests"
+        flexWrap="nowrap"
+      />
     </PageBlock>
   );
 };

--- a/src/frontend/src/pages/HomePage/components/UnreviewedChangeRequests.tsx
+++ b/src/frontend/src/pages/HomePage/components/UnreviewedChangeRequests.tsx
@@ -1,0 +1,44 @@
+import { useAllWorkPackages } from '../../../hooks/work-packages.hooks';
+import LoadingIndicator from '../../../components/LoadingIndicator';
+import PageBlock from '../../../layouts/PageBlock';
+import ErrorPage from '../../ErrorPage';
+import { useCurrentUser } from '../../../hooks/users.hooks';
+import { useAllChangeRequests } from '../../../hooks/change-requests.hooks';
+import { useAllProjects } from '../../../hooks/projects.hooks';
+import { getCRsToReview } from '../../../utils/change-request.utils';
+import Box from '@mui/material/Box';
+import ChangeRequestRow from '../../../components/ChangeRequestRow';
+
+const UnreviewedChangeRequests: React.FC = () => {
+  const user = useCurrentUser();
+  const { data: changeRequests, isError: crIsError, isLoading: crIsLoading, error: crError } = useAllChangeRequests();
+  const { data: projects, isError: projectIsError, isLoading: projectLoading, error: projectError } = useAllProjects();
+  const { data: workPackages, isError: wpIsError, isLoading: wpLoading, error: wpError } = useAllWorkPackages();
+
+  if (crIsLoading || projectLoading || wpLoading || !changeRequests || !projects || !workPackages)
+    return <LoadingIndicator />;
+  if (crIsError) return <ErrorPage message={crError?.message} />;
+  if (projectIsError) return <ErrorPage message={projectError?.message} />;
+  if (wpIsError) return <ErrorPage message={wpError?.message} />;
+
+  const crsToReview = getCRsToReview(projects, workPackages, user, changeRequests);
+
+  return (
+    <PageBlock>
+      <Box sx={{ flexWrap: 'nowrap' }}>
+        <ChangeRequestRow
+          title="My Unreviewed Change Requests"
+          changeRequests={crsToReview}
+          noChangeRequestsMessage="No unreviewed change requests"
+        />
+        <style>{`
+          [data-testid='My Unreviewed Change RequestscrRow'] {
+            flex-wrap: nowrap !important;
+          }
+        `}</style>
+      </Box>
+    </PageBlock>
+  );
+};
+
+export default UnreviewedChangeRequests;

--- a/src/frontend/src/utils/change-request.utils.ts
+++ b/src/frontend/src/utils/change-request.utils.ts
@@ -3,8 +3,70 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { StandardChangeRequest } from 'shared';
+import { ChangeRequest, equalsWbsNumber, Project, StandardChangeRequest, User, WorkPackage } from 'shared';
+import { makeTeamList } from './teams.utils';
 
 export const hasProposedChanges = (cr: StandardChangeRequest) => {
   return cr.workPackageProposedChanges || cr.projectProposedChanges;
+};
+
+export const getCRsToReview = (
+  projects: Project[],
+  workPackages: WorkPackage[],
+  user: User,
+  changeRequests: ChangeRequest[]
+): ChangeRequest[] => {
+  // projects whose change requests the user would have to review
+  const myProjects = projects.filter((project: Project) => {
+    const projectMemberIds = project.teams.flatMap((team) => makeTeamList(team)).map((user) => user.userId);
+    return (
+      projectMemberIds.includes(user.userId) ||
+      (project.lead && project.lead.userId === user.userId) ||
+      (project.manager && project.manager.userId === user.userId)
+    );
+  });
+
+  // work packages whose change requests the user would have to review
+  const myWorkPackages = workPackages.filter(
+    (wp: WorkPackage) =>
+      (wp.lead ? wp.lead.userId === user.userId : false) || (wp.manager ? wp.manager.userId === user.userId : false)
+  );
+
+  // all of the wbs numbers (in x.x.x string format) corresponding to projects and work packages
+  // whose change requests the user would have to review
+  const myWbsNumbers = myProjects
+    .map((project: Project) => project.wbsNum)
+    .concat(myWorkPackages.map((wp: WorkPackage) => wp.wbsNum));
+  const crToReview = changeRequests
+    .filter(
+      (cr) =>
+        !cr.dateReviewed &&
+        cr.submitter.userId !== user.userId &&
+        (myWbsNumbers.some((wbsNum) => equalsWbsNumber(wbsNum, cr.wbsNum)) ||
+          cr.requestedReviewers.map((user) => user.userId).includes(user.userId))
+    )
+    .sort((a, b) => b.dateSubmitted.getTime() - a.dateSubmitted.getTime());
+  return crToReview;
+};
+
+export const getCRsUnreviewed = (user: User, changeRequests: ChangeRequest[]) => {
+  const crUnreviewed = changeRequests
+    .filter((cr: ChangeRequest) => !cr.dateReviewed && cr.submitter.userId === user.userId)
+    .sort((a, b) => b.dateSubmitted.getTime() - a.dateSubmitted.getTime());
+  return crUnreviewed;
+};
+
+export const getCRsApproved = (user: User, changeRequests: ChangeRequest[]) => {
+  const currentDate = new Date();
+  const crApproved = changeRequests
+    .filter(
+      (cr: ChangeRequest) =>
+        cr.dateReviewed &&
+        cr.accepted &&
+        cr.submitter.userId === user.userId &&
+        currentDate.getTime() - cr.dateReviewed.getTime() <= 1000 * 60 * 60 * 24 * 5
+    )
+    .sort((a, b) => (a.dateReviewed && b.dateReviewed ? b.dateReviewed.getTime() - a.dateReviewed.getTime() : 0));
+
+  return crApproved;
 };


### PR DESCRIPTION
## Changes

- Added a component that displays any change requests that currently requires a user's review.
- refactored duplicate code for producing change requests into change request utils file

## Notes

Had to override overflow in the`ChangeRequestRow` component to make it scroll. Also, change request cards are somewhat difficult to see but I couldn't change the color while also using the `ChangeRequestRow`, so lmk if I should just display them myself. 

## Screenshots

<img width="1452" alt="CRsScroll" src="https://github.com/user-attachments/assets/de764777-476d-4299-b873-881be455b9c7">
<img width="1447" alt="CRsEmpty" src="https://github.com/user-attachments/assets/df1907e0-f647-42f9-9e57-0abb5ed0be3b">

Closes #2803 
