### PR TITLE
#3131: BOM materials form add dropdown entries in-line

### DIFF
--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialForm.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialForm.tsx
@@ -5,6 +5,8 @@ import * as yup from 'yup';
 import LoadingIndicator from '../../../../../components/LoadingIndicator';
 import {
   useCreateManufacturer,
+  useCreateMaterialType,
+  useCreateUnit,
   useGetAllManufacturers,
   useGetAllMaterialTypes,
   useGetAllUnits
@@ -95,6 +97,10 @@ const MaterialForm: React.FC<MaterialFormProps> = ({ submitText, assemblies, onS
 
   const { mutateAsync: createManufacturer, isLoading: isLoadingCreateManufacturer } = useCreateManufacturer();
 
+  const { mutateAsync: createType, isLoading: isLoadingCreateType } = useCreateMaterialType();
+
+  const { mutateAsync: createUnit, isLoading: isLoadingCreateUnit } = useCreateUnit();
+
   const {
     data: materialTypes,
     isLoading: isLoadingMaterialTypes,
@@ -121,7 +127,9 @@ const MaterialForm: React.FC<MaterialFormProps> = ({ submitText, assemblies, onS
     !materialTypes ||
     !units ||
     !manufactuers ||
-    isLoadingCreateManufacturer
+    isLoadingCreateManufacturer ||
+    isLoadingCreateType ||
+    isLoadingCreateUnit
   ) {
     return <LoadingIndicator />;
   }
@@ -136,6 +144,28 @@ const MaterialForm: React.FC<MaterialFormProps> = ({ submitText, assemblies, onS
     try {
       const createdManufacturer = await createManufacturer({ name: manufacturerName });
       setValue('manufacturerName', createdManufacturer.name);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        console.error(error.message);
+      }
+    }
+  };
+
+  const createTypeWrapper = async (typeName: string): Promise<void> => {
+    try {
+      const createdType = await createType({ name: typeName });
+      setValue('materialTypeName', createdType.name);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        console.error(error.message);
+      }
+    }
+  };
+
+  const createUnitWrapper = async (unitName: string): Promise<void> => {
+    try {
+      const createdUnit = await createUnit({ name: unitName });
+      setValue('unitName', createdUnit.name);
     } catch (error: unknown) {
       if (error instanceof Error) {
         console.error(error.message);
@@ -158,6 +188,8 @@ const MaterialForm: React.FC<MaterialFormProps> = ({ submitText, assemblies, onS
       open={open}
       watch={watch}
       createManufacturer={createManufacturerWrapper}
+      createType={createTypeWrapper}
+      createUnit={createUnitWrapper}
       setValue={setValue}
     />
   );

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
@@ -1,7 +1,7 @@
 import { FormControl, FormHelperText, FormLabel, Grid, InputAdornment, MenuItem, TextField, Tooltip } from '@mui/material';
 import { Box } from '@mui/system';
 import { Control, Controller, FieldErrors, UseFormHandleSubmit, UseFormSetValue, UseFormWatch } from 'react-hook-form';
-import { Assembly, Manufacturer, MaterialType, Unit } from 'shared';
+import { Assembly, isGuest, isMember, Manufacturer, MaterialType, Unit } from 'shared';
 import ReactHookTextField from '../../../../../components/ReactHookTextField';
 import { MaterialFormInput } from './MaterialForm';
 import NERFormModal from '../../../../../components/NERFormModal';
@@ -13,6 +13,7 @@ import HelpIcon from '@mui/icons-material/Help';
 import { displayEnum } from '../../../../../utils/pipes';
 import { MaterialStatus } from 'shared';
 import { createUnit } from '../../../../../apis/bom.api';
+import { useCurrentUser } from '../../../../../hooks/users.hooks';
 
 export interface MaterialFormViewProps {
   submitText: 'Add' | 'Edit';
@@ -57,7 +58,8 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
   const quantity = watch('quantity');
   const price = watch('price');
   const subtotal = quantity && price && parseFloat((quantity * price).toFixed(2));
-
+  const user = useCurrentUser();
+  const disableEdit = isGuest(user.role) || isMember(user.role);
   const onCostBlurHandler = (value: number) => {
     setValue(`price`, parseFloat(value.toFixed(2)));
   };
@@ -110,7 +112,7 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
             />
           </FormControl>
         </Grid>
-        <Grid item xs={6}>
+        <Grid item xs={disableEdit ? 12 : 6}>
           <FormControl fullWidth>
             <FormLabel>Type</FormLabel>
             <Controller
@@ -135,21 +137,23 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
             />
           </FormControl>
         </Grid>
-        <Grid item xs={6} sx={{ display: 'flex', alignItems: 'center', marginTop: '20px' }}>
-          <NERButton
-            sx={{ width: '100%', height: '56px' }}
-            variant="contained"
-            onClick={() => {
-              const newTypeName = prompt('Enter New Type Name');
-              if (newTypeName !== null) {
-                createType(newTypeName);
-              }
-            }}
-          >
-            Add New Type <AddIcon sx={{ paddingLeft: '7px' }}></AddIcon>
-          </NERButton>
-        </Grid>
-        <Grid item xs={6}>
+        {!disableEdit && (
+          <Grid item xs={6} sx={{ display: 'flex', alignItems: 'center', marginTop: '20px' }}>
+            <NERButton
+              sx={{ width: '100%', height: '56px' }}
+              variant="contained"
+              onClick={() => {
+                const newTypeName = prompt('Enter New Type Name');
+                if (newTypeName !== null) {
+                  createType(newTypeName);
+                }
+              }}
+            >
+              Add New Type <AddIcon sx={{ paddingLeft: '7px' }}></AddIcon>
+            </NERButton>
+          </Grid>
+        )}
+        <Grid item xs={disableEdit ? 12 : 6}>
           <FormControl fullWidth>
             <FormLabel>
               Manufacturer
@@ -191,20 +195,22 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
             />
           </FormControl>
         </Grid>
-        <Grid item xs={6} sx={{ display: 'flex', alignItems: 'center', marginTop: '20px' }}>
-          <NERButton
-            sx={{ width: '100%', height: '56px' }}
-            variant="contained"
-            onClick={() => {
-              const newManufacturerName = prompt('Enter New Manufacturer Name');
-              if (newManufacturerName !== null) {
-                createManufacturer(newManufacturerName);
-              }
-            }}
-          >
-            Add New Manufacturer <AddIcon sx={{ paddingLeft: '7px' }}></AddIcon>
-          </NERButton>
-        </Grid>
+        {!disableEdit && (
+          <Grid item xs={6} sx={{ display: 'flex', alignItems: 'center', marginTop: '20px' }}>
+            <NERButton
+              sx={{ width: '100%', height: '56px' }}
+              variant="contained"
+              onClick={() => {
+                const newManufacturerName = prompt('Enter New Manufacturer Name');
+                if (newManufacturerName !== null) {
+                  createManufacturer(newManufacturerName);
+                }
+              }}
+            >
+              Add New Manufacturer <AddIcon sx={{ paddingLeft: '7px' }}></AddIcon>
+            </NERButton>
+          </Grid>
+        )}
         <Grid item xs={6}>
           <FormControl fullWidth>
             <FormLabel>
@@ -233,7 +239,7 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
             />
           </FormControl>
         </Grid>
-        <Grid xs={6}>
+        <Grid xs={disableEdit ? 12 : 6}>
           <Box display={'flex'} alignItems={'center'} mt={2} ml={2}>
             <FormControl fullWidth>
               <FormLabel>Quantity</FormLabel>
@@ -271,20 +277,22 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
             </FormControl>
           </Box>
         </Grid>
-        <Grid item xs={6} sx={{ display: 'flex', alignItems: 'center', marginTop: '20px' }}>
-          <NERButton
-            sx={{ width: '110%', height: '56px' }}
-            variant="contained"
-            onClick={() => {
-              const newUnitName = prompt('Enter New Unit Name');
-              if (newUnitName !== null) {
-                createUnit(newUnitName);
-              }
-            }}
-          >
-            Add Unit <AddIcon sx={{ paddingLeft: '5px' }}></AddIcon>
-          </NERButton>
-        </Grid>
+        {!disableEdit && (
+          <Grid item xs={6} sx={{ display: 'flex', alignItems: 'center', marginTop: '20px' }}>
+            <NERButton
+              sx={{ width: '110%', height: '56px' }}
+              variant="contained"
+              onClick={() => {
+                const newUnitName = prompt('Enter New Unit Name');
+                if (newUnitName !== null) {
+                  createUnit(newUnitName);
+                }
+              }}
+            >
+              Add Unit <AddIcon sx={{ paddingLeft: '5px' }}></AddIcon>
+            </NERButton>
+          </Grid>
+        )}
         <Grid item xs={3}>
           <FormControl fullWidth>
             <FormLabel style={{ whiteSpace: 'normal' }}>Price per Unit</FormLabel>

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
@@ -12,6 +12,7 @@ import AddIcon from '@mui/icons-material/Add';
 import HelpIcon from '@mui/icons-material/Help';
 import { displayEnum } from '../../../../../utils/pipes';
 import { MaterialStatus } from 'shared';
+import { createUnit } from '../../../../../apis/bom.api';
 
 export interface MaterialFormViewProps {
   submitText: 'Add' | 'Edit';
@@ -27,6 +28,8 @@ export interface MaterialFormViewProps {
   open: boolean;
   watch: UseFormWatch<MaterialFormInput>;
   createManufacturer: (name: string) => void;
+  createType: (name: string) => void;
+  createUnit: (name: string) => void;
   setValue: UseFormSetValue<MaterialFormInput>;
 }
 
@@ -48,6 +51,7 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
   open,
   watch,
   createManufacturer,
+  createType,
   setValue
 }) => {
   const quantity = watch('quantity');
@@ -81,7 +85,7 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
             />
           </FormControl>
         </Grid>
-        <Grid item xs={6}>
+        <Grid item xs={12}>
           <FormControl fullWidth>
             <FormLabel>Status</FormLabel>
             <Controller
@@ -130,6 +134,20 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
               )}
             />
           </FormControl>
+        </Grid>
+        <Grid item xs={6} sx={{ display: 'flex', alignItems: 'center', marginTop: '20px' }}>
+          <NERButton
+            sx={{ width: '100%', height: '56px' }}
+            variant="contained"
+            onClick={() => {
+              const newTypeName = prompt('Enter New Type Name');
+              if (newTypeName !== null) {
+                createType(newTypeName);
+              }
+            }}
+          >
+            Add New Type <AddIcon sx={{ paddingLeft: '7px' }}></AddIcon>
+          </NERButton>
         </Grid>
         <Grid item xs={6}>
           <FormControl fullWidth>
@@ -252,6 +270,20 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
               />
             </FormControl>
           </Box>
+        </Grid>
+        <Grid item xs={6} sx={{ display: 'flex', alignItems: 'center', marginTop: '20px' }}>
+          <NERButton
+            sx={{ width: '110%', height: '56px' }}
+            variant="contained"
+            onClick={() => {
+              const newUnitName = prompt('Enter New Unit Name');
+              if (newUnitName !== null) {
+                createUnit(newUnitName);
+              }
+            }}
+          >
+            Add Unit <AddIcon sx={{ paddingLeft: '5px' }}></AddIcon>
+          </NERButton>
         </Grid>
         <Grid item xs={3}>
           <FormControl fullWidth>

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
@@ -1,7 +1,7 @@
 import { FormControl, FormHelperText, FormLabel, Grid, InputAdornment, MenuItem, TextField, Tooltip } from '@mui/material';
 import { Box } from '@mui/system';
 import { Control, Controller, FieldErrors, UseFormHandleSubmit, UseFormSetValue, UseFormWatch } from 'react-hook-form';
-import { Assembly, isGuest, isMember, Manufacturer, MaterialType, Unit } from 'shared';
+import { Assembly, isGuest, Manufacturer, MaterialType, Unit } from 'shared';
 import ReactHookTextField from '../../../../../components/ReactHookTextField';
 import { MaterialFormInput } from './MaterialForm';
 import NERFormModal from '../../../../../components/NERFormModal';

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
@@ -59,7 +59,7 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
   const price = watch('price');
   const subtotal = quantity && price && parseFloat((quantity * price).toFixed(2));
   const user = useCurrentUser();
-  const disableEdit = isGuest(user.role) || isMember(user.role);
+  const disableEdit = isGuest(user.role);
   const onCostBlurHandler = (value: number) => {
     setValue(`price`, parseFloat(value.toFixed(2)));
   };


### PR DESCRIPTION
## Changes

Added buttons in the BOM materials form for creating new material types and units in-line.

## Screenshots
Viewing as admin:
<img width="1467" alt="Screenshot 2025-02-20 at 1 03 31 PM" src="https://github.com/user-attachments/assets/fadd2102-3e8a-4915-86bc-6288be617ffe" />

<img width="494" alt="Screenshot 2025-02-20 at 1 12 04 PM" src="https://github.com/user-attachments/assets/1569c98f-e3d7-4941-b2b6-02b788b808cd" />

Viewing as guest/member:
<img width="1467" alt="Screenshot 2025-02-26 at 8 47 55 PM" src="https://github.com/user-attachments/assets/4cf2d722-4964-4b3c-9f1b-a182b17fbde5" />

<img width="530" alt="Screenshot 2025-02-26 at 8 49 02 PM" src="https://github.com/user-attachments/assets/0d544604-966f-45ae-8329-c25e9b284cd6" />


Closes #3131
