### PR TITLE
#2942onboarding create toggle checklist endpoint

### DIFF
--- a/src/backend/src/controllers/onboarding.controller.ts
+++ b/src/backend/src/controllers/onboarding.controller.ts
@@ -89,19 +89,18 @@ export default class OnboardingController {
     }
   }
 
-
-  static async toggleChecklistItem(req: Request, res: Response, next: NextFunction) {
+  static async toggleChecklist(req: Request, res: Response, next: NextFunction) {
     try {
       const { checklistId } = req.params;
       const { userId } = req.currentUser;
 
-      const updatedItem = await OnboardingServices.toggleChecklistItem(checklistId, userId);
+      const updatedItem = await OnboardingServices.toggleChecklist(checklistId, userId);
       res.status(200).json(updatedItem);
     } catch (error: unknown) {
       return next(error);
     }
   }
-      
+
   static async downloadImage(req: Request, res: Response, next: NextFunction) {
     try {
       const { fileId } = req.params;

--- a/src/backend/src/controllers/onboarding.controller.ts
+++ b/src/backend/src/controllers/onboarding.controller.ts
@@ -88,4 +88,16 @@ export default class OnboardingController {
       return next(error);
     }
   }
+
+  static async toggleChecklistItem(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { checklistId } = req.params;
+      const { userId } = req.currentUser;
+
+      const updatedItem = await OnboardingServices.toggleChecklistItem(checklistId, userId);
+      res.status(200).json(updatedItem);
+    } catch (error: unknown) {
+      return next(error);
+    }
+  }
 }

--- a/src/backend/src/controllers/onboarding.controller.ts
+++ b/src/backend/src/controllers/onboarding.controller.ts
@@ -92,9 +92,8 @@ export default class OnboardingController {
   static async toggleChecklist(req: Request, res: Response, next: NextFunction) {
     try {
       const { checklistId } = req.params;
-      const { userId } = req.currentUser;
 
-      const updatedItem = await OnboardingServices.toggleChecklist(checklistId, userId);
+      const updatedItem = await OnboardingServices.toggleChecklist(checklistId, req.currentUser, req.organization);
       res.status(200).json(updatedItem);
     } catch (error: unknown) {
       return next(error);

--- a/src/backend/src/routes/onboarding.routes.ts
+++ b/src/backend/src/routes/onboarding.routes.ts
@@ -42,4 +42,10 @@ onboardingRouter.post(
 
 onboardingRouter.post('/checklist/delete/:checklistId', OnboardingController.deleteChecklist);
 
+onboardingRouter.post(
+  '/checklists/item/:checklistId/checked',
+  OnboardingController.toggleChecklistItem
+);
+
+
 export default onboardingRouter;

--- a/src/backend/src/routes/onboarding.routes.ts
+++ b/src/backend/src/routes/onboarding.routes.ts
@@ -42,9 +42,8 @@ onboardingRouter.post(
 
 onboardingRouter.post('/checklist/delete/:checklistId', OnboardingController.deleteChecklist);
 
-onboardingRouter.post('/checklists/item/:checklistId/checked', OnboardingController.toggleChecklistItem);
+onboardingRouter.post('/checklists/item/:checklistId/checked', OnboardingController.toggleChecklist);
 
 onboardingRouter.get('/image/:fileId', OnboardingController.downloadImage);
-
 
 export default onboardingRouter;

--- a/src/backend/src/routes/onboarding.routes.ts
+++ b/src/backend/src/routes/onboarding.routes.ts
@@ -42,10 +42,6 @@ onboardingRouter.post(
 
 onboardingRouter.post('/checklist/delete/:checklistId', OnboardingController.deleteChecklist);
 
-onboardingRouter.post(
-  '/checklists/item/:checklistId/checked',
-  OnboardingController.toggleChecklistItem
-);
-
+onboardingRouter.post('/checklists/item/:checklistId/checked', OnboardingController.toggleChecklistItem);
 
 export default onboardingRouter;

--- a/src/backend/src/services/onboarding.services.ts
+++ b/src/backend/src/services/onboarding.services.ts
@@ -326,9 +326,9 @@ export default class OnboardingServices {
    * @param userId the id of the user to toggle
    * @returns the updated checklist
    */
-  static async toggleChecklist(checklistId: string, userId: string) {
+  static async toggleChecklist(checklistId: string, user: User, organization: Organization) {
     const checklist = await prisma.checklist.findUnique({
-      where: { checklistId },
+      where: { checklistId, organizationId: organization.organizationId },
       include: { usersChecked: true, subtasks: { where: { dateDeleted: null }, include: { usersChecked: true } } }
     });
 
@@ -340,9 +340,13 @@ export default class OnboardingServices {
       throw new DeletedException('Checklist', checklistId);
     }
 
+    const { userId } = user;
     const isChecked = checklist.usersChecked.some((user) => user.userId === userId);
 
-    if (checklist.parentChecklistId == null && checklist.subtasks.length > 0) {
+    if (
+      checklist.subtasks.length > 0 &&
+      !checklist.subtasks.every((subtask) => subtask.usersChecked.some((user) => user.userId === userId))
+    ) {
       throw new HttpException(400, 'Cannot check off this checklist item because not all of its subtasks are checked.');
     }
 

--- a/src/backend/src/services/onboarding.services.ts
+++ b/src/backend/src/services/onboarding.services.ts
@@ -330,10 +330,14 @@ export default class OnboardingServices {
       throw new NotFoundException('Checklist', checklistId);
     }
 
+    if (checklist.dateDeleted) {
+      throw new DeletedException('Checklist', checklistId);
+    }
+
     const isChecked = checklist.usersChecked.some((user) => user.userId === userId);
 
     if (checklist.parentChecklistId == null && checklist.subtasks.length > 0) {
-      throw new HttpException(400, 'Cannot check off this checklist item unless its childred have been checked.');
+      throw new HttpException(400, 'Cannot check off this checklist item because not all of its subtasks are checked.');
     }
 
     if (isChecked) {
@@ -378,6 +382,15 @@ export default class OnboardingServices {
             data: {
               usersChecked: {
                 connect: { userId }
+              }
+            }
+          });
+        } else {
+          await prisma.checklist.update({
+            where: { checklistId: parentChecklist.checklistId },
+            data: {
+              usersChecked: {
+                disconnect: { userId }
               }
             }
           });

--- a/src/backend/src/services/onboarding.services.ts
+++ b/src/backend/src/services/onboarding.services.ts
@@ -308,7 +308,6 @@ export default class OnboardingServices {
       throw new DeletedException('Checklist', checklistId);
     }
 
-    // delete all subtasks
     await prisma.checklist.updateMany({
       where: { parentChecklistId: checklistId },
       data: { dateDeleted: new Date(), userDeletedId: deleter.userId }
@@ -318,5 +317,82 @@ export default class OnboardingServices {
       where: { checklistId },
       data: { dateDeleted: new Date(), userDeletedId: deleter.userId }
     });
+  }
+
+  static async toggleChecklistItem(checklistId: string, userId: string) {
+    const checklist = await prisma.checklist.findUnique({
+      where: { checklistId },
+      include: { usersChecked: true, subtasks: true }
+    });
+
+    if (!checklist) {
+      throw new NotFoundException('Checklist', checklistId);
+    }
+
+    const isChecked = checklist.usersChecked.some((user) => user.userId === userId);
+
+    if (isChecked) {
+      await prisma.checklist.update({
+        where: { checklistId },
+        data: {
+          usersChecked: {
+            disconnect: { userId }
+          }
+        }
+      });
+    } else {
+      await prisma.checklist.update({
+        where: { checklistId },
+        data: {
+          usersChecked: {
+            connect: { userId }
+          }
+        }
+      });
+    }
+
+    if (!checklist.parentChecklistId) {
+      return checklist;
+    }
+
+    const parentChecklist = await prisma.checklist.findUnique({
+      where: { checklistId: checklist.parentChecklistId },
+      include: {
+        subtasks: {
+          where: { dateDeleted: null },
+          include: { usersChecked: true }
+        }
+      }
+    });
+
+    if (!parentChecklist) {
+      return checklist;
+    }
+
+    const allSubtasksChecked = parentChecklist.subtasks.every((subtask) =>
+      subtask.usersChecked.some((user) => user.userId === userId)
+    );
+
+    if (allSubtasksChecked) {
+      await prisma.checklist.update({
+        where: { checklistId: parentChecklist.checklistId },
+        data: {
+          usersChecked: {
+            connect: { userId }
+          }
+        }
+      });
+    } else {
+      await prisma.checklist.update({
+        where: { checklistId: parentChecklist.checklistId },
+        data: {
+          usersChecked: {
+            disconnect: { userId }
+          }
+        }
+      });
+    }
+
+    return checklist;
   }
 }

--- a/src/backend/src/services/onboarding.services.ts
+++ b/src/backend/src/services/onboarding.services.ts
@@ -356,6 +356,7 @@ export default class OnboardingServices {
       });
     }
 
+    // Check off the parent checklist if all subtasks are checked
     if (checklist.parentChecklistId) {
       const parentChecklist = await prisma.checklist.findUnique({
         where: { checklistId: checklist.parentChecklistId },

--- a/src/backend/src/services/onboarding.services.ts
+++ b/src/backend/src/services/onboarding.services.ts
@@ -320,6 +320,12 @@ export default class OnboardingServices {
     });
   }
 
+  /**
+   * Toggles a user's check on a checklist
+   * @param checklistId the id of the checklist to toggle
+   * @param userId the id of the user to toggle
+   * @returns the updated checklist
+   */
   static async toggleChecklist(checklistId: string, userId: string) {
     const checklist = await prisma.checklist.findUnique({
       where: { checklistId },

--- a/src/backend/src/services/onboarding.services.ts
+++ b/src/backend/src/services/onboarding.services.ts
@@ -351,46 +351,41 @@ export default class OnboardingServices {
       });
     }
 
-    if (!checklist.parentChecklistId) {
-      return checklist;
-    }
+    if (checklist.parentChecklistId) {
+      const parentChecklist = await prisma.checklist.findUnique({
+        where: { checklistId: checklist.parentChecklistId },
+        include: {
+          subtasks: {
+            where: { dateDeleted: null },
+            include: { usersChecked: true }
+          }
+        }
+      });
 
-    const parentChecklist = await prisma.checklist.findUnique({
-      where: { checklistId: checklist.parentChecklistId },
-      include: {
-        subtasks: {
-          where: { dateDeleted: null },
-          include: { usersChecked: true }
+      if (parentChecklist) {
+        const allSubtasksChecked = parentChecklist.subtasks.every((subtask) =>
+          subtask.usersChecked.some((user) => user.userId === userId)
+        );
+        if (allSubtasksChecked) {
+          await prisma.checklist.update({
+            where: { checklistId: parentChecklist.checklistId },
+            data: {
+              usersChecked: {
+                connect: { userId }
+              }
+            }
+          });
+        } else {
+          await prisma.checklist.update({
+            where: { checklistId: parentChecklist.checklistId },
+            data: {
+              usersChecked: {
+                disconnect: { userId }
+              }
+            }
+          });
         }
       }
-    });
-
-    if (!parentChecklist) {
-      return checklist;
-    }
-
-    const allSubtasksChecked = parentChecklist.subtasks.every((subtask) =>
-      subtask.usersChecked.some((user) => user.userId === userId)
-    );
-
-    if (allSubtasksChecked) {
-      await prisma.checklist.update({
-        where: { checklistId: parentChecklist.checklistId },
-        data: {
-          usersChecked: {
-            connect: { userId }
-          }
-        }
-      });
-    } else {
-      await prisma.checklist.update({
-        where: { checklistId: parentChecklist.checklistId },
-        data: {
-          usersChecked: {
-            disconnect: { userId }
-          }
-        }
-      });
     }
 
     return checklist;

--- a/src/backend/src/services/onboarding.services.ts
+++ b/src/backend/src/services/onboarding.services.ts
@@ -16,7 +16,7 @@ export default class OnboardingServices {
   static async getAllChecklists(organization: Organization) {
     const allChecklists = await prisma.checklist.findMany({
       where: { organizationId: organization.organizationId, dateDeleted: null, parentChecklistId: null },
-      include: { subtasks: true, teamType: true }
+      include: { subtasks: true, teamType: true, usersChecked: true }
     });
 
     return allChecklists;
@@ -36,7 +36,7 @@ export default class OnboardingServices {
         dateDeleted: null,
         parentChecklistId: null
       },
-      include: { subtasks: true, teamType: true }
+      include: { subtasks: true, teamType: true, usersChecked: true }
     });
     return generalChecklists;
   }
@@ -397,8 +397,12 @@ export default class OnboardingServices {
         }
       }
     }
+    const updatedChecklist = await prisma.checklist.findUnique({
+      where: { checklistId },
+      include: { usersChecked: true }
+    });
 
-    return prisma.checklist.findUnique({ where: { checklistId } });
+    return updatedChecklist;
   }
 
   static async downloadImage(fileId: string) {

--- a/src/backend/src/services/onboarding.services.ts
+++ b/src/backend/src/services/onboarding.services.ts
@@ -322,7 +322,7 @@ export default class OnboardingServices {
   static async toggleChecklistItem(checklistId: string, userId: string) {
     const checklist = await prisma.checklist.findUnique({
       where: { checklistId },
-      include: { usersChecked: true, subtasks: true }
+      include: { usersChecked: true, subtasks: { where: { dateDeleted: null }, include: { usersChecked: true } } }
     });
 
     if (!checklist) {
@@ -330,6 +330,16 @@ export default class OnboardingServices {
     }
 
     const isChecked = checklist.usersChecked.some((user) => user.userId === userId);
+
+    if (checklist.subtasks.length > 0 && !isChecked) {
+      const allSubtasksChecked = checklist.subtasks.every((subtask) =>
+        subtask.usersChecked.some((user) => user.userId === userId)
+      );
+
+      if (!allSubtasksChecked) {
+        throw new Error('Cannot check off this checklist item because not all of its subtasks are checked.');
+      }
+    }
 
     if (isChecked) {
       await prisma.checklist.update({

--- a/src/backend/src/services/onboarding.services.ts
+++ b/src/backend/src/services/onboarding.services.ts
@@ -320,7 +320,7 @@ export default class OnboardingServices {
     });
   }
 
-  static async toggleChecklistItem(checklistId: string, userId: string) {
+  static async toggleChecklist(checklistId: string, userId: string) {
     const checklist = await prisma.checklist.findUnique({
       where: { checklistId },
       include: { usersChecked: true, subtasks: { where: { dateDeleted: null }, include: { usersChecked: true } } }
@@ -332,14 +332,8 @@ export default class OnboardingServices {
 
     const isChecked = checklist.usersChecked.some((user) => user.userId === userId);
 
-    if (checklist.subtasks.length > 0 && !isChecked) {
-      const allSubtasksChecked = checklist.subtasks.every((subtask) =>
-        subtask.usersChecked.some((user) => user.userId === userId)
-      );
-
-      if (!allSubtasksChecked) {
-        throw new Error('Cannot check off this checklist item because not all of its subtasks are checked.');
-      }
+    if (checklist.parentChecklistId == null && checklist.subtasks.length > 0) {
+      throw new HttpException(400, 'Cannot check off this checklist item unless its childred have been checked.');
     }
 
     if (isChecked) {
@@ -386,21 +380,13 @@ export default class OnboardingServices {
               }
             }
           });
-        } else {
-          await prisma.checklist.update({
-            where: { checklistId: parentChecklist.checklistId },
-            data: {
-              usersChecked: {
-                disconnect: { userId }
-              }
-            }
-          });
         }
       }
     }
 
-    return checklist;
-}
+    return prisma.checklist.findUnique({ where: { checklistId } });
+  }
+
   static async downloadImage(fileId: string) {
     const fileData = await downloadImageFile(fileId);
 

--- a/src/backend/tests/test-utils.ts
+++ b/src/backend/tests/test-utils.ts
@@ -301,7 +301,8 @@ export const createTestChecklist = async (
     },
     include: {
       subtasks: true,
-      teamType: true
+      teamType: true,
+      usersChecked: true
     }
   });
 

--- a/src/backend/tests/unmocked/onboarding.test.ts
+++ b/src/backend/tests/unmocked/onboarding.test.ts
@@ -507,7 +507,7 @@ describe('Onboarding tests', () => {
     it('Toggles checklist item and updates the parent checklist item if all children checked', async () => {
       const batman = await createTestUser(batmanAppAdmin, orgId);
 
-      const parentChecklist = await createTestChecklist(batman, orgId, 'Parent Checklist');
+      const parentChecklist = await createTestChecklist(batman, orgId, 'Parent Checklist', undefined, undefined, undefined);
       const parentChecklistItem = await createTestChecklist(
         batman,
         orgId,
@@ -594,6 +594,22 @@ describe('Onboarding tests', () => {
         include: { usersChecked: true }
       });
       expect(revertedParentItem?.usersChecked.length).toBe(0);
+
+      await expect(
+        OnboardingServices.toggleChecklistItem(parentChecklistItem.checklistId, batman.userId)
+      ).rejects.toThrowError('Cannot check off this checklist item because not all of its subtasks are checked.');
+
+      await OnboardingServices.toggleChecklistItem(childChecklistItem1.checklistId, batman.userId);
+
+      await expect(
+        OnboardingServices.toggleChecklistItem(parentChecklistItem.checklistId, batman.userId)
+      ).resolves.not.toThrow();
+
+      const finalParentItem = await prisma.checklist.findUnique({
+        where: { checklistId: parentChecklistItem.checklistId },
+        include: { usersChecked: true }
+      });
+      expect(finalParentItem?.usersChecked.some((user) => user.userId === batman.userId)).toBe(true);
     });
   });
 });

--- a/src/backend/tests/unmocked/onboarding.test.ts
+++ b/src/backend/tests/unmocked/onboarding.test.ts
@@ -502,4 +502,98 @@ describe('Onboarding tests', () => {
       expect(newChildChecklist!.dateDeleted).not.toBeNull();
     });
   });
+
+  describe('Toggle Checklist Item', () => {
+    it('Toggles checklist item and updates the parent checklist item if all children checked', async () => {
+      const batman = await createTestUser(batmanAppAdmin, orgId);
+
+      const parentChecklist = await createTestChecklist(batman, orgId, 'Parent Checklist');
+      const parentChecklistItem = await createTestChecklist(
+        batman,
+        orgId,
+        'Parent Checklist Item',
+        undefined,
+        undefined,
+        parentChecklist.checklistId
+      );
+
+      const childChecklistItem1 = await createTestChecklist(
+        batman,
+        orgId,
+        'Child Checklist Item 1',
+        undefined,
+        undefined,
+        parentChecklistItem.checklistId
+      );
+
+      const childChecklistItem2 = await createTestChecklist(
+        batman,
+        orgId,
+        'Child Checklist Item 2',
+        undefined,
+        undefined,
+        parentChecklistItem.checklistId
+      );
+
+      const initialParentItem = await prisma.checklist.findUnique({
+        where: { checklistId: parentChecklistItem.checklistId },
+        include: { usersChecked: true }
+      });
+      expect(initialParentItem?.usersChecked.length).toBe(0);
+
+      const initialChildItem1 = await prisma.checklist.findUnique({
+        where: { checklistId: childChecklistItem1.checklistId },
+        include: { usersChecked: true }
+      });
+      expect(initialChildItem1?.usersChecked.length).toBe(0);
+
+      const initialChildItem2 = await prisma.checklist.findUnique({
+        where: { checklistId: childChecklistItem2.checklistId },
+        include: { usersChecked: true }
+      });
+      expect(initialChildItem2?.usersChecked.length).toBe(0);
+
+      await OnboardingServices.toggleChecklistItem(childChecklistItem1.checklistId, batman.userId);
+
+      const updatedChildItem1 = await prisma.checklist.findUnique({
+        where: { checklistId: childChecklistItem1.checklistId },
+        include: { usersChecked: true }
+      });
+      expect(updatedChildItem1?.usersChecked.length).toBe(1);
+
+      const partiallyUpdatedParentItem = await prisma.checklist.findUnique({
+        where: { checklistId: parentChecklistItem.checklistId },
+        include: { usersChecked: true }
+      });
+      expect(partiallyUpdatedParentItem?.usersChecked.length).toBe(0);
+
+      await OnboardingServices.toggleChecklistItem(childChecklistItem2.checklistId, batman.userId);
+
+      const updatedChildItem2 = await prisma.checklist.findUnique({
+        where: { checklistId: childChecklistItem2.checklistId },
+        include: { usersChecked: true }
+      });
+      expect(updatedChildItem2?.usersChecked.length).toBe(1);
+
+      const fullyUpdatedParentItem = await prisma.checklist.findUnique({
+        where: { checklistId: parentChecklistItem.checklistId },
+        include: { usersChecked: true }
+      });
+      expect(fullyUpdatedParentItem?.usersChecked.length).toBe(1);
+
+      await OnboardingServices.toggleChecklistItem(childChecklistItem1.checklistId, batman.userId);
+
+      const revertedChildItem1 = await prisma.checklist.findUnique({
+        where: { checklistId: childChecklistItem1.checklistId },
+        include: { usersChecked: true }
+      });
+      expect(revertedChildItem1?.usersChecked.length).toBe(0);
+
+      const revertedParentItem = await prisma.checklist.findUnique({
+        where: { checklistId: parentChecklistItem.checklistId },
+        include: { usersChecked: true }
+      });
+      expect(revertedParentItem?.usersChecked.length).toBe(0);
+    });
+  });
 });

--- a/src/backend/tests/unmocked/onboarding.test.ts
+++ b/src/backend/tests/unmocked/onboarding.test.ts
@@ -538,7 +538,7 @@ describe('Onboarding tests', () => {
       expect(childChecklistItem1?.usersChecked.length).toBe(0);
       expect(childChecklistItem2?.usersChecked.length).toBe(0);
 
-      await OnboardingServices.toggleChecklist(childChecklistItem1.checklistId, batman.userId);
+      await OnboardingServices.toggleChecklist(childChecklistItem1.checklistId, batman, organization);
 
       const updatedChildItem1 = await prisma.checklist.findUnique({
         where: { checklistId: childChecklistItem1.checklistId },
@@ -554,7 +554,7 @@ describe('Onboarding tests', () => {
       expect(partiallyUpdatedParentItem?.usersChecked.length).toBe(0);
 
       // check all child items to update parent item
-      await OnboardingServices.toggleChecklist(childChecklistItem2.checklistId, batman.userId);
+      await OnboardingServices.toggleChecklist(childChecklistItem2.checklistId, batman, organization);
 
       const updatedChildItem2 = await prisma.checklist.findUnique({
         where: { checklistId: childChecklistItem2.checklistId },
@@ -569,7 +569,7 @@ describe('Onboarding tests', () => {
       expect(fullyUpdatedParentItem?.usersChecked.length).toBe(1);
 
       // uncheck child item to automatically uncheck parent item
-      await OnboardingServices.toggleChecklist(childChecklistItem1.checklistId, batman.userId);
+      await OnboardingServices.toggleChecklist(childChecklistItem1.checklistId, batman, organization);
 
       const revertedChildItem1 = await prisma.checklist.findUnique({
         where: { checklistId: childChecklistItem1.checklistId },
@@ -586,7 +586,7 @@ describe('Onboarding tests', () => {
 
     it('throws NotFoundException when toggling a non-existing checklist item', async () => {
       const batman = await createTestUser(batmanAppAdmin, orgId);
-      await expect(OnboardingServices.toggleChecklist('nonExistingId', batman.userId)).rejects.toThrow(
+      await expect(OnboardingServices.toggleChecklist('nonExistingId', batman, organization)).rejects.toThrow(
         new NotFoundException('Checklist', 'nonExistingId')
       );
     });
@@ -599,7 +599,7 @@ describe('Onboarding tests', () => {
         data: { dateDeleted: new Date() }
       });
 
-      await expect(OnboardingServices.toggleChecklist(checklist.checklistId, batman.userId)).rejects.toThrow(
+      await expect(OnboardingServices.toggleChecklist(checklist.checklistId, batman, organization)).rejects.toThrow(
         new DeletedException('Checklist', checklist.checklistId)
       );
     });
@@ -635,17 +635,17 @@ describe('Onboarding tests', () => {
         parentChecklistItem.checklistId
       );
 
-      await OnboardingServices.toggleChecklist(childChecklistItem1.checklistId, batman.userId);
+      await OnboardingServices.toggleChecklist(childChecklistItem1.checklistId, batman, organization);
 
       await expect(
-        async () => await OnboardingServices.toggleChecklist(parentChecklist.checklistId, batman.userId)
+        async () => await OnboardingServices.toggleChecklist(parentChecklist.checklistId, batman, organization)
       ).rejects.toThrowError('Cannot check off this checklist item because not all of its subtasks are checked.');
     });
 
     it('Succeeds and toggles a checklist without any subtasks', async () => {
       const batman = await createTestUser(batmanAppAdmin, orgId);
       const checklist = await createTestChecklist(batman, orgId, 'Checklist 1');
-      await OnboardingServices.toggleChecklist(checklist.checklistId, batman.userId);
+      await OnboardingServices.toggleChecklist(checklist.checklistId, batman, organization);
       const updatedChecklist = await prisma.checklist.findUnique({
         where: { checklistId: checklist.checklistId },
         include: { usersChecked: true }

--- a/src/backend/tests/unmocked/onboarding.test.ts
+++ b/src/backend/tests/unmocked/onboarding.test.ts
@@ -553,7 +553,7 @@ describe('Onboarding tests', () => {
       });
       expect(initialChildItem2?.usersChecked.length).toBe(0);
 
-      await OnboardingServices.toggleChecklistItem(childChecklistItem1.checklistId, batman.userId);
+      await OnboardingServices.toggleChecklist(childChecklistItem1.checklistId, batman.userId);
 
       const updatedChildItem1 = await prisma.checklist.findUnique({
         where: { checklistId: childChecklistItem1.checklistId },
@@ -567,7 +567,7 @@ describe('Onboarding tests', () => {
       });
       expect(partiallyUpdatedParentItem?.usersChecked.length).toBe(0);
 
-      await OnboardingServices.toggleChecklistItem(childChecklistItem2.checklistId, batman.userId);
+      await OnboardingServices.toggleChecklist(childChecklistItem2.checklistId, batman.userId);
 
       const updatedChildItem2 = await prisma.checklist.findUnique({
         where: { checklistId: childChecklistItem2.checklistId },
@@ -581,7 +581,7 @@ describe('Onboarding tests', () => {
       });
       expect(fullyUpdatedParentItem?.usersChecked.length).toBe(1);
 
-      await OnboardingServices.toggleChecklistItem(childChecklistItem1.checklistId, batman.userId);
+      await OnboardingServices.toggleChecklist(childChecklistItem1.checklistId, batman.userId);
 
       const revertedChildItem1 = await prisma.checklist.findUnique({
         where: { checklistId: childChecklistItem1.checklistId },
@@ -595,14 +595,14 @@ describe('Onboarding tests', () => {
       });
       expect(revertedParentItem?.usersChecked.length).toBe(0);
 
-      await expect(
-        OnboardingServices.toggleChecklistItem(parentChecklistItem.checklistId, batman.userId)
-      ).rejects.toThrowError('Cannot check off this checklist item because not all of its subtasks are checked.');
+      await expect(OnboardingServices.toggleChecklist(parentChecklistItem.checklistId, batman.userId)).rejects.toThrowError(
+        'Cannot check off this checklist item because not all of its subtasks are checked.'
+      );
 
-      await OnboardingServices.toggleChecklistItem(childChecklistItem1.checklistId, batman.userId);
+      await OnboardingServices.toggleChecklist(childChecklistItem1.checklistId, batman.userId);
 
       await expect(
-        OnboardingServices.toggleChecklistItem(parentChecklistItem.checklistId, batman.userId)
+        OnboardingServices.toggleChecklist(parentChecklistItem.checklistId, batman.userId)
       ).resolves.not.toThrow();
 
       const finalParentItem = await prisma.checklist.findUnique({
@@ -610,6 +610,151 @@ describe('Onboarding tests', () => {
         include: { usersChecked: true }
       });
       expect(finalParentItem?.usersChecked.some((user) => user.userId === batman.userId)).toBe(true);
+    });
+
+    it('throws NotFoundException when toggling a non-existing checklist item', async () => {
+      const batman = await createTestUser(batmanAppAdmin, orgId);
+      await expect(OnboardingServices.toggleChecklist('nonExistingId', batman.userId)).rejects.toThrow(
+        new NotFoundException('Checklist', 'nonExistingId')
+      );
+    });
+
+    it('throws DeletedException when toggling a deleted checklist item', async () => {
+      const batman = await createTestUser(batmanAppAdmin, orgId);
+      const checklist = await createTestChecklist(batman, orgId, 'Checklist to Delete');
+      await prisma.checklist.update({
+        where: { checklistId: checklist.checklistId },
+        data: { dateDeleted: new Date() }
+      });
+
+      await expect(OnboardingServices.toggleChecklist(checklist.checklistId, batman.userId)).rejects.toThrow(
+        new DeletedException('Checklist', checklist.checklistId)
+      );
+    });
+
+    it('throws HttpException when trying to toggle a parent checklist before all children are checked', async () => {
+      const batman = await createTestUser(batmanAppAdmin, orgId);
+
+      const parentChecklist = await createTestChecklist(batman, orgId, 'Parent Checklist');
+      const parentChecklistItem = await createTestChecklist(
+        batman,
+        orgId,
+        'Parent Checklist Item',
+        undefined,
+        undefined,
+        parentChecklist.checklistId
+      );
+
+      const childChecklistItem1 = await createTestChecklist(
+        batman,
+        orgId,
+        'Child Checklist Item 1',
+        undefined,
+        undefined,
+        parentChecklistItem.checklistId
+      );
+
+      const childChecklistItem2 = await createTestChecklist(
+        batman,
+        orgId,
+        'Child Checklist Item 2',
+        undefined,
+        undefined,
+        parentChecklistItem.checklistId
+      );
+
+      await OnboardingServices.toggleChecklist(childChecklistItem1.checklistId, batman.userId);
+
+      await expect(OnboardingServices.toggleChecklist(parentChecklistItem.checklistId, batman.userId)).rejects.toThrowError(
+        'Cannot check off this checklist item because not all of its subtasks are checked.'
+      );
+    });
+
+    it('allows checking the parent checklist after all children are checked', async () => {
+      const batman = await createTestUser(batmanAppAdmin, orgId);
+
+      const parentChecklist = await createTestChecklist(batman, orgId, 'Parent Checklist');
+      const parentChecklistItem = await createTestChecklist(
+        batman,
+        orgId,
+        'Parent Checklist Item',
+        undefined,
+        undefined,
+        parentChecklist.checklistId
+      );
+
+      const childChecklistItem1 = await createTestChecklist(
+        batman,
+        orgId,
+        'Child Checklist Item 1',
+        undefined,
+        undefined,
+        parentChecklistItem.checklistId
+      );
+
+      const childChecklistItem2 = await createTestChecklist(
+        batman,
+        orgId,
+        'Child Checklist Item 2',
+        undefined,
+        undefined,
+        parentChecklistItem.checklistId
+      );
+
+      await OnboardingServices.toggleChecklist(childChecklistItem1.checklistId, batman.userId);
+      await OnboardingServices.toggleChecklist(childChecklistItem2.checklistId, batman.userId);
+
+      await expect(
+        OnboardingServices.toggleChecklist(parentChecklistItem.checklistId, batman.userId)
+      ).resolves.not.toThrow();
+
+      const finalParentItem = await prisma.checklist.findUnique({
+        where: { checklistId: parentChecklistItem.checklistId },
+        include: { usersChecked: true }
+      });
+      expect(finalParentItem?.usersChecked.some((user) => user.userId === batman.userId)).toBe(true);
+    });
+
+    it('allows unchecking the parent checklist and updates children accordingly', async () => {
+      const batman = await createTestUser(batmanAppAdmin, orgId);
+
+      const parentChecklist = await createTestChecklist(batman, orgId, 'Parent Checklist');
+      const parentChecklistItem = await createTestChecklist(
+        batman,
+        orgId,
+        'Parent Checklist Item',
+        undefined,
+        undefined,
+        parentChecklist.checklistId
+      );
+
+      const childChecklistItem1 = await createTestChecklist(
+        batman,
+        orgId,
+        'Child Checklist Item 1',
+        undefined,
+        undefined,
+        parentChecklistItem.checklistId
+      );
+
+      const childChecklistItem2 = await createTestChecklist(
+        batman,
+        orgId,
+        'Child Checklist Item 2',
+        undefined,
+        undefined,
+        parentChecklistItem.checklistId
+      );
+
+      await OnboardingServices.toggleChecklist(childChecklistItem1.checklistId, batman.userId);
+      await OnboardingServices.toggleChecklist(childChecklistItem2.checklistId, batman.userId);
+      await OnboardingServices.toggleChecklist(parentChecklistItem.checklistId, batman.userId);
+
+      const parentAfter = await prisma.checklist.findUnique({
+        where: { checklistId: parentChecklistItem.checklistId },
+        include: { usersChecked: true }
+      });
+      expect(parentAfter?.usersChecked.length).toBe(0);
     });
   });
 });

--- a/src/backend/tests/unmocked/onboarding.test.ts
+++ b/src/backend/tests/unmocked/onboarding.test.ts
@@ -535,23 +535,8 @@ describe('Onboarding tests', () => {
         parentChecklistItem.checklistId
       );
 
-      const initialParentItem = await prisma.checklist.findUnique({
-        where: { checklistId: parentChecklistItem.checklistId },
-        include: { usersChecked: true }
-      });
-      expect(initialParentItem?.usersChecked.length).toBe(0);
-
-      const initialChildItem1 = await prisma.checklist.findUnique({
-        where: { checklistId: childChecklistItem1.checklistId },
-        include: { usersChecked: true }
-      });
-      expect(initialChildItem1?.usersChecked.length).toBe(0);
-
-      const initialChildItem2 = await prisma.checklist.findUnique({
-        where: { checklistId: childChecklistItem2.checklistId },
-        include: { usersChecked: true }
-      });
-      expect(initialChildItem2?.usersChecked.length).toBe(0);
+      expect(childChecklistItem1?.usersChecked.length).toBe(0);
+      expect(childChecklistItem2?.usersChecked.length).toBe(0);
 
       await OnboardingServices.toggleChecklist(childChecklistItem1.checklistId, batman.userId);
 
@@ -559,14 +544,16 @@ describe('Onboarding tests', () => {
         where: { checklistId: childChecklistItem1.checklistId },
         include: { usersChecked: true }
       });
-      expect(updatedChildItem1?.usersChecked.length).toBe(1);
 
       const partiallyUpdatedParentItem = await prisma.checklist.findUnique({
         where: { checklistId: parentChecklistItem.checklistId },
         include: { usersChecked: true }
       });
+
+      expect(updatedChildItem1?.usersChecked.length).toBe(1);
       expect(partiallyUpdatedParentItem?.usersChecked.length).toBe(0);
 
+      // check all child items to update parent item
       await OnboardingServices.toggleChecklist(childChecklistItem2.checklistId, batman.userId);
 
       const updatedChildItem2 = await prisma.checklist.findUnique({
@@ -581,6 +568,7 @@ describe('Onboarding tests', () => {
       });
       expect(fullyUpdatedParentItem?.usersChecked.length).toBe(1);
 
+      // uncheck child item to automatically uncheck parent item
       await OnboardingServices.toggleChecklist(childChecklistItem1.checklistId, batman.userId);
 
       const revertedChildItem1 = await prisma.checklist.findUnique({
@@ -594,22 +582,6 @@ describe('Onboarding tests', () => {
         include: { usersChecked: true }
       });
       expect(revertedParentItem?.usersChecked.length).toBe(0);
-
-      await expect(OnboardingServices.toggleChecklist(parentChecklistItem.checklistId, batman.userId)).rejects.toThrowError(
-        'Cannot check off this checklist item because not all of its subtasks are checked.'
-      );
-
-      await OnboardingServices.toggleChecklist(childChecklistItem1.checklistId, batman.userId);
-
-      await expect(
-        OnboardingServices.toggleChecklist(parentChecklistItem.checklistId, batman.userId)
-      ).resolves.not.toThrow();
-
-      const finalParentItem = await prisma.checklist.findUnique({
-        where: { checklistId: parentChecklistItem.checklistId },
-        include: { usersChecked: true }
-      });
-      expect(finalParentItem?.usersChecked.some((user) => user.userId === batman.userId)).toBe(true);
     });
 
     it('throws NotFoundException when toggling a non-existing checklist item', async () => {
@@ -654,7 +626,7 @@ describe('Onboarding tests', () => {
         parentChecklistItem.checklistId
       );
 
-      const childChecklistItem2 = await createTestChecklist(
+      await createTestChecklist(
         batman,
         orgId,
         'Child Checklist Item 2',
@@ -664,97 +636,21 @@ describe('Onboarding tests', () => {
       );
 
       await OnboardingServices.toggleChecklist(childChecklistItem1.checklistId, batman.userId);
-
-      await expect(OnboardingServices.toggleChecklist(parentChecklistItem.checklistId, batman.userId)).rejects.toThrowError(
-        'Cannot check off this checklist item because not all of its subtasks are checked.'
-      );
-    });
-
-    it('allows checking the parent checklist after all children are checked', async () => {
-      const batman = await createTestUser(batmanAppAdmin, orgId);
-
-      const parentChecklist = await createTestChecklist(batman, orgId, 'Parent Checklist');
-      const parentChecklistItem = await createTestChecklist(
-        batman,
-        orgId,
-        'Parent Checklist Item',
-        undefined,
-        undefined,
-        parentChecklist.checklistId
-      );
-
-      const childChecklistItem1 = await createTestChecklist(
-        batman,
-        orgId,
-        'Child Checklist Item 1',
-        undefined,
-        undefined,
-        parentChecklistItem.checklistId
-      );
-
-      const childChecklistItem2 = await createTestChecklist(
-        batman,
-        orgId,
-        'Child Checklist Item 2',
-        undefined,
-        undefined,
-        parentChecklistItem.checklistId
-      );
-
-      await OnboardingServices.toggleChecklist(childChecklistItem1.checklistId, batman.userId);
-      await OnboardingServices.toggleChecklist(childChecklistItem2.checklistId, batman.userId);
 
       await expect(
-        OnboardingServices.toggleChecklist(parentChecklistItem.checklistId, batman.userId)
-      ).resolves.not.toThrow();
-
-      const finalParentItem = await prisma.checklist.findUnique({
-        where: { checklistId: parentChecklistItem.checklistId },
-        include: { usersChecked: true }
-      });
-      expect(finalParentItem?.usersChecked.some((user) => user.userId === batman.userId)).toBe(true);
+        async () => await OnboardingServices.toggleChecklist(parentChecklist.checklistId, batman.userId)
+      ).rejects.toThrowError('Cannot check off this checklist item because not all of its subtasks are checked.');
     });
 
-    it('allows unchecking the parent checklist and updates children accordingly', async () => {
+    it('Succeeds and toggles a checklist without any subtasks', async () => {
       const batman = await createTestUser(batmanAppAdmin, orgId);
-
-      const parentChecklist = await createTestChecklist(batman, orgId, 'Parent Checklist');
-      const parentChecklistItem = await createTestChecklist(
-        batman,
-        orgId,
-        'Parent Checklist Item',
-        undefined,
-        undefined,
-        parentChecklist.checklistId
-      );
-
-      const childChecklistItem1 = await createTestChecklist(
-        batman,
-        orgId,
-        'Child Checklist Item 1',
-        undefined,
-        undefined,
-        parentChecklistItem.checklistId
-      );
-
-      const childChecklistItem2 = await createTestChecklist(
-        batman,
-        orgId,
-        'Child Checklist Item 2',
-        undefined,
-        undefined,
-        parentChecklistItem.checklistId
-      );
-
-      await OnboardingServices.toggleChecklist(childChecklistItem1.checklistId, batman.userId);
-      await OnboardingServices.toggleChecklist(childChecklistItem2.checklistId, batman.userId);
-      await OnboardingServices.toggleChecklist(parentChecklistItem.checklistId, batman.userId);
-
-      const parentAfter = await prisma.checklist.findUnique({
-        where: { checklistId: parentChecklistItem.checklistId },
+      const checklist = await createTestChecklist(batman, orgId, 'Checklist 1');
+      await OnboardingServices.toggleChecklist(checklist.checklistId, batman.userId);
+      const updatedChecklist = await prisma.checklist.findUnique({
+        where: { checklistId: checklist.checklistId },
         include: { usersChecked: true }
       });
-      expect(parentAfter?.usersChecked.length).toBe(0);
+      expect(updatedChecklist?.usersChecked.length).toBe(1);
     });
   });
 });


### PR DESCRIPTION
## Changes

-added new endpoint /onboarding/checklists/item/:checklistId/checked in onboarding.routes.ts to toggle the usersChecked. 
-added toggleChecklistItem in onboarding controller and onboarding service
-status of a checklist item for a specific user.
-implemented logic to update parent checklist item if all child checklist items are checked/unchecked.
-throws exceptions if checklistId doesn't exist or is invalid.
-wrote tests
new:
- made sure parent cant be checked if not all children are checked
- added/edited tests to test 
- refactored ppreviouscode


## Test Cases

- toggle a checklist item (add the current user to usersChecked) and check database updates.
- remove the user from usersChecked and check database updates.
- toggle a child item and verify that the parent checklist item is automatically updated when all child items are checked.
- test with a fake checklistId and made sure error (NotFoundException) is thrown.
- edge case: when toggled again, shouldn't throw error and parent checklist should uncheck itself.
- test when toggling parent when all subtasks aren't checked -> should throw error. (the test only checks upto the immediate parent because checking the grandparents, etc. would be too much recursion and need a lot of changes to testing structure.)

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x ] All commits are tagged with the ticket number
- [x ] No linting errors / newline at end of file warnings
- [x ] All code follows repository-configured prettier formatting
- [x ] No merge conflicts
- [x ] All checks passing
- [x ] Screenshots of UI changes (see Screenshots section)
- [x ] Remove any non-applicable sections of this template
- [ x] Assign the PR to yourself
- [x ] No `yarn.lock` changes (unless dependencies have changed)
- [x ] Request reviewers & ping on Slack
- [ x] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
#2942 