### PR TITLE
#3284 part models shared types, query args, and transformers

### DIFF
--- a/src/backend/src/prisma-query-args/part-review.query-args.ts
+++ b/src/backend/src/prisma-query-args/part-review.query-args.ts
@@ -1,0 +1,42 @@
+import { Prisma } from '@prisma/client';
+import { getUserQueryArgs } from './user.query-args';
+
+export type PartQueryArgs = ReturnType<typeof partQueryArgs>;
+export type PartSubmissionQueryArgs = ReturnType<typeof partSubmissionQueryArgs>;
+export type PartReviewQueryArgs = ReturnType<typeof partReviewQueryArgs>;
+export type PartReviewRequestQueryArgs = ReturnType<typeof partReviewRequestQueryArgs>;
+
+export const partQueryArgs = (organizationId: string) =>
+  Prisma.validator<Prisma.PartDefaultArgs>()({
+    include: {
+      tags: true,
+      submissions: partSubmissionQueryArgs(organizationId),
+      assignees: getUserQueryArgs(organizationId),
+      userCreated: getUserQueryArgs(organizationId)
+    }
+  });
+
+export const partSubmissionQueryArgs = (organizationId: string) =>
+  Prisma.validator<Prisma.PartSubmissionDefaultArgs>()({
+    include: {
+      userCreated: getUserQueryArgs(organizationId),
+      reviewRequests: partReviewRequestQueryArgs(organizationId),
+      reviews: partReviewQueryArgs(organizationId)
+    }
+  });
+
+export const partReviewRequestQueryArgs = (organizationId: string) =>
+  Prisma.validator<Prisma.PartReviewRequestDefaultArgs>()({
+    include: {
+      requester: getUserQueryArgs(organizationId),
+      reviewerRequested: getUserQueryArgs(organizationId)
+    }
+  });
+
+export const partReviewQueryArgs = (organizationId: string) =>
+  Prisma.validator<Prisma.PartReviewDefaultArgs>()({
+    include: {
+      popUps: true,
+      userCreated: getUserQueryArgs(organizationId)
+    }
+  });

--- a/src/backend/src/prisma/migrations/20250124235046_cad_part_file_review/migration.sql
+++ b/src/backend/src/prisma/migrations/20250124235046_cad_part_file_review/migration.sql
@@ -77,7 +77,6 @@ CREATE TABLE "PartReviewRequest" (
     "requesterId" TEXT NOT NULL,
     "reviewerId" TEXT NOT NULL,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "reviewBeganAt" TIMESTAMP(3),
 
     CONSTRAINT "PartReviewRequest_pkey" PRIMARY KEY ("partReviewRequestId")
 );
@@ -89,6 +88,7 @@ CREATE TABLE "PartReview" (
     "notes" TEXT,
     "submissionId" TEXT NOT NULL,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completedAt" TIMESTAMP(3),
     "updatedAt" TIMESTAMP(3) NOT NULL,
     "dateDeleted" TIMESTAMP(3),
     "userCreatedId" TEXT NOT NULL,
@@ -140,12 +140,6 @@ CREATE TABLE "_partAssignees" (
     "B" TEXT NOT NULL
 );
 
--- CreateTable
-CREATE TABLE "_partReviewers" (
-    "A" TEXT NOT NULL,
-    "B" TEXT NOT NULL
-);
-
 -- CreateIndex
 CREATE UNIQUE INDEX "_PartToPartTag_AB_unique" ON "_PartToPartTag"("A", "B");
 
@@ -157,12 +151,6 @@ CREATE UNIQUE INDEX "_partAssignees_AB_unique" ON "_partAssignees"("A", "B");
 
 -- CreateIndex
 CREATE INDEX "_partAssignees_B_index" ON "_partAssignees"("B");
-
--- CreateIndex
-CREATE UNIQUE INDEX "_partReviewers_AB_unique" ON "_partReviewers"("A", "B");
-
--- CreateIndex
-CREATE INDEX "_partReviewers_B_index" ON "_partReviewers"("B");
 
 -- AddForeignKey
 ALTER TABLE "Part" ADD CONSTRAINT "Part_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("projectId") ON DELETE RESTRICT ON UPDATE CASCADE;
@@ -226,9 +214,3 @@ ALTER TABLE "_partAssignees" ADD CONSTRAINT "_partAssignees_A_fkey" FOREIGN KEY 
 
 -- AddForeignKey
 ALTER TABLE "_partAssignees" ADD CONSTRAINT "_partAssignees_B_fkey" FOREIGN KEY ("B") REFERENCES "User"("userId") ON DELETE CASCADE ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "_partReviewers" ADD CONSTRAINT "_partReviewers_A_fkey" FOREIGN KEY ("A") REFERENCES "Part"("partId") ON DELETE CASCADE ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "_partReviewers" ADD CONSTRAINT "_partReviewers_B_fkey" FOREIGN KEY ("B") REFERENCES "User"("userId") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/backend/src/prisma/schema.prisma
+++ b/src/backend/src/prisma/schema.prisma
@@ -250,7 +250,6 @@ model User {
   deletedPartSubmissions          PartSubmission[]          @relation(name: "partsSubmissionDeleter")
   createdPartReviews              PartReview[]              @relation(name: "partsReviewCreator")
   deletedPartReviews              PartReview[]              @relation(name: "partsReviewDeleter")
-  partsToReview                   Part[]                    @relation(name: "partReviewers")
   assignedParts                   Part[]                    @relation(name: "partAssignees")
   createdCommonMistakes           PartReviewCommonMistake[] @relation(name: "commonMistakeCreator")
   deletedCommonMistakes           PartReviewCommonMistake[] @relation(name: "commonMistakeDeleter")
@@ -1140,7 +1139,6 @@ model Part {
   project          Project          @relation(fields: [projectId], references: [projectId])
   projectId        String
   assignees        User[]           @relation("partAssignees")
-  reviewers        User[]           @relation("partReviewers")
   createdAt        DateTime         @default(now())
   updatedAt        DateTime         @updatedAt
   dateDeleted      DateTime?
@@ -1188,7 +1186,6 @@ model PartReviewRequest {
   reviewerId          String
   reviewerRequested   User           @relation(fields: [reviewerId], references: [userId], name: "PartReviewRequested")
   createdAt           DateTime       @default(now())
-  reviewBeganAt       DateTime?
 }
 
 model PartReview {
@@ -1198,6 +1195,7 @@ model PartReview {
   submission    PartSubmission      @relation(fields: [submissionId], references: [partSubmissionId])
   submissionId  String
   popUps        Part_Review_Popup[]
+  completedAt   DateTime?
   createdAt     DateTime            @default(now())
   updatedAt     DateTime            @updatedAt
   dateDeleted   DateTime?

--- a/src/backend/src/transformers/part-review.transformer.ts
+++ b/src/backend/src/transformers/part-review.transformer.ts
@@ -1,6 +1,93 @@
-import { PartReviewCommonMistake } from '@prisma/client';
-import { PartReviewCommonMistake as SharedCommonMistake } from 'shared';
+import { PartReviewCommonMistake, Prisma } from '@prisma/client';
+import {
+  PartReviewCommonMistake as SharedCommonMistake,
+  Part as SharedPart,
+  Review_Status,
+  PartSubmission as sharedSubmission,
+  PartReviewRequest as sharedReviewRequest,
+  PartReview,
+  PartPreview
+} from 'shared';
+import {
+  PartQueryArgs,
+  PartReviewQueryArgs,
+  PartReviewRequestQueryArgs,
+  PartSubmissionQueryArgs
+} from '../prisma-query-args/part-review.query-args';
+import { userTransformer } from './user.transformer';
 
 export const partsReviewCommonMistakeTransformer = (commonMistake: PartReviewCommonMistake): SharedCommonMistake => {
   return commonMistake;
+};
+
+export const partTransformer = (part: Prisma.PartGetPayload<PartQueryArgs>): SharedPart => {
+  return {
+    ...partPreviewTransformer(part),
+    submissions: part.submissions.map(submissionTransformer)
+  };
+};
+
+export const partPreviewTransformer = (part: Prisma.PartGetPayload<PartQueryArgs>): PartPreview => {
+  return {
+    partId: part.partId,
+    index: part.index,
+    commonName: part.commonName,
+    description: part.description ?? undefined,
+    previewImageLink: part.previewImageLink ?? undefined,
+    status: part.status as Review_Status,
+    tags: part.tags,
+    projectId: part.projectId,
+    assignees: part.assignees.map(userTransformer),
+    reviewers: part.submissions
+      .map((submission) =>
+        submission.reviewRequests
+          .map((reviewReq) => reviewReq.reviewerRequested)
+          .flat()
+          .concat(submission.reviews.map((review) => review.userCreated).flat())
+      )
+      .flat()
+      .map(userTransformer),
+    userCreated: userTransformer(part.userCreated),
+    createdAt: part.createdAt
+  };
+};
+
+export const submissionTransformer = (
+  submission: Prisma.PartSubmissionGetPayload<PartSubmissionQueryArgs>
+): sharedSubmission => {
+  return {
+    partSubmissionId: submission.partSubmissionId,
+    fileIds: submission.fileIds,
+    name: submission.name,
+    notes: submission.notes ?? undefined,
+    partId: submission.partId,
+    userCreated: userTransformer(submission.userCreated),
+    reviewRequests: submission.reviewRequests.map(partReviewRequestTransformer),
+    reviews: submission.reviews.map(partReviewTransformer)
+  };
+};
+
+export const partReviewRequestTransformer = (
+  reviewRequest: Prisma.PartReviewRequestGetPayload<PartReviewRequestQueryArgs>
+): sharedReviewRequest => {
+  return {
+    partReviewRequestId: reviewRequest.partReviewRequestId,
+    submissionId: reviewRequest.submissionId,
+    requester: userTransformer(reviewRequest.requester),
+    reviewerRequested: userTransformer(reviewRequest.reviewerRequested),
+    createdAt: reviewRequest.createdAt
+  };
+};
+
+export const partReviewTransformer = (review: Prisma.PartReviewGetPayload<PartReviewQueryArgs>): PartReview => {
+  return {
+    partReviewId: review.partReviewId,
+    fileIds: review.fileIds,
+    notes: review.notes ?? undefined,
+    submissionId: review.submissionId,
+    popUps: review.popUps,
+    completedAt: review.completedAt ?? undefined,
+    createdAt: review.createdAt,
+    userCreated: userTransformer(review.userCreated)
+  };
 };

--- a/src/backend/src/transformers/part-review.transformer.ts
+++ b/src/backend/src/transformers/part-review.transformer.ts
@@ -1,10 +1,10 @@
 import { PartReviewCommonMistake, Prisma } from '@prisma/client';
 import {
   PartReviewCommonMistake as SharedCommonMistake,
-  Part as SharedPart,
+  Part,
   Review_Status,
-  PartSubmission as sharedSubmission,
-  PartReviewRequest as sharedReviewRequest,
+  PartSubmission,
+  PartReviewRequest,
   PartReview,
   PartPreview
 } from 'shared';
@@ -20,10 +20,10 @@ export const partsReviewCommonMistakeTransformer = (commonMistake: PartReviewCom
   return commonMistake;
 };
 
-export const partTransformer = (part: Prisma.PartGetPayload<PartQueryArgs>): SharedPart => {
+export const partTransformer = (part: Prisma.PartGetPayload<PartQueryArgs>): Part => {
   return {
     ...partPreviewTransformer(part),
-    submissions: part.submissions.map(submissionTransformer)
+    submissions: part.submissions.map(partSubmissionTransformer)
   };
 };
 
@@ -52,9 +52,9 @@ export const partPreviewTransformer = (part: Prisma.PartGetPayload<PartQueryArgs
   };
 };
 
-export const submissionTransformer = (
+export const partSubmissionTransformer = (
   submission: Prisma.PartSubmissionGetPayload<PartSubmissionQueryArgs>
-): sharedSubmission => {
+): PartSubmission => {
   return {
     partSubmissionId: submission.partSubmissionId,
     fileIds: submission.fileIds,
@@ -69,7 +69,7 @@ export const submissionTransformer = (
 
 export const partReviewRequestTransformer = (
   reviewRequest: Prisma.PartReviewRequestGetPayload<PartReviewRequestQueryArgs>
-): sharedReviewRequest => {
+): PartReviewRequest => {
   return {
     partReviewRequestId: reviewRequest.partReviewRequestId,
     submissionId: reviewRequest.submissionId,

--- a/src/backend/tests/unit/part-review.test.ts
+++ b/src/backend/tests/unit/part-review.test.ts
@@ -138,7 +138,11 @@ describe('part review tests', () => {
       expect(updatedCommonMistake?.description).toBe('some description2');
       expect(updatedCommonMistake?.starred).toBe(true);
 
-      const deletedCommonMistake = await PartReviewService.deleteCommonMistake(commonMistake.partReviewCommonMistakeId, superman, orgId);
+      const deletedCommonMistake = await PartReviewService.deleteCommonMistake(
+        commonMistake.partReviewCommonMistakeId,
+        superman,
+        orgId
+      );
       expect(deletedCommonMistake?.title).toBe('some title2');
       expect(deletedCommonMistake?.description).toBe('some description2');
       expect(deletedCommonMistake?.starred).toBe(true);

--- a/src/shared/src/types/part-review.types.ts
+++ b/src/shared/src/types/part-review.types.ts
@@ -1,3 +1,71 @@
+import { User } from './user-types';
+
+export enum Review_Status {
+  IN_PROGRESS = 'IN_PROGRESS',
+  READY_FOR_REVIEW = 'READY_FOR_REVIEW',
+  IN_REVIEW = 'IN_REVIEW',
+  REVIEWED = 'REVIEWED',
+  APPROVED = 'APPROVED'
+}
+
+export interface PartPreview {
+  partId: string;
+  index: number;
+  commonName: string;
+  description?: string;
+  previewImageLink?: string;
+  status: Review_Status;
+  tags: PartTag[];
+  projectId: string;
+  assignees: User[];
+  reviewers: User[];
+  createdAt: Date;
+  userCreated: User;
+}
+
+export interface Part extends PartPreview {
+  submissions: PartSubmission[];
+}
+
+export interface PartSubmission {
+  partSubmissionId: string;
+  fileIds: string[];
+  name: string;
+  notes?: string;
+  partId: string;
+  userCreated: User;
+  reviewRequests: PartReviewRequest[];
+  reviews: PartReview[];
+}
+
+export interface PartReviewRequest {
+  partReviewRequestId: string;
+  submissionId: string;
+  requester: User;
+  reviewerRequested: User;
+  createdAt: Date;
+}
+
+export interface PartReview {
+  partReviewId: string;
+  fileIds: string[];
+  notes?: string;
+  submissionId: string;
+  popUps: Part_Review_Popup[];
+  completedAt?: Date;
+  createdAt: Date;
+  userCreated: User;
+}
+
+export interface Part_Review_Popup {
+  partReviewPopupId: string;
+  xCoord: number;
+  yCoord: number;
+  title: string;
+  description: string;
+  reviewId: string;
+}
+
 export interface PartReviewCommonMistake {
   partReviewCommonMistakeId: string;
   title: string;


### PR DESCRIPTION
## Changes

Added shared types for part preview, part, part submission, part review request, part review, and part review popup. Added query args for part, part submission, part review request, and part review. Added transformer for part, part preview, part review, part submission, and part review request.

## Notes

Did not add query args for part preview, because to convert a part into a partPreview it needs to have the submission, which will not be included in the partPreview type. To use the partPreviewTransformer, the partQueryArgs would be used

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #3284
