### PR TITLE
#2883 Create Get Graph Collections

### DIFF
--- a/src/backend/src/controllers/statistics.controllers.ts
+++ b/src/backend/src/controllers/statistics.controllers.ts
@@ -48,4 +48,13 @@ export default class StatisticsController {
       next(error);
     }
   }
+
+  static async getAllGraphCollections(req: Request, res: Response, next: NextFunction) {
+    try {
+      const graphCollections = await StatisticsService.getAllGraphCollections(req.organization);
+      return res.status(200).json(graphCollections);
+    } catch (error: unknown) {
+      return next(error);
+    }
+  }
 }

--- a/src/backend/src/controllers/statistics.controllers.ts
+++ b/src/backend/src/controllers/statistics.controllers.ts
@@ -52,9 +52,9 @@ export default class StatisticsController {
   static async getAllGraphCollections(req: Request, res: Response, next: NextFunction) {
     try {
       const graphCollections = await StatisticsService.getAllGraphCollections(req.organization);
-      return res.status(200).json(graphCollections);
+      res.status(200).json(graphCollections);
     } catch (error: unknown) {
-      return next(error);
+      next(error);
     }
   }
 }

--- a/src/backend/src/prisma/seed.ts
+++ b/src/backend/src/prisma/seed.ts
@@ -27,6 +27,7 @@ import {
   DesignReviewStatus,
   MaterialStatus,
   RoleEnum,
+  SpecialPermission,
   StandardChangeRequest,
   WbsElementStatus,
   WorkPackageStage
@@ -47,6 +48,7 @@ import RecruitmentServices from '../services/recruitment.services';
 import OrganizationsService from '../services/organizations.services';
 import StatisticsService from '../services/statistics.services';
 import { seedGraph } from './seed-data/statistics.seed';
+import { graphCollectionTransformer } from '../transformers/statistics-graphCollection.transformer';
 
 const prisma = new PrismaClient();
 
@@ -708,6 +710,32 @@ const performSeed: () => Promise<void> = async () => {
     thomasEmrax,
     ner
   );
+
+  /**
+   * Graph Collection 1
+   */
+  const graph2 = await prisma.graph.create({
+    data: {
+      title: 'graph2',
+      graphType: Graph_Type.PROJECT_BUDGET_BY_PROJECT,
+      displayGraphType: Graph_Display_Type.PIE,
+      measure: Measure.SUM,
+      userCreatedId: thomasEmrax.userId,
+      organizationId: ner.organizationId
+    }
+  });
+
+  const graphCollection1 = await prisma.graph_Collection.create({
+    data: {
+      title: 'Graph Collection 1',
+      viewPermissions: [SpecialPermission.FINANCE_ONLY],
+      graphs: {
+        connect: [{ id: graph2.id }]
+      },
+      userCreatedId: thomasEmrax.userId,
+      organizationId: ner.organizationId
+    }
+  });
 
   /**
    * Change Requests for Creating Work Packages

--- a/src/backend/src/routes/statistics.routes.ts
+++ b/src/backend/src/routes/statistics.routes.ts
@@ -34,6 +34,8 @@ statisticsRouter.post(
   StatisticsController.createGraph
 );
 
+statisticsRouter.get('/statistics/graphCollections', StatisticsController.getAllGraphCollections);
+
 statisticsRouter.get('/graph/:graphId', StatisticsController.getSingleGraph);
 
 export default statisticsRouter;

--- a/src/backend/src/routes/statistics.routes.ts
+++ b/src/backend/src/routes/statistics.routes.ts
@@ -34,7 +34,7 @@ statisticsRouter.post(
   StatisticsController.createGraph
 );
 
-statisticsRouter.get('/statistics/graphCollections', StatisticsController.getAllGraphCollections);
+statisticsRouter.get('/graphCollections', StatisticsController.getAllGraphCollections);
 
 statisticsRouter.get('/graph/:graphId', StatisticsController.getSingleGraph);
 

--- a/src/backend/src/services/statistics.services.ts
+++ b/src/backend/src/services/statistics.services.ts
@@ -1,12 +1,13 @@
-import { Organization, User, Graph_Type, Measure, Graph_Display_Type, Special_Permission } from '@prisma/client';
+import { Organization, User, Graph_Type, Measure, Graph_Display_Type, Special_Permission, Prisma } from '@prisma/client';
 import prisma from '../prisma/prisma';
 import { DeletedException, InvalidOrganizationException, NotFoundException } from '../utils/errors.utils';
 import graphTransformer from '../transformers/statistics-graph.transformer';
-import { getGraphQueryArgs } from '../prisma-query-args/statistics.query-args';
+import { getGraphQueryArgs, getGraphCollectionQueryArgs, GraphQueryArgs } from '../prisma-query-args/statistics.query-args';
 import { userHasPermissionNew } from '../utils/users.utils';
 import { AccessDeniedException, HttpException } from '../utils/errors.utils';
-import { Graph } from 'shared';
+import { Graph, GraphCollection, GraphData } from 'shared';
 import { getGraphData } from '../utils/statistics.utils';
+import { graphCollectionTransformer } from '../transformers/statistics-graphCollection.transformer';
 
 export default class StatisticsService {
   /**
@@ -134,5 +135,45 @@ export default class StatisticsService {
         { carIds: requestedGraph.cars.map((car) => car.carId) }
       )
     });
+  }
+
+  /**
+   * Get all graph collections.
+   * @param organization organization that the user is in.
+   * @returns all the graph collections.
+   */
+
+  static async getAllGraphCollections(organization: Organization): Promise<GraphCollection[]> {
+    const graphCollections = await prisma.graph_Collection.findMany({
+      where: {
+        dateDeleted: null,
+        organizationId: organization.organizationId
+      },
+      ...getGraphCollectionQueryArgs(organization.organizationId)
+    });
+
+    return Promise.all(
+      graphCollections.map(async (graphCollection) => {
+        const addedDataGraphs: (Prisma.GraphGetPayload<GraphQueryArgs> & { graphData: GraphData[] })[] = await Promise.all(
+          graphCollection.graphs.map(async (graph) => ({
+            ...graph,
+            graphData: await getGraphData(
+              graph.graphType,
+              graph.measure,
+              organization.organizationId,
+              graph.startDate ?? null,
+              graph.endDate ?? null,
+              {
+                carIds: graph.cars.map((car) => {
+                  return car.carId;
+                })
+              }
+            )
+          }))
+        );
+
+        return graphCollectionTransformer(graphCollection, addedDataGraphs);
+      })
+    );
   }
 }

--- a/src/backend/src/transformers/statistics-graphCollection.transformer.ts
+++ b/src/backend/src/transformers/statistics-graphCollection.transformer.ts
@@ -1,0 +1,23 @@
+import { Prisma } from '@prisma/client';
+import { userTransformer } from './user.transformer';
+import { GraphCollectionQueryArgs, GraphQueryArgs } from '../prisma-query-args/statistics.query-args';
+import { GraphCollection, GraphData, Graph, SpecialPermission } from 'shared';
+import graphTransformer from './statistics-graph.transformer';
+
+export const graphCollectionTransformer = (
+  graphCollection: Prisma.Graph_CollectionGetPayload<GraphCollectionQueryArgs>,
+  graphs: (Prisma.GraphGetPayload<GraphQueryArgs> & { graphData: GraphData[] })[]
+): GraphCollection => {
+  return {
+    ...graphCollection,
+    userCreated: userTransformer(graphCollection.userCreated),
+    userDeleted: graphCollection.userDeleted ? userTransformer(graphCollection.userDeleted) : undefined,
+    dateDeleted: graphCollection.dateDeleted ?? undefined,
+    graphs: graphs.map((graph) => {
+      return graphTransformer({ ...graph, graphData: graph.graphData });
+    }) as Graph[],
+    title: graphCollection.title,
+    linkId: graphCollection.id,
+    permissions: graphCollection.viewPermissions as SpecialPermission[]
+  };
+};

--- a/src/backend/tests/unmocked/statistics.test.ts
+++ b/src/backend/tests/unmocked/statistics.test.ts
@@ -305,54 +305,60 @@ describe('Statistics Tests', () => {
 
   describe('Get all graph collections', () => {
     it('Succeeds and gets all the graphs', async () => {
-      // const graph1 = await prisma.graph.create({
-      //   data: {
-      //     startDate: new Date('12/12/2024'),
-      //     endDate: new Date(new Date('12/12/2024').getTime() + 10000),
-      //     title: 'title',
-      //     graphType: GraphType.CHANGE_REQUESTS_BY_PROJECT,
-      //     measure: Measure.AVG,
-      //     userCreatedId: user.userId,
-      //     organizationId: orgId
-      //   }
-      // });
-      // const graph2 = await prisma.graph.create({
-      //   data: {
-      //     startDate: new Date('12/12/2024'),
-      //     endDate: new Date(new Date('12/12/2024').getTime() + 10000),
-      //     title: 'title',
-      //     graphType: GraphType.BAR,
-      //     finalTable: graphGen.finalTable,
-      //     finalColumn: graphGen.finalColumn,
-      //     groupByColumn: graphGen.groupByColumn,
-      //     measure: Measure.AVG,
-      //     queryPaths: { create: [{ primaryKey: 'teamTypeId', table: 'Team_Type' }] },
-      //     userCreatedId: user.userId,
-      //     organizationId: orgId
-      //   }
-      // });
-      // const graphCollection1 = await prisma.graph_Collection.create({
-      //   data: {
-      //     title: 'Graph Collection 1',
-      //     viewPermissions: [Permission.VIEW_GRAPH_COLLECTION, Permission.CREATE_GRAPH_COLLECTION],
-      //     graphs: {
-      //       connect: [{ id: graph1.id }, { id: graph2.id }]
-      //     },
-      //     userCreatedId: user.userId,
-      //     organizationId: orgId
-      //   }
-      // });
-      // need to make some seed data graph collections
-      // const result = StatisticsService.getAllGraphCollections(orgId);
-      // expect it to contain the graph collections associated with the given organization
-      // expect(result).toContain({ graphCollection1 });
-      // expect(result).toStrictEqual([graphCollection1]);
-    });
+      const graph1 = await prisma.graph.create({
+        data: {
+          title: 'graph1',
+          graphType: Graph_Type.CHANGE_REQUESTS_BY_DIVISION,
+          displayGraphType: Graph_Display_Type.BAR,
+          measure: Measure.AVG,
+          userCreatedId: user.userId,
+          organizationId: orgId
+        }
+      });
 
-    it('Get Graph Collections with invalid org id returns no collections', async () => {
-      const invalidOrgId = 'invalid';
-      const result = StatisticsService.getAllGraphCollections(invalidOrgId);
-      expect(result).toContain({});
+      const graph2 = await prisma.graph.create({
+        data: {
+          title: 'graph2',
+          graphType: Graph_Type.PROJECT_BUDGET_BY_PROJECT,
+          displayGraphType: Graph_Display_Type.PIE,
+          measure: Measure.SUM,
+          userCreatedId: user.userId,
+          organizationId: orgId
+        }
+      });
+
+      const graphCollection1 = await prisma.graph_Collection.create({
+        data: {
+          title: 'Graph Collection 1',
+          viewPermissions: [SpecialPermission.FINANCE_ONLY],
+          graphs: {
+            connect: [{ id: graph1.id }, { id: graph2.id }]
+          },
+          userCreatedId: user.userId,
+          organizationId: orgId
+        }
+      });
+
+      const graphCollection2 = await prisma.graph_Collection.create({
+        data: {
+          title: 'Graph Collection 2',
+          viewPermissions: [SpecialPermission.FINANCE_ONLY],
+          graphs: {
+            connect: [{ id: graph1.id }, { id: graph2.id }]
+          },
+          userCreatedId: user.userId,
+          organizationId: orgId
+        }
+      });
+
+      const result = await StatisticsService.getAllGraphCollections(organization);
+      expect(result[0].userCreated.userId).toBe(user.userId);
+      expect(result.length).toBe(2);
+      expect(
+        result.map((graphCol) => {
+          return graphCol.id;
+        })
+      ).toEqual([graphCollection1.id, graphCollection2.id]);
     });
   });
 });

--- a/src/backend/tests/unmocked/statistics.test.ts
+++ b/src/backend/tests/unmocked/statistics.test.ts
@@ -1,4 +1,4 @@
-import { Graph_Display_Type, Graph_Type, Organization, User } from '@prisma/client';
+import { Graph_Type, Organization, User, Graph_Display_Type } from '@prisma/client';
 import { supermanAdmin, wonderwomanGuest } from '../test-data/users.test-data';
 import {
   createTestCar,
@@ -11,7 +11,8 @@ import {
 } from '../test-utils';
 import StatisticsService from '../../src/services/statistics.services';
 import { AccessDeniedException, HttpException, NotFoundException } from '../../src/utils/errors.utils';
-import { Measure } from 'shared';
+import { Measure, SpecialPermission } from 'shared';
+import prisma from '../../src/prisma/prisma';
 
 describe('Statistics Tests', () => {
   let orgId: string;
@@ -299,6 +300,65 @@ describe('Statistics Tests', () => {
       await expect(async () => StatisticsService.getSingleGraph(invalidGraphId, user, organization)).rejects.toThrow(
         new NotFoundException('Graph', invalidGraphId)
       );
+    });
+  });
+
+  describe('Get all graph collections', () => {
+    it('Succeeds and gets all the graphs', async () => {
+      const graph1 = await prisma.graph.create({
+        data: {
+          title: 'graph1',
+          graphType: Graph_Type.CHANGE_REQUESTS_BY_DIVISION,
+          displayGraphType: Graph_Display_Type.BAR,
+          measure: Measure.AVG,
+          userCreatedId: user.userId,
+          organizationId: orgId
+        }
+      });
+
+      const graph2 = await prisma.graph.create({
+        data: {
+          title: 'graph2',
+          graphType: Graph_Type.PROJECT_BUDGET_BY_PROJECT,
+          displayGraphType: Graph_Display_Type.PIE,
+          measure: Measure.SUM,
+          userCreatedId: user.userId,
+          organizationId: orgId
+        }
+      });
+
+      const graphCollection1 = await prisma.graph_Collection.create({
+        data: {
+          title: 'Graph Collection 1',
+          viewPermissions: [SpecialPermission.FINANCE_ONLY],
+          graphs: {
+            connect: [{ id: graph1.id }, { id: graph2.id }]
+          },
+          userCreatedId: user.userId,
+          organizationId: orgId
+        }
+      });
+
+      const graphCollection2 = await prisma.graph_Collection.create({
+        data: {
+          title: 'Graph Collection 2',
+          viewPermissions: [SpecialPermission.FINANCE_ONLY],
+          graphs: {
+            connect: [{ id: graph1.id }, { id: graph2.id }]
+          },
+          userCreatedId: user.userId,
+          organizationId: orgId
+        }
+      });
+
+      const result = await StatisticsService.getAllGraphCollections(organization);
+      expect(result[0].userCreated.userId).toBe(user.userId);
+      expect(result.length).toBe(2);
+      expect(
+        result.map((graphCol) => {
+          return graphCol.id;
+        })
+      ).toEqual([graphCollection1.id, graphCollection2.id]);
     });
   });
 });

--- a/src/backend/tests/unmocked/statistics.test.ts
+++ b/src/backend/tests/unmocked/statistics.test.ts
@@ -304,6 +304,31 @@ describe('Statistics Tests', () => {
   });
 
   describe('Get all graph collections', () => {
+    // const graphGen: GraphGen = {
+    //   finalColumn: 'budget',
+    //   finalTable: 'Project',
+    //   groupByColumn: 'name',
+    //   queryPath: {
+    //     table: 'Team_Type',
+    //     primaryKey: 'teamTypeId',
+    //     next: {
+    //       table: 'Team',
+    //       primaryKey: 'teamId',
+    //       parentForeignKey: 'teamTypeId',
+    //       next: {
+    //         table: '_assignedBy',
+    //         primaryKey: 'A',
+    //         parentForeignKey: 'B',
+    //         next: {
+    //           table: 'Project',
+    //           primaryKey: 'projectId',
+    //           parentForeignKey: 'projectId'
+    //         }
+    //       }
+    //     }
+    //   }
+    // };
+
     it('Succeeds and gets all the graphs', async () => {
       const graph1 = await prisma.graph.create({
         data: {

--- a/src/backend/tests/unmocked/statistics.test.ts
+++ b/src/backend/tests/unmocked/statistics.test.ts
@@ -304,86 +304,55 @@ describe('Statistics Tests', () => {
   });
 
   describe('Get all graph collections', () => {
-    // const graphGen: GraphGen = {
-    //   finalColumn: 'budget',
-    //   finalTable: 'Project',
-    //   groupByColumn: 'name',
-    //   queryPath: {
-    //     table: 'Team_Type',
-    //     primaryKey: 'teamTypeId',
-    //     next: {
-    //       table: 'Team',
-    //       primaryKey: 'teamId',
-    //       parentForeignKey: 'teamTypeId',
-    //       next: {
-    //         table: '_assignedBy',
-    //         primaryKey: 'A',
-    //         parentForeignKey: 'B',
-    //         next: {
-    //           table: 'Project',
-    //           primaryKey: 'projectId',
-    //           parentForeignKey: 'projectId'
-    //         }
-    //       }
-    //     }
-    //   }
-    // };
-
     it('Succeeds and gets all the graphs', async () => {
-      const graph1 = await prisma.graph.create({
-        data: {
-          title: 'graph1',
-          graphType: Graph_Type.CHANGE_REQUESTS_BY_DIVISION,
-          displayGraphType: Graph_Display_Type.BAR,
-          measure: Measure.AVG,
-          userCreatedId: user.userId,
-          organizationId: orgId
-        }
-      });
+      // const graph1 = await prisma.graph.create({
+      //   data: {
+      //     startDate: new Date('12/12/2024'),
+      //     endDate: new Date(new Date('12/12/2024').getTime() + 10000),
+      //     title: 'title',
+      //     graphType: GraphType.CHANGE_REQUESTS_BY_PROJECT,
+      //     measure: Measure.AVG,
+      //     userCreatedId: user.userId,
+      //     organizationId: orgId
+      //   }
+      // });
+      // const graph2 = await prisma.graph.create({
+      //   data: {
+      //     startDate: new Date('12/12/2024'),
+      //     endDate: new Date(new Date('12/12/2024').getTime() + 10000),
+      //     title: 'title',
+      //     graphType: GraphType.BAR,
+      //     finalTable: graphGen.finalTable,
+      //     finalColumn: graphGen.finalColumn,
+      //     groupByColumn: graphGen.groupByColumn,
+      //     measure: Measure.AVG,
+      //     queryPaths: { create: [{ primaryKey: 'teamTypeId', table: 'Team_Type' }] },
+      //     userCreatedId: user.userId,
+      //     organizationId: orgId
+      //   }
+      // });
+      // const graphCollection1 = await prisma.graph_Collection.create({
+      //   data: {
+      //     title: 'Graph Collection 1',
+      //     viewPermissions: [Permission.VIEW_GRAPH_COLLECTION, Permission.CREATE_GRAPH_COLLECTION],
+      //     graphs: {
+      //       connect: [{ id: graph1.id }, { id: graph2.id }]
+      //     },
+      //     userCreatedId: user.userId,
+      //     organizationId: orgId
+      //   }
+      // });
+      // need to make some seed data graph collections
+      // const result = StatisticsService.getAllGraphCollections(orgId);
+      // expect it to contain the graph collections associated with the given organization
+      // expect(result).toContain({ graphCollection1 });
+      // expect(result).toStrictEqual([graphCollection1]);
+    });
 
-      const graph2 = await prisma.graph.create({
-        data: {
-          title: 'graph2',
-          graphType: Graph_Type.PROJECT_BUDGET_BY_PROJECT,
-          displayGraphType: Graph_Display_Type.PIE,
-          measure: Measure.SUM,
-          userCreatedId: user.userId,
-          organizationId: orgId
-        }
-      });
-
-      const graphCollection1 = await prisma.graph_Collection.create({
-        data: {
-          title: 'Graph Collection 1',
-          viewPermissions: [SpecialPermission.FINANCE_ONLY],
-          graphs: {
-            connect: [{ id: graph1.id }, { id: graph2.id }]
-          },
-          userCreatedId: user.userId,
-          organizationId: orgId
-        }
-      });
-
-      const graphCollection2 = await prisma.graph_Collection.create({
-        data: {
-          title: 'Graph Collection 2',
-          viewPermissions: [SpecialPermission.FINANCE_ONLY],
-          graphs: {
-            connect: [{ id: graph1.id }, { id: graph2.id }]
-          },
-          userCreatedId: user.userId,
-          organizationId: orgId
-        }
-      });
-
-      const result = await StatisticsService.getAllGraphCollections(organization);
-      expect(result[0].userCreated.userId).toBe(user.userId);
-      expect(result.length).toBe(2);
-      expect(
-        result.map((graphCol) => {
-          return graphCol.id;
-        })
-      ).toEqual([graphCollection1.id, graphCollection2.id]);
+    it('Get Graph Collections with invalid org id returns no collections', async () => {
+      const invalidOrgId = 'invalid';
+      const result = StatisticsService.getAllGraphCollections(invalidOrgId);
+      expect(result).toContain({});
     });
   });
 });


### PR DESCRIPTION
## Changes

Created endpoint to get all graph collections in the database. This endpoint is in the statistics router under statistics/graphCollections.

## Test Cases

- getGraphCollections succeeds and returns valid data

## Screenshots
<img width="843" alt="graphColPostman" src="https://github.com/user-attachments/assets/0786e3d0-1593-4e01-8d00-ca23f13f5674" />


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #2883 
