### PR TITLE
#2820-Created Overdue WorkPackage Card

### DIFF
--- a/src/frontend/src/pages/HomePage/AdminHomePage.tsx
+++ b/src/frontend/src/pages/HomePage/AdminHomePage.tsx
@@ -41,10 +41,10 @@ const AdminHomePage = ({ user }: AdminHomePageProps) => {
           <ChangeRequestsToReview user={user} />
         </Box>
         <Grid container height={'60%'} spacing={2}>
-          <Grid item xs={8} md={8} height="100%">
+          <Grid item xs={7} md={7} height="100%">
             <WorkPackagesSelectionView />
           </Grid>
-          <Grid item xs={4} md={4} height="100%">
+          <Grid item xs={5} md={5} height="100%">
             <OverdueWorkPackages user={user} />
           </Grid>
         </Grid>

--- a/src/frontend/src/pages/HomePage/components/OverdueWorkPackageCard.tsx
+++ b/src/frontend/src/pages/HomePage/components/OverdueWorkPackageCard.tsx
@@ -12,7 +12,7 @@ import {
   useTheme
 } from '@mui/material';
 import { wbsPipe, WorkPackage } from 'shared';
-import { datePipe, fullNamePipe, projectWbsPipe, wbsNamePipe } from '../../../utils/pipes';
+import { datePipe, fullNamePipe, projectWbsPipe } from '../../../utils/pipes';
 import { routes } from '../../../utils/routes';
 import { Link as RouterLink } from 'react-router-dom';
 import { useGetManyWorkPackages } from '../../../hooks/work-packages.hooks';
@@ -84,8 +84,10 @@ const OverdueWorkPackageCard = ({ wp }: { wp: WorkPackage }) => {
               ) : (
                 blockedByWps.map((wp) => (
                   <li key={wp.id}>
-                    <Typography fontWeight="regular" fontSize={16} variant="h6" noWrap>
-                      {wbsNamePipe(wp)}
+                    <Typography fontWeight={'regular'} variant="subtitle2" noWrap>
+                      <Link component={RouterLink} to={`${routes.PROJECTS}/${projectWbsPipe(wp.wbsNum)}`}>
+                        {projectWbsPipe(wp.wbsNum)} - {wp.projectName}
+                      </Link>
                     </Typography>
                   </li>
                 ))

--- a/src/frontend/src/pages/HomePage/components/OverdueWorkPackageCard.tsx
+++ b/src/frontend/src/pages/HomePage/components/OverdueWorkPackageCard.tsx
@@ -1,0 +1,143 @@
+import { Construction, Work, CalendarMonth } from '@mui/icons-material';
+import {
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  CircularProgressProps,
+  Link,
+  Stack,
+  Typography,
+  useTheme
+} from '@mui/material';
+import { wbsPipe, WorkPackage } from 'shared';
+import { datePipe, fullNamePipe, projectWbsPipe, wbsNamePipe } from '../../../utils/pipes';
+import { routes } from '../../../utils/routes';
+import { Link as RouterLink } from 'react-router-dom';
+import { useGetManyWorkPackages } from '../../../hooks/work-packages.hooks';
+import { daysOverdue } from '../../../utils/datetime.utils';
+import LoadingIndicator from '../../../components/LoadingIndicator';
+
+export const CircularProgressWithLabel = (props: CircularProgressProps & { value: number }) => {
+  return (
+    <Box
+      sx={{ position: 'relative', display: 'inline-flex', width: '40px', alignItems: 'center', justifyContent: 'center' }}
+    >
+      <CircularProgress variant="determinate" {...props} />
+      <div
+        style={{
+          position: 'absolute',
+          display: 'flex'
+        }}
+      >
+        <Typography variant="caption" component="div" color="text.primary">{`${Math.round(props.value)}%`}</Typography>
+      </div>
+    </Box>
+  );
+};
+
+const OverdueWorkPackageCard = ({ wp }: { wp: WorkPackage }) => {
+  const theme = useTheme();
+  const { data: blockedByWps, isLoading } = useGetManyWorkPackages(wp.blockedBy);
+  const numDaysOverdue = daysOverdue(new Date(wp.endDate));
+  if (isLoading || !blockedByWps) return <LoadingIndicator />;
+  return (
+    <Card
+      variant="outlined"
+      sx={{
+        minHeight: 'fit-content',
+        width: '100%',
+        mr: 3,
+        background: theme.palette.background.default
+      }}
+    >
+      <CardContent sx={{ padding: 2 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'row',
+            justifyContent: 'space-between'
+          }}
+        >
+          <Box>
+            <Typography fontWeight={'regular'} variant="subtitle2" noWrap>
+              <Link color={'text.primary'} component={RouterLink} to={`${routes.PROJECTS}/${projectWbsPipe(wp.wbsNum)}`}>
+                {projectWbsPipe(wp.wbsNum)} - {wp.projectName}
+              </Link>
+            </Typography>
+            <Link component={RouterLink} to={`${routes.PROJECTS}/${wbsPipe(wp.wbsNum)}`} noWrap>
+              <Typography fontWeight={'regular'} variant="h5">
+                {wbsPipe(wp.wbsNum)} - {wp.name}
+              </Typography>
+            </Link>
+            <Typography fontWeight="regular" fontSize={16} variant="h6" noWrap sx={{ textDecoration: 'underline' }}>
+              Blocked By:
+            </Typography>
+            <ul style={{ marginTop: 0 }}>
+              {blockedByWps.length === 0 ? (
+                <li>
+                  <Typography fontWeight="regular" fontSize={16} variant="h6" noWrap>
+                    No Blockers
+                  </Typography>
+                </li>
+              ) : (
+                blockedByWps.map((wp) => (
+                  <li key={wp.id}>
+                    <Typography fontWeight="regular" fontSize={16} variant="h6" noWrap>
+                      {wbsNamePipe(wp)}
+                    </Typography>
+                  </li>
+                ))
+              )}
+            </ul>
+          </Box>
+          <Stack>
+            <Stack
+              direction="row"
+              sx={{
+                flexWrap: 'wrap',
+                justifyContent: 'end',
+                gap: 1
+              }}
+            >
+              <Chip icon={<Construction />} label={fullNamePipe(wp.lead)} size={'small'} />
+              <Chip icon={<Work />} label={fullNamePipe(wp.manager)} size={'small'} />
+              <Chip icon={<CalendarMonth />} label={datePipe(new Date(wp.endDate))} size={'small'} />
+            </Stack>
+
+            <Box
+              sx={{
+                display: 'flex',
+                justifyContent: 'end',
+                alignItems: 'center',
+                whiteSpace: 'nowrap',
+                gap: 1
+              }}
+            >
+              <Typography
+                variant={'h5'}
+                color={theme.palette.primary.main}
+                sx={{
+                  fontSize: 72
+                }}
+              >
+                {numDaysOverdue}
+              </Typography>
+              <Stack spacing={0}>
+                <Typography variant={'h5'} color={theme.palette.primary.main} sx={{ marginBottom: -1, fontSize: 32 }}>
+                  Days
+                </Typography>
+                <Typography variant={'h5'} color={theme.palette.primary.main} sx={{ fontSize: 32 }}>
+                  Overdue
+                </Typography>
+              </Stack>
+            </Box>
+          </Stack>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default OverdueWorkPackageCard;

--- a/src/frontend/src/pages/HomePage/components/OverdueWorkPackageView.tsx
+++ b/src/frontend/src/pages/HomePage/components/OverdueWorkPackageView.tsx
@@ -1,8 +1,8 @@
 import { Box, Card, CardContent, Stack, Typography, useTheme } from '@mui/material';
-import WorkPackageCard from './WorkPackageCard';
 import { WorkPackage } from 'shared';
 import EmptyPageBlockDisplay from './EmptyPageBlockDisplay';
 import CheckCircleOutlineOutlinedIcon from '@mui/icons-material/CheckCircleOutlineOutlined';
+import OverdueWorkPackageCard from './OverdueWorkPackageCard';
 
 interface OverdueWorkPackagesViewProps {
   workPackages: WorkPackage[];
@@ -41,7 +41,7 @@ const OverdueWorkPackagesView: React.FC<OverdueWorkPackagesViewProps> = ({ workP
         }}
       >
         <Typography variant="h4" align="center">
-          Overdue Work Packages
+          All Overdue Work Packages
         </Typography>
       </Box>
       <Card
@@ -81,7 +81,7 @@ const OverdueWorkPackagesView: React.FC<OverdueWorkPackagesViewProps> = ({ workP
               height: '100%'
             }}
           >
-            {isEmpty ? <NoOverdueWPsDisplay /> : workPackages.map((wp) => <WorkPackageCard wp={wp} />)}
+            {isEmpty ? <NoOverdueWPsDisplay /> : workPackages.map((wp) => <OverdueWorkPackageCard wp={wp} />)}
           </Stack>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Changes

Created a new card for overdue work packages that include the number of days overdue on the work package and its blockers

## Screenshots

![Screenshot 2024-12-14 154318](https://github.com/user-attachments/assets/a18d0545-2b12-44cf-b530-727c44fc19d3)

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [X] All commits are tagged with the ticket number
- [X] No linting errors / newline at end of file warnings
- [X] All code follows repository-configured prettier formatting
- [X] No merge conflicts
- [X] All checks passing
- [X] Screenshots of UI changes (see Screenshots section)
- [X] Remove any non-applicable sections of this template
- [X] Assign the PR to yourself
- [X] No `yarn.lock` changes (unless dependencies have changed)
- [X] Request reviewers & ping on Slack
- [X] PR is linked to the ticket (fill in the closes line below)

Closes #2820
