### PR TITLE
#2509 DRC Debugs

### DIFF
--- a/src/backend/src/services/design-reviews.services.ts
+++ b/src/backend/src/services/design-reviews.services.ts
@@ -340,9 +340,8 @@ export default class DesignReviewsService {
         )));
 
     // if all required members are confirmed, set the status to confirmed
-    const ogDRRequiredMembersIds = originaldesignReview.requiredMembers.map((member) => member.userId);
     const allRequiredMembersConfirmed = updatedRequiredMembers.every((member) =>
-      ogDRRequiredMembersIds.includes(member.userId)
+      originaldesignReview.confirmedMembers.map((user) => user.userId).includes(member.userId)
     );
 
     if (status === Design_Review_Status.SCHEDULED && allRequiredMembersConfirmed) {

--- a/src/backend/src/services/design-reviews.services.ts
+++ b/src/backend/src/services/design-reviews.services.ts
@@ -25,7 +25,7 @@ import {
   areUsersinList,
   updateUserAvailability
 } from '../utils/users.utils';
-import { isUserOnDesignReview, validateMeetingTimes } from '../utils/design-reviews.utils';
+import { isUserOnDesignReview, validateMeetingTimes,  } from '../utils/design-reviews.utils';
 import { designReviewTransformer } from '../transformers/design-reviews.transformer';
 import {
   sendDRConfirmationToThread,
@@ -296,6 +296,13 @@ export default class DesignReviewsService {
     // make sure there is a location if the design review is in person
     if (isInPerson && location === null) {
       throw new HttpException(400, 'location is required for in person design reviews');
+    }
+
+    // Check if all the remaining required memebers are confirmed
+    const allRequiredMembersConfirmed = await areAllRequiredMembersConfirmed(requiredMembersIds);
+
+    if (allRequiredMembersConfirmed) {
+      status = Design_Review_Status.CONFIRMED;
     }
 
     // throws if meeting times are not: consecutive and between 0-11

--- a/src/backend/src/services/design-reviews.services.ts
+++ b/src/backend/src/services/design-reviews.services.ts
@@ -298,7 +298,7 @@ export default class DesignReviewsService {
       throw new HttpException(400, 'location is required for in person design reviews');
     }
 
-    // throws if meeting times are not: consecutive and between 0-11sd
+    // throws if meeting times are not: consecutive and between 0-11
     meetingTimes = validateMeetingTimes(meetingTimes);
 
     // docTemplateLink is required if the status is scheduled or done

--- a/src/backend/src/services/design-reviews.services.ts
+++ b/src/backend/src/services/design-reviews.services.ts
@@ -25,7 +25,7 @@ import {
   areUsersinList,
   updateUserAvailability
 } from '../utils/users.utils';
-import { isUserOnDesignReview, validateMeetingTimes,  } from '../utils/design-reviews.utils';
+import { isUserOnDesignReview, validateMeetingTimes } from '../utils/design-reviews.utils';
 import { designReviewTransformer } from '../transformers/design-reviews.transformer';
 import {
   sendDRConfirmationToThread,
@@ -341,7 +341,7 @@ export default class DesignReviewsService {
 
     // if all required members are confirmed, set the status to confirmed
     const ogDRRequiredMembersIds = originaldesignReview.requiredMembers.map((member) => member.userId);
-    const allRequiredMembersConfirmed = updatedRequiredMembers.every((member) => 
+    const allRequiredMembersConfirmed = updatedRequiredMembers.every((member) =>
       ogDRRequiredMembersIds.includes(member.userId)
     );
 

--- a/src/backend/src/services/design-reviews.services.ts
+++ b/src/backend/src/services/design-reviews.services.ts
@@ -298,14 +298,7 @@ export default class DesignReviewsService {
       throw new HttpException(400, 'location is required for in person design reviews');
     }
 
-    // Check if all the remaining required memebers are confirmed
-    const allRequiredMembersConfirmed = await areAllRequiredMembersConfirmed(requiredMembersIds);
-
-    if (allRequiredMembersConfirmed) {
-      status = Design_Review_Status.CONFIRMED;
-    }
-
-    // throws if meeting times are not: consecutive and between 0-11
+    // throws if meeting times are not: consecutive and between 0-11sd
     meetingTimes = validateMeetingTimes(meetingTimes);
 
     // docTemplateLink is required if the status is scheduled or done
@@ -345,6 +338,17 @@ export default class DesignReviewsService {
           meetingTimes,
           originaldesignReview.wbsElement
         )));
+
+    // if all required members are confirmed, set the status to confirmed
+    const ogDRRequiredMembersIds = originaldesignReview.requiredMembers.map((member) => member.userId);
+    const allRequiredMembersConfirmed = updatedRequiredMembers.every((member) => 
+      ogDRRequiredMembersIds.includes(member.userId)
+    );
+
+    if (status === Design_Review_Status.SCHEDULED && allRequiredMembersConfirmed) {
+      status = Design_Review_Status.CONFIRMED;
+    }
+
     // actually try to update the design review
     const updatedDesignReview = await prisma.design_Review.update({
       where: { designReviewId },

--- a/src/backend/src/utils/design-reviews.utils.ts
+++ b/src/backend/src/utils/design-reviews.utils.ts
@@ -1,7 +1,6 @@
 import { DesignReview } from 'shared';
 import { HttpException } from './errors.utils';
 import { User } from '@prisma/client';
-import prisma from '../prisma/prisma';
 
 /**
  * Validate meeting times

--- a/src/backend/src/utils/design-reviews.utils.ts
+++ b/src/backend/src/utils/design-reviews.utils.ts
@@ -1,6 +1,7 @@
 import { DesignReview } from 'shared';
 import { HttpException } from './errors.utils';
 import { User } from '@prisma/client';
+import prisma from '../prisma/prisma';
 
 /**
  * Validate meeting times
@@ -37,4 +38,13 @@ export const addHours = (date: Date, hours: number) => {
   const hoursToAdd = hours * 60 * 60 * 1000;
   date.setTime(date.getTime() + hoursToAdd);
   return date;
+};
+
+export const areAllRequiredMembersConfirmed = async (requiredMembersIds: string[]): Promise<boolean> => {
+  const requiredMembers = await prisma.user.findMany({
+    where: { userId: { in: requiredMembersIds } },
+    select: { userId: true, availabilityStatus: true }, 
+  });
+
+  return requiredMembers.every(member => member.availabilityStatus === 'confirmed');
 };

--- a/src/backend/src/utils/design-reviews.utils.ts
+++ b/src/backend/src/utils/design-reviews.utils.ts
@@ -39,12 +39,3 @@ export const addHours = (date: Date, hours: number) => {
   date.setTime(date.getTime() + hoursToAdd);
   return date;
 };
-
-export const areAllRequiredMembersConfirmed = async (requiredMembersIds: string[]): Promise<boolean> => {
-  const requiredMembers = await prisma.user.findMany({
-    where: { userId: { in: requiredMembersIds } },
-    select: { userId: true, availabilityStatus: true }, 
-  });
-
-  return requiredMembers.every(member => member.availabilityStatus === 'confirmed');
-};

--- a/src/backend/tests/unit/design-review.test.ts
+++ b/src/backend/tests/unit/design-review.test.ts
@@ -22,6 +22,42 @@ describe('Design Reviews', () => {
     await resetUsers();
   });
 
+  test('Marks design review as confirmed when all required members have confirmed', async () => {
+    const user = await createTestUser(supermanAdmin, organizationId);
+
+    // Assume all required members have confirmed their availability
+    const requiredMembers = (await prisma.design_Review.findUnique({
+      where: { designReviewId: designReview.designReviewId },
+      include: { requiredMembers: true }
+    }))?.requiredMembers.map((member) => member.userId) || [];
+
+    // Call the editDesignReview function
+    await DesignReviewsService.editDesignReview(
+      user,
+      designReview.designReviewId,
+      designReview.dateScheduled,
+      designReview.teamTypeId,
+      requiredMembers,
+      [], 
+      designReview.isOnline,
+      designReview.isInPerson,
+      designReview.zoomLink,
+      designReview.location,
+      designReview.docTemplateLink,
+      DesignReviewStatus.SCHEDULED,
+      requiredMembers, // Attendees are all required members, meaning they have confirmed
+      designReview.meetingTimes,
+      organization
+    );
+
+    const updatedDR = await prisma.design_Review.findUnique({
+      where: { designReviewId: designReview.designReviewId }
+    });
+
+    // Expect the design review status to be updated to CONFIRMED
+    expect(updatedDR?.status).toBe(DesignReviewStatus.CONFIRMED);
+  });
+
   // change with admin who is not creator
   test('Set status works when an admin who is not the creator sets', async () => {
     const user = await createTestUser(supermanAdmin, organizationId);
@@ -66,4 +102,5 @@ describe('Design Reviews', () => {
       )
     ).rejects.toThrow(new AccessDeniedAdminOnlyException('set the status of a design review'));
   });
+  
 });

--- a/src/backend/tests/unit/design-review.test.ts
+++ b/src/backend/tests/unit/design-review.test.ts
@@ -22,40 +22,52 @@ describe('Design Reviews', () => {
     await resetUsers();
   });
 
-  test('Marks design review as confirmed when all required members have confirmed', async () => {
+  test('Marks design review as confirmed if updated list of required members have confirmed', async () => {
     const user = await createTestUser(supermanAdmin, organizationId);
 
-    // Assume all required members have confirmed their availability
-    const requiredMembers = (await prisma.design_Review.findUnique({
+    const origonalDesignreview = await prisma.design_Review.update({
       where: { designReviewId: designReview.designReviewId },
-      include: { requiredMembers: true }
-    }))?.requiredMembers.map((member) => member.userId) || [];
+      data: {
+        requiredMembers: {
+          connect: [{ userId: user.userId }]
+        },
+        confirmedMembers: {
+          connect: [{ userId: designReview.userCreatedId }]
+        }
+      },
+      include: {
+        requiredMembers: true,
+        confirmedMembers: true
+      }
+    });
 
-    // Call the editDesignReview function
-    await DesignReviewsService.editDesignReview(
+    const requiredMembers = origonalDesignreview.requiredMembers.map((member) => member.userId) || [];
+    const confirmedMembers = origonalDesignreview.confirmedMembers.map((member) => member.userId) || [];
+
+    expect(requiredMembers.length).toBe(2);
+    expect(confirmedMembers.length).toBe(1);
+
+    await DesignReviewsService.setStatus(user, designReview.designReviewId, DesignReviewStatus.SCHEDULED, organization);
+
+    const updatedDesignReview = await DesignReviewsService.editDesignReview(
       user,
       designReview.designReviewId,
-      designReview.dateScheduled,
-      designReview.teamTypeId,
-      requiredMembers,
-      [], 
-      designReview.isOnline,
-      designReview.isInPerson,
-      designReview.zoomLink,
-      designReview.location,
-      designReview.docTemplateLink,
+      new Date(),
+      origonalDesignreview.teamTypeId,
+      [designReview.userCreatedId],
+      [],
+      false,
+      false,
+      null,
+      null,
+      '',
       DesignReviewStatus.SCHEDULED,
-      requiredMembers, // Attendees are all required members, meaning they have confirmed
-      designReview.meetingTimes,
+      [],
+      [0, 1],
       organization
     );
 
-    const updatedDR = await prisma.design_Review.findUnique({
-      where: { designReviewId: designReview.designReviewId }
-    });
-
-    // Expect the design review status to be updated to CONFIRMED
-    expect(updatedDR?.status).toBe(DesignReviewStatus.CONFIRMED);
+    expect(updatedDesignReview.status).toBe(DesignReviewStatus.CONFIRMED);
   });
 
   // change with admin who is not creator
@@ -102,5 +114,4 @@ describe('Design Reviews', () => {
       )
     ).rejects.toThrow(new AccessDeniedAdminOnlyException('set the status of a design review'));
   });
-  
 });


### PR DESCRIPTION
## Changes

Made edits in the editDesignReview endpoint. After removing attendees, it checks if the required members are still confirmed to attend. If the required members are or still confirmed, then the design review status is set to confirmed. 

## Screenshots

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #2509
