### PR TITLE
#3287 Parts Review Submission Guide

### DIFF
--- a/src/frontend/src/components/NERSwitch.tsx
+++ b/src/frontend/src/components/NERSwitch.tsx
@@ -1,0 +1,51 @@
+import { Switch, SwitchProps, styled } from '@mui/material';
+
+const NERSwitch = styled((props: SwitchProps) => (
+  <Switch focusVisibleClassName=".Mui-focusVisible" disableRipple {...props} />
+))(({ theme }) => ({
+  width: 34,
+  height: 18,
+  padding: 0,
+  '& .MuiSwitch-switchBase': {
+    padding: 0,
+    margin: 2,
+    transitionDuration: '300ms',
+    '&.Mui-checked': {
+      transform: 'translateX(16px)',
+      color: '#fff',
+      '& + .MuiSwitch-track': {
+        backgroundColor: theme.palette.mode === 'dark' ? '#ef4345' : '#ef4345',
+        opacity: 1,
+        border: 0
+      },
+      '&.Mui-disabled + .MuiSwitch-track': {
+        opacity: 0.5
+      }
+    },
+    '&.Mui-focusVisible .MuiSwitch-thumb': {
+      color: '#ef4345',
+      border: '6px solid #fff'
+    },
+    '&.Mui-disabled .MuiSwitch-thumb': {
+      color: theme.palette.mode === 'light' ? theme.palette.grey[100] : theme.palette.grey[600]
+    },
+    '&.Mui-disabled + .MuiSwitch-track': {
+      opacity: theme.palette.mode === 'light' ? 0.7 : 0.3
+    }
+  },
+  '& .MuiSwitch-thumb': {
+    boxSizing: 'border-box',
+    width: 14,
+    height: 14
+  },
+  '& .MuiSwitch-track': {
+    borderRadius: 18 / 2,
+    backgroundColor: theme.palette.mode === 'light' ? '#E9E9EA' : '#39393D',
+    opacity: 1,
+    transition: theme.transitions.create(['background-color'], {
+      duration: 500
+    })
+  }
+}));
+
+export default NERSwitch;

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/PartReview/PartsReviewPage.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/PartReview/PartsReviewPage.tsx
@@ -1,8 +1,92 @@
 import LoadingIndicator from '../../../../components/LoadingIndicator';
+import { Box } from '@mui/system';
+import { Grid, FormGroup, FormControlLabel, Switch, SwitchProps, styled, Typography } from '@mui/material';
+import { useState } from 'react';
+
+const NERSwitch = styled((props: SwitchProps) => (
+  <Switch focusVisibleClassName=".Mui-focusVisible" disableRipple {...props} />
+))(({ theme }) => ({
+  width: 34,
+  height: 18,
+  padding: 0,
+  '& .MuiSwitch-switchBase': {
+    padding: 0,
+    margin: 2,
+    transitionDuration: '300ms',
+    '&.Mui-checked': {
+      transform: 'translateX(16px)',
+      color: '#fff',
+      '& + .MuiSwitch-track': {
+        backgroundColor: theme.palette.mode === 'dark' ? '#ef4345' : '#ef4345',
+        opacity: 1,
+        border: 0
+      },
+      '&.Mui-disabled + .MuiSwitch-track': {
+        opacity: 0.5
+      }
+    },
+    '&.Mui-focusVisible .MuiSwitch-thumb': {
+      color: '#ef4345',
+      border: '6px solid #fff'
+    },
+    '&.Mui-disabled .MuiSwitch-thumb': {
+      color: theme.palette.mode === 'light' ? theme.palette.grey[100] : theme.palette.grey[600]
+    },
+    '&.Mui-disabled + .MuiSwitch-track': {
+      opacity: theme.palette.mode === 'light' ? 0.7 : 0.3
+    }
+  },
+  '& .MuiSwitch-thumb': {
+    boxSizing: 'border-box',
+    width: 14,
+    height: 14
+  },
+  '& .MuiSwitch-track': {
+    borderRadius: 18 / 2,
+    backgroundColor: theme.palette.mode === 'light' ? '#E9E9EA' : '#39393D',
+    opacity: 1,
+    transition: theme.transitions.create(['background-color'], {
+      duration: 500
+    })
+  }
+}));
 
 const PartsReviewPage = () => {
-  //TODO: Parts Review Page content will go here
-  return <LoadingIndicator />;
+  const [showSubmissionGuide, setShowSubmissionGuide] = useState(false);
+
+  return (
+    <Box>
+      <Grid container spacing={3}>
+        <Grid item xs={12}>
+          <FormGroup>
+            <FormControlLabel
+              label="View Submission Guide?"
+              control={
+                <NERSwitch
+                  sx={{ m: 1 }}
+                  checked={showSubmissionGuide}
+                  onChange={() => setShowSubmissionGuide(!showSubmissionGuide)}
+                />
+              }
+            />
+          </FormGroup>
+        </Grid>
+        <Grid item xs={12}>
+          {showSubmissionGuide ? (
+            <Grid container spacing={3}>
+              <Grid item xs={12}>
+                <Typography variant="h4">Submission Guide</Typography>
+                {/* Submission Guide components will go here */}
+                <LoadingIndicator />\{/* This will be replaced by a grid of all the part cards */}
+              </Grid>
+            </Grid>
+          ) : (
+            <LoadingIndicator /> /* This will be replaced by a grid of all the part cards */
+          )}
+        </Grid>
+      </Grid>
+    </Box>
+  );
 };
 
 export default PartsReviewPage;

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/PartReview/PartsReviewPage.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/PartReview/PartsReviewPage.tsx
@@ -77,11 +77,12 @@ const PartsReviewPage = () => {
               <Grid item xs={12}>
                 <Typography variant="h4">Submission Guide</Typography>
                 {/* Submission Guide components will go here */}
-                <LoadingIndicator />\{/* This will be replaced by a grid of all the part cards */}
+                <LoadingIndicator />
+                {/* Loading indicator will be replaced by a grid of all the part cards */}
               </Grid>
             </Grid>
           ) : (
-            <LoadingIndicator /> /* This will be replaced by a grid of all the part cards */
+            <LoadingIndicator /> /* Loading indicator will be replaced by a grid of all the part cards */
           )}
         </Grid>
       </Grid>

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/PartReview/PartsReviewPage.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/PartReview/PartsReviewPage.tsx
@@ -1,62 +1,14 @@
 import LoadingIndicator from '../../../../components/LoadingIndicator';
 import { Box } from '@mui/system';
-import { Grid, FormGroup, FormControlLabel, Switch, SwitchProps, styled, Typography } from '@mui/material';
+import { Grid, FormGroup, FormControlLabel, Typography } from '@mui/material';
 import { useState } from 'react';
 import { useCurrentUser } from '../../../../hooks/users.hooks';
 import { rankUserRole } from 'shared';
-
-const NERSwitch = styled((props: SwitchProps) => (
-  <Switch focusVisibleClassName=".Mui-focusVisible" disableRipple {...props} />
-))(({ theme }) => ({
-  width: 34,
-  height: 18,
-  padding: 0,
-  '& .MuiSwitch-switchBase': {
-    padding: 0,
-    margin: 2,
-    transitionDuration: '300ms',
-    '&.Mui-checked': {
-      transform: 'translateX(16px)',
-      color: '#fff',
-      '& + .MuiSwitch-track': {
-        backgroundColor: theme.palette.mode === 'dark' ? '#ef4345' : '#ef4345',
-        opacity: 1,
-        border: 0
-      },
-      '&.Mui-disabled + .MuiSwitch-track': {
-        opacity: 0.5
-      }
-    },
-    '&.Mui-focusVisible .MuiSwitch-thumb': {
-      color: '#ef4345',
-      border: '6px solid #fff'
-    },
-    '&.Mui-disabled .MuiSwitch-thumb': {
-      color: theme.palette.mode === 'light' ? theme.palette.grey[100] : theme.palette.grey[600]
-    },
-    '&.Mui-disabled + .MuiSwitch-track': {
-      opacity: theme.palette.mode === 'light' ? 0.7 : 0.3
-    }
-  },
-  '& .MuiSwitch-thumb': {
-    boxSizing: 'border-box',
-    width: 14,
-    height: 14
-  },
-  '& .MuiSwitch-track': {
-    borderRadius: 18 / 2,
-    backgroundColor: theme.palette.mode === 'light' ? '#E9E9EA' : '#39393D',
-    opacity: 1,
-    transition: theme.transitions.create(['background-color'], {
-      duration: 500
-    })
-  }
-}));
+import NERSwitch from '../../../../components/NERSwitch';
 
 const PartsReviewPage = () => {
   const currentUser = useCurrentUser();
   const [showSubmissionGuide, setShowSubmissionGuide] = useState(() => {
-    if (!currentUser) return false;
     const userRole = currentUser.role;
     return rankUserRole(userRole) < rankUserRole('LEADERSHIP');
   });

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/PartReview/PartsReviewPage.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/PartReview/PartsReviewPage.tsx
@@ -2,6 +2,8 @@ import LoadingIndicator from '../../../../components/LoadingIndicator';
 import { Box } from '@mui/system';
 import { Grid, FormGroup, FormControlLabel, Switch, SwitchProps, styled, Typography } from '@mui/material';
 import { useState } from 'react';
+import { useCurrentUser } from '../../../../hooks/users.hooks';
+import { rankUserRole } from 'shared';
 
 const NERSwitch = styled((props: SwitchProps) => (
   <Switch focusVisibleClassName=".Mui-focusVisible" disableRipple {...props} />
@@ -52,7 +54,12 @@ const NERSwitch = styled((props: SwitchProps) => (
 }));
 
 const PartsReviewPage = () => {
-  const [showSubmissionGuide, setShowSubmissionGuide] = useState(false);
+  const currentUser = useCurrentUser();
+  const [showSubmissionGuide, setShowSubmissionGuide] = useState(() => {
+    if (!currentUser) return false;
+    const userRole = currentUser.role;
+    return rankUserRole(userRole) < rankUserRole('LEADERSHIP');
+  });
 
   return (
     <Box>
@@ -72,6 +79,8 @@ const PartsReviewPage = () => {
           </FormGroup>
         </Grid>
         <Grid item xs={12}>
+          {/* The guide should be toggled off by default for admins, heads, and leads and toggled on for all other roles */}
+
           {showSubmissionGuide ? (
             <Grid container spacing={3}>
               <Grid item xs={12}>


### PR DESCRIPTION
## Changes

Created the Submission Guide section of the Parts Review tab for Projects, toggleable via slider and with default toggle based on user role.

## Screenshots

App Admin, Admin, and Leadership default view:
<img width="1420" alt="Screenshot 2025-03-10 at 12 34 25 AM" src="https://github.com/user-attachments/assets/32ec1607-1f16-4143-b195-dc9dc0cc511e" />

Member and Guest default view:
<img width="1404" alt="Screenshot 2025-03-10 at 12 36 28 AM" src="https://github.com/user-attachments/assets/15492457-6046-4c20-8339-6d4f9d18ee3e" />


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3287 