### PR TITLE
#2637 Update Testing Color

### DIFF
--- a/src/frontend/src/pages/GanttPage/GanttChartComponents/GanttChartColorLegend.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChartComponents/GanttChartColorLegend.tsx
@@ -5,11 +5,7 @@
 
 import { Box, Card, Tooltip, Typography } from '@mui/material';
 import { DesignReviewStatus, WbsElementStatus, WorkPackageStage } from 'shared';
-import {
-  GanttDesignReviewStatusColorPipe,
-  GanttWorkPackageStageColorPipe,
-  GanttWorkPackageTextColorPipe
-} from '../../../utils/gantt.utils';
+import { GanttDesignReviewStatusColorPipe, GanttWorkPackageStageColorPipe } from '../../../utils/gantt.utils';
 import { DesignReviewStatusTextPipe, WbsElementStatusTextPipe, WorkPackageStageTextPipe } from '../../../utils/enum-pipes';
 
 const LEGEND_POPUPS_MAP = new Map<WorkPackageStage, JSX.Element>();
@@ -41,7 +37,7 @@ Object.values(WorkPackageStage).map((stage) =>
                 alignItems: 'center'
               }}
             >
-              <Typography variant="body1" sx={{ color: GanttWorkPackageTextColorPipe(stage) }}>
+              <Typography variant="body1" sx={{ color: '#ffffff' }}>
                 {WbsElementStatusTextPipe(status)}
               </Typography>
             </Box>
@@ -133,10 +129,7 @@ const GanttChartColorLegend = () => {
                   tooltip: { sx: { background: 'transparent', width: 'fit-content' } }
                 }}
               >
-                <Typography
-                  variant="body2"
-                  sx={{ color: GanttWorkPackageTextColorPipe(stage), overflow: 'hidden', textWrap: 'nowrap' }}
-                >
+                <Typography variant="body2" sx={{ color: '#ffffff', overflow: 'hidden', textWrap: 'nowrap' }}>
                   {WorkPackageStageTextPipe(stage)}
                 </Typography>
               </Tooltip>

--- a/src/frontend/src/pages/GanttPage/GanttChartComponents/GanttChartColorLegend.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChartComponents/GanttChartColorLegend.tsx
@@ -5,7 +5,11 @@
 
 import { Box, Card, Tooltip, Typography } from '@mui/material';
 import { DesignReviewStatus, WbsElementStatus, WorkPackageStage } from 'shared';
-import { GanttDesignReviewStatusColorPipe, GanttWorkPackageStageColorPipe } from '../../../utils/gantt.utils';
+import {
+  GanttDesignReviewStatusColorPipe,
+  GanttWorkPackageStageColorPipe,
+  GanttWorkPackageTextColor
+} from '../../../utils/gantt.utils';
 import { DesignReviewStatusTextPipe, WbsElementStatusTextPipe, WorkPackageStageTextPipe } from '../../../utils/enum-pipes';
 
 const LEGEND_POPUPS_MAP = new Map<WorkPackageStage, JSX.Element>();
@@ -37,7 +41,7 @@ Object.values(WorkPackageStage).map((stage) =>
                 alignItems: 'center'
               }}
             >
-              <Typography variant="body1" sx={{ color: '#ffffff' }}>
+              <Typography variant="body1" sx={{ color: GanttWorkPackageTextColor }}>
                 {WbsElementStatusTextPipe(status)}
               </Typography>
             </Box>
@@ -129,7 +133,10 @@ const GanttChartColorLegend = () => {
                   tooltip: { sx: { background: 'transparent', width: 'fit-content' } }
                 }}
               >
-                <Typography variant="body2" sx={{ color: '#ffffff', overflow: 'hidden', textWrap: 'nowrap' }}>
+                <Typography
+                  variant="body2"
+                  sx={{ color: GanttWorkPackageTextColor, overflow: 'hidden', textWrap: 'nowrap' }}
+                >
                   {WorkPackageStageTextPipe(stage)}
                 </Typography>
               </Tooltip>

--- a/src/frontend/src/utils/gantt.utils.ts
+++ b/src/frontend/src/utils/gantt.utils.ts
@@ -360,7 +360,7 @@ export const transformWorkPackageToGanttTask = (
     allWorkPackages,
     blocking: workPackage.blocking,
     styles: {
-      color: '#ffffff',
+      color: GanttWorkPackageTextColor,
       backgroundColor: GanttWorkPackageStageColorPipe(workPackage.stage, workPackage.status)
     },
     onClick: () => {
@@ -486,6 +486,8 @@ export const GanttWorkPackageStageColorPipe: (stage: WorkPackageStage | undefine
     }
   }
 };
+
+export const GanttWorkPackageTextColor: string = '#ffffff';
 
 /**
  * Determines if the highlighted change is on the wbs elements project.

--- a/src/frontend/src/utils/gantt.utils.ts
+++ b/src/frontend/src/utils/gantt.utils.ts
@@ -21,7 +21,7 @@ import {
 } from 'shared';
 import { projectWbsPipe } from './pipes';
 import dayjs from 'dayjs';
-import { deepOrange, green, grey, indigo, orange, pink, yellow } from '@mui/material/colors';
+import { deepOrange, green, grey, indigo, lightBlue, orange, pink } from '@mui/material/colors';
 import { projectPreviewTranformer } from '../apis/transformers/projects.transformers';
 
 export const NO_TEAM = 'No Team';
@@ -450,7 +450,7 @@ export const GanttWorkPackageStageColorPipe: (stage: WorkPackageStage | undefine
       case WorkPackageStage.Install:
         return pink[500];
       case WorkPackageStage.Testing:
-        return yellow[600];
+        return lightBlue[600];
       default:
         return grey[500];
     }
@@ -465,7 +465,7 @@ export const GanttWorkPackageStageColorPipe: (stage: WorkPackageStage | undefine
       case WorkPackageStage.Install:
         return pink[300];
       case WorkPackageStage.Testing:
-        return yellow[300];
+        return lightBlue[300];
       default:
         return grey[500];
     }
@@ -480,7 +480,7 @@ export const GanttWorkPackageStageColorPipe: (stage: WorkPackageStage | undefine
       case WorkPackageStage.Install:
         return pink[800];
       case WorkPackageStage.Testing:
-        return yellow[800];
+        return lightBlue[800];
       default:
         return grey[500];
     }
@@ -490,13 +490,6 @@ export const GanttWorkPackageStageColorPipe: (stage: WorkPackageStage | undefine
 // maps stage to the desired text color
 export const GanttWorkPackageTextColorPipe: (stage: WorkPackageStage | undefined) => string = (stage) => {
   switch (stage) {
-    case WorkPackageStage.Research:
-    case WorkPackageStage.Design:
-    case WorkPackageStage.Manufacturing:
-    case WorkPackageStage.Install:
-      return '#ffffff';
-    case WorkPackageStage.Testing:
-      return '#000000';
     default:
       return '#ffffff';
   }

--- a/src/frontend/src/utils/gantt.utils.ts
+++ b/src/frontend/src/utils/gantt.utils.ts
@@ -21,7 +21,7 @@ import {
 } from 'shared';
 import { projectWbsPipe } from './pipes';
 import dayjs from 'dayjs';
-import { deepOrange, green, grey, indigo, lightBlue, orange, pink } from '@mui/material/colors';
+import { deepOrange, green, grey, indigo, orange, pink } from '@mui/material/colors';
 import { projectPreviewTranformer } from '../apis/transformers/projects.transformers';
 
 export const NO_TEAM = 'No Team';
@@ -360,7 +360,7 @@ export const transformWorkPackageToGanttTask = (
     allWorkPackages,
     blocking: workPackage.blocking,
     styles: {
-      color: GanttWorkPackageTextColorPipe(workPackage.stage),
+      color: '#ffffff',
       backgroundColor: GanttWorkPackageStageColorPipe(workPackage.stage, workPackage.status)
     },
     onClick: () => {
@@ -450,7 +450,7 @@ export const GanttWorkPackageStageColorPipe: (stage: WorkPackageStage | undefine
       case WorkPackageStage.Install:
         return pink[500];
       case WorkPackageStage.Testing:
-        return lightBlue[600];
+        return '#44a0b1';
       default:
         return grey[500];
     }
@@ -465,7 +465,7 @@ export const GanttWorkPackageStageColorPipe: (stage: WorkPackageStage | undefine
       case WorkPackageStage.Install:
         return pink[300];
       case WorkPackageStage.Testing:
-        return lightBlue[300];
+        return '#55c7dd';
       default:
         return grey[500];
     }
@@ -480,18 +480,10 @@ export const GanttWorkPackageStageColorPipe: (stage: WorkPackageStage | undefine
       case WorkPackageStage.Install:
         return pink[800];
       case WorkPackageStage.Testing:
-        return lightBlue[800];
+        return '#2d6b77';
       default:
         return grey[500];
     }
-  }
-};
-
-// maps stage to the desired text color
-export const GanttWorkPackageTextColorPipe: (stage: WorkPackageStage | undefined) => string = (stage) => {
-  switch (stage) {
-    default:
-      return '#ffffff';
   }
 };
 


### PR DESCRIPTION
## Changes
Updated Testing Color from Yellow to Turquoise for Better Contrast

## Screenshots
<img width="1512" alt="Screenshot 2024-11-26 at 20 13 17" src="https://github.com/user-attachments/assets/2d7abf20-cdff-4b48-9849-4ec2c77f3ceb">
<img width="179" alt="Screenshot 2024-11-26 at 20 13 23" src="https://github.com/user-attachments/assets/2fbc0e4b-6bd6-4678-bcb9-a9978c4d48cb">

## Checklist
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #2637 
