### PR TITLE
fixed BOM errors

### DIFF
--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/BOMTableWrapper.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/BOMTableWrapper.tsx
@@ -46,13 +46,18 @@ const BOMTableWrapper: React.FC<BOMTableWrapperProps> = ({ project, hideColumn, 
 
   const user = useCurrentUser();
   const toast = useToast();
-  const storedHideColumn = JSON.parse(localStorage.getItem('hideColumn') || 'false');
 
-  if (storedHideColumn === 'false') {
-    setHideColumn(new Array(12).fill(false));
-  } else {
-    setHideColumn(storedHideColumn);
-  }
+  useEffect(() => {
+    const storedHideColumn = JSON.parse(localStorage.getItem('hideColumn') || 'false');
+    if (storedHideColumn === 'false') {
+      setHideColumn((prev) => {
+        const newHideColumn = new Array(12).fill(false);
+        return prev !== newHideColumn ? newHideColumn : prev;
+      });
+    } else {
+      setHideColumn((prev) => (prev !== storedHideColumn ? storedHideColumn : prev));
+    }
+  }, [setHideColumn]);
 
   if (isLoading) return <LoadingIndicator />;
 


### PR DESCRIPTION
Fixed two BOM errors:
1. previously, if you click the "show all columns" button (sometimes you'll have to spam click it a couple of times), an error page would show.
2. previously, if you clicked the "show all columns" button, and then clicked the "new entry" button and tried to fill out information in the modal, an error page would show.

This change fixes both errors. LMK if you want me to do a demo of how to replicate those errors on multitenancy.