### PR TITLE
filter out currentUser from CR reviewer options

### DIFF
--- a/src/frontend/src/pages/ChangeRequestDetailPage/ChangeRequestActionMenu.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ChangeRequestActionMenu.tsx
@@ -1,4 +1,4 @@
-import { ChangeRequest, ChangeRequestStatus, isLeadership, wbsPipe } from 'shared';
+import { ChangeRequest, ChangeRequestStatus, isLeadership, UserWithScheduleSettings, wbsPipe } from 'shared';
 import ActionsMenu from '../../components/ActionsMenu';
 import { Autocomplete, Checkbox, TextField, Box } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
@@ -65,6 +65,10 @@ const ChangeRequestActionMenu: React.FC<ChangeRequestActionMenuProps> = ({
   const isRequestAllowed =
     changeRequest.submitter.userId === currentUser.userId && changeRequest.status === ChangeRequestStatus.Open;
 
+  function potentialCrReviewers(value: UserWithScheduleSettings): value is UserWithScheduleSettings {
+    return isLeadership(value.role) && value.userId !== currentUser.userId;
+  }
+
   const UnreviewedActionsDropdown = () => (
     <div style={{ marginTop: '10px' }}>
       <ActionsMenu
@@ -93,7 +97,7 @@ const ChangeRequestActionMenu: React.FC<ChangeRequestActionMenuProps> = ({
         limitTags={1}
         disableCloseOnSelect
         multiple
-        options={users.filter((user) => isLeadership(user.role)).map(taskUserToAutocompleteOption)}
+        options={users.filter(potentialCrReviewers).map(taskUserToAutocompleteOption)}
         getOptionLabel={(option) => option.label}
         onChange={(_, values) => setReviewers(values)}
         defaultValue={reviewers}

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ChangeRequestActionMenu.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ChangeRequestActionMenu.tsx
@@ -65,9 +65,9 @@ const ChangeRequestActionMenu: React.FC<ChangeRequestActionMenuProps> = ({
   const isRequestAllowed =
     changeRequest.submitter.userId === currentUser.userId && changeRequest.status === ChangeRequestStatus.Open;
 
-  function potentialCrReviewers(value: UserWithScheduleSettings): value is UserWithScheduleSettings {
+  const potentialCrReviewers = (value: UserWithScheduleSettings): boolean => {
     return isLeadership(value.role) && value.userId !== currentUser.userId;
-  }
+  };
 
   const UnreviewedActionsDropdown = () => (
     <div style={{ marginTop: '10px' }}>


### PR DESCRIPTION
## Changes
Previously, the current user wasn't being filtered out of CR reviewer options, so they could technically request themselves (at least from a front-end standpoint). The only change was a quick fix to filter out the current user so they can't request themselves on a CR review.
