### PR TITLE
#2693 Made Required and Optional Users Not Mutually Exclusive When Editing Design Reviews

### DIFF
--- a/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/DesignReviewDetailPage.tsx
+++ b/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/DesignReviewDetailPage.tsx
@@ -254,9 +254,17 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
                   limitTags={1}
                   renderTags={() => null}
                   id="required-users"
-                  options={users.filter((user) => !optionalUsers.some((optUser) => optUser.id === user.id))}
+                  options={users}
                   value={requiredUsers}
-                  onChange={(_event, newValue) => setRequiredUsers(newValue)}
+                  onChange={(_event, newValue) => {
+                    let filteredOptionalUsers = optionalUsers;
+                    for (const reqUser of newValue) {
+                      filteredOptionalUsers = filteredOptionalUsers.filter((user) => user.id !== reqUser.id);
+                      console.log(reqUser);
+                    }
+                    setOptionalUsers(filteredOptionalUsers);
+                    setRequiredUsers(newValue);
+                  }}
                   getOptionLabel={(option) => option.label}
                   renderOption={(props, option, { selected }) => (
                     <li {...props}>

--- a/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/DesignReviewDetailPage.tsx
+++ b/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/DesignReviewDetailPage.tsx
@@ -104,10 +104,8 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
   };
 
   const handleSelectingRequiredUser = (newValue: { label: string; id: string }[]) => {
-    let filteredOptionalUsers = optionalUsers;
-    for (const reqUser of newValue) {
-      filteredOptionalUsers = filteredOptionalUsers.filter((user) => user.id !== reqUser.id);
-    }
+    const newRequiredUserIds = new Set(newValue.map((user) => user.id));
+    const filteredOptionalUsers = optionalUsers.filter((user) => !newRequiredUserIds.has(user.id));
     setOptionalUsers(filteredOptionalUsers);
     setRequiredUsers(newValue);
   };

--- a/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/DesignReviewDetailPage.tsx
+++ b/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/DesignReviewDetailPage.tsx
@@ -103,6 +103,15 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
     }
   };
 
+  const handleSelectingRequiredUser = (newValue: { label: string; id: string }[]) => {
+    let filteredOptionalUsers = optionalUsers;
+    for (const reqUser of newValue) {
+      filteredOptionalUsers = filteredOptionalUsers.filter((user) => user.id !== reqUser.id);
+    }
+    setOptionalUsers(filteredOptionalUsers);
+    setRequiredUsers(newValue);
+  };
+
   const handleEdit = async (data?: FinalizeReviewInformation) => {
     const times = [];
     for (let i = startTime; i < endTime; i++) {
@@ -256,15 +265,7 @@ const DesignReviewDetailPage: React.FC<DesignReviewDetailPageProps> = ({ designR
                   id="required-users"
                   options={users}
                   value={requiredUsers}
-                  onChange={(_event, newValue) => {
-                    let filteredOptionalUsers = optionalUsers;
-                    for (const reqUser of newValue) {
-                      filteredOptionalUsers = filteredOptionalUsers.filter((user) => user.id !== reqUser.id);
-                      console.log(reqUser);
-                    }
-                    setOptionalUsers(filteredOptionalUsers);
-                    setRequiredUsers(newValue);
-                  }}
+                  onChange={(_event, newValue) => handleSelectingRequiredUser(newValue)}
                   getOptionLabel={(option) => option.label}
                   renderOption={(props, option, { selected }) => (
                     <li {...props}>


### PR DESCRIPTION
## Changes

Now when you try to edit a design review and set certain users as optional, they will still show up in the suggestions for required users. 

Also, when setting a optional users as required, they will be deselected as optional.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #2693 
