### PR TITLE
All Components Can Now Be Easily Dynamically Sized

### DIFF
--- a/src/frontend/src/pages/HomePage/AdminHomePage.tsx
+++ b/src/frontend/src/pages/HomePage/AdminHomePage.tsx
@@ -3,11 +3,11 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { Typography } from '@mui/material';
+import { Grid, Typography } from '@mui/material';
 import { useSingleUserSettings } from '../../hooks/users.hooks';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import ErrorPage from '../ErrorPage';
-import PageLayout from '../../components/PageLayout';
+import PageLayout, { PAGE_GRID_HEIGHT } from '../../components/PageLayout';
 import { AuthenticatedUser } from 'shared';
 
 interface AdminHomePageProps {
@@ -25,6 +25,7 @@ const AdminHomePage = ({ user }: AdminHomePageProps) => {
       <Typography variant="h3" marginLeft="auto" sx={{ marginTop: 2, textAlign: 'center', pt: 3, padding: 0 }}>
         Welcome, {user.firstName}!
       </Typography>
+      <Grid container height={`${PAGE_GRID_HEIGHT}vh`} mt={2}></Grid>
     </PageLayout>
   );
 };

--- a/src/frontend/src/pages/HomePage/GuestHomePage.tsx
+++ b/src/frontend/src/pages/HomePage/GuestHomePage.tsx
@@ -3,11 +3,11 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import { useSingleUserSettings } from '../../hooks/users.hooks';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import ErrorPage from '../ErrorPage';
-import PageLayout from '../../components/PageLayout';
+import PageLayout, { PAGE_GRID_HEIGHT } from '../../components/PageLayout';
 import { AuthenticatedUser } from 'shared';
 import MemberEncouragement from './components/MemberEncouragement';
 import GuestOrganizationInfo from './components/GuestOrganizationInfo';
@@ -28,9 +28,25 @@ const GuestHomePage = ({ user }: GuestHomePageProps) => {
       <Typography variant="h3" marginLeft="auto" sx={{ marginTop: 2, textAlign: 'center', pt: 3, padding: 0 }}>
         Welcome, {user.firstName}!
       </Typography>
-      <GuestOrganizationInfo />
-      <MemberEncouragement />
-      <FeaturedProjects />
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 2,
+          height: `${PAGE_GRID_HEIGHT}vh`,
+          mt: 2
+        }}
+      >
+        <Box height={'45%'}>
+          <GuestOrganizationInfo />
+        </Box>
+        <Box height={'15%'}>
+          <MemberEncouragement />
+        </Box>
+        <Box height={'45%'}>
+          <FeaturedProjects />
+        </Box>
+      </Box>
     </PageLayout>
   );
 };

--- a/src/frontend/src/pages/HomePage/LeadHomePage.tsx
+++ b/src/frontend/src/pages/HomePage/LeadHomePage.tsx
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { Box, Grid, Typography } from '@mui/material';
+import { Grid, Typography } from '@mui/material';
 import { useSingleUserSettings } from '../../hooks/users.hooks';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import ErrorPage from '../ErrorPage';
@@ -26,13 +26,11 @@ const LeadHomePage = ({ user }: LeadHomePageProps) => {
       <Typography variant="h3" marginLeft="auto" sx={{ marginTop: 2, textAlign: 'center', pt: 3, padding: 0 }}>
         Welcome, {user.firstName}!
       </Typography>
-      <Box sx={{ flexGrow: 1 }}>
-        <Grid container height={`${PAGE_GRID_HEIGHT}vh`}>
-          <Grid item xs={12} md={6}>
-            <MyTeamsOverdueTasks user={user} />
-          </Grid>
+      <Grid container>
+        <Grid item xs={12} md={6} height={`calc(${PAGE_GRID_HEIGHT}vh)`}>
+          <MyTeamsOverdueTasks user={user} />
         </Grid>
-      </Box>
+      </Grid>
     </PageLayout>
   );
 };

--- a/src/frontend/src/pages/HomePage/LeadHomePage.tsx
+++ b/src/frontend/src/pages/HomePage/LeadHomePage.tsx
@@ -26,8 +26,8 @@ const LeadHomePage = ({ user }: LeadHomePageProps) => {
       <Typography variant="h3" marginLeft="auto" sx={{ marginTop: 2, textAlign: 'center', pt: 3, padding: 0 }}>
         Welcome, {user.firstName}!
       </Typography>
-      <Grid container>
-        <Grid item xs={12} md={6} height={`calc(${PAGE_GRID_HEIGHT}vh)`}>
+      <Grid container height={`${PAGE_GRID_HEIGHT}vh`} mt={2}>
+        <Grid item xs={12} md={6} height={`100%`}>
           <MyTeamsOverdueTasks user={user} />
         </Grid>
       </Grid>

--- a/src/frontend/src/pages/HomePage/MemberHomePage.tsx
+++ b/src/frontend/src/pages/HomePage/MemberHomePage.tsx
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { Box, Grid, Typography } from '@mui/material';
+import { Grid, Typography } from '@mui/material';
 import { useSingleUserSettings } from '../../hooks/users.hooks';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import ErrorPage from '../ErrorPage';
@@ -26,13 +26,11 @@ const MemberHomePage = ({ user }: MemberHomePageProps) => {
       <Typography variant="h3" marginLeft="auto" sx={{ marginTop: 2, textAlign: 'center', pt: 3, padding: 0 }}>
         Welcome, {user.firstName}!
       </Typography>
-      <Box sx={{ flexGrow: 1 }}>
-        <Grid container height={`${PAGE_GRID_HEIGHT}vh`}>
-          <Grid item xs={12} md={6}>
-            <MyTasks />
-          </Grid>
+      <Grid container height={`${PAGE_GRID_HEIGHT}vh`} mt={2}>
+        <Grid item xs={12} md={6} height={'100%'}>
+          <MyTasks />
         </Grid>
-      </Box>
+      </Grid>
     </PageLayout>
   );
 };

--- a/src/frontend/src/pages/HomePage/components/EmptyPageBlockDisplay.tsx
+++ b/src/frontend/src/pages/HomePage/components/EmptyPageBlockDisplay.tsx
@@ -1,4 +1,4 @@
-import { Stack, Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import React from 'react';
 
 interface EmptyPageBlockDisplayProps {
@@ -9,11 +9,20 @@ interface EmptyPageBlockDisplayProps {
 
 const EmptyPageBlockDisplay: React.FC<EmptyPageBlockDisplayProps> = ({ icon, heading, message }) => {
   return (
-    <Stack direction="column" spacing={1} alignItems="center" justifyContent="center">
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '100%',
+        height: '100%'
+      }}
+    >
       {icon}
       <Typography variant="h4">{heading}</Typography>
       <Typography variant="subtitle1">{message}</Typography>
-    </Stack>
+    </Box>
   );
 };
 

--- a/src/frontend/src/pages/HomePage/components/GuestOrganizationInfo.tsx
+++ b/src/frontend/src/pages/HomePage/components/GuestOrganizationInfo.tsx
@@ -1,4 +1,4 @@
-import { Card, Icon, Typography, useTheme } from '@mui/material';
+import { Box, Card, Icon, Typography, useTheme } from '@mui/material';
 import { Grid } from '@mui/material';
 import { useCurrentOrganization } from '../../../hooks/organizations.hooks';
 import React from 'react';
@@ -6,7 +6,6 @@ import { NERButton } from '../../../components/NERButton';
 import { useAllLinkTypes, useAllUsefulLinks } from '../../../hooks/projects.hooks';
 import LoadingIndicator from '../../../components/LoadingIndicator';
 import ErrorPage from '../../ErrorPage';
-import { Stack } from '@mui/system';
 
 interface GuestOrganizationInfoButtonProps {
   href?: string;
@@ -50,26 +49,29 @@ const GuestOrganizationInfo = () => {
         padding: 2,
         bgcolor: theme.palette.background.paper,
         borderRadius: '1',
-        marginTop: 5
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between'
       }}
       variant="outlined"
     >
-      <Stack spacing={2}>
+      <Box>
         <Typography sx={{ paddingLeft: 2 }} variant="h4">
           {organization.name}
         </Typography>
-        <Typography sx={{ marginBottom: 2, fontSize: 18, paddingLeft: 2 }}>{organization.description}</Typography>
-        <Grid container spacing={2}>
-          {usefulLinks.map((link) => (
-            <NERGuestButton
-              key={link.linkId}
-              buttonText={link.linkType.name}
-              href={link.url}
-              iconName={link.linkType.iconName}
-            />
-          ))}
-        </Grid>
-      </Stack>
+        <Typography sx={{ mt: 2, fontSize: 18, paddingLeft: 2 }}>{organization.description}</Typography>
+      </Box>
+      <Grid container spacing={2}>
+        {usefulLinks.map((link) => (
+          <NERGuestButton
+            key={link.linkId}
+            buttonText={link.linkType.name}
+            href={link.url}
+            iconName={link.linkType.iconName}
+          />
+        ))}
+      </Grid>
     </Card>
   );
 };

--- a/src/frontend/src/pages/HomePage/components/MemberEncouragement.tsx
+++ b/src/frontend/src/pages/HomePage/components/MemberEncouragement.tsx
@@ -7,14 +7,19 @@ import { useHistory } from 'react-router-dom';
 const MemberEncouragement: React.FC = () => {
   const history = useHistory();
   return (
-    <Box sx={{ width: '100%', my: 2, mx: 'auto' }}>
+    <Box sx={{ height: '100%', width: '100%', mx: 'auto' }}>
       <Alert
         variant="filled"
         severity="info"
         icon={false}
         sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          height: '100%',
           '& .MuiAlert-message': {
-            width: '100%'
+            width: '100%',
+            overflow: 'hidden'
           }
         }}
       >

--- a/src/frontend/src/pages/HomePage/components/MemberEncouragement.tsx
+++ b/src/frontend/src/pages/HomePage/components/MemberEncouragement.tsx
@@ -23,7 +23,15 @@ const MemberEncouragement: React.FC = () => {
           }
         }}
       >
-        <Grid container alignItems="center" justifyContent="space-between">
+        <Grid
+          container
+          sx={{
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            direction: 'row',
+            flexWrap: 'nowrap'
+          }}
+        >
           <Grid item>
             <Typography variant="h6" color="white">
               Already a member?
@@ -36,7 +44,7 @@ const MemberEncouragement: React.FC = () => {
             <NERButton
               variant="contained"
               size="small"
-              sx={{ color: 'white' }}
+              sx={{ color: 'white', whiteSpace: 'nowrap' }}
               onClick={() => {
                 history.push(routes.TEAMS);
               }}

--- a/src/frontend/src/pages/HomePage/components/MyTasks.tsx
+++ b/src/frontend/src/pages/HomePage/components/MyTasks.tsx
@@ -1,4 +1,4 @@
-import { Box, Stack } from '@mui/material';
+import { Stack } from '@mui/material';
 import LoadingIndicator from '../../../components/LoadingIndicator';
 import { useCurrentUser, useUserTasks } from '../../../hooks/users.hooks';
 import TaskDetailCard from './TaskDetailCard';
@@ -9,21 +9,11 @@ import ScrollablePageBlock from './ScrollablePageBlock';
 
 const NoTasksDisplay: React.FC = () => {
   return (
-    <Box
-      sx={{
-        height: `calc(100vh - 200px)`,
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'center',
-        alignItems: 'center'
-      }}
-    >
-      <EmptyPageBlockDisplay
-        icon={<CheckCircleOutlineOutlinedIcon sx={{ fontSize: 128 }} />}
-        heading={"You're all caught up!"}
-        message={"You've completed all of your assigned tasks!"}
-      />
-    </Box>
+    <EmptyPageBlockDisplay
+      icon={<CheckCircleOutlineOutlinedIcon sx={{ fontSize: 128 }} />}
+      heading={"You're all caught up!"}
+      message={"You've completed all of your assigned tasks!"}
+    />
   );
 };
 
@@ -39,6 +29,7 @@ const MyTasks: React.FC = () => {
 
   if (userTasksIsLoading || !userTasks) return <LoadingIndicator />;
   if (userTasksIsError) return <ErrorPage message={userTasksError.message} />;
+
   return (
     <ScrollablePageBlock title={`My Tasks (${userTasks.length})`}>
       {userTasks.length === 0 ? (

--- a/src/frontend/src/pages/HomePage/components/MyTeamsOverdueTasks.tsx
+++ b/src/frontend/src/pages/HomePage/components/MyTeamsOverdueTasks.tsx
@@ -5,7 +5,6 @@ import { useManyUserTasks } from '../../../hooks/users.hooks';
 import LoadingIndicator from '../../../components/LoadingIndicator';
 import ErrorPage from '../../ErrorPage';
 import TeamTaskCard from './TeamTaskCard';
-import { Box } from '@mui/material';
 import EmptyPageBlockDisplay from './EmptyPageBlockDisplay';
 import CheckCircleOutlineOutlinedIcon from '@mui/icons-material/CheckCircleOutlineOutlined';
 import { getOverdueTasks } from '../../../utils/task.utils';
@@ -16,21 +15,11 @@ interface MyTeamsOverdueTasksProps {
 
 const NoOverdueTeamTaskDisplay: React.FC = () => {
   return (
-    <Box
-      sx={{
-        height: `calc(100vh - 300px)`,
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'center',
-        alignItems: 'center'
-      }}
-    >
-      <EmptyPageBlockDisplay
-        icon={<CheckCircleOutlineOutlinedIcon sx={{ fontSize: 128 }} />}
-        heading={"You're team is all caught up!"}
-        message={"You're team has no overdue tasks!"}
-      />
-    </Box>
+    <EmptyPageBlockDisplay
+      icon={<CheckCircleOutlineOutlinedIcon sx={{ fontSize: 128 }} />}
+      heading={"You're team is all caught up!"}
+      message={"You're team has no overdue tasks!"}
+    />
   );
 };
 

--- a/src/frontend/src/pages/HomePage/components/ScrollablePageBlock.tsx
+++ b/src/frontend/src/pages/HomePage/components/ScrollablePageBlock.tsx
@@ -13,7 +13,6 @@ const ScrollablePageBlock: React.FC<ScrollablePageBlockProps> = ({ children, tit
     <Card
       sx={{
         height: '100%',
-        my: 2,
         background: theme.palette.background.paper
       }}
       variant="outlined"

--- a/src/frontend/src/pages/HomePage/components/ScrollablePageBlock.tsx
+++ b/src/frontend/src/pages/HomePage/components/ScrollablePageBlock.tsx
@@ -1,6 +1,5 @@
-import { Card, CardContent, Stack, Typography, useTheme } from '@mui/material';
+import { Box, Card, CardContent, Typography, useTheme } from '@mui/material';
 import React from 'react';
-import { PAGE_GRID_HEIGHT } from '../../../components/PageLayout';
 
 interface ScrollablePageBlockProps {
   children: React.ReactNode;
@@ -13,41 +12,52 @@ const ScrollablePageBlock: React.FC<ScrollablePageBlockProps> = ({ children, tit
   return (
     <Card
       sx={{
-        height: horizontal ? 'auto' : '100%',
+        height: '100%',
         my: 2,
         background: theme.palette.background.paper
       }}
       variant="outlined"
     >
-      {title && (
-        <Typography ml={2} mt={2} variant="h4">
-          {title}
-        </Typography>
-      )}
       <CardContent
         sx={{
-          marginTop: 1,
-          maxHeight: `calc(${PAGE_GRID_HEIGHT}vh - 100px)`,
-          flexWrap: 'nowrap',
-          overflow: 'auto',
-          justifyContent: 'flex-start',
-          '&::-webkit-scrollbar': {
-            height: '20px'
-          },
-          '&::-webkit-scrollbar-track': {
-            backgroundColor: 'transparent'
-          },
-          '&::-webkit-scrollbar-thumb': {
-            backgroundColor: theme.palette.error.dark,
-            borderRadius: '20px',
-            border: '6px solid transparent',
-            backgroundClip: 'content-box'
-          }
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100%',
+          flexWrap: 'nowrap'
         }}
       >
-        <Stack direction={horizontal ? 'row' : 'column'} spacing={2}>
-          {children}
-        </Stack>
+        {title && (
+          <Typography ml={2} mt={2} variant="h5">
+            {title}
+          </Typography>
+        )}
+        <Box
+          sx={{
+            mt: 2,
+            display: 'flex',
+            flex: 1,
+            flexDirection: horizontal ? 'row' : 'column',
+            gap: 2,
+            overflowX: horizontal ? 'auto' : 'hidden',
+            overflowY: horizontal ? 'hidden' : 'auto',
+            '&::-webkit-scrollbar': {
+              height: '20px'
+            },
+            '&::-webkit-scrollbar-track': {
+              backgroundColor: 'transparent'
+            },
+            '&::-webkit-scrollbar-thumb': {
+              backgroundColor: theme.palette.error.dark,
+              borderRadius: '20px',
+              border: '6px solid transparent',
+              backgroundClip: 'content-box'
+            }
+          }}
+        >
+          {React.Children.map(children, (child) => (
+            <Box sx={{ flex: 1 }}>{child}</Box>
+          ))}
+        </Box>
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Notes

This is a spontaneous task that I needed to do. Previously, components to each page was very difficult in confusing since all the components must be dynamically sized the the page height. This pr is to facilitate adding components and also ensure that no components go offscreen and cause unnecessary scrolling. Now adding a component  is a as simple as defining what percentage of the height it can take up within a grid/box with a fixed height (relative to the page view) on the homepage. This also has the added benefit that we do not need to define heights for the empty page block display. You can just put it in the component and it will center itself, no matter if it is vertical or horizontal.

## Screenshots

https://github.com/user-attachments/assets/f3faa513-d0ea-495e-b396-690006729988

This is  a video showing how you can change the heights of components at will on the screen and it will not cause scrolling on the whole page. The video also shows how I can make page blocks scroll vertically and horizontally at will, and does not cause any problems.