### PR TITLE
#3191 get all sponsors endpoint

### DIFF
--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -4,6 +4,7 @@ import cookieParser from 'cookie-parser';
 import { getUserAndOrganization, prodHeaders, requireJwtDev, requireJwtProd } from './src/utils/auth.utils';
 import { errorHandler } from './src/utils/errors.utils';
 import userRouter from './src/routes/users.routes';
+import financeRouter from './src/routes/finance.routes';
 import projectRouter from './src/routes/projects.routes';
 import teamsRouter from './src/routes/teams.routes';
 import workPackagesRouter from './src/routes/work-packages.routes';
@@ -81,6 +82,7 @@ app.use('/pop-ups', popUpsRouter);
 app.use('/announcements', announcementsRouter);
 app.use('/onboarding', onboardingRouter);
 app.use('/statistics', statisticsRouter);
+app.use('/finance', financeRouter);
 app.use('/', (_req, res) => {
   res.status(200).json('Welcome to FinishLine');
 });

--- a/src/backend/src/controllers/finance.controllers.ts
+++ b/src/backend/src/controllers/finance.controllers.ts
@@ -36,4 +36,13 @@ export default class FinanceController {
       next(error);
     }
   }
+
+  static async getAllSponsors(req: Request, res: Response, next: NextFunction) {
+    try {
+      const allSponsors = await FinanceServices.getAllSponsors(req.organization);
+      res.status(200).json(allSponsors);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
 }

--- a/src/backend/src/prisma-query-args/sponsor.query-args.ts
+++ b/src/backend/src/prisma-query-args/sponsor.query-args.ts
@@ -5,6 +5,10 @@ export type SponsorQueryArgs = ReturnType<typeof getSponsorQueryArgs>;
 export const getSponsorQueryArgs = () =>
   Prisma.validator<Prisma.SponsorDefaultArgs>()({
     include: {
-      sponsorTasks: true
+      sponsorTasks: {
+        include: {
+          sponsor: true
+        }
+      }
     }
   });

--- a/src/backend/src/prisma-query-args/sponsor.query-args.ts
+++ b/src/backend/src/prisma-query-args/sponsor.query-args.ts
@@ -12,9 +12,9 @@ export const getSponsorQueryArgs = (organizationId: string) =>
     }
   });
 
-  export const getSponsorTaskQueryArgs = (organizationId: string) =>
-    Prisma.validator<Prisma.Sponsor_TaskDefaultArgs>()({
-      include: {
-        assignee: getUserQueryArgs(organizationId)
-      }
-    });
+export const getSponsorTaskQueryArgs = (organizationId: string) =>
+  Prisma.validator<Prisma.Sponsor_TaskDefaultArgs>()({
+    include: {
+      assignee: getUserQueryArgs(organizationId)
+    }
+  });

--- a/src/backend/src/prisma-query-args/sponsor.query-args.ts
+++ b/src/backend/src/prisma-query-args/sponsor.query-args.ts
@@ -1,0 +1,10 @@
+import { Prisma } from '@prisma/client';
+
+export type SponsorQueryArgs = ReturnType<typeof getSponsorQueryArgs>;
+
+export const getSponsorQueryArgs = () =>
+  Prisma.validator<Prisma.SponsorDefaultArgs>()({
+    include: {
+      sponsorTasks: true
+    }
+  });

--- a/src/backend/src/prisma-query-args/sponsor.query-args.ts
+++ b/src/backend/src/prisma-query-args/sponsor.query-args.ts
@@ -3,12 +3,8 @@ import { Prisma } from '@prisma/client';
 export type SponsorQueryArgs = ReturnType<typeof getSponsorQueryArgs>;
 
 export const getSponsorQueryArgs = () =>
-  Prisma.validator<Prisma.SponsorDefaultArgs>()({
+  Prisma.validator<Prisma.SponsorFindManyArgs>()({
     include: {
-      sponsorTasks: {
-        include: {
-          sponsor: true
-        }
-      }
+      sponsorTasks: true
     }
   });

--- a/src/backend/src/prisma-query-args/sponsor.query-args.ts
+++ b/src/backend/src/prisma-query-args/sponsor.query-args.ts
@@ -1,10 +1,20 @@
 import { Prisma } from '@prisma/client';
+import { getUserQueryArgs } from './user.query-args';
 
 export type SponsorQueryArgs = ReturnType<typeof getSponsorQueryArgs>;
 
-export const getSponsorQueryArgs = () =>
-  Prisma.validator<Prisma.SponsorFindManyArgs>()({
+export type SponsorTaskQueryArgs = ReturnType<typeof getSponsorTaskQueryArgs>;
+
+export const getSponsorQueryArgs = (organizationId: string) =>
+  Prisma.validator<Prisma.SponsorDefaultArgs>()({
     include: {
-      sponsorTasks: true
+      sponsorTasks: getSponsorTaskQueryArgs(organizationId)
     }
   });
+
+  export const getSponsorTaskQueryArgs = (organizationId: string) =>
+    Prisma.validator<Prisma.Sponsor_TaskDefaultArgs>()({
+      include: {
+        assignee: getUserQueryArgs(organizationId)
+      }
+    });

--- a/src/backend/src/prisma/seed.ts
+++ b/src/backend/src/prisma/seed.ts
@@ -52,7 +52,7 @@ import FinanceServices from '../services/finance.services';
 const prisma = new PrismaClient();
 
 const performSeed: () => Promise<void> = async () => {
-  const thomasEmrax = await prisma.user.create({
+  const thomasEmrax = await prisma.user.yarncreate({
     data: dbSeedAllUsers.thomasEmrax,
     include: { userSettings: true, userSecureSettings: true }
   });

--- a/src/backend/src/prisma/seed.ts
+++ b/src/backend/src/prisma/seed.ts
@@ -2010,6 +2010,14 @@ const performSeed: () => Promise<void> = async () => {
     ner.organizationId
   );
 
+  const sponsorTier = await prisma.sponsor_Tier.create({
+    data: {
+      name: 'Gold Tier',
+      colorHexCode: '#FFFFFF',
+      organizationId: ner.organizationId
+    }
+  });
+
   await FinanceServices.createSponsor(
     thomasEmrax,
     'Google',
@@ -2017,7 +2025,7 @@ const performSeed: () => Promise<void> = async () => {
     5000,
     new Date(12, 1, 24),
     [2024, 2025],
-    'gold',
+    sponsorTier.sponsorTierId,
     true,
     'Bill Gates',
     [],

--- a/src/backend/src/prisma/seed.ts
+++ b/src/backend/src/prisma/seed.ts
@@ -52,7 +52,7 @@ import FinanceServices from '../services/finance.services';
 const prisma = new PrismaClient();
 
 const performSeed: () => Promise<void> = async () => {
-  const thomasEmrax = await prisma.user.yarncreate({
+  const thomasEmrax = await prisma.user.create({
     data: dbSeedAllUsers.thomasEmrax,
     include: { userSettings: true, userSecureSettings: true }
   });

--- a/src/backend/src/routes/finance.routes.ts
+++ b/src/backend/src/routes/finance.routes.ts
@@ -20,3 +20,5 @@ financeRouter.post(
   validateInputs,
   FinanceController.createSponsor
 );
+
+financeRouter.get('/finance/sponsor', FinanceController.getAllSponsors);

--- a/src/backend/src/routes/finance.routes.ts
+++ b/src/backend/src/routes/finance.routes.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { nonEmptyString, validateInputs, isDate, validateSponsorTier } from '../utils/validation.utils';
+import { nonEmptyString, validateInputs, isDate } from '../utils/validation.utils';
 import { body } from 'express-validator';
 import FinanceController from '../controllers/finance.controllers';
 
@@ -12,7 +12,7 @@ financeRouter.post(
   body('sponsorValue').isInt(),
   isDate(body('joinDate')),
   body('activeYears').isArray(),
-  validateSponsorTier(),
+  nonEmptyString(body('sponsorTierId')),
   body('taxExempt').isBoolean(),
   nonEmptyString(body('vendorContact')),
   body('sponsorTasks').isArray(),

--- a/src/backend/src/routes/finance.routes.ts
+++ b/src/backend/src/routes/finance.routes.ts
@@ -6,7 +6,7 @@ import FinanceController from '../controllers/finance.controllers';
 const financeRouter = express.Router();
 
 financeRouter.post(
-  '/finance/sponsor/create',
+  '/sponsor/create',
   nonEmptyString(body('name')),
   body('activeStatus').isBoolean(),
   body('sponsorValue').isInt(),
@@ -21,4 +21,6 @@ financeRouter.post(
   FinanceController.createSponsor
 );
 
-financeRouter.get('/finance/sponsor', FinanceController.getAllSponsors);
+financeRouter.get('/sponsor', FinanceController.getAllSponsors);
+
+export default financeRouter;

--- a/src/backend/src/routes/finance.routes.ts
+++ b/src/backend/src/routes/finance.routes.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { nonEmptyString, validateInputs, isDate } from '../utils/validation.utils';
+import { nonEmptyString, validateInputs, isDate, validateSponsorTier } from '../utils/validation.utils';
 import { body } from 'express-validator';
 import FinanceController from '../controllers/finance.controllers';
 
@@ -12,7 +12,7 @@ financeRouter.post(
   body('sponsorValue').isInt(),
   isDate(body('joinDate')),
   body('activeYears').isArray(),
-  nonEmptyString(body('sponsorTierId')),
+  validateSponsorTier(),
   body('taxExempt').isBoolean(),
   nonEmptyString(body('vendorContact')),
   body('sponsorTasks').isArray(),
@@ -21,6 +21,6 @@ financeRouter.post(
   FinanceController.createSponsor
 );
 
-financeRouter.get('/sponsor', FinanceController.getAllSponsors);
+financeRouter.get('/sponsors', FinanceController.getAllSponsors);
 
 export default financeRouter;

--- a/src/backend/src/services/finance.services.ts
+++ b/src/backend/src/services/finance.services.ts
@@ -65,12 +65,10 @@ export default class FinanceServices {
         },
         organizationId: organization.organizationId
       },
-      include: {
-        sponsorTasks: true
-      }
+      ...getSponsorQueryArgs()
     });
 
-    return sponsor;
+    return sponsorTransformer(sponsor);
   }
 
   static async getAllSponsors(organization: Organization) {

--- a/src/backend/src/services/finance.services.ts
+++ b/src/backend/src/services/finance.services.ts
@@ -1,5 +1,5 @@
 import { isHead } from 'shared';
-import { User, Organization, Sponsor_Task, Sponsor_Tier } from '@prisma/client';
+import { User, Organization, Sponsor_Task } from '@prisma/client';
 import { userHasPermission } from '../utils/users.utils';
 import { AccessDeniedAdminOnlyException } from '../utils/errors.utils';
 import prisma from '../prisma/prisma';
@@ -16,7 +16,7 @@ export default class FinanceServices {
    * @param sponsorValue The financial value associated with the sponsor.
    * @param joinDate The date when the sponsor joins.
    * @param activeYears An array of years indicating the sponsor's active period.
-   * @param sponsorTier The sponsor's tier.
+   * @param sponsorTierId The ID of the sponsor's tier.
    * @param taxExempt Boolean indicating if the sponsor is tax-exempt.
    * @param discountCode The discount code associated with the sponsor.
    * @param vendorContact The contact information for the sponsor's vendor.

--- a/src/backend/src/services/finance.services.ts
+++ b/src/backend/src/services/finance.services.ts
@@ -1,10 +1,10 @@
 import { isHead } from 'shared';
-import { User, Organization, Sponsor_Task } from '@prisma/client';
+import { User, Organization, Sponsor_Task, Sponsor_Tier } from '@prisma/client';
 import { userHasPermission } from '../utils/users.utils';
 import { AccessDeniedAdminOnlyException } from '../utils/errors.utils';
 import prisma from '../prisma/prisma';
 import { getSponsorQueryArgs } from '../prisma-query-args/sponsor.query-args';
-import sponsorTransformer from '../transformers/finance.transformer';
+import { sponsorTransformer } from '../transformers/finance.transformer';
 
 export default class FinanceServices {
   /**
@@ -16,7 +16,7 @@ export default class FinanceServices {
    * @param sponsorValue The financial value associated with the sponsor.
    * @param joinDate The date when the sponsor joins.
    * @param activeYears An array of years indicating the sponsor's active period.
-   * @param sponsorTierId The ID of the sponsor's tier.
+   * @param sponsorTier The sponsor's tier.
    * @param taxExempt Boolean indicating if the sponsor is tax-exempt.
    * @param discountCode The discount code associated with the sponsor.
    * @param vendorContact The contact information for the sponsor's vendor.
@@ -65,16 +65,21 @@ export default class FinanceServices {
         },
         organizationId: organization.organizationId
       },
-      ...getSponsorQueryArgs()
+      ...getSponsorQueryArgs(organization.organizationId)
     });
 
     return sponsorTransformer(sponsor);
   }
 
+  /**
+   * Returns all the sponsors in the database
+   * @param organization The organization the user is currently in
+   * @returns All the sponsors in the database
+   */
   static async getAllSponsors(organization: Organization) {
     const allSponsors = await prisma.sponsor.findMany({
       where: { organizationId: organization.organizationId, dateDeleted: null },
-      ...getSponsorQueryArgs()
+      ...getSponsorQueryArgs(organization.organizationId)
     });
 
     return allSponsors.map(sponsorTransformer);

--- a/src/backend/src/services/finance.services.ts
+++ b/src/backend/src/services/finance.services.ts
@@ -3,6 +3,8 @@ import { User, Organization, Sponsor_Task } from '@prisma/client';
 import { userHasPermission } from '../utils/users.utils';
 import { AccessDeniedAdminOnlyException } from '../utils/errors.utils';
 import prisma from '../prisma/prisma';
+import { getSponsorQueryArgs } from '../prisma-query-args/sponsor.query-args';
+import sponsorTransformer from '../transformers/finance.transformer';
 
 export default class FinanceServices {
   /**
@@ -74,7 +76,7 @@ export default class FinanceServices {
   static async getAllSponsors(organization: Organization) {
     const allSponsors = await prisma.sponsor.findMany({
       where: { organizationId: organization.organizationId, dateDeleted: null },
-      include: { sponsorTasks: true }
+      ...getSponsorQueryArgs()
     });
 
     return allSponsors;

--- a/src/backend/src/services/finance.services.ts
+++ b/src/backend/src/services/finance.services.ts
@@ -70,4 +70,13 @@ export default class FinanceServices {
 
     return sponsor;
   }
+
+  static async getAllSponsors(organization: Organization) {
+    const allSponsors = await prisma.sponsor.findMany({
+      where: { organizationId: organization.organizationId, dateDeleted: null },
+      include: { sponsorTasks: true }
+    });
+
+    return allSponsors;
+  }
 }

--- a/src/backend/src/services/finance.services.ts
+++ b/src/backend/src/services/finance.services.ts
@@ -79,6 +79,6 @@ export default class FinanceServices {
       ...getSponsorQueryArgs()
     });
 
-    return allSponsors;
+    return allSponsors.map(sponsorTransformer);
   }
 }

--- a/src/backend/src/transformers/finance.transformer.ts
+++ b/src/backend/src/transformers/finance.transformer.ts
@@ -3,9 +3,7 @@ import { Sponsor, SponsorTask } from 'shared';
 import { SponsorQueryArgs, SponsorTaskQueryArgs } from '../prisma-query-args/sponsor.query-args';
 import { userTransformer } from './user.transformer';
 
-export const sponsorTransformer = (
-  sponsor: Prisma.SponsorGetPayload<SponsorQueryArgs>
-): Sponsor => {
+export const sponsorTransformer = (sponsor: Prisma.SponsorGetPayload<SponsorQueryArgs>): Sponsor => {
   return {
     sponsorId: sponsor.sponsorId,
     name: sponsor.name,
@@ -21,14 +19,12 @@ export const sponsorTransformer = (
   };
 };
 
-export const sponsorTaskTranformer = (
-  sponsorTask: Prisma.Sponsor_TaskGetPayload<SponsorTaskQueryArgs>
-): SponsorTask => {
+export const sponsorTaskTranformer = (sponsorTask: Prisma.Sponsor_TaskGetPayload<SponsorTaskQueryArgs>): SponsorTask => {
   return {
     sponsorTaskId: sponsorTask.sponsorTaskId,
     dueDate: sponsorTask.dueDate,
     notifyDate: sponsorTask.notifyDate ?? undefined,
     assignee: sponsorTask.assignee ? userTransformer(sponsorTask.assignee) : undefined,
     notes: sponsorTask.notes
-  }
-}
+  };
+};

--- a/src/backend/src/transformers/finance.transformer.ts
+++ b/src/backend/src/transformers/finance.transformer.ts
@@ -1,7 +1,8 @@
 import { Prisma } from '@prisma/client';
 import { Sponsor } from '@prisma/client';
+import { SponsorQueryArgs } from '../prisma-query-args/sponsor.query-args';
 
-const sponsorTransformer = (sponsor: Prisma.SponsorGetPayload<null>): Sponsor => {
+const sponsorTransformer = (sponsor: Prisma.SponsorGetPayload<SponsorQueryArgs>): Sponsor => {
   return {
     sponsorId: sponsor.sponsorId,
     name: sponsor.name,

--- a/src/backend/src/transformers/finance.transformer.ts
+++ b/src/backend/src/transformers/finance.transformer.ts
@@ -1,10 +1,9 @@
-import { Prisma } from '@prisma/client';
+import { Prisma, Sponsor, Sponsor_Task } from '@prisma/client';
 import { SponsorQueryArgs } from '../prisma-query-args/sponsor.query-args';
-import { TransformedSponsor } from './types'; // Import the custom type
 
-const sponsorTransformer = (
-  sponsor: Prisma.SponsorGetPayload<SponsorQueryArgs> // Sponsor with included relations
-): TransformedSponsor => {
+export const sponsorTransformer = (
+  sponsor: Prisma.SponsorGetPayload<SponsorQueryArgs>
+): Sponsor & { sponsorTasks: Sponsor_Task[] } => {
   return {
     sponsorId: sponsor.sponsorId,
     name: sponsor.name,
@@ -19,7 +18,7 @@ const sponsorTransformer = (
     discountCode: sponsor.discountCode ?? null,
     activeYears: sponsor.activeYears,
     taxExempt: sponsor.taxExempt,
-    sponsorTasks: sponsor.sponsorTasks // Include `sponsorTasks` in the return object
+    sponsorTasks: sponsor.sponsorTasks ?? [] // Ensure it’s included
   };
 };
 

--- a/src/backend/src/transformers/finance.transformer.ts
+++ b/src/backend/src/transformers/finance.transformer.ts
@@ -1,8 +1,10 @@
 import { Prisma } from '@prisma/client';
-import { Sponsor } from '@prisma/client';
 import { SponsorQueryArgs } from '../prisma-query-args/sponsor.query-args';
+import { TransformedSponsor } from './types'; // Import the custom type
 
-const sponsorTransformer = (sponsor: Prisma.SponsorGetPayload<SponsorQueryArgs>): Sponsor => {
+const sponsorTransformer = (
+  sponsor: Prisma.SponsorGetPayload<SponsorQueryArgs> // Sponsor with included relations
+): TransformedSponsor => {
   return {
     sponsorId: sponsor.sponsorId,
     name: sponsor.name,
@@ -16,7 +18,8 @@ const sponsorTransformer = (sponsor: Prisma.SponsorGetPayload<SponsorQueryArgs>)
     joinDate: sponsor.joinDate,
     discountCode: sponsor.discountCode ?? null,
     activeYears: sponsor.activeYears,
-    taxExempt: sponsor.taxExempt
+    taxExempt: sponsor.taxExempt,
+    sponsorTasks: sponsor.sponsorTasks // Include `sponsorTasks` in the return object
   };
 };
 

--- a/src/backend/src/transformers/finance.transformer.ts
+++ b/src/backend/src/transformers/finance.transformer.ts
@@ -1,25 +1,34 @@
-import { Prisma, Sponsor, Sponsor_Task } from '@prisma/client';
-import { SponsorQueryArgs } from '../prisma-query-args/sponsor.query-args';
+import { Prisma } from '@prisma/client';
+import { Sponsor, SponsorTask } from 'shared';
+import { SponsorQueryArgs, SponsorTaskQueryArgs } from '../prisma-query-args/sponsor.query-args';
+import { userTransformer } from './user.transformer';
 
 export const sponsorTransformer = (
   sponsor: Prisma.SponsorGetPayload<SponsorQueryArgs>
-): Sponsor & { sponsorTasks: Sponsor_Task[] } => {
+): Sponsor => {
   return {
     sponsorId: sponsor.sponsorId,
     name: sponsor.name,
-    organizationId: sponsor.organizationId,
-    dateCreated: sponsor.dateCreated,
-    dateDeleted: sponsor.dateDeleted ?? null,
     activeStatus: sponsor.activeStatus,
     vendorContact: sponsor.vendorContact,
-    sponsorTierId: sponsor.sponsorTierId,
+    tierId: sponsor.sponsorTierId,
     sponsorValue: sponsor.sponsorValue,
     joinDate: sponsor.joinDate,
-    discountCode: sponsor.discountCode ?? null,
+    discountCode: sponsor.discountCode ?? undefined,
     activeYears: sponsor.activeYears,
     taxExempt: sponsor.taxExempt,
-    sponsorTasks: sponsor.sponsorTasks ?? [] // Ensure it’s included
+    sponsorTasks: sponsor.sponsorTasks.map(sponsorTaskTranformer)
   };
 };
 
-export default sponsorTransformer;
+export const sponsorTaskTranformer = (
+  sponsorTask: Prisma.Sponsor_TaskGetPayload<SponsorTaskQueryArgs>
+): SponsorTask => {
+  return {
+    sponsorTaskId: sponsorTask.sponsorTaskId,
+    dueDate: sponsorTask.dueDate,
+    notifyDate: sponsorTask.notifyDate ?? undefined,
+    assignee: sponsorTask.assignee ? userTransformer(sponsorTask.assignee) : undefined,
+    notes: sponsorTask.notes
+  }
+}

--- a/src/backend/src/transformers/finance.transformer.ts
+++ b/src/backend/src/transformers/finance.transformer.ts
@@ -1,0 +1,22 @@
+import { Prisma } from '@prisma/client';
+import { Sponsor } from '@prisma/client';
+
+const sponsorTransformer = (sponsor: Prisma.SponsorGetPayload<null>): Sponsor => {
+  return {
+    sponsorId: sponsor.sponsorId,
+    name: sponsor.name,
+    organizationId: sponsor.organizationId,
+    dateCreated: sponsor.dateCreated,
+    dateDeleted: sponsor.dateDeleted ?? null,
+    activeStatus: sponsor.activeStatus,
+    vendorContact: sponsor.vendorContact,
+    sponsorTierId: sponsor.sponsorTierId,
+    sponsorValue: sponsor.sponsorValue,
+    joinDate: sponsor.joinDate,
+    discountCode: sponsor.discountCode ?? null,
+    activeYears: sponsor.activeYears,
+    taxExempt: sponsor.taxExempt
+  };
+};
+
+export default sponsorTransformer;

--- a/src/backend/src/utils/validation.utils.ts
+++ b/src/backend/src/utils/validation.utils.ts
@@ -1,4 +1,4 @@
-import { Design_Review_Status, Graph_Display_Type, Graph_Type, Measure, Special_Permission, Sponsor_Tier } from '@prisma/client';
+import { Design_Review_Status, Graph_Display_Type, Graph_Type, Measure, Special_Permission } from '@prisma/client';
 import { Request, Response } from 'express';
 import { body, ValidationChain, validationResult } from 'express-validator';
 import { ClubAccount, MaterialStatus, TaskPriority, TaskStatus, WorkPackageStage, RoleEnum, WbsElementStatus } from 'shared';
@@ -204,12 +204,4 @@ export const validateInputs = (req: Request, res: Response, next: Function): voi
   } else {
     next();
   }
-};
-
-export const validateSponsorTier = () => {
-  return [
-    nonEmptyString(body('sponsorTierId')),
-    nonEmptyString(body('name')),
-    nonEmptyString(body('colorHexCode'))
-  ];
 };

--- a/src/backend/src/utils/validation.utils.ts
+++ b/src/backend/src/utils/validation.utils.ts
@@ -1,4 +1,4 @@
-import { Design_Review_Status, Graph_Display_Type, Graph_Type, Measure, Special_Permission } from '@prisma/client';
+import { Design_Review_Status, Graph_Display_Type, Graph_Type, Measure, Special_Permission, Sponsor_Tier } from '@prisma/client';
 import { Request, Response } from 'express';
 import { body, ValidationChain, validationResult } from 'express-validator';
 import { ClubAccount, MaterialStatus, TaskPriority, TaskStatus, WorkPackageStage, RoleEnum, WbsElementStatus } from 'shared';
@@ -204,4 +204,12 @@ export const validateInputs = (req: Request, res: Response, next: Function): voi
   } else {
     next();
   }
+};
+
+export const validateSponsorTier = () => {
+  return [
+    nonEmptyString(body('sponsorTierId')),
+    nonEmptyString(body('name')),
+    nonEmptyString(body('colorHexCode'))
+  ];
 };

--- a/src/backend/tests/unit/finance.test.ts
+++ b/src/backend/tests/unit/finance.test.ts
@@ -1,7 +1,7 @@
 import { Organization } from '@prisma/client';
 import FinanceServices from '../../src/services/finance.services';
 import { AccessDeniedAdminOnlyException } from '../../src/utils/errors.utils';
-import { batmanAppAdmin, wonderwomanGuest } from '../test-data/users.test-data';
+import { batmanAppAdmin, supermanAdmin, wonderwomanGuest } from '../test-data/users.test-data';
 import { createTestOrganization, createTestUser, resetUsers } from '../test-utils';
 import prisma from '../../src/prisma/prisma';
 
@@ -75,6 +75,41 @@ describe('Finance Tests', () => {
       expect(result.vendorContact).toEqual('Bill Gates');
       expect(result.sponsorTasks).toEqual([]);
       expect(result.organizationId).toEqual(orgId);
+    });
+  });
+
+  describe('Get All Sponsors', () => {
+    it('Succeeds and gets all the sponsors', async () => {
+      const spon1 = await FinanceServices.createSponsor(
+        await createTestUser(batmanAppAdmin, orgId),
+        'Google',
+        true,
+        5000,
+        new Date(12, 1, 24),
+        [2024, 2025],
+        sponsorTierId,
+        true,
+        'Bill Gates',
+        [],
+        organization,
+        'googlecode'
+      );
+      const spon2 = await FinanceServices.createSponsor(
+        await createTestUser(supermanAdmin, orgId),
+        'Apple',
+        true,
+        2000,
+        new Date(11, 23, 24),
+        [2024, 2025],
+        sponsorTierId,
+        true,
+        'Tim Cook',
+        [],
+        organization,
+        'applecode'
+      );
+      const result = await FinanceServices.getAllSponsors(organization);
+      expect(result).toStrictEqual([spon1, spon2]);
     });
   });
 });

--- a/src/backend/tests/unit/finance.test.ts
+++ b/src/backend/tests/unit/finance.test.ts
@@ -69,12 +69,11 @@ describe('Finance Tests', () => {
       expect(result.sponsorValue).toBe(5000);
       expect(result.joinDate).toEqual(new Date(12, 1, 24));
       expect(result.activeYears).toEqual([2024, 2025]);
-      expect(result.sponsorTierId).toEqual(sponsorTierId);
+      expect(result.tierId).toEqual(sponsorTierId);
       expect(result.taxExempt).toBe(true);
       expect(result.discountCode).toEqual('googlecode');
       expect(result.vendorContact).toEqual('Bill Gates');
       expect(result.sponsorTasks).toEqual([]);
-      expect(result.organizationId).toEqual(orgId);
     });
   });
 

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -13,6 +13,7 @@ export * from './src/types/reimbursement-requests-types';
 export * from './src/types/design-review-types';
 export * from './src/types/pop-up-types';
 export * from './src/types/announcements.types';
+export * from './src/types/finance-types';
 export * from './src/validate-wbs';
 export * from './src/date-utils';
 

--- a/src/shared/src/types/finance-types.ts
+++ b/src/shared/src/types/finance-types.ts
@@ -1,0 +1,30 @@
+import { User } from "./user-types";
+
+export interface Sponsor {
+  sponsorId: string;
+  name: string;
+  activeStatus: boolean;
+  vendorContact: string;
+  tierId: string;
+  sponsorValue: number;
+  joinDate: Date;
+  discountCode?: string;
+  activeYears: number[];
+  taxExempt: boolean;
+  sponsorTasks: SponsorTask[];
+}
+
+export interface SponsorTask {
+    sponsorTaskId: string;
+    dueDate: Date;
+    notifyDate?: Date;
+    assignee?: User;
+    notes: string;
+}
+
+export interface SponsorTier {
+    sponsorTierId: string;
+    name: string;
+    colorHexCode: string;
+}
+  

--- a/src/shared/src/types/finance-types.ts
+++ b/src/shared/src/types/finance-types.ts
@@ -1,4 +1,4 @@
-import { User } from "./user-types";
+import { User } from './user-types';
 
 export interface Sponsor {
   sponsorId: string;
@@ -15,15 +15,15 @@ export interface Sponsor {
 }
 
 export interface SponsorTask {
-    sponsorTaskId: string;
-    dueDate: Date;
-    notifyDate?: Date;
-    assignee?: User;
-    notes: string;
+  sponsorTaskId: string;
+  dueDate: Date;
+  notifyDate?: Date;
+  assignee?: User;
+  notes: string;
 }
 
 export interface SponsorTier {
-    sponsorTierId: string;
-    name: string;
-    colorHexCode: string;
+  sponsorTierId: string;
+  name: string;
+  colorHexCode: string;
 }


### PR DESCRIPTION
## Changes

Added the getAllSponsors endpoint

## Test Cases

- Succeeds and gets all sponsors
![image](https://github.com/user-attachments/assets/f70fe10e-2207-4570-957e-6adc08a8c2e5)

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3191 
