### PR TITLE
#2244 - Finance Fixes - Deny own reimbursement request

### DIFF
--- a/src/backend/src/services/reimbursement-requests.services.ts
+++ b/src/backend/src/services/reimbursement-requests.services.ts
@@ -1015,12 +1015,10 @@ export default class ReimbursementRequestService {
    *
    * @param reimbursementRequestId the id of the reimbursement request to deny
    * @param submitter the user who is denying the reimbursement request
-   * @param organizationId the organization the user is currently in
+   * @param organization the organization the user is currently in
    * @returns the created reimbursment status
    */
   static async denyReimbursementRequest(reimbursementRequestId: string, submitter: User, organization: Organization) {
-    await validateUserIsPartOfFinanceTeamOrAdmin(submitter, organization.organizationId);
-
     const reimbursementRequest = await prisma.reimbursement_Request.findUnique({
       where: { reimbursementRequestId },
       include: {
@@ -1040,6 +1038,10 @@ export default class ReimbursementRequestService {
 
     if (reimbursementRequest.reimbursementStatuses.some((status) => status.type === ReimbursementStatusType.REIMBURSED)) {
       throw new HttpException(400, 'This reimbursement request has already been reimbursed');
+    }
+
+    if (submitter.userId !== reimbursementRequest.recipientId) {
+      await validateUserIsPartOfFinanceTeamOrAdmin(submitter, organization.organizationId);
     }
 
     const reimbursementStatus = await prisma.reimbursement_Status.create({

--- a/src/backend/tests/unmocked/reimbursement-requests.test.ts
+++ b/src/backend/tests/unmocked/reimbursement-requests.test.ts
@@ -1,12 +1,25 @@
-import { alfred } from '../test-data/users.test-data';
+import { alfred, batmanAppAdmin, batmanSecureSettings, batmanSettings, financeMember } from '../test-data/users.test-data';
 import ReimbursementRequestService from '../../src/services/reimbursement-requests.services';
 import { AccessDeniedException, HttpException } from '../../src/utils/errors.utils';
 import { createTestReimbursementRequest, createTestUser, resetUsers } from '../test-utils';
 import prisma from '../../src/prisma/prisma';
 import { assert } from 'console';
-import { addDaysToDate, ClubAccount, ReimbursementRequest } from 'shared';
-import { Account_Code, Organization, Vendor } from '@prisma/client';
-import { UserWithSecureSettings } from '../../src/utils/auth.utils';
+import { addDaysToDate, ClubAccount, ReimbursementRequest, ReimbursementStatusType, RoleEnum } from 'shared';
+import {
+  Account_Code,
+  Organization,
+  Reimbursement_Status_Type,
+  Role,
+  Role_Type,
+  Theme,
+  User,
+  User_Secure_Settings,
+  User_Settings,
+  Vendor
+} from '@prisma/client';
+import { UserWithSecureSettings, UserWithSettings } from '../../src/utils/auth.utils';
+import { createUser } from '../../src/prisma/seed-data/users.seed';
+import { updateEnumMember } from 'typescript';
 
 describe('Reimbursement Requests', () => {
   let org: Organization;
@@ -227,6 +240,130 @@ describe('Reimbursement Requests', () => {
       );
 
       expect(updatedRR.dateDelivered).toEqual(dateToSetAsDelivered);
+    });
+  });
+
+  describe('Denying reimbursement request', () => {
+    test('Valid deny reimbursement request', async () => {
+      const rr = await ReimbursementRequestService.createReimbursementRequest(
+        createdUser,
+        reimbursementRequest.vendor.vendorId,
+        reimbursementRequest.account,
+        [],
+        [
+          {
+            name: 'GLUE',
+            reason: {
+              carNumber: 0,
+              projectNumber: 0,
+              workPackageNumber: 0
+            },
+            cost: 200000
+          }
+        ],
+        reimbursementRequest.accountCode.accountCodeId,
+        reimbursementRequest.totalCost,
+        org
+      );
+      const status = await ReimbursementRequestService.denyReimbursementRequest(rr.reimbursementRequestId, createdUser, org);
+      expect(status.type).toEqual(ReimbursementStatusType.DENIED);
+    });
+    test('Creator of reimbursement request can deny their own', async () => {
+      const member: User = await prisma.user.create({
+        data: {
+          firstName: 'Johnny',
+          lastName: 'Bravo',
+          googleAuthId: '25',
+          email: 'jbravo@gmail.com',
+          emailId: 'jbravo'
+        }
+      });
+
+      const memberSettings: User_Settings = await prisma.user_Settings.create({
+        data: {
+          user: {
+            connect: {
+              userId: member.userId
+            }
+          },
+          defaultTheme: Theme.DARK,
+          slackId: 'slackID'
+        }
+      });
+
+      const memberSecureSettings: User_Secure_Settings = await prisma.user_Secure_Settings.create({
+        data: {
+          userSecureSettingsId: 'member',
+          user: {
+            connect: {
+              userId: member.userId
+            }
+          },
+          nuid: '0012345632323',
+          phoneNumber: '23232323',
+          street: '123 Gotham St.',
+          city: 'Gotham',
+          state: 'NY',
+          zipcode: '12345'
+        }
+      });
+
+      const memberRole: Role = await prisma.role.create({
+        data: {
+          user: {
+            connect: {
+              userId: member.userId
+            }
+          },
+          roleType: Role_Type.MEMBER,
+          organization: {
+            connect: {
+              organizationId: org.organizationId
+            }
+          }
+        }
+      });
+
+      const recipient = await prisma.user.findUnique({
+        where: { userId: member.userId },
+        include: {
+          userSettings: true,
+          userSecureSettings: true,
+          roles: true
+        }
+      });
+
+      if (!recipient) {
+        throw new Error('No recipient found');
+      }
+
+      const reimbReq = await ReimbursementRequestService.createReimbursementRequest(
+        recipient,
+        createdVendor.vendorId,
+        ClubAccount.CASH,
+        [],
+        [
+          {
+            name: 'GLUE',
+            reason: {
+              carNumber: 0,
+              projectNumber: 0,
+              workPackageNumber: 0
+            },
+            cost: 200000
+          }
+        ],
+        createdAccountCode.accountCodeId,
+        100,
+        org
+      );
+
+      const status = await ReimbursementRequestService.denyReimbursementRequest(
+        reimbReq.reimbursementRequestId,
+        recipient,
+        org
+      );
+      expect(status.type).toEqual(ReimbursementStatusType.DENIED);
     });
   });
 });

--- a/src/backend/tests/unmocked/reimbursement-requests.test.ts
+++ b/src/backend/tests/unmocked/reimbursement-requests.test.ts
@@ -1,25 +1,12 @@
-import { alfred, batmanAppAdmin, batmanSecureSettings, batmanSettings, financeMember } from '../test-data/users.test-data';
+import { alfred } from '../test-data/users.test-data';
 import ReimbursementRequestService from '../../src/services/reimbursement-requests.services';
 import { AccessDeniedException, HttpException } from '../../src/utils/errors.utils';
 import { createTestReimbursementRequest, createTestUser, resetUsers } from '../test-utils';
 import prisma from '../../src/prisma/prisma';
 import { assert } from 'console';
-import { addDaysToDate, ClubAccount, ReimbursementRequest, ReimbursementStatusType, RoleEnum } from 'shared';
-import {
-  Account_Code,
-  Organization,
-  Reimbursement_Status_Type,
-  Role,
-  Role_Type,
-  Theme,
-  User,
-  User_Secure_Settings,
-  User_Settings,
-  Vendor
-} from '@prisma/client';
-import { UserWithSecureSettings, UserWithSettings } from '../../src/utils/auth.utils';
-import { createUser } from '../../src/prisma/seed-data/users.seed';
-import { updateEnumMember } from 'typescript';
+import { addDaysToDate, ClubAccount, ReimbursementRequest, ReimbursementStatusType } from 'shared';
+import { Account_Code, Organization, Role_Type, Theme, User, Vendor } from '@prisma/client';
+import { UserWithSecureSettings } from '../../src/utils/auth.utils';
 
 describe('Reimbursement Requests', () => {
   let org: Organization;
@@ -279,7 +266,7 @@ describe('Reimbursement Requests', () => {
         }
       });
 
-      const memberSettings: User_Settings = await prisma.user_Settings.create({
+      await prisma.user_Settings.create({
         data: {
           user: {
             connect: {
@@ -291,7 +278,7 @@ describe('Reimbursement Requests', () => {
         }
       });
 
-      const memberSecureSettings: User_Secure_Settings = await prisma.user_Secure_Settings.create({
+      await prisma.user_Secure_Settings.create({
         data: {
           userSecureSettingsId: 'member',
           user: {
@@ -308,7 +295,7 @@ describe('Reimbursement Requests', () => {
         }
       });
 
-      const memberRole: Role = await prisma.role.create({
+      await prisma.role.create({
         data: {
           user: {
             connect: {

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
@@ -462,7 +462,7 @@ const ReimbursementRequestDetailsView: React.FC<ReimbursementRequestDetailsViewP
       onClick: () => setShowDenyModal(true),
       icon: <CloseIcon />,
       disabled:
-        (!user.isFinance && user.userId !== reimbursementRequest.recipient.userId) ||
+        (!isAdmin(user.role) && !user.isFinance && user.userId !== reimbursementRequest.recipient.userId) ||
         isReimbursementRequestReimbursed(reimbursementRequest) ||
         isReimbursementRequestDenied(reimbursementRequest)
     }

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
@@ -462,7 +462,7 @@ const ReimbursementRequestDetailsView: React.FC<ReimbursementRequestDetailsViewP
       onClick: () => setShowDenyModal(true),
       icon: <CloseIcon />,
       disabled:
-        !user.isFinance ||
+        (!user.isFinance && user.userId !== reimbursementRequest.recipient.userId) ||
         isReimbursementRequestReimbursed(reimbursementRequest) ||
         isReimbursementRequestDenied(reimbursementRequest)
     }


### PR DESCRIPTION
## Changes

User can now deny their own reimbursements requests, regardless of whether they are on the finance team. Updated both backend and frontend.

## Test Cases

- Regular deny reimbursement request still works
- Non finance user can deny their own reimbursement request

## Screenshots
<img width="1190" alt="Screenshot 2025-02-18 at 10 08 56 PM" src="https://github.com/user-attachments/assets/ac47ffa7-1188-4499-8cf6-207626e7b1db" />


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #2244 
