### PR TITLE
#3260 added partReviewRequest model

### DIFF
--- a/src/backend/src/prisma/migrations/20250124235046_cad_part_file_review/migration.sql
+++ b/src/backend/src/prisma/migrations/20250124235046_cad_part_file_review/migration.sql
@@ -56,7 +56,7 @@ CREATE TABLE "PartTag" (
 
 -- CreateTable
 CREATE TABLE "PartSubmission" (
-    "id" TEXT NOT NULL,
+    "partSubmissionId" TEXT NOT NULL,
     "fileIds" TEXT[],
     "name" TEXT NOT NULL,
     "notes" TEXT,
@@ -67,7 +67,19 @@ CREATE TABLE "PartSubmission" (
     "userCreatedId" TEXT NOT NULL,
     "userDeletedId" TEXT,
 
-    CONSTRAINT "PartSubmission_pkey" PRIMARY KEY ("id")
+    CONSTRAINT "PartSubmission_pkey" PRIMARY KEY ("partSubmissionId")
+);
+
+-- CreateTable
+CREATE TABLE "PartReviewRequest" (
+    "partReviewRequestId" TEXT NOT NULL,
+    "submissionId" TEXT NOT NULL,
+    "requesterId" TEXT NOT NULL,
+    "reviewerId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "reviewBeganAt" TIMESTAMP(3),
+
+    CONSTRAINT "PartReviewRequest_pkey" PRIMARY KEY ("partReviewRequestId")
 );
 
 -- CreateTable
@@ -103,7 +115,7 @@ CREATE TABLE "Part_Review_Popup" (
 
 -- CreateTable
 CREATE TABLE "PartReviewCommonMistake" (
-    "id" TEXT NOT NULL,
+    "partReviewCommonMistakeId" TEXT NOT NULL,
     "title" TEXT NOT NULL,
     "description" TEXT NOT NULL,
     "starred" BOOLEAN NOT NULL,
@@ -113,7 +125,7 @@ CREATE TABLE "PartReviewCommonMistake" (
     "dateDeleted" TIMESTAMP(3),
     "organizationId" TEXT,
 
-    CONSTRAINT "PartReviewCommonMistake_pkey" PRIMARY KEY ("id")
+    CONSTRAINT "PartReviewCommonMistake_pkey" PRIMARY KEY ("partReviewCommonMistakeId")
 );
 
 -- CreateTable
@@ -174,7 +186,19 @@ ALTER TABLE "PartSubmission" ADD CONSTRAINT "PartSubmission_userCreatedId_fkey" 
 ALTER TABLE "PartSubmission" ADD CONSTRAINT "PartSubmission_userDeletedId_fkey" FOREIGN KEY ("userDeletedId") REFERENCES "User"("userId") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "PartReview" ADD CONSTRAINT "PartReview_submissionId_fkey" FOREIGN KEY ("submissionId") REFERENCES "PartSubmission"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "PartReviewRequest" ADD CONSTRAINT "PartReviewRequest_submissionId_fkey" FOREIGN KEY ("submissionId") REFERENCES "PartSubmission"("partSubmissionId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PartReviewRequest" ADD CONSTRAINT "PartReviewRequest_requesterId_fkey" FOREIGN KEY ("requesterId") REFERENCES "User"("userId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PartReviewRequest" ADD CONSTRAINT "PartReviewRequest_reviewerId_fkey" FOREIGN KEY ("reviewerId") REFERENCES "User"("userId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PartReview" ADD CONSTRAINT "PartReview_submissionId_fkey" FOREIGN KEY ("submissionId") REFERENCES "PartSubmission"("partSubmissionId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PartReview" ADD CONSTRAINT "PartReview_submissionId_fkey" FOREIGN KEY ("submissionId") REFERENCES "PartSubmission"("partSubmissionId") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "PartReview" ADD CONSTRAINT "PartReview_userCreatedId_fkey" FOREIGN KEY ("userCreatedId") REFERENCES "User"("userId") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/src/backend/src/prisma/migrations/20250124235046_cad_part_file_review/migration.sql
+++ b/src/backend/src/prisma/migrations/20250124235046_cad_part_file_review/migration.sql
@@ -32,7 +32,6 @@ CREATE TABLE "Part" (
     "previewImageLink" TEXT,
     "status" "Review_Status" NOT NULL DEFAULT 'IN_PROGRESS',
     "projectId" TEXT NOT NULL,
-    "history" TEXT[],
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
     "dateDeleted" TIMESTAMP(3),

--- a/src/backend/src/prisma/migrations/20250124235046_cad_part_file_review/migration.sql
+++ b/src/backend/src/prisma/migrations/20250124235046_cad_part_file_review/migration.sql
@@ -197,9 +197,6 @@ ALTER TABLE "PartReviewRequest" ADD CONSTRAINT "PartReviewRequest_reviewerId_fke
 ALTER TABLE "PartReview" ADD CONSTRAINT "PartReview_submissionId_fkey" FOREIGN KEY ("submissionId") REFERENCES "PartSubmission"("partSubmissionId") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "PartReview" ADD CONSTRAINT "PartReview_submissionId_fkey" FOREIGN KEY ("submissionId") REFERENCES "PartSubmission"("partSubmissionId") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
 ALTER TABLE "PartReview" ADD CONSTRAINT "PartReview_userCreatedId_fkey" FOREIGN KEY ("userCreatedId") REFERENCES "User"("userId") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey

--- a/src/backend/src/prisma/schema.prisma
+++ b/src/backend/src/prisma/schema.prisma
@@ -1141,7 +1141,6 @@ model Part {
   projectId        String
   assignees        User[]           @relation("partAssignees")
   reviewers        User[]           @relation("partReviewers")
-  history          String[]
   createdAt        DateTime         @default(now())
   updatedAt        DateTime         @updatedAt
   dateDeleted      DateTime?

--- a/src/backend/src/prisma/schema.prisma
+++ b/src/backend/src/prisma/schema.prisma
@@ -254,6 +254,8 @@ model User {
   assignedParts                   Part[]                    @relation(name: "partAssignees")
   createdCommonMistakes           PartReviewCommonMistake[] @relation(name: "commonMistakeCreator")
   deletedCommonMistakes           PartReviewCommonMistake[] @relation(name: "commonMistakeDeleter")
+  partReviewRequests              PartReviewRequest[]       @relation(name: "PartReviewRequestor")
+  partReviewRequested             PartReviewRequest[]       @relation(name: "PartReviewRequested")
 }
 
 model Role {
@@ -1161,27 +1163,40 @@ model PartTag {
 }
 
 model PartSubmission {
-  id            String       @id @default(uuid())
-  fileIds       String[]
-  name          String
-  notes         String?
-  part          Part         @relation(fields: [partId], references: [partId])
-  partId        String
-  createdAt     DateTime     @default(now())
-  updatedAt     DateTime     @updatedAt
-  dateDeleted   DateTime?
-  userCreatedId String
-  userCreated   User         @relation(fields: [userCreatedId], references: [userId], name: "partsSubmissionCreator")
-  userDeletedId String?
-  userDeleted   User?        @relation(fields: [userDeletedId], references: [userId], name: "partsSubmissionDeleter")
-  reviews       PartReview[]
+  partSubmissionId String              @id @default(uuid())
+  fileIds          String[]
+  name             String
+  notes            String?
+  part             Part                @relation(fields: [partId], references: [partId])
+  partId           String
+  createdAt        DateTime            @default(now())
+  updatedAt        DateTime            @updatedAt
+  dateDeleted      DateTime?
+  userCreatedId    String
+  userCreated      User                @relation(fields: [userCreatedId], references: [userId], name: "partsSubmissionCreator")
+  userDeletedId    String?
+  userDeleted      User?               @relation(fields: [userDeletedId], references: [userId], name: "partsSubmissionDeleter")
+  reviewRequests   PartReviewRequest[]
+  reviews          PartReview[]
+}
+
+model PartReviewRequest {
+  partReviewRequestId String         @id @default(uuid())
+  submissionId        String
+  submission          PartSubmission @relation(fields: [submissionId], references: [partSubmissionId])
+  requesterId         String
+  requester           User           @relation(fields: [requesterId], references: [userId], name: "PartReviewRequestor")
+  reviewerId          String
+  reviewerRequested   User           @relation(fields: [reviewerId], references: [userId], name: "PartReviewRequested")
+  createdAt           DateTime       @default(now())
+  reviewBeganAt       DateTime?
 }
 
 model PartReview {
   partReviewId  String              @id @default(uuid())
   fileIds       String[]
   notes         String?
-  submission    PartSubmission      @relation(fields: [submissionId], references: [id])
+  submission    PartSubmission      @relation(fields: [submissionId], references: [partSubmissionId])
   submissionId  String
   popUps        Part_Review_Popup[]
   createdAt     DateTime            @default(now())
@@ -1208,16 +1223,16 @@ model Part_Review_Popup {
 }
 
 model PartReviewCommonMistake {
-  id             String        @id @default(uuid())
-  title          String
-  description    String
-  starred        Boolean
-  userCreated    User          @relation(fields: [userCreatedId], references: [userId], name: "commonMistakeCreator")
-  userCreatedId  String
-  userDeleted    User?         @relation(fields: [userDeletedId], references: [userId], name: "commonMistakeDeleter")
-  userDeletedId  String?
-  dateCreated    DateTime      @default(now())
-  dateDeleted    DateTime?
-  organization   Organization? @relation(fields: [organizationId], references: [organizationId])
-  organizationId String?
+  partReviewCommonMistakeId String        @id @default(uuid())
+  title                     String
+  description               String
+  starred                   Boolean
+  userCreated               User          @relation(fields: [userCreatedId], references: [userId], name: "commonMistakeCreator")
+  userCreatedId             String
+  userDeleted               User?         @relation(fields: [userDeletedId], references: [userId], name: "commonMistakeDeleter")
+  userDeletedId             String?
+  dateCreated               DateTime      @default(now())
+  dateDeleted               DateTime?
+  organization              Organization? @relation(fields: [organizationId], references: [organizationId])
+  organizationId            String?
 }


### PR DESCRIPTION
## Changes

Added a PartReviewRequest model, that keeps track of all of the requests for reviews. Every submission has an array of review requests than represent a request for someone to review that submission, and keeps track of who is requesting who, when the request was made and when the review has been started. This along with the information in the other models should provide all the information necessary to create the history of a part

Also changed "id" fields of other models to better naming convention for consistency, and editted migration to reflect these changes.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #3260 
