### PR TITLE
#1586 - Add Date Picker to Reimbursement Delivered Confirmation Modal

### DIFF
--- a/src/backend/src/controllers/reimbursement-requests.controllers.ts
+++ b/src/backend/src/controllers/reimbursement-requests.controllers.ts
@@ -325,11 +325,13 @@ export default class ReimbursementRequestsController {
   static async markReimbursementRequestAsDelivered(req: Request, res: Response, next: NextFunction) {
     try {
       const { requestId } = req.params;
+      const { dateDelivered } = req.body;
 
       const updatedRequest = await ReimbursementRequestService.markReimbursementRequestAsDelivered(
         req.currentUser,
         requestId,
-        req.organization
+        req.organization,
+        dateDelivered
       );
       return res.status(200).json(updatedRequest);
     } catch (error: unknown) {

--- a/src/backend/src/services/notifications.services.ts
+++ b/src/backend/src/services/notifications.services.ts
@@ -7,7 +7,7 @@ import {
   usersToSlackPings
 } from '../utils/notifications.utils';
 import { sendMessage } from '../integrations/slack';
-import { daysBetween, wbsPipe } from 'shared';
+import { daysBetween, startOfDay, wbsPipe } from 'shared';
 import { buildDueString } from '../utils/slack.utils';
 import WorkPackagesService from './work-packages.services';
 import { addWeeksToDate } from 'shared';
@@ -117,15 +117,14 @@ export default class NotificationsService {
    * Sends the design review slack notifications for all design reviews scheduled for today
    */
   static async sendDesignReviewSlackNotifications() {
-    const endOfDay = startOfDayTomorrow();
-    const startOfDay = new Date();
-    startOfDay.setHours(0, 0, 0, 0);
+    const endOfToday = startOfDayTomorrow();
+    const startOfToday = startOfDay(new Date());
 
     const designReviews = await prisma.design_Review.findMany({
       where: {
         dateScheduled: {
-          lt: endOfDay,
-          gte: startOfDay
+          lt: endOfToday,
+          gte: startOfToday
         },
         status: 'SCHEDULED',
         dateDeleted: null

--- a/src/backend/src/services/reimbursement-requests.services.ts
+++ b/src/backend/src/services/reimbursement-requests.services.ts
@@ -775,9 +775,6 @@ export default class ReimbursementRequestService {
     const startOfDay = (date: Date): Date => {
       return new Date(new Date(date).setHours(0, 0, 0, 0));
     };
-    const startOfNextDay = (date: Date): Date => {
-      return new Date(new Date(date).setHours(24, 0, 0, 0));
-    };
 
     const reimbursementRequest = await prisma.reimbursement_Request.findUnique({
       where: { reimbursementRequestId }
@@ -792,7 +789,8 @@ export default class ReimbursementRequestService {
       throw new InvalidOrganizationException('Reimbursement Request');
     if (reimbursementRequest.dateOfExpense && startOfDay(dateDelivered) < startOfDay(reimbursementRequest.dateOfExpense))
       throw new HttpException(400, 'Items cannot be delivered before the expense date.');
-    if (startOfNextDay(dateDelivered) > new Date()) throw new HttpException(400, 'Delivery date cannot be in the future.');
+    if (startOfDay(dateDelivered) > startOfDay(new Date()))
+      throw new HttpException(400, 'Delivery date cannot be in the future.');
 
     const reimbursementRequestDelivered = await prisma.reimbursement_Request.update({
       where: { reimbursementRequestId },

--- a/src/backend/src/services/reimbursement-requests.services.ts
+++ b/src/backend/src/services/reimbursement-requests.services.ts
@@ -761,6 +761,7 @@ export default class ReimbursementRequestService {
    * @param submitter The User marking the request as delivered
    * @param requestId The ID of the reimbursement request to be marked as delivered
    * @param organizationId The organization the user is currently in
+   * @param dateDelivered The date the reimbursed items were delivered
    * @throws NotFoundException if the id is invalid or not there
    * @throws AccessDeniedException if the creator of the request is not the submitter
    * @returns the updated reimbursement request
@@ -768,7 +769,8 @@ export default class ReimbursementRequestService {
   static async markReimbursementRequestAsDelivered(
     submitter: User,
     reimbursementRequestId: string,
-    organization: Organization
+    organization: Organization,
+    dateDelivered: Date
   ) {
     const reimbursementRequest = await prisma.reimbursement_Request.findUnique({
       where: { reimbursementRequestId }
@@ -784,9 +786,7 @@ export default class ReimbursementRequestService {
 
     const reimbursementRequestDelivered = await prisma.reimbursement_Request.update({
       where: { reimbursementRequestId },
-      data: {
-        dateDelivered: new Date()
-      }
+      data: { dateDelivered }
     });
 
     return reimbursementRequestDelivered;

--- a/src/backend/src/services/reimbursement-requests.services.ts
+++ b/src/backend/src/services/reimbursement-requests.services.ts
@@ -18,7 +18,8 @@ import {
   WbsReimbursementProductCreateArgs,
   OtherReimbursementProductCreateArgs,
   AccountCode,
-  ReimbursementStatus
+  ReimbursementStatus,
+  startOfDay
 } from 'shared';
 import prisma from '../prisma/prisma';
 import {
@@ -772,10 +773,6 @@ export default class ReimbursementRequestService {
     organization: Organization,
     dateDelivered: Date
   ) {
-    const startOfDay = (date: Date): Date => {
-      return new Date(new Date(date).setHours(0, 0, 0, 0));
-    };
-
     const reimbursementRequest = await prisma.reimbursement_Request.findUnique({
       where: { reimbursementRequestId }
     });

--- a/src/frontend/src/apis/finance.api.ts
+++ b/src/frontend/src/apis/finance.api.ts
@@ -7,7 +7,8 @@ import {
   EditReimbursementRequestPayload,
   EditVendorPayload,
   AccountCodePayload,
-  RefundPayload
+  RefundPayload,
+  MarkDeliveredRequestPayload
 } from '../hooks/finance.hooks';
 import axios from '../utils/axios';
 import { apiUrls } from '../utils/urls';
@@ -53,8 +54,8 @@ export const createReimbursementRequest = (formData: CreateReimbursementRequestP
  * @param id id of the reimbursement request being marked as delivered
  * @returns the updated reimbursement request
  */
-export const markReimbursementRequestAsDelivered = (id: string) => {
-  return axios.post(apiUrls.financeMarkAsDelivered(id));
+export const markReimbursementRequestAsDelivered = (id: string, formData: MarkDeliveredRequestPayload) => {
+  return axios.post(apiUrls.financeMarkAsDelivered(id), formData);
 };
 
 /**

--- a/src/frontend/src/hooks/finance.hooks.ts
+++ b/src/frontend/src/hooks/finance.hooks.ts
@@ -85,6 +85,10 @@ export interface RefundPayload {
   dateReceived: string;
 }
 
+export interface MarkDeliveredRequestPayload {
+  dateDelivered: Date;
+}
+
 /**
  * Custom React Hook to upload a new picture.
  */
@@ -232,10 +236,10 @@ export const useAllReimbursements = () => {
  */
 export const useMarkReimbursementRequestAsDelivered = (id: string) => {
   const queryClient = useQueryClient();
-  return useMutation<ReimbursementRequest, Error>(
+  return useMutation<ReimbursementRequest, Error, MarkDeliveredRequestPayload>(
     ['reimbursement-requests', 'edit'],
-    async () => {
-      const { data } = await markReimbursementRequestAsDelivered(id);
+    async (markDeliveredData: MarkDeliveredRequestPayload) => {
+      const { data } = await markReimbursementRequestAsDelivered(id, markDeliveredData);
       return data;
     },
     {

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/MarkDeliveredModal.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/MarkDeliveredModal.tsx
@@ -1,0 +1,113 @@
+import { Controller, useForm } from 'react-hook-form';
+import NERFormModal from '../../../components/NERFormModal';
+import { useMarkReimbursementRequestAsDelivered } from '../../../hooks/finance.hooks';
+import { useToast } from '../../../hooks/toasts.hooks';
+import * as yup from 'yup';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { FormControl, FormControlLabel, FormLabel, Radio, RadioGroup } from '@mui/material';
+import { DatePicker } from '@mui/x-date-pickers';
+
+const schema = yup.object().shape({
+  dateDelivered: yup.date().required('Must provide delivery date.'),
+  confirmDelivered: yup
+    .boolean()
+    .required('Please confirm items delivered.')
+    .test('is-true', 'Please confirm', (value) => value === true)
+});
+
+interface MarkDeliveredModalProps {
+  modalShow: boolean;
+  onHide: () => void;
+  reimbursementRequestId: string;
+}
+
+const MarkDeliveredModal = ({ modalShow, onHide, reimbursementRequestId }: MarkDeliveredModalProps) => {
+  const toast = useToast();
+  const { mutateAsync: markDelivered } = useMarkReimbursementRequestAsDelivered(reimbursementRequestId);
+
+  const dateIsInTheFuture = (date: Date) => {
+    const now = new Date();
+    return date > now;
+  };
+
+  const {
+    handleSubmit,
+    control,
+    formState: { errors, isValid },
+    reset
+  } = useForm({
+    resolver: yupResolver(schema),
+    defaultValues: {
+      dateDelivered: new Date(),
+      confirmDelivered: false
+    },
+    mode: 'onChange'
+  });
+
+  const handleMarkDelivered = async (data: { dateDelivered: Date; confirmDelivered: boolean }) => {
+    if (!data.confirmDelivered) {
+      toast.error('Delivery not confirmed!');
+    }
+    try {
+      await markDelivered({ dateDelivered: data.dateDelivered });
+      toast.success('Marked as delivered!');
+      onHide();
+    } catch (e: unknown) {
+      if (e instanceof Error) {
+        toast.error(e.message, 3000);
+      }
+    }
+  };
+
+  return (
+    <NERFormModal
+      open={modalShow}
+      onHide={onHide}
+      title="Confirm Items Delivered"
+      submitText="Submit"
+      reset={reset}
+      handleUseFormSubmit={handleSubmit}
+      onFormSubmit={handleMarkDelivered}
+    >
+      <FormControl fullWidth>
+        <FormLabel>Date Final Item Delivered (MM-DD-YYYY)</FormLabel>
+        <Controller
+          name="dateDelivered"
+          control={control}
+          render={({ field: { onChange, value } }) => (
+            <DatePicker
+              format="MM-dd-yyyy"
+              onChange={(date) => onChange(date ?? new Date())}
+              className={'padding: 10'}
+              value={value}
+              shouldDisableDate={dateIsInTheFuture}
+              slotProps={{ textField: { autoComplete: 'off' } }}
+            />
+          )}
+        />
+        <FormLabel>Are you sure the items in this reimbursement request have all been delivered?</FormLabel>
+        <Controller
+          name="confirmDelivered"
+          control={control}
+          render={({ field: { onChange, value } }) => (
+            <RadioGroup
+              value={value}
+              row
+              aria-labelledby="demo-row-radio-buttons-group-label"
+              name="row-radio-buttons-group"
+              onChange={onChange}
+            >
+              <FormControlLabel value={true} control={<Radio />} label="Yes" />
+              <FormControlLabel value={false} control={<Radio />} label="No" />
+              {errors.confirmDelivered ? (
+                <p style={{ color: 'red', fontSize: '12px' }}>Please confirm all items delivered before proceeding.</p>
+              ) : null}
+            </RadioGroup>
+          )}
+        />
+      </FormControl>
+    </NERFormModal>
+  );
+};
+
+export default MarkDeliveredModal;

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/MarkDeliveredModal.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/MarkDeliveredModal.tsx
@@ -92,7 +92,11 @@ const MarkDeliveredModal = ({ modalShow, onHide, reimbursementRequest }: MarkDel
             />
           )}
         />
-        <FormLabel>Are you sure the items in this reimbursement request have all been delivered?</FormLabel>
+      </FormControl>
+      <FormControl>
+        <FormLabel sx={{ marginTop: '1rem' }}>
+          Are you sure the items in this reimbursement request have all been delivered?
+        </FormLabel>
         <Controller
           name="confirmDelivered"
           control={control}

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/MarkDeliveredModal.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/MarkDeliveredModal.tsx
@@ -28,9 +28,7 @@ const MarkDeliveredModal = ({ modalShow, onHide, reimbursementRequest }: MarkDel
 
   const dateIsBeforeExpenseCreated = (date: Date): boolean => {
     if (!reimbursementRequest.dateOfExpense) return false;
-    else {
-      return date < new Date(new Date(reimbursementRequest.dateOfExpense).setHours(0, 0, 0, 0));
-    }
+    return date < new Date(new Date(reimbursementRequest.dateOfExpense).setHours(0, 0, 0, 0));
   };
 
   const dateIsInTheFuture = (date: Date) => {

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/MarkDeliveredModal.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/MarkDeliveredModal.tsx
@@ -6,7 +6,7 @@ import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { FormControl, FormControlLabel, FormLabel, Radio, RadioGroup } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers';
-import { ReimbursementRequest } from 'shared';
+import { ReimbursementRequest, startOfDay } from 'shared';
 
 const schema = yup.object().shape({
   dateDelivered: yup.date().required('Must provide delivery date.'),
@@ -28,11 +28,11 @@ const MarkDeliveredModal = ({ modalShow, onHide, reimbursementRequest }: MarkDel
 
   const dateIsBeforeExpenseCreated = (date: Date): boolean => {
     if (!reimbursementRequest.dateOfExpense) return false;
-    return date < new Date(new Date(reimbursementRequest.dateOfExpense).setHours(0, 0, 0, 0));
+    return date < startOfDay(reimbursementRequest.dateOfExpense);
   };
 
   const dateIsInTheFuture = (date: Date) => {
-    const now = new Date(new Date().setHours(0, 0, 0, 0));
+    const now = startOfDay(new Date());
     return date > now;
   };
 
@@ -55,7 +55,7 @@ const MarkDeliveredModal = ({ modalShow, onHide, reimbursementRequest }: MarkDel
       toast.error('Delivery not confirmed!');
     }
     try {
-      await markDelivered({ dateDelivered: new Date(data.dateDelivered.setHours(0, 0, 0, 0)) });
+      await markDelivered({ dateDelivered: startOfDay(data.dateDelivered) });
       toast.success('Marked as delivered!');
       onHide();
     } catch (e: unknown) {

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/MarkDeliveredModal.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/MarkDeliveredModal.tsx
@@ -34,7 +34,7 @@ const MarkDeliveredModal = ({ modalShow, onHide, reimbursementRequest }: MarkDel
   };
 
   const dateIsInTheFuture = (date: Date) => {
-    const now = new Date();
+    const now = new Date(new Date().setHours(0, 0, 0, 0));
     return date > now;
   };
 
@@ -57,7 +57,7 @@ const MarkDeliveredModal = ({ modalShow, onHide, reimbursementRequest }: MarkDel
       toast.error('Delivery not confirmed!');
     }
     try {
-      await markDelivered({ dateDelivered: data.dateDelivered });
+      await markDelivered({ dateDelivered: new Date(data.dateDelivered.setHours(0, 0, 0, 0)) });
       toast.success('Marked as delivered!');
       onHide();
     } catch (e: unknown) {

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/MarkDeliveredModal.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/MarkDeliveredModal.tsx
@@ -33,7 +33,7 @@ const MarkDeliveredModal = ({ modalShow, onHide, reimbursementRequestId }: MarkD
   const {
     handleSubmit,
     control,
-    formState: { errors, isValid },
+    formState: { errors },
     reset
   } = useForm({
     resolver: yupResolver(schema),
@@ -68,6 +68,7 @@ const MarkDeliveredModal = ({ modalShow, onHide, reimbursementRequestId }: MarkD
       reset={reset}
       handleUseFormSubmit={handleSubmit}
       onFormSubmit={handleMarkDelivered}
+      formId={'confirm-delivered-form'}
     >
       <FormControl fullWidth>
         <FormLabel>Date Final Item Delivered (MM-DD-YYYY)</FormLabel>

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/MarkDeliveredModal.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/MarkDeliveredModal.tsx
@@ -6,6 +6,7 @@ import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { FormControl, FormControlLabel, FormLabel, Radio, RadioGroup } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers';
+import { ReimbursementRequest } from 'shared';
 
 const schema = yup.object().shape({
   dateDelivered: yup.date().required('Must provide delivery date.'),
@@ -18,12 +19,19 @@ const schema = yup.object().shape({
 interface MarkDeliveredModalProps {
   modalShow: boolean;
   onHide: () => void;
-  reimbursementRequestId: string;
+  reimbursementRequest: ReimbursementRequest;
 }
 
-const MarkDeliveredModal = ({ modalShow, onHide, reimbursementRequestId }: MarkDeliveredModalProps) => {
+const MarkDeliveredModal = ({ modalShow, onHide, reimbursementRequest }: MarkDeliveredModalProps) => {
   const toast = useToast();
-  const { mutateAsync: markDelivered } = useMarkReimbursementRequestAsDelivered(reimbursementRequestId);
+  const { mutateAsync: markDelivered } = useMarkReimbursementRequestAsDelivered(reimbursementRequest.reimbursementRequestId);
+
+  const dateIsBeforeExpenseCreated = (date: Date): boolean => {
+    if (!reimbursementRequest.dateOfExpense) return false;
+    else {
+      return date < new Date(new Date(reimbursementRequest.dateOfExpense).setHours(0, 0, 0, 0));
+    }
+  };
 
   const dateIsInTheFuture = (date: Date) => {
     const now = new Date();
@@ -81,7 +89,7 @@ const MarkDeliveredModal = ({ modalShow, onHide, reimbursementRequestId }: MarkD
               onChange={(date) => onChange(date ?? new Date())}
               className={'padding: 10'}
               value={value}
-              shouldDisableDate={dateIsInTheFuture}
+              shouldDisableDate={(date) => dateIsBeforeExpenseCreated(date) || dateIsInTheFuture(date)}
               slotProps={{ textField: { autoComplete: 'off' } }}
             />
           )}

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/MarkDeliveredModal.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/MarkDeliveredModal.tsx
@@ -26,7 +26,8 @@ const MarkDeliveredModal = ({ modalShow, onHide, reimbursementRequest }: MarkDel
   const toast = useToast();
   const { mutateAsync: markDelivered } = useMarkReimbursementRequestAsDelivered(reimbursementRequest.reimbursementRequestId);
 
-  const dateIsBeforeExpenseCreated = (date: Date): boolean => {
+  // is the given date before the date the expense happened (not when it was reported to FinishLine)?
+  const dateIsBeforeExpense = (date: Date): boolean => {
     if (!reimbursementRequest.dateOfExpense) return false;
     return date < startOfDay(reimbursementRequest.dateOfExpense);
   };
@@ -87,7 +88,7 @@ const MarkDeliveredModal = ({ modalShow, onHide, reimbursementRequest }: MarkDel
               onChange={(date) => onChange(date ?? new Date())}
               className={'padding: 10'}
               value={value}
-              shouldDisableDate={(date) => dateIsBeforeExpenseCreated(date) || dateIsInTheFuture(date)}
+              shouldDisableDate={(date) => dateIsBeforeExpense(date) || dateIsInTheFuture(date)}
               slotProps={{ textField: { autoComplete: 'off' } }}
             />
           )}

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
@@ -25,7 +25,6 @@ import {
   useDenyReimbursementRequest,
   useLeadershipApproveReimbursementRequest,
   useMarkPendingFinance,
-  useMarkReimbursementRequestAsDelivered,
   useMarkReimbursementRequestAsReimbursed,
   useRequestReimbursementRequestChanges
 } from '../../../hooks/finance.hooks';
@@ -56,6 +55,7 @@ import SubmitToSaboModal from './SubmitToSaboModal';
 import DownloadIcon from '@mui/icons-material/Download';
 import ReimbursementRequestStatusPill from '../../../components/ReimbursementRequestStatusPill';
 import CheckList from '../../../components/CheckList';
+import MarkDeliveredModal from './MarkDeliveredModal';
 
 interface ReimbursementRequestDetailsViewProps {
   reimbursementRequest: ReimbursementRequest;
@@ -80,7 +80,6 @@ const ReimbursementRequestDetailsView: React.FC<ReimbursementRequestDetailsViewP
     reimbursementRequest.reimbursementRequestId
   );
   const { mutateAsync: denyReimbursementRequest } = useDenyReimbursementRequest(reimbursementRequest.reimbursementRequestId);
-  const { mutateAsync: markDelivered } = useMarkReimbursementRequestAsDelivered(reimbursementRequest.reimbursementRequestId);
   const { mutateAsync: markReimbursed } = useMarkReimbursementRequestAsReimbursed(
     reimbursementRequest.reimbursementRequestId
   );
@@ -112,17 +111,6 @@ const ReimbursementRequestDetailsView: React.FC<ReimbursementRequestDetailsViewP
     try {
       await denyReimbursementRequest();
       setShowDenyModal(false);
-    } catch (e: unknown) {
-      if (e instanceof Error) {
-        toast.error(e.message, 3000);
-      }
-    }
-  };
-
-  const handleMarkDelivered = async () => {
-    try {
-      await markDelivered();
-      setShowMarkDelivered(false);
     } catch (e: unknown) {
       if (e instanceof Error) {
         toast.error(e.message, 3000);
@@ -224,19 +212,6 @@ const ReimbursementRequestDetailsView: React.FC<ReimbursementRequestDetailsViewP
       </NERModal>
     );
   };
-
-  const MarkDeliveredModal = () => (
-    <NERModal
-      open={showMarkDelivered}
-      onHide={() => setShowMarkDelivered(false)}
-      title="Warning!"
-      cancelText="No"
-      submitText="Yes"
-      onSubmit={handleMarkDelivered}
-    >
-      <Typography>Are you sure the items in this reimbursement request have all been delivered?</Typography>
-    </NERModal>
-  );
 
   const MarkReimbursedModal = () => (
     <NERModal
@@ -511,7 +486,11 @@ const ReimbursementRequestDetailsView: React.FC<ReimbursementRequestDetailsViewP
     >
       <DeleteModal />
       <DenyModal />
-      <MarkDeliveredModal />
+      <MarkDeliveredModal
+        modalShow={showMarkDelivered}
+        onHide={() => setShowMarkDelivered(false)}
+        reimbursementRequestId={reimbursementRequest.reimbursementRequestId}
+      />
       <MarkReimbursedModal />
       <LeadershipApproveModal />
       <MarkPendingFinanceModal />

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
@@ -489,7 +489,7 @@ const ReimbursementRequestDetailsView: React.FC<ReimbursementRequestDetailsViewP
       <MarkDeliveredModal
         modalShow={showMarkDelivered}
         onHide={() => setShowMarkDelivered(false)}
-        reimbursementRequestId={reimbursementRequest.reimbursementRequestId}
+        reimbursementRequest={reimbursementRequest}
       />
       <MarkReimbursedModal />
       <LeadershipApproveModal />

--- a/src/shared/src/date-utils.ts
+++ b/src/shared/src/date-utils.ts
@@ -36,6 +36,16 @@ const getDay = (date: Date): number => {
 };
 
 /**
+ * Gets the beginning of the day
+ * @returns the beginning of the day (at 12am local)
+ */
+export const startOfDay = (date: Date): Date => {
+  const ret = new Date(date);
+  ret.setHours(0, 0, 0, 0);
+  return ret;
+};
+
+/**
  * Calculate the days between two dates
  */
 const daysBetween = (date1: Date, date2: Date): number => {


### PR DESCRIPTION
## Changes

Add Calendar Selector to Date Delivered modal so people can select date delivered so it's not always today

## Notes

Changed confirm button from useless checkbox to validated Yes/No (No by default, you have to manually move it to yes)

Calendar has filters in FE and BE so (dateOfExpense <= dateDelivered <= today). Some timezone shenanigans but I think it works

## Test Cases

See screenshots

- Click "No, not delivered" 
- Edge cases for calendar validation (not in screenshots)
- The Working Case: Delivery date added as expected

## Screenshots

_If you made UI changes you must post a screenshot of the whole page for each change in 1) a normal sized window and 2) the smallest possible window_
<img width="1440" alt="Screenshot 2024-10-22 at 8 44 07 PM" src="https://github.com/user-attachments/assets/5f4435c0-4335-4a0e-91c8-2d1289eaaf93">
<img width="500" alt="Screenshot 2024-10-22 at 8 44 17 PM" src="https://github.com/user-attachments/assets/47ca8802-1e52-46fe-85ba-77e3ee892562">

Refuse to submit if you don't confirm
<img width="700" alt="Screenshot 2024-10-22 at 8 44 35 PM" src="https://github.com/user-attachments/assets/5174d4a9-46d7-40b3-ba88-af4b7a5117ad">

Calendar disabled in FE
![Screenshot 2024-09-25 at 8 27 16 AM](https://github.com/user-attachments/assets/ba0c5e81-e826-4e96-ab4e-1d278daea4a4)

Date is updated!
![Screenshot 2024-09-25 at 8 43 10 AM](https://github.com/user-attachments/assets/bc590f8b-91e7-4652-8c3b-08fd6a3d8c7d)

_If you did any manual testing (e.g., with Postman), put screenshots of the http request and before and after of the db_

Too Early
![Screenshot 2024-09-25 at 8 41 15 AM](https://github.com/user-attachments/assets/3c38c4bd-dbe5-4fa9-bda8-81f6fa6151b6)

Too Late
![Screenshot 2024-09-25 at 8 42 31 AM](https://github.com/user-attachments/assets/a8a5669b-6611-4fb0-9652-3404d89991f0)

Just Right
![Screenshot 2024-09-25 at 8 42 52 AM](https://github.com/user-attachments/assets/5f47cc3f-e611-417f-ba99-a5b908e462ce)

![Screenshot 2024-09-25 at 8 30 12 AM](https://github.com/user-attachments/assets/74242dbc-3515-4dce-90f9-c5c6ec4d14a7)
![Screenshot 2024-09-25 at 8 43 25 AM](https://github.com/user-attachments/assets/f5421db2-f3c1-412a-8a92-00c10f77a73c)

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #1586 
