### PR TITLE
#3229 - Make Changed WBS Bullets Visible

### DIFF
--- a/src/frontend/src/pages/ChangeRequestDetailPage/DiffSection/DiffPanel.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/DiffSection/DiffPanel.tsx
@@ -107,11 +107,11 @@ const DiffPanel: React.FC<ProjectDiffPanelProps> = ({
     } else if (Array.isArray(detailText) && detailText.length > 0) {
       if (typeof detailText[0] === 'string') {
         return (
-          <List sx={{ listStyleType: 'disc', pl: 6 }}>
+          <List sx={{ listStyleType: 'disc', pl: 6, pb: 1, pt: 0 }}>
             {(detailText as string[]).map((bullet) => {
               const url = bullet.includes('http') ? bullet.split(': ')[1] : undefined;
               return (
-                <ListItem sx={{ display: 'list-item' }}>
+                <ListItem sx={{ display: 'list-item', py: 0 }}>
                   {url ? (
                     <>
                       {bullet.split(': ')[0]}:{' '}
@@ -132,7 +132,7 @@ const DiffPanel: React.FC<ProjectDiffPanelProps> = ({
   };
 
   return (
-    <Box>
+    <Box sx={{ padding: '8px' }}>
       {changeBullets.map((changeBullet) => {
         return (
           <>

--- a/src/frontend/src/utils/diff-page.utils.ts
+++ b/src/frontend/src/utils/diff-page.utils.ts
@@ -59,7 +59,7 @@ export const changeBulletDetailText = (changeBullet: ChangeBullet): string | str
     return detail as string[];
   } else if ('teamName' in testVal) {
     return (detail as TeamPreview[]).map((team) => team.teamName);
-  } else if ('userChecked' in testVal) {
+  } else if ('detail' in testVal && 'type' in testVal) {
     return (detail as DescriptionBullet[]).map((bullet) => bullet.detail);
   } else if ('carNumber' in testVal) {
     return (detail as WbsNumber[]).map(wbsPipe);


### PR DESCRIPTION
## Changes

The function `changeBulletDetailText` has a very hacky sort of "see which fields are in this object" to cast it to the right type and apply the appropriate pipe. (Can you find a better idea?) For the DescriptionBullet, modify the fields to look for from the optional `userChecked` to a combination of the required `detail`+`type` in order to identify DescriptionBullets without userChecked field.

Clean up view to remove unsightly spacing between bullet points.

## Notes

Tried to look into cleaner ways to write it, but it seems this method is common in JS?

MUI padding can have units (e.g. "12px") or not (e.g. 2). By default if there are no units the default unit is [8px](https://mui.com/material-ui/customization/spacing/).

Description bullets are listed under "Description Bullets," not the specific category of bullet (i.e. Deliverable). (Is this a bug?)

## Test Cases

No automated tests :(

(See screenshots)
- Description bullets appear in Edit WP CR (both panels).
- Description bullets appear in Create WP CR.
- Description bullets appear in Create Project CR.
- Description bullets do NOT appear if nothing created or edited.

## Screenshots

<img width="456" alt="Screenshot 2025-03-21 at 5 14 07 PM" src="https://github.com/user-attachments/assets/8a476e67-aa28-47a9-a566-0b3ff5b6a6cd" />
<img width="717" alt="Screenshot 2025-03-21 at 5 12 19 PM" src="https://github.com/user-attachments/assets/4643093a-f3cd-49fc-8bd8-debe25258552" />
<img width="518" alt="Screenshot 2025-03-21 at 4 58 27 PM" src="https://github.com/user-attachments/assets/2d488f0b-2107-419c-9e8d-ba46eae29411" />
<img width="377" alt="Screenshot 2025-03-21 at 4 58 13 PM" src="https://github.com/user-attachments/assets/6f1ed88e-9097-4805-ad8b-6a4b58615a95" />
<img width="418" alt="Screenshot 2025-03-21 at 4 56 04 PM" src="https://github.com/user-attachments/assets/359fd5a3-21d3-4285-92e8-a903b26930a0" />
<img width="512" alt="Screenshot 2025-03-21 at 4 53 56 PM" src="https://github.com/user-attachments/assets/021ff568-8a57-45b2-be83-a605bdc5cdca" />
<img width="1439" alt="Screenshot 2025-03-21 at 4 53 40 PM" src="https://github.com/user-attachments/assets/24186179-9acf-411c-9194-1c941624b0ab" />

## To Do

See Notes and do we need tests?

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3229
