### PR TITLE
#2698 Allow custom zoom links in user schedule settings

### DIFF
--- a/src/frontend/src/pages/SettingsPage/UserScheduleSettings/UserScheduleSettingsEdit.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserScheduleSettings/UserScheduleSettingsEdit.tsx
@@ -38,12 +38,14 @@ const UserScheduleSettingsEdit: React.FC<UserScheduleSettingsEditProps> = ({
   const toast = useToast();
 
   const onFormSubmit = (data: ScheduleSettingsFormInput) => {
-    if (
-      data.personalZoomLink !== '' &&
-      (!data.personalZoomLink.startsWith('https://') || !data.personalZoomLink.includes('zoom.us/'))
-    ) {
-      toast.error('Invalid Zoom Link Format. Link must contains "zoom.us/".');
-      return;
+    if (data.personalZoomLink !== '') {
+      if (!data.personalZoomLink.startsWith('https://')) {
+        toast.error('Invalid Zoom Link Format. Link must start with "https://".');
+        return;
+      } else if (!data.personalZoomLink.includes('zoom.us/')) {
+        toast.error('Invalid Zoom Link Format. Link must contains "zoom.us/".');
+        return;
+      }
     }
     onSubmit({ availability: Array.from(availabilities.values()), ...data });
   };

--- a/src/frontend/src/pages/SettingsPage/UserScheduleSettings/UserScheduleSettingsEdit.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserScheduleSettings/UserScheduleSettingsEdit.tsx
@@ -43,7 +43,7 @@ const UserScheduleSettingsEdit: React.FC<UserScheduleSettingsEditProps> = ({
         toast.error('Invalid Zoom Link Format. Link must start with "https://".');
         return;
       } else if (!data.personalZoomLink.includes('zoom.us/j/')) {
-        toast.error('Invalid Zoom Link Format. Link must contains "zoom.us/j/".');
+        toast.error('Invalid Zoom Link Format. Link must contain "zoom.us/j/".');
         return;
       }
     }

--- a/src/frontend/src/pages/SettingsPage/UserScheduleSettings/UserScheduleSettingsEdit.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserScheduleSettings/UserScheduleSettingsEdit.tsx
@@ -42,8 +42,8 @@ const UserScheduleSettingsEdit: React.FC<UserScheduleSettingsEditProps> = ({
       if (!data.personalZoomLink.startsWith('https://')) {
         toast.error('Invalid Zoom Link Format. Link must start with "https://".');
         return;
-      } else if (!data.personalZoomLink.includes('zoom.us/')) {
-        toast.error('Invalid Zoom Link Format. Link must contains "zoom.us/".');
+      } else if (!data.personalZoomLink.includes('zoom.us/j/')) {
+        toast.error('Invalid Zoom Link Format. Link must contains "zoom.us/j/".');
         return;
       }
     }

--- a/src/frontend/src/pages/SettingsPage/UserScheduleSettings/UserScheduleSettingsEdit.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserScheduleSettings/UserScheduleSettingsEdit.tsx
@@ -38,8 +38,11 @@ const UserScheduleSettingsEdit: React.FC<UserScheduleSettingsEditProps> = ({
   const toast = useToast();
 
   const onFormSubmit = (data: ScheduleSettingsFormInput) => {
-    if (data.personalZoomLink !== '' && !data.personalZoomLink.startsWith('https://zoom.us/j/')) {
-      toast.error('Invalid Zoom Link Format. Must start with "https://zoom.us/j/"');
+    if (
+      data.personalZoomLink !== '' &&
+      (!data.personalZoomLink.startsWith('https://') || !data.personalZoomLink.includes('zoom.us/'))
+    ) {
+      toast.error('Invalid Zoom Link Format. Link must contains "zoom.us/".');
       return;
     }
     onSubmit({ availability: Array.from(availabilities.values()), ...data });


### PR DESCRIPTION
## Changes

Changed the UserScheduleSettingsEdit.tsx file to allow the user to save custom Zoom links (that contain the snippit "zoom.us/" in the url) instead of just Zoom links that start with https://zoom.us/.


## Screenshots

<img width="833" alt="Screenshot 2024-11-21 at 10 51 24 AM" src="https://github.com/user-attachments/assets/f6ac7fe5-e4a4-424c-8f23-65283579d7ee">


<img width="1725" alt="Screenshot 2024-11-21 at 10 52 10 AM" src="https://github.com/user-attachments/assets/5f753299-7015-451c-850b-68569e009d0d">


<img width="1725" alt="Screenshot 2024-11-21 at 10 52 25 AM" src="https://github.com/user-attachments/assets/b513477d-0660-4e39-853c-819f35c7d8e6">



## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #2698 
