### PR TITLE
#2849 added set description endpoint for organizations

### DIFF
--- a/src/backend/src/controllers/organizations.controller.ts
+++ b/src/backend/src/controllers/organizations.controller.ts
@@ -85,4 +85,18 @@ export default class OrganizationsController {
       next(error);
     }
   }
+
+  static async setOrganizationDescription(req: Request, res: Response, next: NextFunction) {
+    try {
+      const updatedOrg = await OrganizationsService.setOrganizationDescription(
+        req.body.description,
+        req.currentUser,
+        req.organization
+      );
+
+      return res.status(200).json(updatedOrg);
+    } catch (error: unknown) {
+      return next(error);
+    }
+  }
 }

--- a/src/backend/src/controllers/organizations.controller.ts
+++ b/src/backend/src/controllers/organizations.controller.ts
@@ -108,7 +108,7 @@ export default class OrganizationsController {
       return next(error);
     }
   }
-      
+
   static async getOrganizationFeaturedProjects(req: Request, res: Response, next: NextFunction) {
     try {
       const featuredProjects = await OrganizationsService.getOrganizationFeaturedProjects(req.organization.organizationId);

--- a/src/backend/src/routes/organizations.routes.ts
+++ b/src/backend/src/routes/organizations.routes.ts
@@ -28,4 +28,10 @@ organizationRouter.post(
 );
 organizationRouter.post('/logo/update', upload.single('logo'), OrganizationsController.setLogoImage);
 organizationRouter.get('/logo', OrganizationsController.getOrganizationLogoImage);
+organizationRouter.post(
+  '/description/set',
+  body('description').isString(),
+  validateInputs,
+  OrganizationsController.setOrganizationDescription
+);
 export default organizationRouter;

--- a/src/backend/src/services/organizations.services.ts
+++ b/src/backend/src/services/organizations.services.ts
@@ -211,10 +211,11 @@ export default class OrganizationsService {
   }
 
   /**
-   *
-   * @param description
-   * @param submitter
-   * @param organization
+   * Sets the description of a given organization.
+   * @param description the new description
+   * @param submitter the user making the change (must be admin)
+   * @param organization the organization whos description is changing
+   * @throws if the user is not an admin
    */
   static async setOrganizationDescription(
     description: string,

--- a/src/backend/src/services/organizations.services.ts
+++ b/src/backend/src/services/organizations.services.ts
@@ -254,7 +254,8 @@ export default class OrganizationsService {
       }
     });
     return updatedOrg;
-    }
+  }
+
   /**
    * Gets the featured projects for the given organization Id
    * @param organizationId the organization to get the projects for

--- a/src/backend/src/services/organizations.services.ts
+++ b/src/backend/src/services/organizations.services.ts
@@ -209,4 +209,29 @@ export default class OrganizationsService {
 
     return organization.logoImageId;
   }
+
+  /**
+   *
+   * @param description
+   * @param submitter
+   * @param organization
+   */
+  static async setOrganizationDescription(
+    description: string,
+    submitter: User,
+    organization: Organization
+  ): Promise<Organization> {
+    if (!(await userHasPermission(submitter.userId, organization.organizationId, isAdmin))) {
+      throw new AccessDeniedAdminOnlyException('set description');
+    }
+    const updatedOrg = prisma.organization.update({
+      where: {
+        organizationId: organization.organizationId
+      },
+      data: {
+        description
+      }
+    });
+    return updatedOrg;
+  }
 }

--- a/src/backend/tests/unmocked/organization.test.ts
+++ b/src/backend/tests/unmocked/organization.test.ts
@@ -255,4 +255,37 @@ describe('Team Type Tests', () => {
       expect(image).toBe('uploaded-image1.png');
     });
   });
+
+  describe('Set Organization Description', () => {
+    it('Fails if user is not an admin', async () => {
+      await expect(
+        OrganizationsService.setOrganizationDescription(
+          'test description',
+          await createTestUser(wonderwomanGuest, orgId),
+          organization
+        )
+      ).rejects.toThrow(new AccessDeniedAdminOnlyException('set description'));
+    });
+
+    it('Succeeds and updates the description', async () => {
+      const testBatman = await createTestUser(batmanAppAdmin, orgId);
+
+      const returnedOrganization = await OrganizationsService.setOrganizationDescription(
+        'sample description',
+        testBatman,
+        organization
+      );
+
+      const oldOrganization = await prisma.organization.findUnique({
+        where: {
+          organizationId: orgId
+        }
+      });
+
+      expect(oldOrganization).not.toBeNull();
+      expect(oldOrganization?.description).toBe('sample description');
+      expect(oldOrganization?.organizationId).toBe(returnedOrganization.organizationId);
+      expect(oldOrganization?.description).toBe(returnedOrganization.description);
+    });
+  });
 });


### PR DESCRIPTION
## Changes

Added a set description endpoint to organizations in the path 'organizations/description/set' that takes in a string and updates the description of the user's organization. Requires the user to be an admin. Returns the new organization.

## Test Cases

- The user is not an admin --> fails
- The user is an admin and the description gets updated

## Screenshots

<img width="1144" alt="SetDescriptionPostman" src="https://github.com/user-attachments/assets/8fd73d86-0ff6-44d1-9244-abdd37742786">

Closes #2849 
