### PR TITLE
#3199 project name abbreviations table 

### DIFF
--- a/src/frontend/src/pages/AdminToolsPage/AdminToolsProjectsConfig.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/AdminToolsProjectsConfig.tsx
@@ -4,6 +4,7 @@ import WorkPackageTemplateTable from './ProjectsConfig/WorkPackageTemplateTable'
 import LinkTypeTable from './ProjectsConfig/LinkTypes/LinkTypeTable';
 import DescriptionBulletTypeTable from './ProjectsConfig/DescriptionBulletTypes/DescriptionBulletTypeTable';
 import CarsTable from './ProjectsConfig/CarsTable';
+import AbbreviationsTable from './ProjectsConfig/AbbreviationsTable';
 
 const AdminToolsProjectsConfig: React.FC = () => {
   return (
@@ -11,6 +12,7 @@ const AdminToolsProjectsConfig: React.FC = () => {
       <Typography variant="h5" gutterBottom borderBottom={1} color="#ef4345" borderColor={'white'}>
         Parts Review Config
       </Typography>
+      <AbbreviationsTable />
       <Typography variant="h5" gutterBottom borderBottom={1} color="#ef4345" borderColor={'white'}>
         Cars Config
       </Typography>

--- a/src/frontend/src/pages/AdminToolsPage/AdminToolsProjectsConfig.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/AdminToolsProjectsConfig.tsx
@@ -1,4 +1,5 @@
 import { Box } from '@mui/system';
+import { Grid } from '@mui/material';
 import { Typography } from '@mui/material';
 import WorkPackageTemplateTable from './ProjectsConfig/WorkPackageTemplateTable';
 import LinkTypeTable from './ProjectsConfig/LinkTypes/LinkTypeTable';
@@ -12,7 +13,11 @@ const AdminToolsProjectsConfig: React.FC = () => {
       <Typography variant="h5" gutterBottom borderBottom={1} color="#ef4345" borderColor={'white'}>
         Parts Review Config
       </Typography>
-      <AbbreviationsTable />
+      <Grid container spacing="3%">
+        <Grid item direction="column" xs={12} md={6}>
+          <AbbreviationsTable />
+        </Grid>
+      </Grid>
       <Typography variant="h5" gutterBottom borderBottom={1} color="#ef4345" borderColor={'white'}>
         Cars Config
       </Typography>

--- a/src/frontend/src/pages/AdminToolsPage/ProjectsConfig/AbbreviationsTable.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/ProjectsConfig/AbbreviationsTable.tsx
@@ -8,7 +8,6 @@ import ErrorPage from '../../ErrorPage';
 
 const AbbreviationsTable: React.FC = () => {
   const { data: projects, isLoading: projectsIsLoading, isError: projectsIsError, error: projectsError } = useAllProjects();
-  const [, setCreateModalShow] = useState(false);
 
   if (!projects || projectsIsLoading) {
     return <LoadingIndicator />;

--- a/src/frontend/src/pages/AdminToolsPage/ProjectsConfig/AbbreviationsTable.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/ProjectsConfig/AbbreviationsTable.tsx
@@ -4,24 +4,25 @@ import { NERButton } from '../../../components/NERButton';
 import { useState } from 'react';
 import { useAllProjects } from '../../../hooks/projects.hooks';
 import LoadingIndicator from '../../../components/LoadingIndicator';
+import ErrorPage from '../../ErrorPage';
 
 const AbbreviationsTable: React.FC = () => {
-  const { data: projects, isLoading: projectsIsLoading } = useAllProjects();
-  const [openModal, setCreateModalShow] = useState(false);
+  const { data: projects, isLoading: projectsIsLoading, isError: projectsIsError, error: projectsError } = useAllProjects();
+  const [, setCreateModalShow] = useState(false);
 
   if (!projects || projectsIsLoading) {
     return <LoadingIndicator />;
   }
-
-  if (openModal) {
+  if (projectsIsError) {
+    return <ErrorPage message={projectsError?.message} />;
   }
 
   return (
     <Box>
       <Typography variant="subtitle1">Project Name Abbreviations</Typography>
-      <AdminToolTable columns={[{ name: 'Project Name' }, { name: 'Abbreviation' }, { name: ' ' }]} rows={[]} />
+      <AdminToolTable columns={[{ name: 'Project Name' }, { name: 'Abbreviation' }]} rows={[]} />
       <Box sx={{ display: 'flex', justifyContent: 'right', marginTop: '10px' }}>
-        <NERButton variant="contained" onClick={() => setCreateModalShow(true)}>
+        <NERButton variant="contained" onClick={() => {}}>
           New Abbreviation
         </NERButton>
       </Box>

--- a/src/frontend/src/pages/AdminToolsPage/ProjectsConfig/AbbreviationsTable.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/ProjectsConfig/AbbreviationsTable.tsx
@@ -1,19 +1,25 @@
-import { TableRow, TableCell, Box, Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import AdminToolTable from '../AdminToolTable';
 import { NERButton } from '../../../components/NERButton';
 import { useState } from 'react';
 import CreateCarModal from './CreateCarFormModal';
+import { useAllProjects } from '../../../hooks/projects.hooks';
+import LoadingIndicator from '../../../components/LoadingIndicator';
 
 const AbbreviationsTable: React.FC = () => {
-  const [openModal, setOpenModal] = useState(false);
+  const { data: projects, isLoading: projectsIsLoading, isError: projectsIsError, error: projectsError } = useAllProjects();
+  const [openModal, setCreateModalShow] = useState(false);
+
+  if (!projects || projectsIsLoading) {
+    return <LoadingIndicator />;
+  }
 
   return (
     <Box>
       <Typography variant="subtitle1">Project Name Abbreviations</Typography>
-      <CreateCarModal showModal={openModal} handleClose={() => setOpenModal(false)} />
       <AdminToolTable columns={[{ name: 'Project Name' }, { name: 'Abbreviation' }, { name: ' ' }]} rows={[]} />
       <Box sx={{ display: 'flex', justifyContent: 'right', marginTop: '10px' }}>
-        <NERButton variant="contained" onClick={() => setOpenModal(true)}>
+        <NERButton variant="contained" onClick={() => setCreateModalShow(true)}>
           New Abbreviation
         </NERButton>
       </Box>

--- a/src/frontend/src/pages/AdminToolsPage/ProjectsConfig/AbbreviationsTable.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/ProjectsConfig/AbbreviationsTable.tsx
@@ -2,16 +2,18 @@ import { Box, Typography } from '@mui/material';
 import AdminToolTable from '../AdminToolTable';
 import { NERButton } from '../../../components/NERButton';
 import { useState } from 'react';
-import CreateCarModal from './CreateCarFormModal';
 import { useAllProjects } from '../../../hooks/projects.hooks';
 import LoadingIndicator from '../../../components/LoadingIndicator';
 
 const AbbreviationsTable: React.FC = () => {
-  const { data: projects, isLoading: projectsIsLoading, isError: projectsIsError, error: projectsError } = useAllProjects();
+  const { data: projects, isLoading: projectsIsLoading } = useAllProjects();
   const [openModal, setCreateModalShow] = useState(false);
 
   if (!projects || projectsIsLoading) {
     return <LoadingIndicator />;
+  }
+
+  if (openModal) {
   }
 
   return (

--- a/src/frontend/src/pages/AdminToolsPage/ProjectsConfig/AbbreviationsTable.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/ProjectsConfig/AbbreviationsTable.tsx
@@ -1,0 +1,24 @@
+import { TableRow, TableCell, Box, Typography } from '@mui/material';
+import AdminToolTable from '../AdminToolTable';
+import { NERButton } from '../../../components/NERButton';
+import { useState } from 'react';
+import CreateCarModal from './CreateCarFormModal';
+
+const AbbreviationsTable: React.FC = () => {
+  const [openModal, setOpenModal] = useState(false);
+
+  return (
+    <Box>
+      <Typography variant="subtitle1">Project Name Abbreviations</Typography>
+      <CreateCarModal showModal={openModal} handleClose={() => setOpenModal(false)} />
+      <AdminToolTable columns={[{ name: 'Project Name' }, { name: 'Abbreviation' }, { name: ' ' }]} rows={[]} />
+      <Box sx={{ display: 'flex', justifyContent: 'right', marginTop: '10px' }}>
+        <NERButton variant="contained" onClick={() => setOpenModal(true)}>
+          New Abbreviation
+        </NERButton>
+      </Box>
+    </Box>
+  );
+};
+
+export default AbbreviationsTable;

--- a/src/frontend/src/pages/AdminToolsPage/ProjectsConfig/AbbreviationsTable.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/ProjectsConfig/AbbreviationsTable.tsx
@@ -1,7 +1,6 @@
 import { Box, Typography } from '@mui/material';
 import AdminToolTable from '../AdminToolTable';
 import { NERButton } from '../../../components/NERButton';
-import { useState } from 'react';
 import { useAllProjects } from '../../../hooks/projects.hooks';
 import LoadingIndicator from '../../../components/LoadingIndicator';
 import ErrorPage from '../../ErrorPage';


### PR DESCRIPTION
## Changes

Created a table for project name abbreviations in the Project Config section of the admin tools

## Screenshots
<img width="1439" alt="Screenshot 2025-02-19 at 8 25 44 PM" src="https://github.com/user-attachments/assets/66851b57-2f38-48b4-a91f-ac7cf5bb3d1b" />

<img width="501" alt="Screenshot 2025-02-19 at 8 25 58 PM" src="https://github.com/user-attachments/assets/5778a18c-3d73-47f1-9752-a6b5caf99563" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3199
