### PR TITLE
#2714 FAQs dropdown component

### DIFF
--- a/src/frontend/src/pages/HomePage/components/Dropdown.tsx
+++ b/src/frontend/src/pages/HomePage/components/Dropdown.tsx
@@ -1,0 +1,32 @@
+import { Box, Accordion, AccordionSummary, Typography, AccordionDetails } from '@mui/material';
+
+import { KeyboardArrowDown } from '@mui/icons-material';
+
+interface DropdownProps {
+  title: string;
+  description: string;
+}
+
+const Dropdown = ({ title, description }: DropdownProps) => {
+  return (
+    <Box marginBottom={2}>
+      <Accordion
+        sx={{
+          backgroundColor: '#ef4244'
+        }}
+      >
+        <AccordionSummary
+          expandIcon={<KeyboardArrowDown />}
+          sx={{ flexDirection: 'row-reverse', borderBottomLeftRadius: '100px', borderBottomRightRadius: '100px' }}
+        >
+          <Typography sx={{ color: 'white', fontWeight: 'bold', fontSize: 20 }}>{title}</Typography>
+        </AccordionSummary>
+        <AccordionDetails sx={{ backgroundColor: 'white', borderBottomLeftRadius: '4px', borderBottomRightRadius: '4px' }}>
+          <Typography sx={{ color: 'black' }}>{description}</Typography>
+        </AccordionDetails>
+      </Accordion>
+    </Box>
+  );
+};
+
+export default Dropdown;

--- a/src/frontend/src/pages/HomePage/components/Dropdown.tsx
+++ b/src/frontend/src/pages/HomePage/components/Dropdown.tsx
@@ -1,6 +1,7 @@
 import { Box, Accordion, AccordionSummary, Typography, AccordionDetails } from '@mui/material';
 
-import { KeyboardArrowDown } from '@mui/icons-material';
+import { ChevronRight } from '@mui/icons-material';
+import React, { useState } from 'react';
 
 interface DropdownProps {
   title: string;
@@ -8,17 +9,27 @@ interface DropdownProps {
 }
 
 const Dropdown = ({ title, description }: DropdownProps) => {
+  const [expanded, setExpanded] = useState(false);
+
   return (
     <Box marginBottom={2}>
       <Accordion
+        expanded={expanded}
+        onChange={() => setExpanded(!expanded)}
         sx={{
           backgroundColor: '#ef4244'
         }}
       >
         <AccordionSummary
-          expandIcon={<KeyboardArrowDown />}
           sx={{ flexDirection: 'row-reverse', borderBottomLeftRadius: '100px', borderBottomRightRadius: '100px' }}
         >
+          <ChevronRight
+            sx={{
+              transition: 'transform 0.3s ease',
+              transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)',
+              fontSize: 30
+            }}
+          />
           <Typography sx={{ color: 'white', fontWeight: 'bold', fontSize: 20 }}>{title}</Typography>
         </AccordionSummary>
         <AccordionDetails sx={{ backgroundColor: 'white', borderBottomLeftRadius: '4px', borderBottomRightRadius: '4px' }}>

--- a/src/frontend/src/pages/HomePage/components/FAQsSection.tsx
+++ b/src/frontend/src/pages/HomePage/components/FAQsSection.tsx
@@ -1,8 +1,23 @@
-import { Typography } from '@mui/material';
+import { Box } from '@mui/system';
+import LoadingIndicator from '../../../components/LoadingIndicator';
+import { useAllFaqs } from '../../../hooks/recruitment.hooks';
+import ErrorPage from '../../ErrorPage';
+import Dropdown from './Dropdown';
+import React from 'react';
 
 const FAQsSection = () => {
-  // TODO: Ticket #2714
-  return <Typography>FAQ section</Typography>;
+  const { isLoading, isError, error, data: faqs } = useAllFaqs();
+  if (isLoading || !faqs) return <LoadingIndicator />;
+
+  if (isError) return <ErrorPage message={error.message} />;
+
+  return (
+    <Box sx={{ width: '100%' }}>
+      {faqs.map((faq) => (
+        <Dropdown title={faq.question} description={faq.answer} />
+      ))}
+    </Box>
+  );
 };
 
 export default FAQsSection;


### PR DESCRIPTION
## Changes

Created a dropdown component. Mapped all FAQs with the new dropdown component to the recruitment page. 

## Notes

I could not get the arrow icon to rotate 90º as it does in the example picture I can do some extra styling with the `expandIcon` but I didn't know if it was a big deal. Let me know if you want that to be changed. 

## Screenshots
<img width="1512" alt="Screenshot 2024-09-27 at 5 01 58 PM" src="https://github.com/user-attachments/assets/27c3aa1d-dbe9-447b-b222-e4cccb5a34f8">
<img width="492" alt="Screenshot 2024-09-27 at 5 02 29 PM" src="https://github.com/user-attachments/assets/edd58b4c-3796-4bb4-8bac-53a3bb45864e">
<img width="1512" alt="Screenshot 2024-09-27 at 5 04 43 PM" src="https://github.com/user-attachments/assets/c5b5aaf5-77a9-4808-bd20-54e392cfc171">

## To Do

- Any requested styling changes 

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #2714 
