### PR TITLE
#2595: Added a faint border around the current day to the design review calendar

### DIFF
--- a/src/frontend/src/pages/CalendarPage/CalendarComponents/CalendarDayCard.tsx
+++ b/src/frontend/src/pages/CalendarPage/CalendarComponents/CalendarDayCard.tsx
@@ -191,8 +191,15 @@ const CalendarDayCard: React.FC<CalendarDayCardProps> = ({ cardDate, events, tea
         teamTypes={teamTypes}
         defaultDate={cardDate}
       />
-      <Card sx={{ borderRadius: 2, width: { xs: '95%', md: '80%' }, height: { xs: '10vh', sm: '15vh' }, 
-      border: isCurrentDay ? '2px solid gray' : 'none', boxShadow: isCurrentDay ? '0 0 10px rgba(255, 255, 255, 0.5)' : 'none', }}>
+      <Card
+        sx={{
+          borderRadius: 2,
+          width: { xs: '95%', md: '80%' },
+          height: { xs: '10vh', sm: '15vh' },
+          border: isCurrentDay ? '2px solid gray' : 'none',
+          boxShadow: isCurrentDay ? '0 0 10px rgba(255, 255, 255, 0.5)' : 'none'
+        }}
+      >
         <CardContent sx={{ padding: 0 }}>
           <DayCardTitle />
           {events.length < 3 ? (

--- a/src/frontend/src/pages/CalendarPage/CalendarComponents/CalendarDayCard.tsx
+++ b/src/frontend/src/pages/CalendarPage/CalendarComponents/CalendarDayCard.tsx
@@ -178,6 +178,9 @@ const CalendarDayCard: React.FC<CalendarDayCardProps> = ({ cardDate, events, tea
     );
   };
 
+  const today = new Date().toDateString();
+  const isCurrentDay = cardDate.toDateString() === today;
+
   return (
     <>
       <DesignReviewCreateModal
@@ -188,7 +191,8 @@ const CalendarDayCard: React.FC<CalendarDayCardProps> = ({ cardDate, events, tea
         teamTypes={teamTypes}
         defaultDate={cardDate}
       />
-      <Card sx={{ borderRadius: 2, width: { xs: '95%', md: '80%' }, height: { xs: '10vh', sm: '15vh' } }}>
+      <Card sx={{ borderRadius: 2, width: { xs: '95%', md: '80%' }, height: { xs: '10vh', sm: '15vh' }, 
+      border: isCurrentDay ? '2px solid gray' : 'none', boxShadow: isCurrentDay ? '0 0 10px rgba(255, 255, 255, 0.5)' : 'none', }}>
         <CardContent sx={{ padding: 0 }}>
           <DayCardTitle />
           {events.length < 3 ? (

--- a/yarn.lock
+++ b/yarn.lock
@@ -6551,9 +6551,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30000981, caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001125, caniuse-lite@npm:^1.0.30001587":
-  version: 1.0.30001629
-  resolution: "caniuse-lite@npm:1.0.30001629"
-  checksum: c5e646e1b309b2a70b01499e0f0fca3a54bc111212f121b32614fe925b8f24ff6c1832a4306ddadf35678fbb11a6a97f953be07ccdc96bce5b530a4f84f40c45
+  version: 1.0.30001680
+  resolution: "caniuse-lite@npm:1.0.30001680"
+  checksum: 2641d2b18c5ab0a6663cb350c5adc81e5ede1a7677d1c7518a8053ada87bf6f206419e1820a2608f76fa5e4f7bea327cbe47df423783e571569a88c0ea645270
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6551,9 +6551,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30000981, caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001125, caniuse-lite@npm:^1.0.30001587":
-  version: 1.0.30001680
-  resolution: "caniuse-lite@npm:1.0.30001680"
-  checksum: 2641d2b18c5ab0a6663cb350c5adc81e5ede1a7677d1c7518a8053ada87bf6f206419e1820a2608f76fa5e4f7bea327cbe47df423783e571569a88c0ea645270
+  version: 1.0.30001629
+  resolution: "caniuse-lite@npm:1.0.30001629"
+  checksum: c5e646e1b309b2a70b01499e0f0fca3a54bc111212f121b32614fe925b8f24ff6c1832a4306ddadf35678fbb11a6a97f953be07ccdc96bce5b530a4f84f40c45
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Changes

Added a faint gray border around the current day to the design review calendar.

## Screenshots

![Screenshot 2024-11-25 124941](https://github.com/user-attachments/assets/cac37db1-fcd5-40e2-907d-503237322eef)

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #2595
