### PR TITLE
#3192- finance redesign deleteSponsor endpoint

### DIFF
--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -22,6 +22,7 @@ import announcementsRouter from './src/routes/announcements.routes';
 import onboardingRouter from './src/routes/onboarding.routes';
 import popUpsRouter from './src/routes/pop-up.routes';
 import statisticsRouter from './src/routes/statistics.routes';
+import financeRouter from './src/routes/finance.routes';
 
 const app = express();
 
@@ -81,6 +82,7 @@ app.use('/pop-ups', popUpsRouter);
 app.use('/announcements', announcementsRouter);
 app.use('/onboarding', onboardingRouter);
 app.use('/statistics', statisticsRouter);
+app.use('/finance', financeRouter);
 app.use('/', (_req, res) => {
   res.status(200).json('Welcome to FinishLine');
 });

--- a/src/backend/src/controllers/finance.controllers.ts
+++ b/src/backend/src/controllers/finance.controllers.ts
@@ -36,4 +36,14 @@ export default class FinanceController {
       next(error);
     }
   }
+
+  static async deleteSponsor(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { requestId } = req.params;
+      const deletedSponsor = await FinanceServices.deleteSponsor(requestId, req.currentUser, req.organization);
+      res.status(200).json(deletedSponsor);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
 }

--- a/src/backend/src/controllers/finance.controllers.ts
+++ b/src/backend/src/controllers/finance.controllers.ts
@@ -39,8 +39,8 @@ export default class FinanceController {
 
   static async deleteSponsor(req: Request, res: Response, next: NextFunction) {
     try {
-      const { requestId } = req.params;
-      const deletedSponsor = await FinanceServices.deleteSponsor(requestId, req.currentUser, req.organization);
+      const { sponsorId } = req.params;
+      const deletedSponsor = await FinanceServices.deleteSponsor(sponsorId, req.currentUser, req.organization);
       res.status(200).json(deletedSponsor);
     } catch (error: unknown) {
       next(error);

--- a/src/backend/src/prisma/seed.ts
+++ b/src/backend/src/prisma/seed.ts
@@ -47,6 +47,7 @@ import RecruitmentServices from '../services/recruitment.services';
 import OrganizationsService from '../services/organizations.services';
 import { seedGraph } from './seed-data/statistics.seed';
 import AnnouncementService from '../services/announcement.service';
+import FinanceServices from '../services/finance.services';
 
 const prisma = new PrismaClient();
 
@@ -2008,7 +2009,7 @@ const performSeed: () => Promise<void> = async () => {
     'powertrain',
     ner.organizationId
   );
-  
+
   await FinanceServices.createSponsor(
     thomasEmrax,
     'Google',

--- a/src/backend/src/prisma/seed.ts
+++ b/src/backend/src/prisma/seed.ts
@@ -2010,6 +2010,21 @@ const performSeed: () => Promise<void> = async () => {
     ner.organizationId
   );
 
+  // await FinanceServices.createSponsor(
+  //   thomasEmrax,
+  //   'Google',
+  //   true,
+  //   5000,
+  //   new Date(12, 1, 24),
+  //   [2024, 2025],
+  //   'gold',
+  //   true,
+  //   'Bill Gates',
+  //   [],
+  //   ner,
+  //   'googlecode'
+  // );
+
   await FinanceServices.createSponsor(
     thomasEmrax,
     'Google',
@@ -2017,7 +2032,15 @@ const performSeed: () => Promise<void> = async () => {
     5000,
     new Date(12, 1, 24),
     [2024, 2025],
-    'gold',
+    (
+      await prisma.sponsor_Tier.create({
+        data: {
+          organizationId: ner.organizationId,
+          name: 'tier1',
+          colorHexCode: '#FF0000'
+        }
+      })
+    ).sponsorTierId,
     true,
     'Bill Gates',
     [],

--- a/src/backend/src/routes/finance.routes.ts
+++ b/src/backend/src/routes/finance.routes.ts
@@ -21,4 +21,6 @@ financeRouter.post(
   FinanceController.createSponsor
 );
 
-financeRouter.delete('/:sponsorId/delete', FinanceController.deleteSponsor);
+financeRouter.delete('/sponsor/:sponsorId/delete', FinanceController.deleteSponsor);
+
+export default financeRouter;

--- a/src/backend/src/routes/finance.routes.ts
+++ b/src/backend/src/routes/finance.routes.ts
@@ -20,3 +20,5 @@ financeRouter.post(
   validateInputs,
   FinanceController.createSponsor
 );
+
+financeRouter.delete('/:sponsorId/delete', FinanceController.deleteSponsor);

--- a/src/backend/src/services/finance.services.ts
+++ b/src/backend/src/services/finance.services.ts
@@ -1,7 +1,13 @@
 import { isHead } from 'shared';
-import { User, Organization, Sponsor_Task } from '@prisma/client';
+import { User, Organization, Sponsor_Task, Sponsor } from '@prisma/client';
 import { userHasPermission } from '../utils/users.utils';
-import { AccessDeniedAdminOnlyException } from '../utils/errors.utils';
+import {
+  AccessDeniedAdminOnlyException,
+  AccessDeniedException,
+  DeletedException,
+  InvalidOrganizationException,
+  NotFoundException
+} from '../utils/errors.utils';
 import prisma from '../prisma/prisma';
 
 export default class FinanceServices {
@@ -69,5 +75,35 @@ export default class FinanceServices {
     });
 
     return sponsor;
+  }
+
+  /**
+   * Soft deletes a given sponsor
+   * @param sponsorId the id of the sponsor that is getting deleted
+   * @param deleter the person deleting the sponsor
+   * @param organization the organization the person deleting belongs to
+   * @returns
+   */
+  static async deleteSponsor(sponsorId: string, deleter: User, organization: Organization): Promise<Sponsor> {
+    const sponsor = await prisma.sponsor.findUnique({
+      where: {
+        sponsorId
+      }
+    });
+
+    if (!(await userHasPermission(deleter.userId, organization.organizationId, isHead))) {
+      throw new AccessDeniedException('Only heads can delete sponsors.');
+    }
+
+    if (!sponsor) throw new NotFoundException('Sponsor', sponsorId);
+    if (sponsor.organizationId !== organization.organizationId) throw new InvalidOrganizationException('Sponsor');
+    if (sponsor.dateDeleted) throw new DeletedException('Sponsor', sponsorId);
+
+    const deletedSponsor = await prisma.sponsor.update({
+      where: { sponsorId },
+      data: { dateDeleted: new Date() }
+    });
+
+    return deletedSponsor;
   }
 }

--- a/src/backend/src/utils/errors.utils.ts
+++ b/src/backend/src/utils/errors.utils.ts
@@ -142,4 +142,5 @@ export type ExceptionObjectNames =
   | 'Pop Up'
   | 'Announcement'
   | 'Graph'
-  | 'Graph Collection';
+  | 'Graph Collection'
+  | 'Sponsor';

--- a/src/backend/tests/unit/finance.test.ts
+++ b/src/backend/tests/unit/finance.test.ts
@@ -1,7 +1,7 @@
 import { Organization } from '@prisma/client';
 import FinanceServices from '../../src/services/finance.services';
-import { AccessDeniedAdminOnlyException } from '../../src/utils/errors.utils';
-import { batmanAppAdmin, wonderwomanGuest } from '../test-data/users.test-data';
+import { AccessDeniedAdminOnlyException, AccessDeniedException, NotFoundException } from '../../src/utils/errors.utils';
+import { batmanAppAdmin, wonderwomanGuest, supermanAdmin, theVisitorGuest } from '../test-data/users.test-data';
 import { createTestOrganization, createTestUser, resetUsers } from '../test-utils';
 import prisma from '../../src/prisma/prisma';
 
@@ -75,6 +75,58 @@ describe('Finance Tests', () => {
       expect(result.vendorContact).toEqual('Bill Gates');
       expect(result.sponsorTasks).toEqual([]);
       expect(result.organizationId).toEqual(orgId);
+    });
+  });
+  describe('Delete a sponsor works', () => {
+    it('Successful deletion', async () => {
+      const sponsor = await FinanceServices.createSponsor(
+        await createTestUser(supermanAdmin, orgId),
+        'Google',
+        true,
+        5000,
+        new Date(12, 1, 24),
+        [2024, 2025],
+        sponsorTierId,
+        true,
+        'Bill Gates',
+        [],
+        organization,
+        'googlecode'
+      );
+
+      const deletedSponsor = await FinanceServices.deleteSponsor(
+        sponsor.sponsorId,
+        await createTestUser(batmanAppAdmin, orgId),
+        organization
+      );
+
+      expect(deletedSponsor).not.toBe(null);
+      expect(deletedSponsor?.dateDeleted).not.toBe(null);
+    });
+    it('Delete fails if user is not head or above', async () => {
+      const sponsor = await FinanceServices.createSponsor(
+        await createTestUser(supermanAdmin, orgId),
+        'Google',
+        true,
+        5000,
+        new Date(12, 1, 24),
+        [2024, 2025],
+        sponsorTierId,
+        true,
+        'Bill Gates',
+        [],
+        organization,
+        'googlecode'
+      );
+
+      await expect(async () =>
+        FinanceServices.deleteSponsor(sponsor.sponsorId, await createTestUser(theVisitorGuest, orgId), organization)
+      ).rejects.toThrow(new AccessDeniedException('Only heads can delete sponsors.'));
+    });
+    it('Delete fails if given sponsor cannot be found', async () => {
+      await expect(async () =>
+        FinanceServices.deleteSponsor('badsponsorid', await createTestUser(supermanAdmin, orgId), organization)
+      ).rejects.toThrow(new NotFoundException('Sponsor', 'badsponsorid'));
     });
   });
 });

--- a/src/backend/tests/unit/finance.test.ts
+++ b/src/backend/tests/unit/finance.test.ts
@@ -1,6 +1,11 @@
 import { Organization } from '@prisma/client';
 import FinanceServices from '../../src/services/finance.services';
-import { AccessDeniedAdminOnlyException, AccessDeniedException, NotFoundException } from '../../src/utils/errors.utils';
+import {
+  AccessDeniedAdminOnlyException,
+  AccessDeniedException,
+  DeletedException,
+  NotFoundException
+} from '../../src/utils/errors.utils';
 import { batmanAppAdmin, wonderwomanGuest, supermanAdmin, theVisitorGuest } from '../test-data/users.test-data';
 import { createTestOrganization, createTestUser, resetUsers } from '../test-utils';
 import prisma from '../../src/prisma/prisma';
@@ -127,6 +132,29 @@ describe('Finance Tests', () => {
       await expect(async () =>
         FinanceServices.deleteSponsor('badsponsorid', await createTestUser(supermanAdmin, orgId), organization)
       ).rejects.toThrow(new NotFoundException('Sponsor', 'badsponsorid'));
+    });
+    it('Delete fails sponsor has already been deleted', async () => {
+      const user = await createTestUser(supermanAdmin, orgId);
+      const sponsor = await FinanceServices.createSponsor(
+        user,
+        'Google',
+        true,
+        5000,
+        new Date(12, 1, 24),
+        [2024, 2025],
+        sponsorTierId,
+        true,
+        'Bill Gates',
+        [],
+        organization,
+        'googlecode'
+      );
+
+      await FinanceServices.deleteSponsor(sponsor.sponsorId, user, organization);
+
+      await expect(async () => FinanceServices.deleteSponsor(sponsor.sponsorId, user, organization)).rejects.toThrow(
+        new DeletedException('Sponsor', sponsor.sponsorId)
+      );
     });
   });
 });


### PR DESCRIPTION
## Changes

Added the deleteSponsor endpoint.

## Test Cases

- Succeeds and deletes the endpoint
- Delete fails if deleter is not head or above
- Delete fails if a given sponsor cannot be found
- Delete fails if a given sponsor is already deleted.

## Screenshots
<img width="1148" alt="3192postman" src="https://github.com/user-attachments/assets/e1a487fe-5127-41d6-94ef-5bbdd51c8f83" />


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3192 
