### PR TITLE
#3188: Created Part Page

### DIFF
--- a/src/frontend/src/pages/PartPage/PartPage.tsx
+++ b/src/frontend/src/pages/PartPage/PartPage.tsx
@@ -1,14 +1,85 @@
-import { Box } from '@mui/material';
-import PageLayout from '../../components/PageLayout';
-import { Grid } from '@mui/system';
+import { Box, Typography, Grid, Breadcrumbs } from '@mui/material';
 
 const PartPage: React.FC = () => {
   return (
-    <PageLayout title="Part Review">
-      <Grid>
-        <Box>Part goes here</Box>
+    <Box padding={4}>
+      {/* This is where the breadcrumbs (series of links) will go */}
+      <Breadcrumbs sx={{ mb: 2 }}></Breadcrumbs>
+
+      {/* Need to query for the part title */}
+      <Typography variant="h4" fontWeight="bold" mb={3}>
+        [PROJ_PartName_PartNum]
+      </Typography>
+
+      <Grid container spacing={3}>
+        {/* The code below will be replaced by the part preview */}
+        <Grid item xs={12} md={6}>
+          <Box
+            sx={{
+              backgroundColor: 'black',
+              height: '75vh',
+              width: '100%',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              border: '2px solid white'
+            }}
+          >
+            <Typography color="white">No submission yet.</Typography>
+          </Box>
+        </Grid>
+
+        {/* The code below will be replaced by the Overview, Details, and History components */}
+        <Grid item xs={12} md={6}>
+          <Grid container spacing={2} direction="column">
+            <Grid item>
+              <Box
+                sx={{
+                  backgroundColor: 'gray',
+                  height: '24vh',
+                  width: '100%',
+                  borderRadius: 2,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  mb: 2
+                }}
+              >
+                <Typography>Overview</Typography>
+              </Box>
+              <Box
+                sx={{
+                  backgroundColor: 'gray',
+                  height: '24vh',
+                  width: '100%',
+                  borderRadius: 2,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  mb: 2
+                }}
+              >
+                <Typography>Details for Submission</Typography>
+              </Box>
+              <Box
+                sx={{
+                  backgroundColor: 'gray',
+                  height: '24vh',
+                  width: '100%',
+                  borderRadius: 2,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  mb: 2
+                }}
+              >
+                <Typography>History</Typography>
+              </Box>
+            </Grid>
+          </Grid>
+        </Grid>
       </Grid>
-    </PageLayout>
+    </Box>
   );
 };
 

--- a/src/frontend/src/pages/PartPage/PartPage.tsx
+++ b/src/frontend/src/pages/PartPage/PartPage.tsx
@@ -1,0 +1,15 @@
+import { Box } from '@mui/material';
+import PageLayout from '../../components/PageLayout';
+import { Grid } from '@mui/system';
+
+const PartPage: React.FC = () => {
+  return (
+    <PageLayout title="Part Review">
+      <Grid>
+        <Box>Part goes here</Box>
+      </Grid>
+    </PageLayout>
+  );
+};
+
+export default PartPage;

--- a/src/frontend/src/pages/ProjectsPage/Projects.tsx
+++ b/src/frontend/src/pages/ProjectsPage/Projects.tsx
@@ -18,9 +18,9 @@ const Projects: React.FC = () => {
       <Route path={routes.PROJECTS_ALL} component={ProjectsPage} />
       <Route path={routes.WORK_PACKAGE_NEW} component={CreateWorkPackageForm} />
       <Route path={routes.PROJECTS_NEW} component={ProjectCreateContainer} />
+      <Route path={routes.PROJECT_PART} component={PartPage} />
       <Route path={routes.PROJECTS_BY_WBS} component={WBSDetails} />
       <Route path={routes.PROJECTS} component={ProjectsPage} />
-      <Route path={routes.PROJECT_PART} component={PartPage} />
     </Switch>
   );
 };

--- a/src/frontend/src/pages/ProjectsPage/Projects.tsx
+++ b/src/frontend/src/pages/ProjectsPage/Projects.tsx
@@ -9,6 +9,7 @@ import WBSDetails from '../WBSDetails';
 import ProjectsPage from './ProjectsPage';
 import CreateWorkPackageForm from '../WorkPackageForm/CreateWorkPackageForm';
 import ProjectCreateContainer from '../ProjectDetailPage/ProjectForm/ProjectCreateContainer';
+import PartPage from '../PartPage/PartPage';
 
 const Projects: React.FC = () => {
   return (
@@ -19,6 +20,7 @@ const Projects: React.FC = () => {
       <Route path={routes.PROJECTS_NEW} component={ProjectCreateContainer} />
       <Route path={routes.PROJECTS_BY_WBS} component={WBSDetails} />
       <Route path={routes.PROJECTS} component={ProjectsPage} />
+      <Route path={routes.PROJECT_PART} component={PartPage} />
     </Switch>
   );
 };

--- a/src/frontend/src/utils/routes.ts
+++ b/src/frontend/src/utils/routes.ts
@@ -34,6 +34,8 @@ const PROJECTS_BY_WBS = PROJECTS + `/:wbsNum`;
 const PROJECTS_NEW = PROJECTS + `/new`;
 const WORK_PACKAGE_NEW = PROJECTS + `/work-package/new`;
 
+const PROJECT_PART = PROJECTS_BY_WBS + '/part';
+
 /**************** Teams Section ****************/
 const TEAMS = `/teams`;
 const TEAMS_BY_ID = TEAMS + `/:teamId`;
@@ -96,6 +98,7 @@ export const routes = {
   PROJECTS_BY_WBS,
   PROJECTS_NEW,
   WORK_PACKAGE_NEW,
+  PROJECT_PART,
 
   CHANGE_REQUESTS,
   ALL_CHANGE_REQUESTS,

--- a/src/frontend/src/utils/routes.ts
+++ b/src/frontend/src/utils/routes.ts
@@ -33,7 +33,6 @@ const PROJECTS_ALL = PROJECTS + '/all';
 const PROJECTS_BY_WBS = PROJECTS + `/:wbsNum`;
 const PROJECTS_NEW = PROJECTS + `/new`;
 const WORK_PACKAGE_NEW = PROJECTS + `/work-package/new`;
-
 const PROJECT_PART = PROJECTS_BY_WBS + '/part';
 
 /**************** Teams Section ****************/


### PR DESCRIPTION
## Changes

Added a frontend route for the part page and created an empty PartPage component.

## Notes

- Route is currently set to /projects/part to check the component but it's not working as expected

## Screenshots

<img width="1728" alt="Screenshot 2025-02-24 at 23 27 39" src="https://github.com/user-attachments/assets/29944c3a-b48d-4aed-a224-1cd54e7a0bf6" />


## To Do

- [x] Get route to work so PartPage component can be seen

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3188
