### PR TITLE
#3186 blank parts review page

### DIFF
--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/PartReview/PartsReviewPage.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/PartReview/PartsReviewPage.tsx
@@ -1,0 +1,8 @@
+import LoadingIndicator from '../../../../components/LoadingIndicator';
+
+const PartsReviewPage = () => {
+  //TODO: Parts Review Page content will go here
+  return <LoadingIndicator />;
+};
+
+export default PartsReviewPage;

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
@@ -34,6 +34,7 @@ import BOMTab, { addMaterialCosts } from './BOMTab';
 import SavingsIcon from '@mui/icons-material/Savings';
 import ChangeRequestTab from './ChangeRequestTab';
 import { TaskList } from './TaskList/v2';
+import PartsReviewPage from './PartReview/PartsReviewPage';
 
 interface ProjectViewContainerProps {
   project: Project;
@@ -226,7 +227,8 @@ const ProjectViewContainer: React.FC<ProjectViewContainerProps> = ({ project, en
             { tabUrlValue: 'scope', tabName: 'Scope' },
             { tabUrlValue: 'changes', tabName: 'Changes' },
             { tabUrlValue: 'gantt', tabName: 'Gantt' },
-            { tabUrlValue: 'change-requests', tabName: 'Change Requests' }
+            { tabUrlValue: 'change-requests', tabName: 'Change Requests' },
+            { tabUrlValue: 'parts-review', tabName: 'Parts Review' }
           ]}
           baseUrl={`${routes.PROJECTS}/${wbsNum}`}
           defaultTab="overview"
@@ -247,8 +249,10 @@ const ProjectViewContainer: React.FC<ProjectViewContainerProps> = ({ project, en
         <ChangesList changes={project.changes} />
       ) : tab === 5 ? (
         <ProjectGantt workPackages={project.workPackages} />
-      ) : (
+      ) : tab === 6 ? (
         <ChangeRequestTab project={project} />
+      ) : (
+        <PartsReviewPage />
       )}
       {deleteModalShow && (
         <DeleteProject modalShow={deleteModalShow} handleClose={handleDeleteClose} wbsNum={project.wbsNum} />


### PR DESCRIPTION
## Changes

Added a parts review tab to the projects page

## Notes

No content at this time, only a blank page for developers to work off of

## Screenshot
<img width="1011" alt="Screenshot 2025-02-17 at 6 43 19 PM" src="https://github.com/user-attachments/assets/c31a1286-c9b2-4fff-9a8a-ecd924713f93" />


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3186
