### PR TITLE
#3235 sizing fixes, admin homepage, and image aspect ratio fix

### DIFF
--- a/src/frontend/src/pages/HomePage/AdminHomePage.tsx
+++ b/src/frontend/src/pages/HomePage/AdminHomePage.tsx
@@ -11,8 +11,7 @@ import PageLayout, { PAGE_GRID_HEIGHT } from '../../components/PageLayout';
 import { AuthenticatedUser } from 'shared';
 import WorkPackagesSelectionView from './components/WorkPackagesSelectionView';
 import ChangeRequestsToReview from './components/ChangeRequestsToReview';
-import GeneralAnnouncements from './components/GeneralAnnouncements';
-import UpcomingDesignReviews from './components/UpcomingDesignReviews';
+import OverdueWorkPackages from './components/OverdueWorkPackages';
 
 interface AdminHomePageProps {
   user: AuthenticatedUser;
@@ -38,18 +37,33 @@ const AdminHomePage = ({ user }: AdminHomePageProps) => {
           mt: 1
         }}
       >
-        <Box height={'40%'}>
+        <Box height={'min-content'} display="flex" flexDirection="column">
           <ChangeRequestsToReview />
         </Box>
-        <Grid container height={'60%'} spacing={2}>
-          <Grid item xs={12} md={4} height="100%">
-            <GeneralAnnouncements />
-          </Grid>
-          <Grid item xs={12} md={4} height="100%">
+        <Grid
+          container
+          spacing={2}
+          height={'60%'}
+          style={{
+            flexGrow: 1,
+            display: 'flex',
+            width: '100%'
+          }}
+        >
+          <Grid
+            item
+            style={{
+              flexGrow: 1,
+              display: 'flex',
+              flexDirection: 'column',
+              minWidth: 'min-content',
+              overflow: 'hidden'
+            }}
+          >
             <WorkPackagesSelectionView />
           </Grid>
-          <Grid item xs={12} md={4} height="100%">
-            <UpcomingDesignReviews user={user} />
+          <Grid item height="100%" style={{ width: 'min-content', minWidth: 'min-content', overflow: 'hidden' }}>
+            <OverdueWorkPackages user={user} />
           </Grid>
         </Grid>
       </Box>

--- a/src/frontend/src/pages/HomePage/GuestHomePage.tsx
+++ b/src/frontend/src/pages/HomePage/GuestHomePage.tsx
@@ -46,26 +46,27 @@ const GuestHomePage = ({ user }: GuestHomePageProps) => {
           display: 'flex',
           flexDirection: 'column',
           gap: 1.5,
-          height: `${PAGE_GRID_HEIGHT}vh`,
-          mt: 2
+          minHeight: `${PAGE_GRID_HEIGHT}vh`,
+          mt: 2,
+          overflow: 'auto' // Ensures content remains accessible on zoom
         }}
       >
-        <Grid container height={'60%'} spacing={2}>
-          <Grid item height={'100%'} xs={8.5}>
-            <Stack height={'100%'} spacing={1.5}>
-              <Box height={'70%'}>
+        <Grid container sx={{ flexGrow: 1 }} spacing={2}>
+          <Grid item xs={8.5} sx={{ display: 'flex', flexDirection: 'column' }}>
+            <Stack sx={{ flexGrow: 1, gap: 1.5 }}>
+              <Box sx={{ flexGrow: 1, minHeight: 0, overflow: 'auto' }}>
                 <GuestOrganizationInfo />
               </Box>
-              <Box height={'30%'}>
+              <Box sx={{ flexGrow: 1, minHeight: 0, overflow: 'auto' }}>
                 <MemberEncouragement />
               </Box>
             </Stack>
           </Grid>
-          <Grid item height={'100%'} xs={3.5}>
+          <Grid item xs={3.5} sx={{ display: 'flex', alignItems: 'center' }}>
             <OrganizationLogo />
           </Grid>
         </Grid>
-        <Box height={'40%'}>
+        <Box sx={{ flexShrink: 0, overflow: 'auto' }}>
           <FeaturedProjects />
         </Box>
       </Box>

--- a/src/frontend/src/pages/HomePage/LeadHomePage.tsx
+++ b/src/frontend/src/pages/HomePage/LeadHomePage.tsx
@@ -38,17 +38,52 @@ const LeadHomePage = ({ user }: LeadHomePageProps) => {
           gap: 2
         }}
       >
-        <Box height={'40%'}>
+        <Box height={'min-content'}>
           <ChangeRequestsToReview />
         </Box>
-        <Grid container height={'60%'} spacing={2}>
-          <Grid item xs={4} md={4} height={'100%'}>
+        <Grid
+          container
+          maxHeight={'60%'}
+          spacing={2}
+          style={{
+            flexGrow: 1,
+            display: 'flex'
+          }}
+        >
+          <Grid
+            item
+            xs={12}
+            md={4}
+            maxHeight={'100%'}
+            style={{
+              minWidth: 'min-content',
+              overflow: 'hidden'
+            }}
+          >
             <GeneralAnnouncements />
           </Grid>
-          <Grid item xs={4} md={4} height={'100%'}>
+          <Grid
+            item
+            xs={12}
+            md={4}
+            maxHeight={'100%'}
+            style={{
+              minWidth: 'min-content',
+              overflow: 'hidden'
+            }}
+          >
             <MyTeamsOverdueTasks user={user} />
           </Grid>
-          <Grid item xs={4} md={4} height={'100%'}>
+          <Grid
+            item
+            xs={12}
+            md={4}
+            maxHeight={'100%'}
+            style={{
+              minWidth: 'min-content',
+              overflow: 'hidden'
+            }}
+          >
             <UpcomingDesignReviews user={user} />
           </Grid>
         </Grid>

--- a/src/frontend/src/pages/HomePage/components/MyTeamsOverdueTasks.tsx
+++ b/src/frontend/src/pages/HomePage/components/MyTeamsOverdueTasks.tsx
@@ -37,7 +37,7 @@ const MyTeamsOverdueTasks: React.FC<MyTeamsOverdueTasksProps> = ({ user }) => {
   const overdueTasks = getOverdueTasks(tasks);
 
   return (
-    <ScrollablePageBlock title={`My Team's Overdue Tasks (${overdueTasks.length})`}>
+    <ScrollablePageBlock title={`My Team's Overdue Tasks (${overdueTasks.length})` }>
       {overdueTasks.length === 0 ? (
         <NoOverdueTeamTaskDisplay />
       ) : (

--- a/src/frontend/src/pages/HomePage/components/MyTeamsOverdueTasks.tsx
+++ b/src/frontend/src/pages/HomePage/components/MyTeamsOverdueTasks.tsx
@@ -37,7 +37,7 @@ const MyTeamsOverdueTasks: React.FC<MyTeamsOverdueTasksProps> = ({ user }) => {
   const overdueTasks = getOverdueTasks(tasks);
 
   return (
-    <ScrollablePageBlock title={`My Team's Overdue Tasks (${overdueTasks.length})` }>
+    <ScrollablePageBlock title={`My Team's Overdue Tasks (${overdueTasks.length})`}>
       {overdueTasks.length === 0 ? (
         <NoOverdueTeamTaskDisplay />
       ) : (

--- a/src/frontend/src/pages/HomePage/components/OrganizationLogo.tsx
+++ b/src/frontend/src/pages/HomePage/components/OrganizationLogo.tsx
@@ -9,7 +9,19 @@ const OrganizationLogo = () => {
   if (isLoading) return <LoadingIndicator />;
   if (isError) return <ErrorPage message={error.message} />;
 
-  return <LogoDisplay imageUrl={imageData && URL.createObjectURL(imageData)} />;
+  return (
+    <div
+      style={{
+        width: '100%',
+        aspectRatio: 'auto',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center'
+      }}
+    >
+      <LogoDisplay imageUrl={imageData && URL.createObjectURL(imageData)} />
+    </div>
+  );
 };
 
 export default OrganizationLogo;

--- a/src/frontend/src/pages/HomePage/components/ScrollablePageBlock.tsx
+++ b/src/frontend/src/pages/HomePage/components/ScrollablePageBlock.tsx
@@ -34,10 +34,10 @@ const ScrollablePageBlock: React.FC<ScrollablePageBlockProps> = ({ children, tit
           sx={{
             mt: 2,
             display: 'flex',
-            flexDirection: 'row',
-            flexWrap: 'wrap',
+            flexDirection: horizontal ? 'row' : 'column',
+            flexWrap: 'nowrap',
             gap: 2,
-            height: '100%',
+            alignItems: 'start',
             overflowX: horizontal ? 'auto' : 'hidden',
             overflowY: horizontal ? 'hidden' : 'auto',
             '&::-webkit-scrollbar': {

--- a/src/frontend/src/pages/HomePage/components/TeamTaskCard.tsx
+++ b/src/frontend/src/pages/HomePage/components/TeamTaskCard.tsx
@@ -30,6 +30,7 @@ const TeamTaskCard: React.FC<TeamTaskCardProps> = ({ task, taskNumber }) => {
       sx={{
         width: '100%',
         height: 'fit-content',
+        minHeight: 'fit-content',
         mr: 3,
         background: theme.palette.background.default,
         borderRadius: 2

--- a/src/frontend/src/pages/HomePage/components/WorkPackagesSelectionView.tsx
+++ b/src/frontend/src/pages/HomePage/components/WorkPackagesSelectionView.tsx
@@ -59,9 +59,8 @@ const WorkPackagesSelectionView: React.FC = () => {
   const WorkPackagesDisplay = (workPackages: WorkPackagePreview[]) => (
     <Box
       sx={{
-        display: 'flex',
-        flexDirection: 'row',
-        flexWrap: 'wrap',
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))',
         overflow: 'auto',
         width: '100%',
         gap: 2


### PR DESCRIPTION
## Changes

- Changed home page contents so that all content is visible at any size, and containers fit more naturally to the size of their components
- added admin home page with highlighted overdue work package section and 2 col wide regular work package view
- made image on member homepage constant aspect ratio
- misc changes to prevent content from overlapping with other components, or cropping and making it impossible to see all content at certain screen sizes

## Screenshots

<img width="1215" alt="Screenshot 2025-02-25 at 1 01 48 AM" src="https://github.com/user-attachments/assets/dd5e90e5-d12d-4cd2-b689-b3b2b830a75a" />
<img width="1185" alt="Screenshot 2025-02-25 at 1 01 39 AM" src="https://github.com/user-attachments/assets/e5416a10-8962-451e-ab1b-fdf78862b925" />
<img width="1119" alt="Screenshot 2025-02-25 at 1 31 32 AM" src="https://github.com/user-attachments/assets/5dfce6d2-9175-4a56-9010-88dc01adb238" />
<img width="1211" alt="Screenshot 2025-02-25 at 1 00 58 AM" src="https://github.com/user-attachments/assets/1c8f96ad-19d0-44d5-bfb8-053ed501760a" />
<img width="1158" alt="Screenshot 2025-02-25 at 1 01 14 AM" src="https://github.com/user-attachments/assets/36e97a78-3fd1-400b-b12a-ec1972386ff4" />


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #3235
