### PR TITLE
#2874 Allow admins to mark all reimbursement requests as pending finance

### DIFF
--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
@@ -15,7 +15,7 @@ import { Grid, Typography, useTheme, Link, IconButton } from '@mui/material';
 import { Box } from '@mui/system';
 import { useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { ReimbursementRequest, isHead } from 'shared';
+import { ReimbursementRequest, isAdmin, isHead } from 'shared';
 import ActionsMenu, { ButtonInfo } from '../../../components/ActionsMenu';
 import NERModal from '../../../components/NERModal';
 import PageLayout from '../../../components/PageLayout';
@@ -413,7 +413,7 @@ const ReimbursementRequestDetailsView: React.FC<ReimbursementRequestDetailsViewP
     !isSaboSubmitted &&
     !isReimbursementRequestReimbursed(reimbursementRequest);
 
-  const buttons: ButtonInfo[] = [ 
+  const buttons: ButtonInfo[] = [
     {
       title: 'Edit',
       onClick: () => history.push(`${routes.REIMBURSEMENT_REQUESTS}/${reimbursementRequest.reimbursementRequestId}/edit`),
@@ -468,7 +468,10 @@ const ReimbursementRequestDetailsView: React.FC<ReimbursementRequestDetailsViewP
       title: 'Mark Pending Finance',
       onClick: () => setShowMarkPendingFinanceModal(true),
       icon: <Pending />,
-      disabled: user.userId !== reimbursementRequest.recipient.userId || isPendingFinance || !isLeadershipApproved
+      disabled:
+        isPendingFinance ||
+        !isLeadershipApproved ||
+        (isAdmin(user.role) ? false : user.userId !== reimbursementRequest.recipient.userId)
     },
     {
       title: 'Request Changes',

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
@@ -471,7 +471,7 @@ const ReimbursementRequestDetailsView: React.FC<ReimbursementRequestDetailsViewP
       disabled:
         isPendingFinance ||
         !isLeadershipApproved ||
-        (isAdmin(user.role) ? false : user.userId !== reimbursementRequest.recipient.userId)
+        (!isAdmin(user.role) && user.userId !== reimbursementRequest.recipient.userId)
     },
     {
       title: 'Request Changes',


### PR DESCRIPTION
## Changes

Allow admins to mark all reimbursement requests as pending finance even if it is not theirs

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #2874 