### PR TITLE
#3166 Created Part/PartPreview Shared Types and Relevant Data

### DIFF
--- a/src/shared/src/types/parts-review.types.ts
+++ b/src/shared/src/types/parts-review.types.ts
@@ -1,0 +1,70 @@
+import { User } from './user-types';
+
+export interface PartPreview {
+  id: string;
+  index: number;
+  commonName: string;
+  description?: string;
+  previewImageLink?: string;
+  status: PartReviewStatus;
+  tags: PartTag[];
+  projectId: string;
+  assignees: User[];
+  history: string[];
+  createdAt: Date;
+  updatedAt: Date;
+  userCreatedId: string;
+}
+
+export interface Part extends PartPreview {
+  submissions: PartSubmission[];
+  reviews: PartReview[];
+}
+
+export enum PartReviewStatus {
+  NA = 'NA',
+  READY_FOR_REVIEW = 'READY_FOR_REVIEW',
+  IN_REVIEW = 'IN_REVIEW',
+  REVIEWED = 'REVIEWED',
+  APPROVED = 'APPROVED'
+}
+
+export interface PartTag {
+  id: string;
+  name: string;
+  color: string;
+}
+
+export interface PartSubmission {
+  id: string;
+  files: string[];
+  name: string;
+  notes?: string;
+  part: Part;
+  createdAt: Date;
+  updatedAt: Date;
+  userCreated: User;
+  review: PartReview[];
+}
+
+export interface PartReview {
+  id: string;
+  files: string[];
+  notes?: string;
+  submission: PartSubmission;
+  popUps: PartReviewPopUp[];
+  createdAt: Date;
+  updatedAt: Date;
+  userCreated: User;
+}
+
+export interface PartReviewPopUp {
+  id: string;
+  xCoord: number;
+  yCoord: number;
+  title: string;
+  description: string;
+  review: PartReview;
+  createdAt: Date;
+  updatedAt: Date;
+}


### PR DESCRIPTION
## Changes

Created Part, PartPreview, PartTag, PartSubmission, PartReview, and PartReviewPopUp interfaces

## To Do

- [ ] There is a parts-review.query-args.ts file with query args for part-preview, which returns the model with all relevant information within a part, including submissions and reviews
- [ ] There is a transformer in parts-review.transformer.ts that converts a prisma model type into the part shared type
- [ ] There is a shared type in parts-review.types.ts in the shared folder with corresponding interfaces and relevant data

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)