### PR TITLE
2248 delete team type endpoint

### DIFF
--- a/src/backend/src/controllers/teams.controllers.ts
+++ b/src/backend/src/controllers/teams.controllers.ts
@@ -1,6 +1,10 @@
 import { NextFunction, Request, Response } from 'express';
 import TeamsService from '../services/teams.services';
-import { HttpException } from '../utils/errors.utils';
+import { AccessDeniedAdminOnlyException, DeletedException, HttpException, NotFoundException } from '../utils/errors.utils';
+import { userHasPermission } from '../utils/users.utils';
+import prisma from '../prisma/prisma';
+import { Organization, User } from '@prisma/client';
+import { isAdmin } from 'shared';
 
 export default class TeamsController {
   static async getAllTeams(req: Request, res: Response, next: NextFunction) {
@@ -189,6 +193,17 @@ export default class TeamsController {
         req.organization
       );
       res.status(200).json(teamType);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
+  static async deleteTeamType(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { teamTypeId } = req.params;
+      const deleter = req.currentUser;
+      await TeamsService.deleteTeamType(deleter, teamTypeId, req.organization);
+      res.status(200).json({ message: `Successfully deleted team type ${req.params.teamTypeId}` });
     } catch (error: unknown) {
       next(error);
     }

--- a/src/backend/src/controllers/teams.controllers.ts
+++ b/src/backend/src/controllers/teams.controllers.ts
@@ -1,10 +1,6 @@
 import { NextFunction, Request, Response } from 'express';
 import TeamsService from '../services/teams.services';
-import { AccessDeniedAdminOnlyException, DeletedException, HttpException, NotFoundException } from '../utils/errors.utils';
-import { userHasPermission } from '../utils/users.utils';
-import prisma from '../prisma/prisma';
-import { Organization, User } from '@prisma/client';
-import { isAdmin } from 'shared';
+import { HttpException } from '../utils/errors.utils';
 
 export default class TeamsController {
   static async getAllTeams(req: Request, res: Response, next: NextFunction) {

--- a/src/backend/src/routes/teams.routes.ts
+++ b/src/backend/src/routes/teams.routes.ts
@@ -78,4 +78,6 @@ teamsRouter.post(
   TeamsController.setTeamTypeImage
 );
 
+teamsRouter.delete('teamType/:teamTypeId/delete', TeamsController.deleteTeamType);
+
 export default teamsRouter;

--- a/src/backend/src/services/teams.services.ts
+++ b/src/backend/src/services/teams.services.ts
@@ -561,6 +561,7 @@ export default class TeamsService {
 
     if (!teamType) throw new NotFoundException('Team Type', teamTypeId);
     if (teamType.dateDeleted) throw new DeletedException('Team Type', teamTypeId);
+    if (teamType.organizationId !== organization.organizationId) throw new InvalidOrganizationException('Team Type');
 
     await prisma.team_Type.update({
       where: { teamTypeId },

--- a/src/backend/src/services/teams.services.ts
+++ b/src/backend/src/services/teams.services.ts
@@ -6,6 +6,7 @@ import {
   NotFoundException,
   AccessDeniedException,
   HttpException,
+  DeletedException,
   AccessDeniedAdminOnlyException,
   InvalidOrganizationException
 } from '../utils/errors.utils';
@@ -542,6 +543,31 @@ export default class TeamsService {
     });
 
     return teamTransformer(updatedTeam);
+  }
+
+  /**
+   * Deletes the Team Type with the given organization Id and Team_Type id
+   * @param deleter a user who is making this request
+   * @param teamTypeId the id of the Team Type to be deleted
+   * @param organizationId the organization Id of the Team Type
+   */
+  static async deleteTeamType(deleter: User, teamTypeId: string, organization: Organization) {
+    if (!(await userHasPermission(deleter.userId, organization.organizationId, isAdmin)))
+      throw new AccessDeniedAdminOnlyException('only admins can delete team types');
+
+    const teamType = await prisma.team_Type.findUnique({
+      where: { teamTypeId }
+    });
+
+    if (!teamType) throw new NotFoundException('Team Type', teamTypeId);
+    if (teamType.dateDeleted) throw new DeletedException('Team Type', teamTypeId);
+
+    await prisma.team_Type.update({
+      where: { teamTypeId },
+      data: { dateDeleted: new Date(), deletedById: deleter.userId }
+    });
+
+    return teamType;
   }
 
   static async setTeamTypeImage(

--- a/src/backend/tests/unmocked/team-type.test.ts
+++ b/src/backend/tests/unmocked/team-type.test.ts
@@ -1,3 +1,4 @@
+import prisma from '../../src/prisma/prisma';
 import { Organization } from '@prisma/client';
 import TeamsService from '../../src/services/teams.services';
 import {
@@ -232,8 +233,9 @@ describe('Team Type Tests', () => {
         where: { teamTypeId: teamType.teamTypeId }
       });
 
-      expect(deletedTeamType.dateDeleted).not.toBe(null);
-      expect(deletedTeamType.deletedById).not.toBe(null);
+      expect(deletedTeamType).not.toBe(null);
+      expect(deletedTeamType!.dateDeleted).not.toBe(null);
+      expect(deletedTeamType!.deletedById).not.toBe(null);
     });
   });
 });

--- a/src/backend/tests/unmocked/team-type.test.ts
+++ b/src/backend/tests/unmocked/team-type.test.ts
@@ -194,12 +194,12 @@ describe('Team Type Tests', () => {
       await expect(
         async () =>
           await TeamsService.deleteTeamType(await createTestUser(wonderwomanGuest, orgId), teamType.teamTypeId, organization)
-      ).rejects.toThrow(new AccessDeniedAdminOnlyException('you must be an admin to delete a team type'));
+      ).rejects.toThrow(new AccessDeniedAdminOnlyException('only admins can delete team types'));
     });
 
     it('Fails if team type doesn`t exist', async () => {
       await expect(
-        async () => await TeamsService.deleteTeamType(await createTestUser(wonderwomanGuest, orgId), '1', organization)
+        async () => await TeamsService.deleteTeamType(await createTestUser(supermanAdmin, orgId), '1', organization)
       ).rejects.toThrow(new NotFoundException('Team Type', '1'));
     });
 

--- a/src/backend/tests/unmocked/team-type.test.ts
+++ b/src/backend/tests/unmocked/team-type.test.ts
@@ -207,7 +207,7 @@ describe('Team Type Tests', () => {
       const teamType = await TeamsService.createTeamType(
         await createTestUser(supermanAdmin, orgId),
         'teamType1',
-        '',
+        'YouTubeIcon',
         '',
         organization
       );
@@ -215,7 +215,7 @@ describe('Team Type Tests', () => {
 
       await expect(
         async () =>
-          await TeamsService.deleteTeamType(await createTestUser(supermanAdmin, orgId), teamType.teamTypeId, organization)
+          await TeamsService.deleteTeamType(await createTestUser(batmanAppAdmin, orgId), teamType.teamTypeId, organization)
       ).rejects.toThrow(new DeletedException('Team Type', teamType.teamTypeId));
     });
 
@@ -223,19 +223,19 @@ describe('Team Type Tests', () => {
       const teamType = await TeamsService.createTeamType(
         await createTestUser(supermanAdmin, orgId),
         'teamType1',
-        '',
+        'YouTubeIcon',
         '',
         organization
       );
-      await TeamsService.deleteTeamType(await createTestUser(supermanAdmin, orgId), teamType.teamTypeId, organization);
+      await TeamsService.deleteTeamType(await createTestUser(batmanAppAdmin, orgId), teamType.teamTypeId, organization);
 
       const deletedTeamType = await prisma.team_Type.findUnique({
         where: { teamTypeId: teamType.teamTypeId }
       });
 
       expect(deletedTeamType).not.toBe(null);
-      expect(deletedTeamType!.dateDeleted).not.toBe(null);
-      expect(deletedTeamType!.deletedById).not.toBe(null);
+      expect(deletedTeamType?.dateDeleted).not.toBe(null);
+      expect(deletedTeamType?.deletedById).not.toBe(null);
     });
   });
 });

--- a/src/backend/tests/unmocked/team-type.test.ts
+++ b/src/backend/tests/unmocked/team-type.test.ts
@@ -8,7 +8,7 @@ import {
   NotFoundException,
   DeletedException
 } from '../../src/utils/errors.utils';
-import { batmanAppAdmin, supermanAdmin, wonderwomanGuest } from '../test-data/users.test-data';
+import { batmanAppAdmin, supermanAdmin, wonderwomanGuest, flashAdmin } from '../test-data/users.test-data';
 import { createTestOrganization, createTestUser, resetUsers } from '../test-utils';
 import { vi } from 'vitest';
 
@@ -211,7 +211,7 @@ describe('Team Type Tests', () => {
         '',
         organization
       );
-      await TeamsService.deleteTeamType(await createTestUser(supermanAdmin, orgId), teamType.teamTypeId, organization);
+      await TeamsService.deleteTeamType(await createTestUser(flashAdmin, orgId), teamType.teamTypeId, organization);
 
       await expect(
         async () =>

--- a/src/backend/tests/unmocked/team-type.test.ts
+++ b/src/backend/tests/unmocked/team-type.test.ts
@@ -4,7 +4,8 @@ import {
   AccessDeniedAdminOnlyException,
   AccessDeniedException,
   HttpException,
-  NotFoundException
+  NotFoundException,
+  DeletedException
 } from '../../src/utils/errors.utils';
 import { batmanAppAdmin, supermanAdmin, wonderwomanGuest } from '../test-data/users.test-data';
 import { createTestOrganization, createTestUser, resetUsers } from '../test-utils';
@@ -177,6 +178,62 @@ describe('Team Type Tests', () => {
       expect(updatedTeamType.name).toBe('new name');
       expect(updatedTeamType.iconName).toBe('new icon');
       expect(updatedTeamType.description).toBe('new description');
+    });
+  });
+
+  describe('Delete team type', () => {
+    it('Fails if user is not an admin', async () => {
+      const teamType = await TeamsService.createTeamType(
+        await createTestUser(supermanAdmin, orgId),
+        'teamType1',
+        '',
+        '',
+        organization
+      );
+      await expect(
+        async () =>
+          await TeamsService.deleteTeamType(await createTestUser(wonderwomanGuest, orgId), teamType.teamTypeId, organization)
+      ).rejects.toThrow(new AccessDeniedAdminOnlyException('you must be an admin to delete a team type'));
+    });
+
+    it('Fails if team type doesn`t exist', async () => {
+      await expect(
+        async () => await TeamsService.deleteTeamType(await createTestUser(wonderwomanGuest, orgId), '1', organization)
+      ).rejects.toThrow(new NotFoundException('Team Type', '1'));
+    });
+
+    it('Fails if team type is already deleted', async () => {
+      const teamType = await TeamsService.createTeamType(
+        await createTestUser(supermanAdmin, orgId),
+        'teamType1',
+        '',
+        '',
+        organization
+      );
+      await TeamsService.deleteTeamType(await createTestUser(supermanAdmin, orgId), teamType.teamTypeId, organization);
+
+      await expect(
+        async () =>
+          await TeamsService.deleteTeamType(await createTestUser(supermanAdmin, orgId), teamType.teamTypeId, organization)
+      ).rejects.toThrow(new DeletedException('Team Type', teamType.teamTypeId));
+    });
+
+    it('Successfully soft deletes the team type', async () => {
+      const teamType = await TeamsService.createTeamType(
+        await createTestUser(supermanAdmin, orgId),
+        'teamType1',
+        '',
+        '',
+        organization
+      );
+      await TeamsService.deleteTeamType(await createTestUser(supermanAdmin, orgId), teamType.teamTypeId, organization);
+
+      const deletedTeamType = await prisma.team_Type.findUnique({
+        where: { teamTypeId: teamType.teamTypeId }
+      });
+
+      expect(deletedTeamType.dateDeleted).not.toBe(null);
+      expect(deletedTeamType.deletedById).not.toBe(null);
     });
   });
 });


### PR DESCRIPTION
## Changes

Endpoint that soft deletes a single team type.

## Test Cases

- delete team type fails if user is not admin
- delete team type fails if team type doesn't exist
- delete team type fails if team type is already deleted
- delete team type correctly updates dateDeleted and deletedById

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #2248
