### PR TITLE
#3195 getSponsorTier Endpoint

### DIFF
--- a/src/backend/src/controllers/finance.controllers.ts
+++ b/src/backend/src/controllers/finance.controllers.ts
@@ -71,8 +71,8 @@ export default class FinanceController {
   static async getSingleSponsorTier(req: Request, res: Response, next: NextFunction) {
     try {
       const { sponsorId } = req.params;
-      const SponsorTier = await FinanceServices.getSingleSponsorTier(req.currentUser, sponsorId, req.organization);
-      res.status(200).json(SponsorTier);
+      const sponsorTier = await FinanceServices.getSingleSponsorTier(req.currentUser, sponsorId, req.organization);
+      res.status(200).json(sponsorTier);
     } catch (error: unknown) {
       next(error);
     }

--- a/src/backend/src/controllers/finance.controllers.ts
+++ b/src/backend/src/controllers/finance.controllers.ts
@@ -46,4 +46,14 @@ export default class FinanceController {
       next(error);
     }
   }
+
+  static async getSingleSponsorTier(req: Request, res: Response, next: NextFunction) {
+    try {
+      const stId: string = req.params.sponsorId;
+      const SponsorTier = await FinanceServices.getSingleSponsierTier(req.currentUser, stId, req.organization);
+      res.status(200).json(SponsorTier);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
 }

--- a/src/backend/src/controllers/finance.controllers.ts
+++ b/src/backend/src/controllers/finance.controllers.ts
@@ -58,8 +58,8 @@ export default class FinanceController {
 
   static async getSingleSponsorTier(req: Request, res: Response, next: NextFunction) {
     try {
-      const stId: string = req.params.sponsorId;
-      const SponsorTier = await FinanceServices.getSingleSponsierTier(req.currentUser, stId, req.organization);
+      const { sponsorTierId } = req.params;
+      const SponsorTier = await FinanceServices.getSingleSponsierTier(sponsorTierId);
       res.status(200).json(SponsorTier);
     } catch (error: unknown) {
       next(error);

--- a/src/backend/src/controllers/finance.controllers.ts
+++ b/src/backend/src/controllers/finance.controllers.ts
@@ -70,8 +70,8 @@ export default class FinanceController {
 
   static async getSingleSponsorTier(req: Request, res: Response, next: NextFunction) {
     try {
-      const { sponsorTierId } = req.params;
-      const SponsorTier = await FinanceServices.getSingleSponsierTier(sponsorTierId);
+      const { sponsorId } = req.params;
+      const SponsorTier = await FinanceServices.getSingleSponsorTier(req.currentUser, sponsorId, req.organization);
       res.status(200).json(SponsorTier);
     } catch (error: unknown) {
       next(error);

--- a/src/backend/src/routes/finance.routes.ts
+++ b/src/backend/src/routes/finance.routes.ts
@@ -25,7 +25,7 @@ financeRouter.get('/sponsors', FinanceController.getAllSponsors);
 
 financeRouter.delete('/sponsor/:sponsorId/delete', FinanceController.deleteSponsor);
 
-financeRouter.get('/sponsor/:sponsorId', FinanceController.getSingleSponsorTier);
+financeRouter.get('/sponsorTier/:sponsorId/single', FinanceController.getSingleSponsorTier);
 
 financeRouter.post(
   '/sponsorTier/create',

--- a/src/backend/src/routes/finance.routes.ts
+++ b/src/backend/src/routes/finance.routes.ts
@@ -27,7 +27,7 @@ financeRouter.get('/sponsor/:sponsorId/sponsorTasks', FinanceController.getSpons
 
 financeRouter.delete('/sponsor/:sponsorId/delete', FinanceController.deleteSponsor);
 
-financeRouter.get('/sponsorTier/:sponsorId/sponsorTier', FinanceController.getSingleSponsorTier);
+financeRouter.get('/sponsor/:sponsorId/sponsorTier', FinanceController.getSingleSponsorTier);
 
 financeRouter.post(
   '/sponsorTier/create',

--- a/src/backend/src/routes/finance.routes.ts
+++ b/src/backend/src/routes/finance.routes.ts
@@ -27,7 +27,7 @@ financeRouter.get('/sponsor/:sponsorId/sponsorTasks', FinanceController.getSpons
 
 financeRouter.delete('/sponsor/:sponsorId/delete', FinanceController.deleteSponsor);
 
-financeRouter.get('/sponsorTier/:sponsorId/single', FinanceController.getSingleSponsorTier);
+financeRouter.get('/sponsorTier/:sponsorId/sponsorTier', FinanceController.getSingleSponsorTier);
 
 financeRouter.post(
   '/sponsorTier/create',

--- a/src/backend/src/routes/finance.routes.ts
+++ b/src/backend/src/routes/finance.routes.ts
@@ -23,4 +23,6 @@ financeRouter.post(
 
 financeRouter.delete('/sponsor/:sponsorId/delete', FinanceController.deleteSponsor);
 
+financeRouter.get('/sponsor/:sponsorId', FinanceController.getSingleSponsorTier);
+
 export default financeRouter;

--- a/src/backend/src/services/finance.services.ts
+++ b/src/backend/src/services/finance.services.ts
@@ -9,6 +9,7 @@ import {
   NotFoundException
 } from '../utils/errors.utils';
 import prisma from '../prisma/prisma';
+import { get } from 'http';
 
 export default class FinanceServices {
   /**
@@ -105,5 +106,18 @@ export default class FinanceServices {
     });
 
     return deletedSponsor;
+  }
+
+  static async getSingleSponsierTier(_submitter: User, sponsorId: string, organization: Organization): Promise<Sponsor> {
+    const sponsor = await prisma.sponsor.findUnique({
+      where: {
+        sponsorId
+      }
+    });
+
+    if (!sponsor) throw new NotFoundException('Sponsor', sponsorId);
+    if (sponsor.organizationId !== organization.organizationId) throw new InvalidOrganizationException('Sponsor');
+
+    return sponsor;
   }
 }

--- a/src/backend/src/services/finance.services.ts
+++ b/src/backend/src/services/finance.services.ts
@@ -125,8 +125,8 @@ export default class FinanceServices {
   /**
    * Get Sponsor Tier from sponsor ID
    * @param submitter the person getting the sponsor
-   * @param sponsorId ID of the sponsor 
-   * @param organization organization the person belongs to 
+   * @param sponsorId ID of the sponsor
+   * @param organization organization the person belongs to
    * @returns the designated sponsor tier
    */
   static async getSingleSponsorTier(submitter: User, sponsorId: string, organization: Organization): Promise<SponsorTier> {

--- a/src/backend/src/services/finance.services.ts
+++ b/src/backend/src/services/finance.services.ts
@@ -9,7 +9,6 @@ import {
   NotFoundException
 } from '../utils/errors.utils';
 import prisma from '../prisma/prisma';
-import { get } from 'http';
 
 export default class FinanceServices {
   /**

--- a/src/backend/src/services/finance.services.ts
+++ b/src/backend/src/services/finance.services.ts
@@ -130,24 +130,17 @@ export default class FinanceServices {
    * @returns the designated sponsor tier
    */
   static async getSingleSponsorTier(submitter: User, sponsorId: string, organization: Organization): Promise<SponsorTier> {
-    const sponsor = await prisma.sponsor.findUnique({
-      where: {
-        sponsorId
-      }
-    });
+    const sponsor = await prisma.sponsor.findUnique({ where: { sponsorId } });
 
     if (!(await userHasPermission(submitter.userId, organization.organizationId, isHead))) {
       throw new AccessDeniedException('Only heads can delete sponsors.');
     }
+
     if (!sponsor) throw new NotFoundException('Sponsor', sponsorId);
 
-    const sponsorTier = await prisma.sponsor_Tier.findUnique({
-      where: {
-        sponsorTierId: sponsor.sponsorTierId
-      }
-    });
+    const sponsorTier = await prisma.sponsor_Tier.findUnique({ where: { sponsorTierId: sponsor.sponsorTierId } });
 
-    if (!sponsorTier) throw new NotFoundException('SponsorTier', sponsor.sponsorTierId);
+    if (!sponsorTier) throw new NotFoundException('Sponsor Tier', sponsor.sponsorTierId);
 
     return sponsorTier;
   }

--- a/src/backend/src/services/finance.services.ts
+++ b/src/backend/src/services/finance.services.ts
@@ -143,7 +143,7 @@ export default class FinanceServices {
 
     return sponsorTier;
   }
-  
+
   /**
    * Creates a sponsor tier.
    * @param submitter current user creating the sponsor tier

--- a/src/backend/src/services/finance.services.ts
+++ b/src/backend/src/services/finance.services.ts
@@ -122,14 +122,32 @@ export default class FinanceServices {
     return deletedSponsor;
   }
 
-  static async getSingleSponsierTier(sponsorTierId: string): Promise<SponsorTier> {
-    const sponsorTier = await prisma.sponsor_Tier.findUnique({
+  /**
+   * Get Sponsor Tier from sponsor ID
+   * @param submitter the person getting the sponsor
+   * @param sponsorId ID of the sponsor 
+   * @param organization organization the person belongs to 
+   * @returns the designated sponsor tier
+   */
+  static async getSingleSponsorTier(submitter: User, sponsorId: string, organization: Organization): Promise<SponsorTier> {
+    const sponsor = await prisma.sponsor.findUnique({
       where: {
-        sponsorTierId
+        sponsorId
       }
     });
 
-    if (!sponsorTier) throw new NotFoundException('SponsorTier', sponsorTierId);
+    if (!(await userHasPermission(submitter.userId, organization.organizationId, isHead))) {
+      throw new AccessDeniedException('Only heads can delete sponsors.');
+    }
+    if (!sponsor) throw new NotFoundException('Sponsor', sponsorId);
+
+    const sponsorTier = await prisma.sponsor_Tier.findUnique({
+      where: {
+        sponsorTierId: sponsor.sponsorTierId
+      }
+    });
+
+    if (!sponsorTier) throw new NotFoundException('SponsorTier', sponsor.sponsorTierId);
 
     return sponsorTier;
   }

--- a/src/backend/src/services/finance.services.ts
+++ b/src/backend/src/services/finance.services.ts
@@ -120,7 +120,7 @@ export default class FinanceServices {
 
     return deletedSponsor;
   }
-  
+
   static async getSingleSponsierTier(_submitter: User, sponsorId: string, organization: Organization): Promise<Sponsor> {
     const sponsor = await prisma.sponsor.findUnique({
       where: {
@@ -130,10 +130,10 @@ export default class FinanceServices {
 
     if (!sponsor) throw new NotFoundException('Sponsor', sponsorId);
     if (sponsor.organizationId !== organization.organizationId) throw new InvalidOrganizationException('Sponsor');
-    
+
     return sponsor;
   }
-  
+
   static async createSponsorTier(submitter: User, name: string, organization: Organization, colorHexCode: string) {
     if (!(await userHasPermission(submitter.userId, organization.organizationId, isHead)))
       throw new AccessDeniedAdminOnlyException('create a sponsor tier');
@@ -148,5 +148,7 @@ export default class FinanceServices {
         organization: true
       }
     });
+
+    return sponsor;
   }
 }

--- a/src/backend/src/services/finance.services.ts
+++ b/src/backend/src/services/finance.services.ts
@@ -1,4 +1,4 @@
-import { isHead } from 'shared';
+import { isHead, SponsorTier } from 'shared';
 import { User, Organization, Sponsor_Task, Sponsor } from '@prisma/client';
 import { userHasPermission } from '../utils/users.utils';
 import { getSponsorQueryArgs } from '../prisma-query-args/sponsor.query.args';
@@ -121,17 +121,16 @@ export default class FinanceServices {
     return deletedSponsor;
   }
 
-  static async getSingleSponsierTier(_submitter: User, sponsorId: string, organization: Organization): Promise<Sponsor> {
-    const sponsor = await prisma.sponsor.findUnique({
+  static async getSingleSponsierTier(sponsorTierId: string): Promise<SponsorTier> {
+    const sponsorTier = await prisma.sponsor_Tier.findUnique({
       where: {
-        sponsorId
+        sponsorTierId
       }
     });
 
-    if (!sponsor) throw new NotFoundException('Sponsor', sponsorId);
-    if (sponsor.organizationId !== organization.organizationId) throw new InvalidOrganizationException('Sponsor');
+    if (!sponsorTier) throw new NotFoundException('SponsorTier', sponsorTierId);
 
-    return sponsor;
+    return sponsorTier;
   }
 
   static async createSponsorTier(submitter: User, name: string, organization: Organization, colorHexCode: string) {

--- a/src/backend/src/utils/errors.utils.ts
+++ b/src/backend/src/utils/errors.utils.ts
@@ -144,4 +144,4 @@ export type ExceptionObjectNames =
   | 'Graph'
   | 'Graph Collection'
   | 'Sponsor'
-  | 'SponsorTier';
+  | 'Sponsor Tier';

--- a/src/backend/src/utils/errors.utils.ts
+++ b/src/backend/src/utils/errors.utils.ts
@@ -143,4 +143,5 @@ export type ExceptionObjectNames =
   | 'Announcement'
   | 'Graph'
   | 'Graph Collection'
-  | 'Sponsor';
+  | 'Sponsor'
+  | 'SponsorTier';

--- a/src/backend/tests/unit/finance.test.ts
+++ b/src/backend/tests/unit/finance.test.ts
@@ -220,16 +220,21 @@ describe('Finance Tests', () => {
   });
 
   describe('Get Single Sponsor Tier', () => {
-    it('Succeeds and retrieves the sponsor tier', async () => {
-      const sponsorTier1 = await FinanceServices.createSponsorTier(
-        await createTestUser(batmanAppAdmin, orgId),
-        'Silver',
-        organization,
-        'C0C0C0'
-      );
+    let batmanAdminUser;
+    let supermanAdminUser;
+    let wonderwomanGuestUser;
+    let sponsorTier1;
+    let sponsor1;
 
-      const sponsor1 = await FinanceServices.createSponsor(
-        await createTestUser(supermanAdmin, orgId),
+    beforeAll(async () => {
+      batmanAdminUser = await createTestUser(batmanAppAdmin, orgId);
+      supermanAdminUser = await createTestUser(supermanAdmin, orgId);
+      wonderwomanGuestUser = await createTestUser(wonderwomanGuest, orgId);
+
+      sponsorTier1 = await FinanceServices.createSponsorTier(batmanAdminUser, 'Silver', organization, 'C0C0C0');
+
+      sponsor1 = await FinanceServices.createSponsor(
+        supermanAdminUser,
         'Google',
         true,
         5000,
@@ -242,12 +247,10 @@ describe('Finance Tests', () => {
         organization,
         'googlecode'
       );
+    });
 
-      const result = await FinanceServices.getSingleSponsorTier(
-        await createTestUser(batmanAppAdmin, orgId),
-        sponsor1.sponsorId,
-        organization
-      );
+    it('Succeeds and retrieves the sponsor tier', async () => {
+      const result = await FinanceServices.getSingleSponsorTier(batmanAdminUser, sponsor1.sponsorId, organization);
 
       expect(result.colorHexCode).toEqual(sponsorTier1.colorHexCode);
       expect(result.name).toEqual(sponsorTier1.name);
@@ -257,28 +260,13 @@ describe('Finance Tests', () => {
     it('Get a single Sponsor Tier fails', async () => {
       const nonexistentTierId = 'nonexistingTierId';
       await expect(async () =>
-        FinanceServices.getSingleSponsorTier(await createTestUser(batmanAppAdmin, orgId), nonexistentTierId, organization)
+        FinanceServices.getSingleSponsorTier(batmanAdminUser, nonexistentTierId, organization)
       ).rejects.toThrow(new NotFoundException('Sponsor', nonexistentTierId));
     });
 
     it('Fails if user is not a head', async () => {
-      const sponsor1 = await FinanceServices.createSponsor(
-        await createTestUser(supermanAdmin, orgId),
-        'Google',
-        true,
-        5000,
-        new Date(12, 1, 24),
-        [2024, 2025],
-        sponsorTierId,
-        true,
-        'Bill Gates',
-        [],
-        organization,
-        'googlecode'
-      );
-
       await expect(async () =>
-        FinanceServices.getSingleSponsorTier(await createTestUser(wonderwomanGuest, orgId), sponsor1.sponsorId, organization)
+        FinanceServices.getSingleSponsorTier(wonderwomanGuestUser, sponsor1.sponsorId, organization)
       ).rejects.toThrow(new AccessDeniedException('Only heads can delete sponsors.'));
     });
   });

--- a/src/backend/tests/unit/finance.test.ts
+++ b/src/backend/tests/unit/finance.test.ts
@@ -218,4 +218,39 @@ describe('Finance Tests', () => {
       expect(result.organizationId).toEqual(orgId);
     });
   });
+
+  // describe('Get Sponsor Tier', () => {
+  //   it('Succeeds and retrieves the sponsor tier', async () => {
+  //     const spon1 = await FinanceServices.createSponsorTier(
+  //       await createTestUser(batmanAppAdmin, orgId), 
+
+  //     const testUser = await createTestUser(batmanAppAdmin, orgId);
+  //     const result = await FinanceServices.getSingleSponsierTier(sponsorTierId);
+
+  //     expect(result).toStrictEqual(spon1);
+  //   });
+
+  //   it('Fails to retrieve a Single Sponsor Tier', async () => {
+  //     const nonExistingSponsorTier = "nonExistingId";
+  //     it('Succeeds and retrieves the sponsor tier', async () => {
+  //       const spon1 = await FinanceServices.createSponsor(
+  //         await createTestUser(batmanAppAdmin, orgId),
+  //         'Google',
+  //         true,
+  //         5000,
+  //         new Date(12, 1, 24),
+  //         [2024, 2025],
+  //         sponsorTierId,
+  //         true,
+  //         'Bill Gates',
+  //         [],
+  //         organization,
+  //         'googlecode'
+  //       );
+  //       const testUser = await createTestUser(batmanAppAdmin, orgId);
+
+  //     await expect(async () => 
+  //     FinanceServices.getSingleSponsierTier(testUser, spon1.sponsorId, nonExistingSponsorTier)).rejects.toThrow(new NotFoundException('SponsorTier', nonExistingSponsorTier));
+  //   })
+  // });
 });

--- a/src/backend/tests/unit/finance.test.ts
+++ b/src/backend/tests/unit/finance.test.ts
@@ -258,7 +258,7 @@ describe('Finance Tests', () => {
       const nonexistentTierId = 'nonexistingTierId';
       await expect(async () =>
         FinanceServices.getSingleSponsorTier(await createTestUser(batmanAppAdmin, orgId), nonexistentTierId, organization)
-      ).rejects.toThrow(new NotFoundException('SponsorTier', nonexistentTierId));
+      ).rejects.toThrow(new NotFoundException('Sponsor', nonexistentTierId));
     });
 
     it('Fails if user is not a head', async () => {

--- a/src/backend/tests/unit/finance.test.ts
+++ b/src/backend/tests/unit/finance.test.ts
@@ -221,12 +221,12 @@ describe('Finance Tests', () => {
 
   describe('Get Single Sponsor Tier', () => {
     it('Succeeds and retrieves the sponsor tier', async () => {
-      // const sponsorTier1 = await FinanceServices.createSponsorTier(
-      //   await createTestUser(batmanAppAdmin, orgId),
-      //   'Silver',
-      //   organization,
-      //   'C0C0C0'
-      // );
+      const sponsorTier1 = await FinanceServices.createSponsorTier(
+        await createTestUser(batmanAppAdmin, orgId),
+        'Silver',
+        organization,
+        'C0C0C0'
+      );
 
       const sponsor1 = await FinanceServices.createSponsor(
         await createTestUser(supermanAdmin, orgId),
@@ -235,7 +235,7 @@ describe('Finance Tests', () => {
         5000,
         new Date(12, 1, 24),
         [2024, 2025],
-        sponsorTierId,
+        sponsorTier1.sponsorTierId,
         true,
         'Bill Gates',
         [],
@@ -249,8 +249,9 @@ describe('Finance Tests', () => {
         organization
       );
 
-      expect(result.name).toEqual(sponsor1.name);
-      expect(result.sponsorTierId).toEqual(sponsorTierId);
+      expect(result.name).toEqual(sponsorTier1.name);
+      expect(result.sponsorTierId).toEqual(sponsorTier1.sponsorTierId);
+      expect(result.colorHexCode).toEqual(sponsorTier1.colorHexCode);
     });
 
     it('Get a single Sponsor Tier fails', async () => {

--- a/src/backend/tests/unit/finance.test.ts
+++ b/src/backend/tests/unit/finance.test.ts
@@ -241,7 +241,7 @@ describe('Finance Tests', () => {
       );
     });
   });
-  
+
   describe('Get Sponsor Tasks', () => {
     it('Succeeds and gets the sponsor tasks from a sponsor', async () => {
       const sponsor = await FinanceServices.createSponsor(

--- a/src/backend/tests/unit/finance.test.ts
+++ b/src/backend/tests/unit/finance.test.ts
@@ -221,15 +221,11 @@ describe('Finance Tests', () => {
 
   describe('Get Single Sponsor Tier', () => {
     it('Succeeds and retrieves the sponsor tier', async () => {
-      const sponsorTier1 = await FinanceServices.createSponsorTier(
-        await createTestUser(batmanAppAdmin, orgId),
-        'Silver',
-        organization,
-        'C0C0C0'
-      );
+      const user = await createTestUser(batmanAppAdmin, orgId);
+      const sponsorTier1 = await FinanceServices.createSponsorTier(user, 'Silver', organization, 'C0C0C0');
 
       const sponsor1 = await FinanceServices.createSponsor(
-        await createTestUser(supermanAdmin, orgId),
+        user,
         'Google',
         true,
         5000,
@@ -243,11 +239,7 @@ describe('Finance Tests', () => {
         'googlecode'
       );
 
-      const result = await FinanceServices.getSingleSponsorTier(
-        await createTestUser(batmanAppAdmin, orgId),
-        sponsor1.sponsorId,
-        organization
-      );
+      const result = await FinanceServices.getSingleSponsorTier(user, sponsor1.sponsorId, organization);
 
       expect(result.name).toEqual(sponsorTier1.name);
       expect(result.sponsorTierId).toEqual(sponsorTier1.sponsorTierId);

--- a/src/backend/tests/unit/finance.test.ts
+++ b/src/backend/tests/unit/finance.test.ts
@@ -227,7 +227,27 @@ describe('Finance Tests', () => {
         organization,
         'C0C0C0'
       );
-      const result = await FinanceServices.getSingleSponsierTier(sponsorTier1.sponsorTierId);
+
+      const sponsor1 = await FinanceServices.createSponsor(
+        await createTestUser(supermanAdmin, orgId),
+        'Google',
+        true,
+        5000,
+        new Date(12, 1, 24),
+        [2024, 2025],
+        sponsorTierId,
+        true,
+        'Bill Gates',
+        [],
+        organization,
+        'googlecode'
+      );
+
+      const result = await FinanceServices.getSingleSponsorTier(
+        await createTestUser(batmanAppAdmin, orgId),
+        sponsor1.sponsorId,
+        organization
+      );
 
       expect(result.colorHexCode).toEqual(sponsorTier1.colorHexCode);
       expect(result.name).toEqual(sponsorTier1.name);
@@ -236,9 +256,30 @@ describe('Finance Tests', () => {
 
     it('Get a single Sponsor Tier fails', async () => {
       const nonexistentTierId = 'nonexistingTierId';
-      await expect(async () => FinanceServices.getSingleSponsierTier(nonexistentTierId)).rejects.toThrow(
-        new NotFoundException('SponsorTier', nonexistentTierId)
+      await expect(async () =>
+        FinanceServices.getSingleSponsorTier(await createTestUser(batmanAppAdmin, orgId), nonexistentTierId, organization)
+      ).rejects.toThrow(new NotFoundException('SponsorTier', nonexistentTierId));
+    });
+
+    it('Fails if user is not a head', async () => {
+      const sponsor1 = await FinanceServices.createSponsor(
+        await createTestUser(supermanAdmin, orgId),
+        'Google',
+        true,
+        5000,
+        new Date(12, 1, 24),
+        [2024, 2025],
+        sponsorTierId,
+        true,
+        'Bill Gates',
+        [],
+        organization,
+        'googlecode'
       );
+
+      await expect(async () =>
+        FinanceServices.getSingleSponsorTier(await createTestUser(wonderwomanGuest, orgId), sponsor1.sponsorId, organization)
+      ).rejects.toThrow(new AccessDeniedException('Only heads can delete sponsors.'));
     });
   });
 

--- a/src/backend/tests/unit/finance.test.ts
+++ b/src/backend/tests/unit/finance.test.ts
@@ -220,21 +220,16 @@ describe('Finance Tests', () => {
   });
 
   describe('Get Single Sponsor Tier', () => {
-    let batmanAdminUser;
-    let supermanAdminUser;
-    let wonderwomanGuestUser;
-    let sponsorTier1;
-    let sponsor1;
+    it('Succeeds and retrieves the sponsor tier', async () => {
+      // const sponsorTier1 = await FinanceServices.createSponsorTier(
+      //   await createTestUser(batmanAppAdmin, orgId),
+      //   'Silver',
+      //   organization,
+      //   'C0C0C0'
+      // );
 
-    beforeAll(async () => {
-      batmanAdminUser = await createTestUser(batmanAppAdmin, orgId);
-      supermanAdminUser = await createTestUser(supermanAdmin, orgId);
-      wonderwomanGuestUser = await createTestUser(wonderwomanGuest, orgId);
-
-      sponsorTier1 = await FinanceServices.createSponsorTier(batmanAdminUser, 'Silver', organization, 'C0C0C0');
-
-      sponsor1 = await FinanceServices.createSponsor(
-        supermanAdminUser,
+      const sponsor1 = await FinanceServices.createSponsor(
+        await createTestUser(supermanAdmin, orgId),
         'Google',
         true,
         5000,
@@ -247,26 +242,42 @@ describe('Finance Tests', () => {
         organization,
         'googlecode'
       );
-    });
 
-    it('Succeeds and retrieves the sponsor tier', async () => {
-      const result = await FinanceServices.getSingleSponsorTier(batmanAdminUser, sponsor1.sponsorId, organization);
+      const result = await FinanceServices.getSingleSponsorTier(
+        await createTestUser(batmanAppAdmin, orgId),
+        sponsor1.sponsorId,
+        organization
+      );
 
-      expect(result.colorHexCode).toEqual(sponsorTier1.colorHexCode);
-      expect(result.name).toEqual(sponsorTier1.name);
-      expect(result.sponsorTierId).toEqual(sponsorTier1.sponsorTierId);
+      expect(result.name).toEqual(sponsor1.name);
+      expect(result.sponsorTierId).toEqual(sponsorTierId);
     });
 
     it('Get a single Sponsor Tier fails', async () => {
       const nonexistentTierId = 'nonexistingTierId';
       await expect(async () =>
-        FinanceServices.getSingleSponsorTier(batmanAdminUser, nonexistentTierId, organization)
+        FinanceServices.getSingleSponsorTier(await createTestUser(batmanAppAdmin, orgId), nonexistentTierId, organization)
       ).rejects.toThrow(new NotFoundException('Sponsor', nonexistentTierId));
     });
 
     it('Fails if user is not a head', async () => {
+      const sponsor1 = await FinanceServices.createSponsor(
+        await createTestUser(supermanAdmin, orgId),
+        'Google',
+        true,
+        5000,
+        new Date(12, 1, 24),
+        [2024, 2025],
+        sponsorTierId,
+        true,
+        'Bill Gates',
+        [],
+        organization,
+        'googlecode'
+      );
+
       await expect(async () =>
-        FinanceServices.getSingleSponsorTier(wonderwomanGuestUser, sponsor1.sponsorId, organization)
+        FinanceServices.getSingleSponsorTier(await createTestUser(wonderwomanGuest, orgId), sponsor1.sponsorId, organization)
       ).rejects.toThrow(new AccessDeniedException('Only heads can delete sponsors.'));
     });
   });

--- a/src/backend/tests/unit/finance.test.ts
+++ b/src/backend/tests/unit/finance.test.ts
@@ -219,38 +219,20 @@ describe('Finance Tests', () => {
     });
   });
 
-  // describe('Get Sponsor Tier', () => {
-  //   it('Succeeds and retrieves the sponsor tier', async () => {
-  //     const spon1 = await FinanceServices.createSponsorTier(
-  //       await createTestUser(batmanAppAdmin, orgId), 
+  describe('Get Sponsor Tier', () => {
+    it('Succeeds and retrieves the sponsor tier', async () => {
+      const sponsorTier1 = await FinanceServices.createSponsorTier(await createTestUser(batmanAppAdmin, orgId), 'Silver', organization, 'C0C0C0');
+      const result = await FinanceServices.getSingleSponsierTier(sponsorTier1.sponsorTierId);
 
-  //     const testUser = await createTestUser(batmanAppAdmin, orgId);
-  //     const result = await FinanceServices.getSingleSponsierTier(sponsorTierId);
+      expect(result).toStrictEqual(sponsorTier1);
+    }); 
 
-  //     expect(result).toStrictEqual(spon1);
-  //   });
-
-  //   it('Fails to retrieve a Single Sponsor Tier', async () => {
-  //     const nonExistingSponsorTier = "nonExistingId";
-  //     it('Succeeds and retrieves the sponsor tier', async () => {
-  //       const spon1 = await FinanceServices.createSponsor(
-  //         await createTestUser(batmanAppAdmin, orgId),
-  //         'Google',
-  //         true,
-  //         5000,
-  //         new Date(12, 1, 24),
-  //         [2024, 2025],
-  //         sponsorTierId,
-  //         true,
-  //         'Bill Gates',
-  //         [],
-  //         organization,
-  //         'googlecode'
-  //       );
-  //       const testUser = await createTestUser(batmanAppAdmin, orgId);
-
-  //     await expect(async () => 
-  //     FinanceServices.getSingleSponsierTier(testUser, spon1.sponsorId, nonExistingSponsorTier)).rejects.toThrow(new NotFoundException('SponsorTier', nonExistingSponsorTier));
-  //   })
-  // });
+    it('Get a single Sponsor Tier fails', async () => {
+      const nonexistentTierId = 'nonexistingTierId';
+      await expect(async () => 
+      FinanceServices.getSingleSponsierTier(nonexistentTierId)).rejects.toThrow(
+        new NotFoundException('SponsorTier', nonexistentTierId)
+      );
+    });
+  });
 });

--- a/src/backend/tests/unit/finance.test.ts
+++ b/src/backend/tests/unit/finance.test.ts
@@ -219,18 +219,24 @@ describe('Finance Tests', () => {
     });
   });
 
-  describe('Get Sponsor Tier', () => {
+  describe('Get Single Sponsor Tier', () => {
     it('Succeeds and retrieves the sponsor tier', async () => {
-      const sponsorTier1 = await FinanceServices.createSponsorTier(await createTestUser(batmanAppAdmin, orgId), 'Silver', organization, 'C0C0C0');
+      const sponsorTier1 = await FinanceServices.createSponsorTier(
+        await createTestUser(batmanAppAdmin, orgId),
+        'Silver',
+        organization,
+        'C0C0C0'
+      );
       const result = await FinanceServices.getSingleSponsierTier(sponsorTier1.sponsorTierId);
 
-      expect(result).toStrictEqual(sponsorTier1);
-    }); 
+      expect(result.colorHexCode).toEqual(sponsorTier1.colorHexCode);
+      expect(result.name).toEqual(sponsorTier1.name);
+      expect(result.sponsorTierId).toEqual(sponsorTier1.sponsorTierId);
+    });
 
     it('Get a single Sponsor Tier fails', async () => {
       const nonexistentTierId = 'nonexistingTierId';
-      await expect(async () => 
-      FinanceServices.getSingleSponsierTier(nonexistentTierId)).rejects.toThrow(
+      await expect(async () => FinanceServices.getSingleSponsierTier(nonexistentTierId)).rejects.toThrow(
         new NotFoundException('SponsorTier', nonexistentTierId)
       );
     });


### PR DESCRIPTION
## Changes

Created a get Single Sponsor Tier Endpoint where it takes in the SponsorTierId and return the SponsorTier

## Screenshots

<img width="750" alt="Screenshot 2025-03-28 at 11 21 30 AM" src="https://github.com/user-attachments/assets/f4efbeda-972c-43f5-a9d2-832bf39e7f1e" />


## To Do

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #3195 
