### PR TITLE
Moving review reqs to parts and fixing typos

### DIFF
--- a/src/backend/src/prisma-query-args/part-review.query-args.ts
+++ b/src/backend/src/prisma-query-args/part-review.query-args.ts
@@ -11,6 +11,7 @@ export const partQueryArgs = (organizationId: string) =>
     include: {
       tags: true,
       submissions: partSubmissionQueryArgs(organizationId),
+      reviewRequests: partReviewRequestQueryArgs(organizationId),
       assignees: getUserQueryArgs(organizationId),
       userCreated: getUserQueryArgs(organizationId)
     }
@@ -20,7 +21,6 @@ export const partSubmissionQueryArgs = (organizationId: string) =>
   Prisma.validator<Prisma.PartSubmissionDefaultArgs>()({
     include: {
       userCreated: getUserQueryArgs(organizationId),
-      reviewRequests: partReviewRequestQueryArgs(organizationId),
       reviews: partReviewQueryArgs(organizationId)
     }
   });

--- a/src/backend/src/prisma/migrations/20250124235046_cad_part_file_review/migration.sql
+++ b/src/backend/src/prisma/migrations/20250124235046_cad_part_file_review/migration.sql
@@ -73,7 +73,7 @@ CREATE TABLE "PartSubmission" (
 -- CreateTable
 CREATE TABLE "PartReviewRequest" (
     "partReviewRequestId" TEXT NOT NULL,
-    "submissionId" TEXT NOT NULL,
+    "partId" TEXT NOT NULL,
     "requesterId" TEXT NOT NULL,
     "reviewerId" TEXT NOT NULL,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -108,7 +108,7 @@ CREATE TABLE "Part_Review_Popup" (
     "reviewId" TEXT NOT NULL,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
-    "deletedAd" TIMESTAMP(3),
+    "deletedAt" TIMESTAMP(3),
 
     CONSTRAINT "Part_Review_Popup_pkey" PRIMARY KEY ("partReviewPopupId")
 );
@@ -174,7 +174,7 @@ ALTER TABLE "PartSubmission" ADD CONSTRAINT "PartSubmission_userCreatedId_fkey" 
 ALTER TABLE "PartSubmission" ADD CONSTRAINT "PartSubmission_userDeletedId_fkey" FOREIGN KEY ("userDeletedId") REFERENCES "User"("userId") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "PartReviewRequest" ADD CONSTRAINT "PartReviewRequest_submissionId_fkey" FOREIGN KEY ("submissionId") REFERENCES "PartSubmission"("partSubmissionId") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "PartReviewRequest" ADD CONSTRAINT "PartReviewRequest_partId_fkey" FOREIGN KEY ("partId") REFERENCES "Part"("partId") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "PartReviewRequest" ADD CONSTRAINT "PartReviewRequest_requesterId_fkey" FOREIGN KEY ("requesterId") REFERENCES "User"("userId") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/src/backend/src/prisma/schema.prisma
+++ b/src/backend/src/prisma/schema.prisma
@@ -1128,24 +1128,25 @@ model Contact {
 }
 
 model Part {
-  partId           String           @id @default(uuid())
+  partId           String              @id @default(uuid())
   index            Int
   commonName       String
   description      String?
   previewImageLink String?
-  status           Review_Status    @default(IN_PROGRESS)
+  status           Review_Status       @default(IN_PROGRESS)
   tags             PartTag[]
   submissions      PartSubmission[]
-  project          Project          @relation(fields: [projectId], references: [projectId])
+  reviewRequests   PartReviewRequest[]
+  project          Project             @relation(fields: [projectId], references: [projectId])
   projectId        String
-  assignees        User[]           @relation("partAssignees")
-  createdAt        DateTime         @default(now())
-  updatedAt        DateTime         @updatedAt
+  assignees        User[]              @relation("partAssignees")
+  createdAt        DateTime            @default(now())
+  updatedAt        DateTime            @updatedAt
   dateDeleted      DateTime?
   userCreatedId    String
-  userCreated      User             @relation(fields: [userCreatedId], references: [userId], name: "partCreator")
+  userCreated      User                @relation(fields: [userCreatedId], references: [userId], name: "partCreator")
   userDeletedId    String?
-  userDeleted      User?            @relation(fields: [userDeletedId], references: [userId], name: "partDeleter")
+  userDeleted      User?               @relation(fields: [userDeletedId], references: [userId], name: "partDeleter")
 }
 
 model PartTag {
@@ -1160,32 +1161,31 @@ model PartTag {
 }
 
 model PartSubmission {
-  partSubmissionId String              @id @default(uuid())
+  partSubmissionId String       @id @default(uuid())
   fileIds          String[]
   name             String
   notes            String?
-  part             Part                @relation(fields: [partId], references: [partId])
+  part             Part         @relation(fields: [partId], references: [partId])
   partId           String
-  createdAt        DateTime            @default(now())
-  updatedAt        DateTime            @updatedAt
+  createdAt        DateTime     @default(now())
+  updatedAt        DateTime     @updatedAt
   dateDeleted      DateTime?
   userCreatedId    String
-  userCreated      User                @relation(fields: [userCreatedId], references: [userId], name: "partsSubmissionCreator")
+  userCreated      User         @relation(fields: [userCreatedId], references: [userId], name: "partsSubmissionCreator")
   userDeletedId    String?
-  userDeleted      User?               @relation(fields: [userDeletedId], references: [userId], name: "partsSubmissionDeleter")
-  reviewRequests   PartReviewRequest[]
+  userDeleted      User?        @relation(fields: [userDeletedId], references: [userId], name: "partsSubmissionDeleter")
   reviews          PartReview[]
 }
 
 model PartReviewRequest {
-  partReviewRequestId String         @id @default(uuid())
-  submissionId        String
-  submission          PartSubmission @relation(fields: [submissionId], references: [partSubmissionId])
+  partReviewRequestId String   @id @default(uuid())
+  partId              String
+  part                Part     @relation(fields: [partId], references: [partId])
   requesterId         String
-  requester           User           @relation(fields: [requesterId], references: [userId], name: "PartReviewRequestor")
+  requester           User     @relation(fields: [requesterId], references: [userId], name: "PartReviewRequestor")
   reviewerId          String
-  reviewerRequested   User           @relation(fields: [reviewerId], references: [userId], name: "PartReviewRequested")
-  createdAt           DateTime       @default(now())
+  reviewerRequested   User     @relation(fields: [reviewerId], references: [userId], name: "PartReviewRequested")
+  createdAt           DateTime @default(now())
 }
 
 model PartReview {
@@ -1216,7 +1216,7 @@ model Part_Review_Popup {
   review            PartReview @relation(fields: [reviewId], references: [partReviewId])
   createdAt         DateTime   @default(now())
   updatedAt         DateTime   @updatedAt
-  deletedAd         DateTime?
+  deletedAt         DateTime?
 }
 
 model PartReviewCommonMistake {

--- a/src/backend/src/transformers/part-review.transformer.ts
+++ b/src/backend/src/transformers/part-review.transformer.ts
@@ -38,15 +38,7 @@ export const partPreviewTransformer = (part: Prisma.PartGetPayload<PartQueryArgs
     tags: part.tags,
     projectId: part.projectId,
     assignees: part.assignees.map(userTransformer),
-    reviewers: part.submissions
-      .map((submission) =>
-        submission.reviewRequests
-          .map((reviewReq) => reviewReq.reviewerRequested)
-          .flat()
-          .concat(submission.reviews.map((review) => review.userCreated).flat())
-      )
-      .flat()
-      .map(userTransformer),
+    reviewRequests: part.reviewRequests.map(partReviewRequestTransformer),
     userCreated: userTransformer(part.userCreated),
     createdAt: part.createdAt
   };
@@ -62,7 +54,6 @@ export const partSubmissionTransformer = (
     notes: submission.notes ?? undefined,
     partId: submission.partId,
     userCreated: userTransformer(submission.userCreated),
-    reviewRequests: submission.reviewRequests.map(partReviewRequestTransformer),
     reviews: submission.reviews.map(partReviewTransformer)
   };
 };
@@ -72,7 +63,7 @@ export const partReviewRequestTransformer = (
 ): PartReviewRequest => {
   return {
     partReviewRequestId: reviewRequest.partReviewRequestId,
-    submissionId: reviewRequest.submissionId,
+    partId: reviewRequest.partId,
     requester: userTransformer(reviewRequest.requester),
     reviewerRequested: userTransformer(reviewRequest.reviewerRequested),
     createdAt: reviewRequest.createdAt

--- a/src/backend/src/transformers/part-review.transformer.ts
+++ b/src/backend/src/transformers/part-review.transformer.ts
@@ -54,7 +54,8 @@ export const partSubmissionTransformer = (
     notes: submission.notes ?? undefined,
     partId: submission.partId,
     userCreated: userTransformer(submission.userCreated),
-    reviews: submission.reviews.map(partReviewTransformer)
+    reviews: submission.reviews.map(partReviewTransformer),
+    createdAt: submission.createdAt
   };
 };
 

--- a/src/shared/src/types/part-review.types.ts
+++ b/src/shared/src/types/part-review.types.ts
@@ -35,6 +35,7 @@ export interface PartSubmission {
   partId: string;
   userCreated: User;
   reviews: PartReview[];
+  createdAt: Date;
 }
 
 export interface PartReviewRequest {

--- a/src/shared/src/types/part-review.types.ts
+++ b/src/shared/src/types/part-review.types.ts
@@ -18,7 +18,7 @@ export interface PartPreview {
   tags: PartTag[];
   projectId: string;
   assignees: User[];
-  reviewers: User[];
+  reviewRequests: PartReviewRequest[];
   createdAt: Date;
   userCreated: User;
 }
@@ -34,13 +34,12 @@ export interface PartSubmission {
   notes?: string;
   partId: string;
   userCreated: User;
-  reviewRequests: PartReviewRequest[];
   reviews: PartReview[];
 }
 
 export interface PartReviewRequest {
   partReviewRequestId: string;
-  submissionId: string;
+  partId: string;
   requester: User;
   reviewerRequested: User;
   createdAt: Date;


### PR DESCRIPTION
## Changes

Moved review requests to the parts table, so that review requests are by part instead of by submission. Also fixed typo from deletedAd to deletedAt

## Notes

Made migration, transformer, shared type, and query arg changes on top of schema changes.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
