### PR TITLE
Set Organization Workspace Id

### DIFF
--- a/src/backend/src/controllers/organizations.controllers.ts
+++ b/src/backend/src/controllers/organizations.controllers.ts
@@ -117,4 +117,19 @@ export default class OrganizationsController {
       next(error);
     }
   }
+
+  static async setSlackWorkspaceId(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { workspaceId } = req.body;
+
+      const updatedOrg = await OrganizationsService.setSlackWorkspaceId(
+        workspaceId,
+        req.currentUser,
+        req.organization.organizationId
+      );
+      res.status(200).json(updatedOrg);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
 }

--- a/src/backend/src/prisma/migrations/20241221002428_homepage_redesign/migration.sql
+++ b/src/backend/src/prisma/migrations/20241221002428_homepage_redesign/migration.sql
@@ -1,5 +1,6 @@
 -- AlterTable
-ALTER TABLE "Organization" ADD COLUMN     "logoImageId" TEXT;
+ALTER TABLE "Organization" ADD COLUMN     "logoImageId" TEXT,
+ADD COLUMN     "slackWorkspaceId" TEXT;
 
 -- AlterTable
 ALTER TABLE "Project" ADD COLUMN     "organizationId" TEXT;
@@ -8,7 +9,7 @@ ALTER TABLE "Project" ADD COLUMN     "organizationId" TEXT;
 CREATE TABLE "Announcement" (
     "announcementId" TEXT NOT NULL,
     "text" TEXT NOT NULL,
-    "dateCrated" TIMESTAMP(3) NOT NULL,
+    "dateCreated" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "userCreatedId" TEXT NOT NULL,
 
     CONSTRAINT "Announcement_pkey" PRIMARY KEY ("announcementId")

--- a/src/backend/src/prisma/schema.prisma
+++ b/src/backend/src/prisma/schema.prisma
@@ -878,6 +878,7 @@ model Organization {
   applyInterestImageId  String?   @unique
   exploreAsGuestImageId String?   @unique
   logoImageId           String?
+  slackWorkspaceId      String?
 
   // Relation references
   wbsElements              WBS_Element[]
@@ -935,7 +936,7 @@ model Announcement {
   announcementId String   @id @default(uuid())
   text           String
   usersReceived  User[]   @relation("receivedAnnouncements")
-  dateCrated     DateTime
+  dateCreated    DateTime @default(now())
   userCreatedId  String
   userCreated    User     @relation("createdAnnouncements", fields: [userCreatedId], references: [userId])
 }

--- a/src/backend/src/routes/organizations.routes.ts
+++ b/src/backend/src/routes/organizations.routes.ts
@@ -36,4 +36,9 @@ organizationRouter.post(
   OrganizationsController.setOrganizationDescription
 );
 organizationRouter.get('/featured-projects', OrganizationsController.getOrganizationFeaturedProjects);
+organizationRouter.post(
+  '/workspaceId/set',
+  nonEmptyString(body('workspaceId')),
+  OrganizationsController.setSlackWorkspaceId
+);
 export default organizationRouter;

--- a/src/backend/src/services/organizations.services.ts
+++ b/src/backend/src/services/organizations.services.ts
@@ -292,8 +292,6 @@ export default class OrganizationsService {
       data: { slackWorkspaceId: workspaceId }
     });
 
-    console.log(updatedOrg);
-
     return updatedOrg;
   }
 }

--- a/src/backend/src/services/organizations.services.ts
+++ b/src/backend/src/services/organizations.services.ts
@@ -275,4 +275,16 @@ export default class OrganizationsService {
 
     return organization.featuredProjects.map(projectTransformer);
   }
+
+  static async setSlackWorkspaceId(workspaceId: string, submitter: User, organizationId: string) {
+    if (!(await userHasPermission(submitter.userId, organizationId, isAdmin))) {
+      throw new AccessDeniedAdminOnlyException('set workspace id');
+    }
+    const updatedOrg = await prisma.organization.update({
+      where: { organizationId },
+      data: { slackWorkspaceId: workspaceId }
+    });
+
+    return updatedOrg;
+  }
 }

--- a/src/backend/src/services/organizations.services.ts
+++ b/src/backend/src/services/organizations.services.ts
@@ -276,6 +276,13 @@ export default class OrganizationsService {
     return organization.featuredProjects.map(projectTransformer);
   }
 
+  /**
+   * sets the slack workspace id of the organization
+   * @param workspaceId workspace id to set
+   * @param submitter user who submitted the workspace id
+   * @param organizationId id of organization to update with workspace id
+   * @returns updated organization
+   */
   static async setSlackWorkspaceId(workspaceId: string, submitter: User, organizationId: string) {
     if (!(await userHasPermission(submitter.userId, organizationId, isAdmin))) {
       throw new AccessDeniedAdminOnlyException('set workspace id');
@@ -284,6 +291,8 @@ export default class OrganizationsService {
       where: { organizationId },
       data: { slackWorkspaceId: workspaceId }
     });
+
+    console.log(updatedOrg);
 
     return updatedOrg;
   }

--- a/src/backend/tests/unmocked/organization.test.ts
+++ b/src/backend/tests/unmocked/organization.test.ts
@@ -325,4 +325,15 @@ describe('Organization Tests', () => {
       expect(oldOrganization?.description).toBe(returnedOrganization.description);
     });
   });
+
+  describe('Set Organization Workspace Id', () => {
+    it('Succeeds and updates the workspace id', async () => {
+      const testBatman = await createTestUser(batmanAppAdmin, orgId);
+
+      const updatedOrganization = await OrganizationsService.setSlackWorkspaceId('1234', testBatman, orgId);
+
+      expect(updatedOrganization).not.toBeNull();
+      expect(updatedOrganization.slackWorkspaceId).toBe('1234');
+    });
+  });
 });

--- a/src/frontend/src/apis/organizations.api.ts
+++ b/src/frontend/src/apis/organizations.api.ts
@@ -29,3 +29,9 @@ export const setOrganizationFeaturedProjects = async (featuredProjectIds: string
     projectIds: featuredProjectIds
   });
 };
+
+export const setOrganizationWorkspaceId = async (workspaceId: string) => {
+  return axios.post<Organization>(apiUrls.organizationsSetWorkspaceId(), {
+    workspaceId
+  });
+};

--- a/src/frontend/src/hooks/organizations.hooks.ts
+++ b/src/frontend/src/hooks/organizations.hooks.ts
@@ -6,7 +6,8 @@ import {
   getFeaturedProjects,
   getCurrentOrganization,
   setOrganizationDescription,
-  setOrganizationFeaturedProjects
+  setOrganizationFeaturedProjects,
+  setOrganizationWorkspaceId
 } from '../apis/organizations.api';
 
 interface OrganizationProvider {
@@ -75,6 +76,22 @@ export const useSetFeaturedProjects = () => {
     ['organizations', 'featured-projects'],
     async (featuredProjects: Project[]) => {
       const { data } = await setOrganizationFeaturedProjects(featuredProjects.map((project) => project.id));
+      return data;
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(['organizations']);
+      }
+    }
+  );
+};
+
+export const useSetWorkspaceId = () => {
+  const queryClient = useQueryClient();
+  return useMutation<Organization, Error, string>(
+    ['organizations', 'featured-projects'],
+    async (workspaceId: string) => {
+      const { data } = await setOrganizationWorkspaceId(workspaceId);
       return data;
     },
     {

--- a/src/frontend/src/pages/AdminToolsPage/AdminToolsPage.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/AdminToolsPage.tsx
@@ -19,6 +19,7 @@ import { routes } from '../../utils/routes';
 import { Box } from '@mui/system';
 import AdminToolsRecruitmentConfig from './RecruitmentConfig/AdminToolsRecruitmentConfig';
 import GuestViewConfig from './EditGuestView/GuestViewConfig';
+import AdminToolsWorkspaceId from './AdminToolsSlackWorkspaceId';
 
 const AdminToolsPage: React.FC = () => {
   const currentUser = useCurrentUser();
@@ -100,6 +101,7 @@ const AdminToolsPage: React.FC = () => {
           <Box pb={2}>
             <AdminToolsSlackUpcomingDeadlines />
           </Box>
+          <AdminToolsWorkspaceId />
           <AdminToolsAttendeeDesignReviewInfo />
         </Box>
       )}

--- a/src/frontend/src/pages/AdminToolsPage/AdminToolsSlackWorkspaceId.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/AdminToolsSlackWorkspaceId.tsx
@@ -30,6 +30,8 @@ const AdminToolsWorkspaceIdView: React.FC<AdminToolsWorkspaceIdViewProps> = ({ o
   const { mutateAsync, isLoading } = useSetWorkspaceId();
   const [workspaceId, setWorkspaceId] = useState(organization.slackWorkspaceId ?? '');
 
+  if (isLoading) return <LoadingIndicator />;
+
   const slackWorkspaceId = async () => {
     try {
       await mutateAsync(workspaceId);

--- a/src/frontend/src/pages/AdminToolsPage/AdminToolsSlackWorkspaceId.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/AdminToolsSlackWorkspaceId.tsx
@@ -4,13 +4,14 @@
  */
 
 import { NERButton } from '../../components/NERButton';
-import { Box, TextField, Typography } from '@mui/material';
+import { Box, Link, TextField, Typography } from '@mui/material';
 import { useState } from 'react';
 import { useToast } from '../../hooks/toasts.hooks';
 import { useCurrentOrganization, useSetWorkspaceId } from '../../hooks/organizations.hooks';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import ErrorPage from '../ErrorPage';
 import { Organization } from 'shared';
+import HelpIcon from '@mui/icons-material/Help';
 
 interface AdminToolsWorkspaceIdViewProps {
   organization: Organization;
@@ -52,6 +53,9 @@ const AdminToolsWorkspaceIdView: React.FC<AdminToolsWorkspaceIdViewProps> = ({ o
           alignItems: 'center'
         }}
       >
+        <Link color={'#ffffff'} href={'https://slack.com/help/articles/221769328-Locate-your-Slack-URL-or-ID'}>
+          <HelpIcon sx={{ mr: 2, height: 50 }} />
+        </Link>
         <TextField value={workspaceId} onChange={(e) => setWorkspaceId(e.target.value)} />
         <Box>
           <NERButton variant="contained" disabled={isLoading} onClick={slackWorkspaceId}>

--- a/src/frontend/src/pages/AdminToolsPage/AdminToolsSlackWorkspaceId.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/AdminToolsSlackWorkspaceId.tsx
@@ -1,0 +1,66 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { NERButton } from '../../components/NERButton';
+import { Box, TextField, Typography } from '@mui/material';
+import { useState } from 'react';
+import { useToast } from '../../hooks/toasts.hooks';
+import { useCurrentOrganization, useSetWorkspaceId } from '../../hooks/organizations.hooks';
+import LoadingIndicator from '../../components/LoadingIndicator';
+import ErrorPage from '../ErrorPage';
+import { Organization } from 'shared';
+
+interface AdminToolsWorkspaceIdViewProps {
+  organization: Organization;
+}
+
+const AdminToolsWorkspaceId: React.FC = () => {
+  const { data: organization, isLoading, isError, error } = useCurrentOrganization();
+  if (!organization || isLoading) return <LoadingIndicator />;
+  if (isError) return <ErrorPage message={error.message} />;
+
+  return <AdminToolsWorkspaceIdView organization={organization} />;
+};
+
+const AdminToolsWorkspaceIdView: React.FC<AdminToolsWorkspaceIdViewProps> = ({ organization }) => {
+  const toast = useToast();
+  const { mutateAsync, isLoading } = useSetWorkspaceId();
+  const [workspaceId, setWorkspaceId] = useState(organization.slackWorkspaceId ?? '');
+
+  const slackWorkspaceId = async () => {
+    try {
+      await mutateAsync(workspaceId);
+      toast.success('Successfully updated the slack workspace id');
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        toast.error(error.message);
+      }
+    }
+  };
+
+  return (
+    <Box>
+      <Typography variant="h5" gutterBottom color={'#ef4345'} borderBottom={1} borderColor={'white'}>
+        {organization.name} Slack Workspace Id
+      </Typography>
+      <Box
+        sx={{
+          display: 'flex',
+          gap: 1,
+          alignItems: 'center'
+        }}
+      >
+        <TextField value={workspaceId} onChange={(e) => setWorkspaceId(e.target.value)} />
+        <Box>
+          <NERButton variant="contained" disabled={isLoading} onClick={slackWorkspaceId}>
+            Update
+          </NERButton>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default AdminToolsWorkspaceId;

--- a/src/frontend/src/utils/urls.ts
+++ b/src/frontend/src/utils/urls.ts
@@ -180,6 +180,7 @@ const organizationsSetUsefulLinks = () => `${organizationsUsefulLinks()}/set`;
 const organizationsSetDescription = () => `${organizations()}/description/set`;
 const organizationsFeaturedProjects = () => `${organizations()}/featured-projects`;
 const organizationsSetFeaturedProjects = () => `${organizationsFeaturedProjects()}/set`;
+const organizationsSetWorkspaceId = () => `${organizations()}/workspaceId/set`;
 
 /******************* Car Endpoints ********************/
 const cars = () => `${API_URL}/cars`;
@@ -342,6 +343,7 @@ export const apiUrls = {
   organizationsFeaturedProjects,
   organizationsSetDescription,
   organizationsSetFeaturedProjects,
+  organizationsSetWorkspaceId,
 
   cars,
   carsCreate,

--- a/src/shared/src/types/user-types.ts
+++ b/src/shared/src/types/user-types.ts
@@ -44,6 +44,7 @@ export interface Organization {
   treasurer?: UserPreview;
   advisor?: UserPreview;
   description: string;
+  workspaceId?: string;
 }
 
 /**

--- a/src/shared/src/types/user-types.ts
+++ b/src/shared/src/types/user-types.ts
@@ -44,7 +44,7 @@ export interface Organization {
   treasurer?: UserPreview;
   advisor?: UserPreview;
   description: string;
-  workspaceId?: string;
+  slackWorkspaceId?: string;
 }
 
 /**


### PR DESCRIPTION
## Changes

- Created Endpoint to set the slack workspace id of an organization
- Created text field in admin tools to set the workspace id
- add the slack workspace id to the prisma schema

## Notes

- This was a last minute task that was needed for the slack event listener integration. We needed to assign an 
a slack workspace id to an organization to create slack announcements.
- I included both the endpoint and the text field input since the frontend wasn't too involved

## Test Cases

- Successfully setting the org workspace id

## Screenshots

![image](https://github.com/user-attachments/assets/9fcb9fde-6a4c-43fe-9c7f-d073996684e4)![Screenshot 2024-12-20 193858](https://github.com/user-attachments/assets/9e360566-aa88-4c99-9fff-5daed504d646)

