### PR TITLE
#2908 Added limits to the reinbursement receipt's file name

### DIFF
--- a/src/backend/src/utils/google-integration.utils.ts
+++ b/src/backend/src/utils/google-integration.utils.ts
@@ -88,13 +88,11 @@ export const uploadFile = async (fileObject: Express.Multer.File) => {
   const bufferStream = new stream.PassThrough();
   bufferStream.end(fileObject.buffer);
 
-  if (fileObject.filename.length > 20) {
+  if (fileObject.filename.length > 20)
     throw new HttpException(400, 'File name can only be at most 20 characters long');
-  }
   /* The regex /^[\w.]+$/ limits the file name to the set of alphanumeric characters (\w) and dots (for file type) */
-  if (!/^[\w.]+$/.test(fileObject.filename)) {
+  if (!/^[\w.]+$/.test(fileObject.filename))
     throw new HttpException(400, 'File name should only contain letters and numbers');
-  }
 
   oauth2Client.setCredentials({
     refresh_token: DRIVE_REFRESH_TOKEN

--- a/src/backend/src/utils/google-integration.utils.ts
+++ b/src/backend/src/utils/google-integration.utils.ts
@@ -89,11 +89,11 @@ export const uploadFile = async (fileObject: Express.Multer.File) => {
   bufferStream.end(fileObject.buffer);
 
   if (fileObject.filename.length > 20) {
-    throw new HttpException(400, 'File name is too long');
+    throw new HttpException(400, 'File name can only be at most 20 characters long');
   }
-  /* The regex /^[\w\-\s]+$/ limits the file name to the set of alphanumeric characters (\w), hyphens (-), spaces (\s), and dots */
-  if (!/^[\w\-\s.]+$/.test(fileObject.filename)) {
-    throw new HttpException(400, 'File name contains invalid characters');
+  /* The regex /^[\w.]+$/ limits the file name to the set of alphanumeric characters (\w) and dots (for file type) */
+  if (!/^[\w.]+$/.test(fileObject.filename)) {
+    throw new HttpException(400, 'File name should only contain letters and numbers');
   }
 
   oauth2Client.setCredentials({

--- a/src/backend/src/utils/google-integration.utils.ts
+++ b/src/backend/src/utils/google-integration.utils.ts
@@ -88,6 +88,13 @@ export const uploadFile = async (fileObject: Express.Multer.File) => {
   const bufferStream = new stream.PassThrough();
   bufferStream.end(fileObject.buffer);
 
+  if (fileObject.filename.length > 20) {
+    throw new HttpException(400, 'File name is too long');
+  }
+  if (!/^[\w\-\s]+$/.test(fileObject.filename)) {
+    throw new HttpException(400, 'File name contains invalid characters');
+  }
+
   oauth2Client.setCredentials({
     refresh_token: DRIVE_REFRESH_TOKEN
   });

--- a/src/backend/src/utils/google-integration.utils.ts
+++ b/src/backend/src/utils/google-integration.utils.ts
@@ -91,7 +91,8 @@ export const uploadFile = async (fileObject: Express.Multer.File) => {
   if (fileObject.filename.length > 20) {
     throw new HttpException(400, 'File name is too long');
   }
-  if (!/^[\w\-\s]+$/.test(fileObject.filename)) {
+  /* The regex /^[\w\-\s]+$/ limits the file name to the set of alphanumeric characters (\w), hyphens (-), spaces (\s), and dots */
+  if (!/^[\w\-\s.]+$/.test(fileObject.filename)) {
     throw new HttpException(400, 'File name contains invalid characters');
   }
 

--- a/src/backend/src/utils/google-integration.utils.ts
+++ b/src/backend/src/utils/google-integration.utils.ts
@@ -89,8 +89,9 @@ export const uploadFile = async (fileObject: Express.Multer.File) => {
   bufferStream.end(fileObject.buffer);
 
   if (fileObject.filename.length > 20) throw new HttpException(400, 'File name can only be at most 20 characters long');
-  /* The regex /^[\w.]+$/ limits the file name to the set of alphanumeric characters (\w) and dots (for file type) */
-  if (!/^[\w.]+$/.test(fileObject.filename)) throw new HttpException(400, 'File name should only contain letters and numbers');
+  //The regex /^[\w.]+$/ limits the file name to the set of alphanumeric characters (\w) and dots (for file type)
+  if (!/^[\w.]+$/.test(fileObject.filename))
+    throw new HttpException(400, 'File name should only contain letters and numbers');
 
   oauth2Client.setCredentials({
     refresh_token: DRIVE_REFRESH_TOKEN

--- a/src/backend/src/utils/google-integration.utils.ts
+++ b/src/backend/src/utils/google-integration.utils.ts
@@ -88,11 +88,9 @@ export const uploadFile = async (fileObject: Express.Multer.File) => {
   const bufferStream = new stream.PassThrough();
   bufferStream.end(fileObject.buffer);
 
-  if (fileObject.filename.length > 20)
-    throw new HttpException(400, 'File name can only be at most 20 characters long');
+  if (fileObject.filename.length > 20) throw new HttpException(400, 'File name can only be at most 20 characters long');
   /* The regex /^[\w.]+$/ limits the file name to the set of alphanumeric characters (\w) and dots (for file type) */
-  if (!/^[\w.]+$/.test(fileObject.filename))
-    throw new HttpException(400, 'File name should only contain letters and numbers');
+  if (!/^[\w.]+$/.test(fileObject.filename)) throw new HttpException(400, 'File name should only contain letters and numbers');
 
   oauth2Client.setCredentials({
     refresh_token: DRIVE_REFRESH_TOKEN

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
@@ -367,7 +367,7 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
                   onChange={(e) => {
                     if (e.target.files) {
                       [...e.target.files].forEach((file) => {
-                        /* The regex /^[\w\-\s]+$/ limits the input to the set of alphanumeric characters (\w), hyphens (\-), and spaces (\s) */
+                        /* The regex /^[\w\-\s]+$/ limits the file name to the set of alphanumeric characters (\w), hyphens (-), spaces (\s), and dots */
                         if (file.size < 1000000 && file.name.length <= 20 && /^[\w\-\s.]+$/.test(file.name)) {
                           receiptPrepend({
                             file,

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
@@ -367,14 +367,20 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
                   onChange={(e) => {
                     if (e.target.files) {
                       [...e.target.files].forEach((file) => {
-                        if (file.size < 1000000) {
+                        if (file.size < 1000000 && file.name.length <= 20 && /^[\w\-\s]+$/.test(file.name)) {
                           receiptPrepend({
                             file,
                             name: file.name,
                             googleFileId: ''
                           });
-                        } else {
+                        } else if (file.size >= 1000000) {
                           toast.error(`Error uploading ${file.name}; file must be less than 1 MB`, 5000);
+                          document.getElementById('receipt-image')!.innerHTML = '';
+                        } else if (file.name.length > 20) {
+                          toast.error(`Error uploading ${file.name}; file name must be less than 20 characters`, 5000);
+                          document.getElementById('receipt-image')!.innerHTML = '';
+                        } else {
+                          toast.error(`Error uploading ${file.name}; file name must contain only letters and numbers`, 5000);
                           document.getElementById('receipt-image')!.innerHTML = '';
                         }
                       });

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
@@ -367,7 +367,8 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
                   onChange={(e) => {
                     if (e.target.files) {
                       [...e.target.files].forEach((file) => {
-                        if (file.size < 1000000 && file.name.length <= 20 && /^[\w\-\s]+$/.test(file.name)) {
+                        /* The regex /^[\w\-\s]+$/ limits the input to the set of alphanumeric characters (\w), hyphens (\-), and spaces (\s) */
+                        if (file.size < 1000000 && file.name.length <= 20 && /^[\w\-\s.]+$/.test(file.name)) {
                           receiptPrepend({
                             file,
                             name: file.name,

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
@@ -367,22 +367,22 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
                   onChange={(e) => {
                     if (e.target.files) {
                       [...e.target.files].forEach((file) => {
-                        /* The regex /^[\w\-\s]+$/ limits the file name to the set of alphanumeric characters (\w), hyphens (-), spaces (\s), and dots */
-                        if (file.size < 1000000 && file.name.length <= 20 && /^[\w\-\s.]+$/.test(file.name)) {
-                          receiptPrepend({
-                            file,
-                            name: file.name,
-                            googleFileId: ''
-                          });
-                        } else if (file.size >= 1000000) {
+                        /* The regex /^[\w.]+$/ limits the file name to the set of alphanumeric characters (\w) and dots (for file type) */
+                        if (file.size >= 1000000) {
                           toast.error(`Error uploading ${file.name}; file must be less than 1 MB`, 5000);
                           document.getElementById('receipt-image')!.innerHTML = '';
                         } else if (file.name.length > 20) {
                           toast.error(`Error uploading ${file.name}; file name must be less than 20 characters`, 5000);
                           document.getElementById('receipt-image')!.innerHTML = '';
-                        } else {
-                          toast.error(`Error uploading ${file.name}; file name must contain only letters and numbers`, 5000);
+                        } else if (!/^[\w.]+$/.test(file.name)) {
+                          toast.error(`Error uploading ${file.name}; file name must only contain letter and numbers`, 5000);
                           document.getElementById('receipt-image')!.innerHTML = '';
+                        } else {
+                          receiptPrepend({
+                            file,
+                            name: file.name,
+                            googleFileId: ''
+                          });
                         }
                       });
                     }


### PR DESCRIPTION
## Changes

Added a check for the receipt file name length limit and special characters limit in ReinbursementViewForm.tsx
Added a HTTP error throw in google-integrations.utils.tsx for the file name check

## Screenshots

<img width="1512" alt="Screenshot 2024-11-19 at 8 57 52 PM" src="https://github.com/user-attachments/assets/6601bee4-b546-4a7c-af97-ff09f76a6777">
<img width="1512" alt="Screenshot 2024-11-19 at 8 58 38 PM" src="https://github.com/user-attachments/assets/d2053b04-080e-4feb-9051-bd2816727af1">

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #2908
