### PR TITLE
#2897-getManyUserTasksEndpoint

### DIFF
--- a/src/backend/src/controllers/users.controllers.ts
+++ b/src/backend/src/controllers/users.controllers.ts
@@ -1,6 +1,7 @@
 import { NextFunction, Request, Response } from 'express';
 import UsersService from '../services/users.services';
 import { AccessDeniedException } from '../utils/errors.utils';
+import { Task } from 'shared';
 
 export default class UsersController {
   static async getAllUsers(_req: Request, res: Response, next: NextFunction) {
@@ -184,7 +185,7 @@ export default class UsersController {
     try {
       const { userIds } = req.body;
 
-      const tasks = await UsersService.getManyUserTasks(userIds, req.organization);
+      const tasks: Task[] = await UsersService.getManyUserTasks(userIds, req.organization);
       return res.status(200).json(tasks);
     } catch (error: unknown) {
       return next(error);

--- a/src/backend/src/controllers/users.controllers.ts
+++ b/src/backend/src/controllers/users.controllers.ts
@@ -179,4 +179,15 @@ export default class UsersController {
       return next(error);
     }
   }
+
+  static async getManyUserTasks(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { userIds } = req.body;
+
+      const tasks = await UsersService.getManyUserTasks(userIds, req.organization);
+      return res.status(200).json(tasks);
+    } catch (error: unknown) {
+      return next(error);
+    }
+  }
 }

--- a/src/backend/src/routes/users.routes.ts
+++ b/src/backend/src/routes/users.routes.ts
@@ -47,5 +47,12 @@ userRouter.post(
 userRouter.get('/:userId/secure-settings', UsersController.getUserSecureSettings);
 userRouter.get('/:userId/schedule-settings', UsersController.getUserScheduleSettings);
 userRouter.get('/:userId/tasks', UsersController.getUserTasks);
+userRouter.post(
+  '/tasks/get-many',
+  body('userIds').isArray(),
+  nonEmptyString(body('userIds.*')),
+  validateInputs,
+  UsersController.getManyUserTasks
+);
 
 export default userRouter;

--- a/src/backend/src/services/users.services.ts
+++ b/src/backend/src/services/users.services.ts
@@ -557,6 +557,12 @@ export default class UsersService {
     return requestedUser.assignedTasks.map(taskTransformer);
   }
 
+  /**
+   * Get all tasks from a list of userIds
+   * @param userIds list of users to get the tasks from
+   * @param organization the users' organization
+   * @returns a list of tasks of the given users
+   */
   static async getManyUserTasks(userIds: string[], organization: Organization) {
     const tasksPromises = userIds.map(async (userId) => {
       return UsersService.getUserTasks(userId, organization);

--- a/src/backend/src/services/users.services.ts
+++ b/src/backend/src/services/users.services.ts
@@ -563,6 +563,6 @@ export default class UsersService {
     });
 
     const resolvedTasks = await Promise.all(tasksPromises);
-    return resolvedTasks;
+    return resolvedTasks.flat();
   }
 }

--- a/src/backend/src/services/users.services.ts
+++ b/src/backend/src/services/users.services.ts
@@ -556,4 +556,13 @@ export default class UsersService {
 
     return requestedUser.assignedTasks.map(taskTransformer);
   }
+
+  static async getManyUserTasks(userIds: string[], organization: Organization) {
+    const tasksPromises = userIds.map(async (userId) => {
+      return UsersService.getUserTasks(userId, organization);
+    });
+
+    const resolvedTasks = await Promise.all(tasksPromises);
+    return resolvedTasks;
+  }
 }

--- a/src/backend/tests/unmocked/users.test.ts
+++ b/src/backend/tests/unmocked/users.test.ts
@@ -3,7 +3,6 @@ import { createTestOrganization, createTestTask, createTestUser, resetUsers } fr
 import { batmanAppAdmin, supermanAdmin } from '../test-data/users.test-data';
 import UsersService from '../../src/services/users.services';
 import { NotFoundException } from '../../src/utils/errors.utils';
-import TeamsService from '../../src/services/teams.services';
 
 describe('User Tests', () => {
   let orgId: string;
@@ -26,16 +25,8 @@ describe('User Tests', () => {
 
     it("Succeeds and gets user's assigned tasks", async () => {
       const testBatman = await createTestUser(batmanAppAdmin, orgId);
-      const testTeam = await TeamsService.createTeam(
-        testBatman,
-        'Test Task team',
-        testBatman.userId,
-        'Test',
-        '',
-        false,
-        organization
-      );
-      const { task } = await createTestTask(testBatman, testTeam, organization);
+
+      const { task } = await createTestTask(testBatman, organization);
       const userTasks = await UsersService.getUserTasks(testBatman.userId, organization);
 
       expect(userTasks).toStrictEqual([task]);
@@ -51,21 +42,10 @@ describe('User Tests', () => {
 
     it("Succeeds and gets all user' tasks in the list", async () => {
       const testBatman = await createTestUser(batmanAppAdmin, orgId);
-      const testClarkKent = await createTestUser(supermanAdmin, orgId);
-      const testTeam = await TeamsService.createTeam(
-        testBatman,
-        'Many Tasks Test team',
-        testBatman.userId,
-        'Test',
-        '',
-        false,
-        organization
-      );
-      const { task: batmanTask } = await createTestTask(testBatman, testTeam, organization);
-      const { task: clarkKentTask } = await createTestTask(testClarkKent, testTeam, organization);
-      const userTasks = await UsersService.getManyUserTasks([testBatman.userId, testClarkKent.userId], organization);
+      const { task: batmanTask } = await createTestTask(testBatman, organization);
+      const userTasks = await UsersService.getManyUserTasks([testBatman.userId, testBatman.userId], organization);
 
-      expect(userTasks).toStrictEqual([batmanTask, clarkKentTask]);
+      expect(userTasks).toStrictEqual([batmanTask, batmanTask]);
     });
   });
 });

--- a/src/backend/tests/unmocked/users.test.ts
+++ b/src/backend/tests/unmocked/users.test.ts
@@ -1,6 +1,6 @@
 import { Organization } from '@prisma/client';
 import { createTestOrganization, createTestTask, createTestUser, resetUsers } from '../test-utils';
-import { batmanAppAdmin, supermanAdmin } from '../test-data/users.test-data';
+import { batmanAppAdmin } from '../test-data/users.test-data';
 import UsersService from '../../src/services/users.services';
 import { NotFoundException } from '../../src/utils/errors.utils';
 

--- a/src/backend/tests/unmocked/users.test.ts
+++ b/src/backend/tests/unmocked/users.test.ts
@@ -3,6 +3,7 @@ import { createTestOrganization, createTestTask, createTestUser, resetUsers } fr
 import { batmanAppAdmin, supermanAdmin } from '../test-data/users.test-data';
 import UsersService from '../../src/services/users.services';
 import { NotFoundException } from '../../src/utils/errors.utils';
+import TeamsService from '../../src/services/teams.services';
 
 describe('User Tests', () => {
   let orgId: string;
@@ -25,7 +26,16 @@ describe('User Tests', () => {
 
     it("Succeeds and gets user's assigned tasks", async () => {
       const testBatman = await createTestUser(batmanAppAdmin, orgId);
-      const { task } = await createTestTask(testBatman, organization);
+      const testTeam = await TeamsService.createTeam(
+        testBatman,
+        'Test Task team',
+        testBatman.userId,
+        'Test',
+        '',
+        false,
+        organization
+      );
+      const { task } = await createTestTask(testBatman, testTeam, organization);
       const userTasks = await UsersService.getUserTasks(testBatman.userId, organization);
 
       expect(userTasks).toStrictEqual([task]);
@@ -42,8 +52,17 @@ describe('User Tests', () => {
     it("Succeeds and gets all user' tasks in the list", async () => {
       const testBatman = await createTestUser(batmanAppAdmin, orgId);
       const testClarkKent = await createTestUser(supermanAdmin, orgId);
-      const { task: batmanTask } = await createTestTask(testBatman, organization);
-      const { task: clarkKentTask } = await createTestTask(testClarkKent, organization);
+      const testTeam = await TeamsService.createTeam(
+        testBatman,
+        'Many Tasks Test team',
+        testBatman.userId,
+        'Test',
+        '',
+        false,
+        organization
+      );
+      const { task: batmanTask } = await createTestTask(testBatman, testTeam, organization);
+      const { task: clarkKentTask } = await createTestTask(testClarkKent, testTeam, organization);
       const userTasks = await UsersService.getManyUserTasks([testBatman.userId, testClarkKent.userId], organization);
 
       expect(userTasks).toStrictEqual([batmanTask, clarkKentTask]);

--- a/src/backend/tests/unmocked/users.test.ts
+++ b/src/backend/tests/unmocked/users.test.ts
@@ -1,6 +1,6 @@
 import { Organization } from '@prisma/client';
 import { createTestOrganization, createTestTask, createTestUser, resetUsers } from '../test-utils';
-import { batmanAppAdmin } from '../test-data/users.test-data';
+import { batmanAppAdmin, supermanAdmin } from '../test-data/users.test-data';
 import UsersService from '../../src/services/users.services';
 import { NotFoundException } from '../../src/utils/errors.utils';
 
@@ -29,6 +29,24 @@ describe('User Tests', () => {
       const userTasks = await UsersService.getUserTasks(testBatman.userId, organization);
 
       expect(userTasks).toStrictEqual([task]);
+    });
+  });
+
+  describe('Get Many Users Tasks', () => {
+    it('fails on invalid user id', async () => {
+      await expect(async () => await UsersService.getManyUserTasks(['1'], organization)).rejects.toThrow(
+        new NotFoundException('User', '1')
+      );
+    });
+
+    it("Succeeds and gets all user' tasks in the list", async () => {
+      const testBatman = await createTestUser(batmanAppAdmin, orgId);
+      const testClarkKent = await createTestUser(supermanAdmin, orgId);
+      const { task: batmanTask } = await createTestTask(testBatman, organization);
+      const { task: clarkKentTask } = await createTestTask(testClarkKent, organization);
+      const userTasks = await UsersService.getManyUserTasks([testBatman.userId, testClarkKent.userId], organization);
+
+      expect(userTasks).toStrictEqual([batmanTask, clarkKentTask]);
     });
   });
 });


### PR DESCRIPTION
## Changes

Added a new endpoint to get all tasks within a list of users

## Notes

This was added to get all tasks from a team

## Test Cases

- Invalid User id
- Valid list of user ids

## Screenshots

![Screenshot 2024-10-29 134602](https://github.com/user-attachments/assets/54675eda-699b-44b5-9bda-5cceed4ac395)

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [X] All commits are tagged with the ticket number
- [X] No linting errors / newline at end of file warnings
- [X] All code follows repository-configured prettier formatting
- [X] No merge conflicts
- [X] All checks passing
- [X] Screenshots of UI changes (see Screenshots section)
- [X] Remove any non-applicable sections of this template
- [X] Assign the PR to yourself
- [X] No `yarn.lock` changes (unless dependencies have changed)
- [X] Request reviewers & ping on Slack
- [X] PR is linked to the ticket (fill in the closes line below)

Closes #2897
