### PR TITLE
#3152 Updating Material Transformer/Endpoints

### DIFF
--- a/src/backend/src/controllers/projects.controllers.ts
+++ b/src/backend/src/controllers/projects.controllers.ts
@@ -161,7 +161,8 @@ export default class ProjectsController {
         price,
         subtotal,
         linkUrl,
-        notes
+        notes,
+        reimbursementRequestId
       } = req.body;
       const wbsNum = validateWBS(req.params.wbsNum);
       const material = await BillOfMaterialsService.createMaterial(
@@ -180,7 +181,8 @@ export default class ProjectsController {
         notes,
         assemblyId,
         pdmFileName,
-        unitName
+        unitName,
+        reimbursementRequestId
       );
       res.status(200).json(material);
     } catch (error: unknown) {

--- a/src/backend/src/prisma/seed.ts
+++ b/src/backend/src/prisma/seed.ts
@@ -1817,6 +1817,30 @@ const performSeed: () => Promise<void> = async () => {
     'Here are some more notes'
   );
 
+  await BillOfMaterialsService.createMaterial(
+    thomasEmrax,
+    '100k Resistor',
+    MaterialStatus.ReadyToOrder,
+    'Resistor',
+    'Digikey',
+    'lalsd',
+    new Decimal(5),
+    10,
+    50,
+    'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+    {
+      carNumber: 0,
+      projectNumber: 1,
+      workPackageNumber: 0
+    },
+    ner,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    reimbursement1.reimbursementRequestId
+  );
+
   // Need to do this because the design review cannot be scheduled for a past day
   const nextDay = new Date();
   nextDay.setDate(nextDay.getDate() + 1);

--- a/src/backend/src/routes/projects.routes.ts
+++ b/src/backend/src/routes/projects.routes.ts
@@ -100,6 +100,7 @@ projectRouter.post(
   intMinZero(body('subtotal')), // in cents
   nonEmptyString(body('linkUrl').isURL()),
   body('notes').isString().optional(),
+  body('reimbursementRequestId').isString().optional(),
   validateInputs,
   ProjectsController.createMaterial
 );

--- a/src/backend/src/routes/projects.routes.ts
+++ b/src/backend/src/routes/projects.routes.ts
@@ -100,7 +100,7 @@ projectRouter.post(
   intMinZero(body('subtotal')), // in cents
   nonEmptyString(body('linkUrl').isURL()),
   body('notes').isString().optional(),
-  body('reimbursementRequestId').isString().optional(),
+  nonEmptyString(body('reimbursementRequestId')).optional(),
   validateInputs,
   ProjectsController.createMaterial
 );

--- a/src/backend/src/services/boms.services.ts
+++ b/src/backend/src/services/boms.services.ts
@@ -101,6 +101,16 @@ export default class BillOfMaterialsService {
       if (!unit) throw new NotFoundException('Unit', unitName);
     }
 
+    if (reimbursementRequestId) {
+      const reimbursementRequest = await prisma.reimbursement_Request.findUnique({
+        where: { reimbursementRequestId, dateDeleted: null }
+      });
+
+      if (!reimbursementRequest) {
+        throw new NotFoundException('Reimbursement Request', reimbursementRequestId);
+      }
+    }
+
     const perms =
       (await userHasPermission(creator.userId, organization.organizationId, isLeadership)) ||
       isUserPartOfTeams(project.teams, creator);

--- a/src/backend/src/transformers/material.transformer.ts
+++ b/src/backend/src/transformers/material.transformer.ts
@@ -45,7 +45,8 @@ export const materialTransformer = (material: Prisma.MaterialGetPayload<Material
     unitName: material.unit?.name ?? undefined,
     materialType: { ...material.materialType, dateDeleted: material.materialType.dateDeleted ?? undefined },
     manufacturer: { ...material.manufacturer, dateDeleted: material.manufacturer.dateDeleted ?? undefined },
-    notes: material.notes ?? undefined
+    notes: material.notes ?? undefined,
+    reimbursementRequestId: material.reimbursementRequestId ?? undefined
   };
 };
 
@@ -55,6 +56,7 @@ export const materialPreviewTransformer = (
   return {
     ...material,
     notes: material.notes ?? undefined,
+    reimbursementRequestId: material.reimbursementRequestId ?? undefined,
     dateDeleted: material.dateDeleted ?? undefined,
     assemblyId: material.assemblyId ?? undefined,
     pdmFileName: material.pdmFileName ?? undefined,

--- a/src/backend/src/transformers/reimbursement-requests.transformer.ts
+++ b/src/backend/src/transformers/reimbursement-requests.transformer.ts
@@ -34,8 +34,7 @@ export const receiptTransformer = (receipt: Prisma.ReceiptGetPayload<ReceiptQuer
   return {
     receiptId: receipt.receiptId,
     googleFileId: receipt.googleFileId,
-    name: receipt.name,
-    deletedBy: receipt.deletedBy ? userTransformer(receipt.deletedBy) : undefined
+    name: receipt.name
   };
 };
 

--- a/src/backend/tests/unmocked/project.test.ts
+++ b/src/backend/tests/unmocked/project.test.ts
@@ -1,0 +1,90 @@
+import { createTestReimbursementRequest, resetUsers } from '../test-utils';
+import { Organization, User } from '@prisma/client';
+import BillOfMaterials from '../../src/services/boms.services';
+import Decimal from 'decimal.js';
+import { MaterialStatus, ReimbursementRequest } from 'shared';
+import { NotFoundException } from '../../src/utils/errors.utils';
+
+describe('Material Tests', () => {
+  let org: Organization;
+  let reimbursementRequest: ReimbursementRequest;
+
+  let createdUser: User;
+
+  beforeEach(async () => {
+    const result = await createTestReimbursementRequest();
+    reimbursementRequest = result.rr;
+    org = result.organization;
+    createdUser = result.user;
+  });
+
+  afterEach(async () => {
+    await resetUsers();
+  });
+
+  test('Creating a valid material', async () => {
+    const materialType = await BillOfMaterials.createMaterialType('Resistor', createdUser, org);
+    const manufacturer = await BillOfMaterials.createManufacturer(createdUser, 'Digikey', org);
+    const material = await BillOfMaterials.createMaterial(
+      createdUser,
+      '100k Resistor',
+      MaterialStatus.ReadyToOrder,
+      materialType.name,
+      manufacturer.name,
+      'lalsd',
+      new Decimal(5),
+      10,
+      50,
+      'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      {
+        carNumber: 0,
+        projectNumber: 1,
+        workPackageNumber: 0
+      },
+      org,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      reimbursementRequest.reimbursementRequestId
+    );
+
+    expect(material.name).toEqual('100k Resistor');
+    expect(material.linkUrl).toEqual('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+    expect(material.userCreatedId).toEqual(createdUser.userId);
+    expect(material.price).toEqual(10);
+    expect(material.subtotal).toMatchObject(50);
+    expect(material.reimbursementRequestId).toEqual(reimbursementRequest.reimbursementRequestId);
+  });
+
+  test('Fails on invalid reimbursement request id', async () => {
+    const materialType = await BillOfMaterials.createMaterialType('Resistor', createdUser, org);
+    const manufacturer = await BillOfMaterials.createManufacturer(createdUser, 'Digikey', org);
+    await expect(
+      async () =>
+        await BillOfMaterials.createMaterial(
+          createdUser,
+          '100k Resistor',
+          MaterialStatus.ReadyToOrder,
+          materialType.name,
+          manufacturer.name,
+          'lalsd',
+          new Decimal(5),
+          10,
+          50,
+          'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+          {
+            carNumber: 0,
+            projectNumber: 1,
+            workPackageNumber: 0
+          },
+          org,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          'invalid'
+        )
+    ).rejects.toThrow(new NotFoundException('Reimbursement Request', 'invalid'));
+  });
+});

--- a/src/frontend/src/apis/transformers/bom.transformers.ts
+++ b/src/frontend/src/apis/transformers/bom.transformers.ts
@@ -14,6 +14,7 @@ export const manufacturerTransformer = (manufacturer: Manufacturer): Manufacture
   };
 };
 
+// should this be deleted, looks like we have a duplicate transformer but this one is never used
 export const materialTransformer = (material: Material): Material => {
   return {
     ...material,

--- a/src/shared/src/types/bom-types.ts
+++ b/src/shared/src/types/bom-types.ts
@@ -72,6 +72,7 @@ export interface Material {
   subtotal: number;
   linkUrl: string;
   notes?: string;
+  reimbursementRequestId?: string;
 }
 
 export type MaterialPreview = Omit<

--- a/src/shared/src/types/reimbursement-requests-types.ts
+++ b/src/shared/src/types/reimbursement-requests-types.ts
@@ -40,7 +40,6 @@ export interface Receipt {
   receiptId: string;
   googleFileId: string;
   name: string;
-  deletedBy?: User;
 }
 
 export interface ReimbursementRequest {


### PR DESCRIPTION
## Changes

Recent schema changes have material now including reimbursement requests as a field.
- Material include RRId in the transformer 
- createMaterial takes an optional RRId (updated route + controller)

## Notes

- There is two material transformers and one of them is never used, is it okay to delete? 

## Test Cases


## To Do

_Any remaining things that need to get done_

- [ ] determine if we need to implement get endpoints for materials 


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #3152 
