### PR TITLE
#3163 get all common mistakes endpoint

### DIFF
--- a/src/backend/src/controllers/part-review.controllers.ts
+++ b/src/backend/src/controllers/part-review.controllers.ts
@@ -39,6 +39,15 @@ export default class PartReviewController {
     }
   }
 
+  static async getAllCommonMistakes(req: Request, res: Response, next: NextFunction) {
+    try {
+      const commonMistakes = await PartReviewService.getAllCommonMistakes(req.organization.organizationId);
+      res.status(200).json(commonMistakes);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
   static async createCommonMistake(req: Request, res: Response, next: NextFunction) {
     try {
       const { title, description, starred } = req.body;

--- a/src/backend/src/routes/parts.routes.ts
+++ b/src/backend/src/routes/parts.routes.ts
@@ -23,6 +23,8 @@ partsRouter.post(
 
 partsRouter.post('/faq/:faqId/delete', PartsReviewController.deleteFaq);
 
+partsRouter.get('/common-mistakes', PartsReviewController.getAllCommonMistakes);
+
 partsRouter.post(
   '/common-mistake/create',
   nonEmptyString(body('title')),

--- a/src/backend/src/services/part-review.services.ts
+++ b/src/backend/src/services/part-review.services.ts
@@ -137,6 +137,23 @@ export default class PartReviewService {
   }
 
   /**
+   * Gets all of the common mistakes associated with part reviews in the given organization
+   * @param organizationId the organization
+   * @returns an array of common mistakes
+   */
+  static async getAllCommonMistakes(organizationId: string): Promise<PartReviewCommonMistake[]> {
+    const commonMistakes = await prisma.partReviewCommonMistake.findMany({
+      where: {
+        dateDeleted: null,
+        organizationId
+      },
+      ...getFaqQueryArgs(organizationId)
+    });
+
+    return commonMistakes.map(partsReviewCommonMistakeTransformer);
+  }
+
+  /**
    * Creates a common mistake
    * @param title the title
    * @param description the description

--- a/src/backend/tests/unit/part-review.test.ts
+++ b/src/backend/tests/unit/part-review.test.ts
@@ -231,7 +231,7 @@ describe('part review tests', () => {
     await PartReviewService.createCommonMistake('mistake3', 'desc3', true, batman, orgId);
     await PartReviewService.createCommonMistake('mistake4', 'desc4', false, batman, orgId);
 
-    const commonMistakes = PartReviewService.getAllCommonMistakes(orgId);
+    const commonMistakes = await PartReviewService.getAllCommonMistakes(orgId);
     expect(commonMistakes).toHaveLength(3);
     expect(commonMistakes[0].title).toBe('mistake');
     expect(commonMistakes[1].title).toBe('mistake3');

--- a/src/backend/tests/unit/part-review.test.ts
+++ b/src/backend/tests/unit/part-review.test.ts
@@ -201,4 +201,44 @@ describe('part review tests', () => {
         )
     ).rejects.toThrow(new DeletedException('common mistake', commonMistake.id));
   });
+
+  it('gets all common mistakes', async () => {
+    const org2Creator = await prisma.user.create({
+      data: {
+        firstName: 'Admin2',
+        lastName: 'User2',
+        email: 'admin2@gmail.com',
+        googleAuthId: 'organizationCreator2'
+      }
+    });
+
+    const org2 = await prisma.organization.create({
+      data: {
+        name: 'Joe mama2',
+        description: 'Joe mama2`s organization',
+        applicationLink: '',
+        userCreated: {
+          connect: {
+            userId: org2Creator.userId
+          }
+        }
+      }
+    });
+    await PartReviewService.createCommonMistake('mistake', 'desc', false, batman, orgId);
+    await PartReviewService.createCommonMistake('mistake2', 'desc2', false, batman, org2.organizationId);
+    await PartReviewService.createCommonMistake('mistake3', 'desc3', true, batman, orgId);
+    await PartReviewService.createCommonMistake('mistake4', 'desc4', false, batman, orgId);
+
+    const commonMistakes = PartReviewService.getAllCommonMistakes(orgId);
+    expect(commonMistakes).toHaveLength(3);
+    expect(commonMistakes[0].title).toBe('mistake');
+    expect(commonMistakes[1].title).toBe('mistake3');
+    expect(commonMistakes[2].title).toBe('mistake4');
+    expect(commonMistakes[0].description).toBe('desc');
+    expect(commonMistakes[1].description).toBe('desc3');
+    expect(commonMistakes[2].description).toBe('desc4');
+    expect(commonMistakes[0].starred).toBe(false);
+    expect(commonMistakes[1].starred).toBe(true);
+    expect(commonMistakes[2].starred).toBe(false);
+  });
 });

--- a/src/backend/tests/unit/part-review.test.ts
+++ b/src/backend/tests/unit/part-review.test.ts
@@ -225,7 +225,7 @@ describe('part review tests', () => {
       }
     });
     await PartReviewService.createCommonMistake('mistake', 'desc', false, batman, orgId);
-    await PartReviewService.createCommonMistake('mistake2', 'desc2', false, batman, org2.organizationId);
+    await PartReviewService.createCommonMistake('mistake2', 'desc2', false, org2Creator, org2.organizationId);
     await PartReviewService.createCommonMistake('mistake3', 'desc3', true, batman, orgId);
     await PartReviewService.createCommonMistake('mistake4', 'desc4', false, batman, orgId);
 

--- a/src/backend/tests/unit/part-review.test.ts
+++ b/src/backend/tests/unit/part-review.test.ts
@@ -1,7 +1,7 @@
 import { Organization, User } from '@prisma/client';
 import { createTestOrganization, createTestUser, resetUsers } from '../test-utils';
 import PartReviewService from '../../src/services/part-review.services';
-import { batmanAppAdmin, supermanAdmin, aquamanLeadership } from '../test-data/users.test-data';
+import { batmanAppAdmin, supermanAdmin, aquamanLeadership, flashAdmin } from '../test-data/users.test-data';
 import prisma from '../../src/prisma/prisma';
 import { AccessDeniedAdminOnlyException, DeletedException } from '../../src/utils/errors.utils';
 
@@ -224,8 +224,10 @@ describe('part review tests', () => {
         }
       }
     });
+
+    const flash = await createTestUser(flashAdmin, org2.organizationId);
     await PartReviewService.createCommonMistake('mistake', 'desc', false, batman, orgId);
-    await PartReviewService.createCommonMistake('mistake2', 'desc2', false, org2Creator, org2.organizationId);
+    await PartReviewService.createCommonMistake('mistake2', 'desc2', false, flash, org2.organizationId);
     await PartReviewService.createCommonMistake('mistake3', 'desc3', true, batman, orgId);
     await PartReviewService.createCommonMistake('mistake4', 'desc4', false, batman, orgId);
 


### PR DESCRIPTION
## Changes

Added endpoint to get all common mistakes at /parts/common-mistakes

## Test Cases

- gets all common mistakes only from given org with correct title, description, and starred fields
<img width="1088" alt="Screenshot 2025-03-07 at 10 23 17 PM" src="https://github.com/user-attachments/assets/5a35ffe9-3f21-4eb2-8c89-75c1188731ad" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #3163
