### PR TITLE
#3075 - Remove Announcement

### DIFF
--- a/src/backend/src/controllers/users.controllers.ts
+++ b/src/backend/src/controllers/users.controllers.ts
@@ -216,4 +216,16 @@ export default class UsersController {
       next(error);
     }
   }
+
+  static async getUserUnreadAnnouncements(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { userId } = req.params;
+      const { organization } = req;
+
+      const unreadAnnouncements = await UsersService.getUserUnreadAnnouncements(userId, organization);
+      res.status(200).json(unreadAnnouncements);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
 }

--- a/src/backend/src/controllers/users.controllers.ts
+++ b/src/backend/src/controllers/users.controllers.ts
@@ -228,4 +228,17 @@ export default class UsersController {
       next(error);
     }
   }
+
+  static async removeUserAnnouncement(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { userId } = req.params;
+      const { announcementId } = req.body;
+      const { organization } = req;
+
+      const unreadAnnouncements = await UsersService.removeUserAnnouncement(userId, announcementId, organization);
+      res.status(200).json(unreadAnnouncements);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
 }

--- a/src/backend/src/prisma-query-args/announcements.query.args.ts
+++ b/src/backend/src/prisma-query-args/announcements.query.args.ts
@@ -1,0 +1,12 @@
+import { Prisma } from '@prisma/client';
+import { getUserQueryArgs } from './user.query-args';
+
+export type AnnouncementQueryArgs = ReturnType<typeof getAnnouncementQueryArgs>;
+
+export const getAnnouncementQueryArgs = (organizationId: string) =>
+  Prisma.validator<Prisma.AnnouncementDefaultArgs>()({
+    include: {
+      usersReceived: getUserQueryArgs(organizationId),
+      userCreated: getUserQueryArgs(organizationId)
+    }
+  });

--- a/src/backend/src/prisma-query-args/announcements.query.args.ts
+++ b/src/backend/src/prisma-query-args/announcements.query.args.ts
@@ -6,7 +6,6 @@ export type AnnouncementQueryArgs = ReturnType<typeof getAnnouncementQueryArgs>;
 export const getAnnouncementQueryArgs = (organizationId: string) =>
   Prisma.validator<Prisma.AnnouncementDefaultArgs>()({
     include: {
-      usersReceived: getUserQueryArgs(organizationId),
-      userCreated: getUserQueryArgs(organizationId)
+      usersReceived: getUserQueryArgs(organizationId)
     }
   });

--- a/src/backend/src/prisma/migrations/20241218044032_homepage_updates/migration.sql
+++ b/src/backend/src/prisma/migrations/20241218044032_homepage_updates/migration.sql
@@ -8,8 +8,10 @@ ALTER TABLE "Project" ADD COLUMN     "organizationId" TEXT;
 CREATE TABLE "Announcement" (
     "announcementId" TEXT NOT NULL,
     "text" TEXT NOT NULL,
-    "dateCrated" TIMESTAMP(3) NOT NULL,
+    "dateCreated" TIMESTAMP(3) NOT NULL,
     "userCreatedId" TEXT NOT NULL,
+    "slackEventId" TEXT NOT NULL,
+    "slackChannelName" TEXT NOT NULL,
 
     CONSTRAINT "Announcement_pkey" PRIMARY KEY ("announcementId")
 );

--- a/src/backend/src/prisma/migrations/20241219125602_homepage_updates/migration.sql
+++ b/src/backend/src/prisma/migrations/20241219125602_homepage_updates/migration.sql
@@ -9,7 +9,8 @@ CREATE TABLE "Announcement" (
     "announcementId" TEXT NOT NULL,
     "text" TEXT NOT NULL,
     "dateCreated" TIMESTAMP(3) NOT NULL,
-    "userCreatedId" TEXT NOT NULL,
+    "dateDeleted" TIMESTAMP(3),
+    "senderName" TEXT NOT NULL,
     "slackEventId" TEXT NOT NULL,
     "slackChannelName" TEXT NOT NULL,
 
@@ -39,6 +40,9 @@ CREATE TABLE "_userNotifications" (
 );
 
 -- CreateIndex
+CREATE UNIQUE INDEX "Announcement_slackEventId_key" ON "Announcement"("slackEventId");
+
+-- CreateIndex
 CREATE UNIQUE INDEX "_receivedAnnouncements_AB_unique" ON "_receivedAnnouncements"("A", "B");
 
 -- CreateIndex
@@ -52,9 +56,6 @@ CREATE INDEX "_userNotifications_B_index" ON "_userNotifications"("B");
 
 -- AddForeignKey
 ALTER TABLE "Project" ADD CONSTRAINT "Project_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("organizationId") ON DELETE SET NULL ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "Announcement" ADD CONSTRAINT "Announcement_userCreatedId_fkey" FOREIGN KEY ("userCreatedId") REFERENCES "User"("userId") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "_receivedAnnouncements" ADD CONSTRAINT "_receivedAnnouncements_A_fkey" FOREIGN KEY ("A") REFERENCES "Announcement"("announcementId") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/backend/src/prisma/schema.prisma
+++ b/src/backend/src/prisma/schema.prisma
@@ -181,7 +181,6 @@ model User {
   createdMilestones               Milestone[]               @relation(name: "milestoneCreator")
   deletedMilestones               Milestone[]               @relation(name: "milestoneDeleter")
   unreadAnnouncements             Announcement[]            @relation(name: "receivedAnnouncements")
-  createdAnnouncements            Announcement[]            @relation(name: "createdAnnouncements")
   unreadNotifications             Notification[]            @relation(name: "userNotifications")
 }
 
@@ -932,13 +931,13 @@ model Milestone {
 }
 
 model Announcement {
-  announcementId   String   @id @default(uuid())
+  announcementId   String    @id @default(uuid())
   text             String
-  usersReceived    User[]   @relation("receivedAnnouncements")
+  usersReceived    User[]    @relation("receivedAnnouncements")
   dateCreated      DateTime
-  userCreatedId    String
-  userCreated      User     @relation("createdAnnouncements", fields: [userCreatedId], references: [userId])
-  slackEventId     String
+  dateDeleted      DateTime?
+  senderName       String
+  slackEventId     String    @unique
   slackChannelName String
 }
 

--- a/src/backend/src/prisma/schema.prisma
+++ b/src/backend/src/prisma/schema.prisma
@@ -180,7 +180,7 @@ model User {
   deletedFrequentlyAskedQuestions FrequentlyAskedQuestion[] @relation(name: "frequentlyAskedQuestionDeleter")
   createdMilestones               Milestone[]               @relation(name: "milestoneCreator")
   deletedMilestones               Milestone[]               @relation(name: "milestoneDeleter")
-  receivedAnnouncements           Announcement[]            @relation(name: "receivedAnnouncements")
+  unreadAnnouncements             Announcement[]            @relation(name: "receivedAnnouncements")
   createdAnnouncements            Announcement[]            @relation(name: "createdAnnouncements")
   unreadNotifications             Notification[]            @relation(name: "userNotifications")
 }
@@ -932,12 +932,14 @@ model Milestone {
 }
 
 model Announcement {
-  announcementId String   @id @default(uuid())
-  text           String
-  usersReceived  User[]   @relation("receivedAnnouncements")
-  dateCrated     DateTime
-  userCreatedId  String
-  userCreated    User     @relation("createdAnnouncements", fields: [userCreatedId], references: [userId])
+  announcementId   String   @id @default(uuid())
+  text             String
+  usersReceived    User[]   @relation("receivedAnnouncements")
+  dateCreated      DateTime
+  userCreatedId    String
+  userCreated      User     @relation("createdAnnouncements", fields: [userCreatedId], references: [userId])
+  slackEventId     String
+  slackChannelName String
 }
 
 model Notification {

--- a/src/backend/src/prisma/seed.ts
+++ b/src/backend/src/prisma/seed.ts
@@ -33,7 +33,7 @@ import { writeFileSync } from 'fs';
 import WorkPackageTemplatesService from '../services/work-package-template.services';
 import RecruitmentServices from '../services/recruitment.services';
 import OrganizationsService from '../services/organizations.services';
-import NotificationsService from '../services/notifications.services';
+import AnnouncementService from '../services/announcement.service';
 
 const prisma = new PrismaClient();
 
@@ -1894,6 +1894,16 @@ const performSeed: () => Promise<void> = async () => {
   await RecruitmentServices.createFaq(batman, 'When was FinishLine created?', 'FinishLine was created in 2019', ner);
 
   await RecruitmentServices.createFaq(batman, 'How many developers are working on FinishLine?', '178 as of 2024', ner);
+
+  await AnnouncementService.createAnnouncement(
+    'Welcome to Finishline!',
+    [regina.userId],
+    new Date(),
+    'Thomas Emrax',
+    '1',
+    'software',
+    ner.organizationId
+  );
 };
 
 performSeed()

--- a/src/backend/src/routes/users.routes.ts
+++ b/src/backend/src/routes/users.routes.ts
@@ -61,5 +61,10 @@ userRouter.post(
   nonEmptyString(body('notificationId')),
   UsersController.removeUserNotification
 );
+userRouter.post(
+  '/:userId/announcements/remove',
+  nonEmptyString(body('announcementId')),
+  UsersController.removeUserAnnouncement
+);
 
 export default userRouter;

--- a/src/backend/src/routes/users.routes.ts
+++ b/src/backend/src/routes/users.routes.ts
@@ -55,6 +55,7 @@ userRouter.post(
   UsersController.getManyUserTasks
 );
 userRouter.get('/:userId/notifications', UsersController.getUserUnreadNotifications);
+userRouter.get('/:userId/announcements', UsersController.getUserUnreadAnnouncements);
 userRouter.post(
   '/:userId/notifications/remove',
   nonEmptyString(body('notificationId')),

--- a/src/backend/src/services/announcement.service.ts
+++ b/src/backend/src/services/announcement.service.ts
@@ -1,0 +1,34 @@
+import { Announcement } from 'shared';
+import prisma from '../prisma/prisma';
+import { getAnnouncementQueryArgs } from '../prisma-query-args/announcements.query.args';
+import announcementTransformer from '../transformers/announcements.transformer';
+
+export default class AnnouncementService {
+  static async createAnnouncement(
+    text: string,
+    usersReceivedIds: string[],
+    dateCreated: Date,
+    senderName: string,
+    slackEventId: string,
+    slackChannelName: string,
+    organizationId: string
+  ): Promise<Announcement> {
+    const announcement = await prisma.announcement.create({
+      data: {
+        text,
+        usersReceived: {
+          connect: usersReceivedIds.map((id) => ({
+            userId: id
+          }))
+        },
+        dateCreated,
+        senderName,
+        slackEventId,
+        slackChannelName
+      },
+      ...getAnnouncementQueryArgs(organizationId)
+    });
+
+    return announcementTransformer(announcement);
+  }
+}

--- a/src/backend/src/services/announcement.service.ts
+++ b/src/backend/src/services/announcement.service.ts
@@ -4,6 +4,18 @@ import { getAnnouncementQueryArgs } from '../prisma-query-args/announcements.que
 import announcementTransformer from '../transformers/announcements.transformer';
 
 export default class AnnouncementService {
+  /**
+   * Creates an announcement that is sent to users
+   * this data is populated from slack events
+   * @param text slack message text
+   * @param usersReceivedIds users to send announcements to
+   * @param dateCreated date created of slack message
+   * @param senderName name of user who sent slack message
+   * @param slackEventId id of slack event (provided by slack api)
+   * @param slackChannelName name of channel message was sent in
+   * @param organizationId id of organization of users
+   * @returns the created announcement
+   */
   static async createAnnouncement(
     text: string,
     usersReceivedIds: string[],

--- a/src/backend/src/services/users.services.ts
+++ b/src/backend/src/services/users.services.ts
@@ -631,4 +631,33 @@ export default class UsersService {
 
     return updatedUser.unreadNotifications.map(notificationTransformer);
   }
+
+  /**
+   * Removes a announcement from the user's unread announcement
+   * @param userId id of the user to remove announcement from
+   * @param announcementId id of the announcement to remove
+   * @param organization the user's organization
+   * @returns the user's updated unread announcement
+   */
+  static async removeUserAnnouncement(userId: string, announcementId: string, organization: Organization) {
+    const requestedUser = await prisma.user.findUnique({
+      where: { userId }
+    });
+
+    if (!requestedUser) throw new NotFoundException('User', userId);
+
+    const updatedUser = await prisma.user.update({
+      where: { userId },
+      data: {
+        unreadAnnouncements: {
+          disconnect: {
+            announcementId
+          }
+        }
+      },
+      include: { unreadAnnouncements: getAnnouncementQueryArgs(organization.organizationId) }
+    });
+
+    return updatedUser.unreadAnnouncements.map(announcementTransformer);
+  }
 }

--- a/src/backend/src/services/users.services.ts
+++ b/src/backend/src/services/users.services.ts
@@ -40,6 +40,8 @@ import { getTaskQueryArgs } from '../prisma-query-args/tasks.query-args';
 import taskTransformer from '../transformers/tasks.transformer';
 import { getNotificationQueryArgs } from '../prisma-query-args/notifications.query-args';
 import notificationTransformer from '../transformers/notifications.transformer';
+import { getAnnouncementQueryArgs } from '../prisma-query-args/announcements.query.args';
+import announcementTransformer from '../transformers/announcements.transformer';
 
 export default class UsersService {
   /**
@@ -583,6 +585,22 @@ export default class UsersService {
     if (!requestedUser) throw new NotFoundException('User', userId);
 
     return requestedUser.unreadNotifications.map(notificationTransformer);
+  }
+
+  /**
+   * Gets all of a user's unread announcements
+   * @param userId id of user to get unread announcements from
+   * @param organization the user's orgainzation
+   * @returns the unread announcements of the user
+   */
+  static async getUserUnreadAnnouncements(userId: string, organization: Organization) {
+    const requestedUser = await prisma.user.findUnique({
+      where: { userId },
+      include: { unreadAnnouncements: getAnnouncementQueryArgs(organization.organizationId) }
+    });
+    if (!requestedUser) throw new NotFoundException('User', userId);
+
+    return requestedUser.unreadAnnouncements.map(announcementTransformer);
   }
 
   /**

--- a/src/backend/src/transformers/announcements.transformer.ts
+++ b/src/backend/src/transformers/announcements.transformer.ts
@@ -7,10 +7,12 @@ const announcementTransformer = (announcement: Prisma.AnnouncementGetPayload<Ann
   return {
     announcementId: announcement.announcementId,
     text: announcement.text,
+    usersReceived: announcement.usersReceived.map(userTransformer),
     dateCreated: announcement.dateCreated,
-    userCreated: userTransformer(announcement.userCreated),
+    senderName: announcement.senderName,
     slackEventId: announcement.slackEventId,
-    slackChannelName: announcement.slackChannelName
+    slackChannelName: announcement.slackChannelName,
+    dateDeleted: announcement.dateDeleted ?? undefined
   };
 };
 

--- a/src/backend/src/transformers/announcements.transformer.ts
+++ b/src/backend/src/transformers/announcements.transformer.ts
@@ -1,0 +1,17 @@
+import { Prisma } from '@prisma/client';
+import { AnnouncementQueryArgs } from '../prisma-query-args/announcements.query.args';
+import { Announcement } from 'shared';
+import { userTransformer } from './user.transformer';
+
+const announcementTransformer = (announcement: Prisma.AnnouncementGetPayload<AnnouncementQueryArgs>): Announcement => {
+  return {
+    announcementId: announcement.announcementId,
+    text: announcement.text,
+    dateCreated: announcement.dateCreated,
+    userCreated: userTransformer(announcement.userCreated),
+    slackEventId: announcement.slackEventId,
+    slackChannelName: announcement.slackChannelName
+  };
+};
+
+export default announcementTransformer;

--- a/src/backend/tests/test-utils.ts
+++ b/src/backend/tests/test-utils.ts
@@ -120,6 +120,7 @@ export const resetUsers = async () => {
   await prisma.frequentlyAskedQuestion.deleteMany();
   await prisma.organization.deleteMany();
   await prisma.user.deleteMany();
+  await prisma.announcement.deleteMany();
 };
 
 export const createFinanceTeamAndLead = async (organization?: Organization) => {

--- a/src/backend/tests/unmocked/users.test.ts
+++ b/src/backend/tests/unmocked/users.test.ts
@@ -139,4 +139,61 @@ describe('User Tests', () => {
       expect(announcements[1].text).toBe('test2');
     });
   });
+
+  describe('Remove Announcement', () => {
+    it('Fails with invalid user', async () => {
+      const testBatman = await createTestUser(batmanAppAdmin, orgId);
+      await AnnouncementService.createAnnouncement(
+        'test1',
+        [testBatman.userId],
+        new Date(),
+        'Thomas Emrax',
+        '1',
+        'software',
+        organization.organizationId
+      );
+      const announcements = await UsersService.getUserUnreadAnnouncements(testBatman.userId, organization);
+
+      await expect(
+        async () => await UsersService.removeUserAnnouncement('1', announcements[0].announcementId, organization)
+      ).rejects.toThrow(new NotFoundException('User', '1'));
+    });
+
+    it('Succeeds and removes user announcement', async () => {
+      const testBatman = await createTestUser(batmanAppAdmin, orgId);
+      await AnnouncementService.createAnnouncement(
+        'test1',
+        [testBatman.userId],
+        new Date(),
+        'Thomas Emrax',
+        '1',
+        'software',
+        organization.organizationId
+      );
+      await AnnouncementService.createAnnouncement(
+        'test2',
+        [testBatman.userId],
+        new Date(),
+        'Superman',
+        '50',
+        'mechanical',
+        organization.organizationId
+      );
+
+      const announcements = await UsersService.getUserUnreadAnnouncements(testBatman.userId, organization);
+
+      expect(announcements).toHaveLength(2);
+      expect(announcements[0].text).toBe('test1');
+      expect(announcements[1].text).toBe('test2');
+
+      const updatedAnnouncements = await UsersService.removeUserAnnouncement(
+        testBatman.userId,
+        announcements[0].announcementId,
+        organization
+      );
+
+      expect(updatedAnnouncements).toHaveLength(1);
+      expect(updatedAnnouncements[0].text).toBe('test2');
+    });
+  });
 });

--- a/src/backend/tests/unmocked/users.test.ts
+++ b/src/backend/tests/unmocked/users.test.ts
@@ -4,6 +4,7 @@ import { batmanAppAdmin } from '../test-data/users.test-data';
 import UsersService from '../../src/services/users.services';
 import { NotFoundException } from '../../src/utils/errors.utils';
 import NotificationsService from '../../src/services/notifications.services';
+import AnnouncementService from '../../src/services/announcement.service';
 
 describe('User Tests', () => {
   let orgId: string;
@@ -81,7 +82,7 @@ describe('User Tests', () => {
       ).rejects.toThrow(new NotFoundException('User', '1'));
     });
 
-    it('Succeeds and gets user notifications', async () => {
+    it('Succeeds and removes user notification', async () => {
       const testBatman = await createTestUser(batmanAppAdmin, orgId);
       await NotificationsService.sendNotifcationToUsers('test1', 'test1', [testBatman.userId], orgId);
       await NotificationsService.sendNotifcationToUsers('test2', 'test2', [testBatman.userId], orgId);
@@ -100,6 +101,42 @@ describe('User Tests', () => {
 
       expect(updatedNotifications).toHaveLength(1);
       expect(updatedNotifications[0].text).toBe('test2');
+    });
+  });
+
+  describe('Get Announcements', () => {
+    it('fails on invalid user id', async () => {
+      await expect(async () => await UsersService.getUserUnreadAnnouncements('1', organization)).rejects.toThrow(
+        new NotFoundException('User', '1')
+      );
+    });
+
+    it('Succeeds and gets user announcements', async () => {
+      const testBatman = await createTestUser(batmanAppAdmin, orgId);
+      await AnnouncementService.createAnnouncement(
+        'test1',
+        [testBatman.userId],
+        new Date(),
+        'Thomas Emrax',
+        '1',
+        'software',
+        organization.organizationId
+      );
+      await AnnouncementService.createAnnouncement(
+        'test2',
+        [testBatman.userId],
+        new Date(),
+        'Superman',
+        '50',
+        'mechanical',
+        organization.organizationId
+      );
+
+      const announcements = await UsersService.getUserUnreadAnnouncements(testBatman.userId, organization);
+
+      expect(announcements).toHaveLength(2);
+      expect(announcements[0].text).toBe('test1');
+      expect(announcements[1].text).toBe('test2');
     });
   });
 });

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -12,6 +12,7 @@ export * from './src/types/task-types';
 export * from './src/types/reimbursement-requests-types';
 export * from './src/types/design-review-types';
 export * from './src/types/notifications.types';
+export * from './src/types/announcements.types';
 export * from './src/validate-wbs';
 export * from './src/date-utils';
 

--- a/src/shared/src/types/announcements.types.ts
+++ b/src/shared/src/types/announcements.types.ts
@@ -1,0 +1,10 @@
+import { User } from './user-types';
+
+export interface Announcement {
+  announcementId: string;
+  text: string;
+  userCreated: User;
+  dateCreated: Date;
+  slackEventId: string;
+  slackChannelName: string;
+}

--- a/src/shared/src/types/announcements.types.ts
+++ b/src/shared/src/types/announcements.types.ts
@@ -3,8 +3,10 @@ import { User } from './user-types';
 export interface Announcement {
   announcementId: string;
   text: string;
-  userCreated: User;
+  usersReceived: User[];
+  senderName: string;
   dateCreated: Date;
   slackEventId: string;
   slackChannelName: string;
+  dateDeleted?: Date;
 }


### PR DESCRIPTION
## Changes

Added endpoint to remove an announcement from a user's unread announcements 

## Screenshots

before:
![Screenshot 2024-12-19 082405](https://github.com/user-attachments/assets/af6c3020-49e0-4dfd-b373-3db5a90d0769)
after:
![Screenshot 2024-12-20 073424](https://github.com/user-attachments/assets/e10a6304-5143-470c-b763-4a5dac30e592)

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [X] All commits are tagged with the ticket number
- [X] No linting errors / newline at end of file warnings
- [X] All code follows repository-configured prettier formatting
- [X] No merge conflicts
- [X] All checks passing
- [X] Screenshots of UI changes (see Screenshots section)
- [X] Remove any non-applicable sections of this template
- [X] Assign the PR to yourself
- [X] No `yarn.lock` changes (unless dependencies have changed)
- [X] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #3075 
