### PR TITLE
#3296 create sponsor task endpoint

### DIFF
--- a/src/backend/src/controllers/finance.controllers.ts
+++ b/src/backend/src/controllers/finance.controllers.ts
@@ -81,7 +81,8 @@ export default class FinanceController {
 
   static async createSponsorTask(req: Request, res: Response, next: NextFunction) {
     try {
-      const { dueDate, notes, sponsorId, notifyDate, assigneeId } = req.body;
+      const { dueDate, notes, notifyDate, assigneeId } = req.body;
+      const { sponsorId } = req.params;
 
       const sponsorTask = await FinanceServices.createSponsorTask(
         req.currentUser,

--- a/src/backend/src/controllers/finance.controllers.ts
+++ b/src/backend/src/controllers/finance.controllers.ts
@@ -78,4 +78,23 @@ export default class FinanceController {
       next(error);
     }
   }
+
+  static async createSponsorTask(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { dueDate, notes, sponsorId, notifyDate, assigneeId } = req.body;
+
+      const sponsorTask = await FinanceServices.createSponsorTask(
+        req.currentUser,
+        req.organization,
+        dueDate,
+        notes,
+        sponsorId,
+        notifyDate,
+        assigneeId
+      );
+      res.status(200).json(sponsorTask);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
 }

--- a/src/backend/src/prisma/seed.ts
+++ b/src/backend/src/prisma/seed.ts
@@ -2034,16 +2034,9 @@ const performSeed: () => Promise<void> = async () => {
     ner.organizationId
   );
 
-  // to be replaced with createSponsorTier
-  const sponsorTier = await prisma.sponsor_Tier.create({
-    data: {
-      name: 'Gold Tier',
-      colorHexCode: '#FFFFFF',
-      organizationId: ner.organizationId
-    }
-  });
+  const sponsorTier = await FinanceServices.createSponsorTier(thomasEmrax, 'Gold Tier', ner, '#FFFFFF');
 
-  await FinanceServices.createSponsor(
+  const sponsor = await FinanceServices.createSponsor(
     thomasEmrax,
     'Google',
     true,
@@ -2058,7 +2051,15 @@ const performSeed: () => Promise<void> = async () => {
     'googlecode'
   );
 
-  await FinanceServices.createSponsorTier(thomasEmrax, 'Silver', ner, 'C0C0C0');
+  await FinanceServices.createSponsorTask(
+    thomasEmrax,
+    ner,
+    new Date(12, 1, 25),
+    'notes...',
+    sponsor.sponsorId,
+    new Date(7, 5, 25),
+    thomasEmrax.userId
+  );
 };
 
 performSeed()

--- a/src/backend/src/prisma/seed.ts
+++ b/src/backend/src/prisma/seed.ts
@@ -2034,7 +2034,9 @@ const performSeed: () => Promise<void> = async () => {
     ner.organizationId
   );
 
-  const sponsorTier = await FinanceServices.createSponsorTier(thomasEmrax, 'Gold Tier', ner, '#FFFFFF');
+  const goldSponsorTier = await FinanceServices.createSponsorTier(thomasEmrax, 'Gold Tier', ner, '#FFD700');
+  await FinanceServices.createSponsorTier(thomasEmrax, 'Silver Tier', ner, '#C0C0C0');
+  await FinanceServices.createSponsorTier(thomasEmrax, 'Bronze Tier', ner, '#CD7F32');
 
   const sponsor = await FinanceServices.createSponsor(
     thomasEmrax,
@@ -2043,7 +2045,7 @@ const performSeed: () => Promise<void> = async () => {
     5000,
     new Date(12, 1, 24),
     [2024, 2025],
-    sponsorTier.sponsorTierId,
+    goldSponsorTier.sponsorTierId,
     true,
     'Bill Gates',
     [],

--- a/src/backend/src/routes/finance.routes.ts
+++ b/src/backend/src/routes/finance.routes.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { nonEmptyString, validateInputs, isDate } from '../utils/validation.utils';
+import { nonEmptyString, validateInputs, isDate, isOptionalDate } from '../utils/validation.utils';
 import { body } from 'express-validator';
 import FinanceController from '../controllers/finance.controllers';
 
@@ -33,6 +33,17 @@ financeRouter.post(
   nonEmptyString(body('colorHexCode')),
   validateInputs,
   FinanceController.createSponsorTier
+);
+
+financeRouter.post(
+  '/sponsorTask/create',
+  isDate(body('dueDate')),
+  nonEmptyString(body('notes')),
+  nonEmptyString(body('notes')),
+  nonEmptyString(body('sponsorId')),
+  isOptionalDate(body('notifyDate')),
+  nonEmptyString(body('assigneeId')).optional(),
+  FinanceController.createSponsorTask
 );
 
 export default financeRouter;

--- a/src/backend/src/routes/finance.routes.ts
+++ b/src/backend/src/routes/finance.routes.ts
@@ -40,7 +40,7 @@ financeRouter.post(
   isDate(body('dueDate')),
   nonEmptyString(body('notes')),
   nonEmptyString(body('sponsorId')),
-  isOptionalDate(body('notifyDate')),
+  isOptionalDate(body('notifyDate')).optional(),
   nonEmptyString(body('assigneeId')).optional(),
   FinanceController.createSponsorTask
 );

--- a/src/backend/src/routes/finance.routes.ts
+++ b/src/backend/src/routes/finance.routes.ts
@@ -40,8 +40,9 @@ financeRouter.post(
   isDate(body('dueDate')),
   nonEmptyString(body('notes')),
   nonEmptyString(body('sponsorId')),
-  isOptionalDate(body('notifyDate')).optional(),
-  nonEmptyString(body('assigneeId')).optional(),
+  isOptionalDate(body('notifyDate')),
+  nonEmptyString(body('assigneeId').optional()),
+  validateInputs,
   FinanceController.createSponsorTask
 );
 

--- a/src/backend/src/routes/finance.routes.ts
+++ b/src/backend/src/routes/finance.routes.ts
@@ -36,10 +36,9 @@ financeRouter.post(
 );
 
 financeRouter.post(
-  '/sponsorTask/create',
+  '/sponsor/:sponsorId/sponsorTasks',
   isDate(body('dueDate')),
   nonEmptyString(body('notes')),
-  nonEmptyString(body('sponsorId')),
   isOptionalDate(body('notifyDate')),
   nonEmptyString(body('assigneeId').optional()),
   validateInputs,

--- a/src/backend/src/routes/finance.routes.ts
+++ b/src/backend/src/routes/finance.routes.ts
@@ -39,7 +39,6 @@ financeRouter.post(
   '/sponsorTask/create',
   isDate(body('dueDate')),
   nonEmptyString(body('notes')),
-  nonEmptyString(body('notes')),
   nonEmptyString(body('sponsorId')),
   isOptionalDate(body('notifyDate')),
   nonEmptyString(body('assigneeId')).optional(),

--- a/src/backend/src/services/finance.services.ts
+++ b/src/backend/src/services/finance.services.ts
@@ -3,7 +3,6 @@ import { User, Organization, Sponsor_Task, Sponsor } from '@prisma/client';
 import { userHasPermission } from '../utils/users.utils';
 import { getSponsorQueryArgs, getSponsorTaskQueryArgs } from '../prisma-query-args/sponsor.query.args';
 import {
-  AccessDeniedAdminOnlyException,
   AccessDeniedException,
   DeletedException,
   InvalidOrganizationException,
@@ -49,7 +48,7 @@ export default class FinanceServices {
     discountCode?: string
   ) {
     if (!(await userHasPermission(submitter.userId, organization.organizationId, isHead)))
-      throw new AccessDeniedAdminOnlyException('Only heads can create a sponsor');
+      throw new AccessDeniedException('Only heads can create a sponsor');
 
     const sponsor = await prisma.sponsor.create({
       data: {
@@ -132,7 +131,7 @@ export default class FinanceServices {
    */
   static async createSponsorTier(submitter: User, name: string, organization: Organization, colorHexCode: string) {
     if (!(await userHasPermission(submitter.userId, organization.organizationId, isHead)))
-      throw new AccessDeniedAdminOnlyException('Only heads can create a sponsor tier');
+      throw new AccessDeniedException('Only heads can create a sponsor tier');
 
     const sponsorTier = await prisma.sponsor_Tier.create({
       data: {
@@ -191,7 +190,7 @@ export default class FinanceServices {
     assigneeUserId?: string
   ) {
     if (!(await userHasPermission(submitter.userId, organization.organizationId, isHead))) {
-      throw new AccessDeniedAdminOnlyException('Only heads can create a sponsor task');
+      throw new AccessDeniedException('Only heads can create a sponsor task');
     }
 
     const sponsor = await prisma.sponsor.findUnique({ where: { sponsorId }, include: { sponsorTasks: true } });
@@ -214,14 +213,6 @@ export default class FinanceServices {
       ...getSponsorTaskQueryArgs(organization.organizationId)
     });
 
-    const updatedSponsor = await prisma.sponsor.findUnique({
-      where: { sponsorId },
-      include: { sponsorTasks: true }
-    });
-
-    return {
-      ...sponsorTaskTransformer(createdSponsorTask),
-      updatedSponsor
-    };
+    return sponsorTaskTransformer(createdSponsorTask);
   }
 }

--- a/src/backend/src/services/finance.services.ts
+++ b/src/backend/src/services/finance.services.ts
@@ -1,7 +1,7 @@
 import { isHead } from 'shared';
 import { User, Organization, Sponsor_Task, Sponsor } from '@prisma/client';
 import { userHasPermission } from '../utils/users.utils';
-import { getSponsorQueryArgs } from '../prisma-query-args/sponsor.query.args';
+import { getSponsorQueryArgs, getSponsorTaskQueryArgs } from '../prisma-query-args/sponsor.query.args';
 import {
   AccessDeniedAdminOnlyException,
   AccessDeniedException,
@@ -132,7 +132,7 @@ export default class FinanceServices {
    */
   static async createSponsorTier(submitter: User, name: string, organization: Organization, colorHexCode: string) {
     if (!(await userHasPermission(submitter.userId, organization.organizationId, isHead)))
-      throw new AccessDeniedAdminOnlyException('create a sponsor tier');
+      throw new AccessDeniedAdminOnlyException('Only heads can create a sponsor tier');
 
     const sponsorTier = await prisma.sponsor_Tier.create({
       data: {
@@ -176,7 +176,7 @@ export default class FinanceServices {
    * @param sponsorId the sponsor associated with this sponsor task
    * @param notifyDate notification date for this sponsor tasks
    * @param assigneeUserId assignee of this sponsor task
-   * @returns newly created sponsor task
+   * @returns newly created sponsor task, and the given sponsor updated with this sponsor task added
    * @throws AccessDeniedAdminOnlyException if the user lacks permissions.
    * @throws NotFoundException if the sponsor or assignee is not found.
    * @throws DeletedException if the sponsor is marked as deleted.
@@ -194,9 +194,9 @@ export default class FinanceServices {
       throw new AccessDeniedAdminOnlyException('Only heads can create a sponsor task');
     }
 
-    const sponsor = await prisma.sponsor.findUnique({ where: { sponsorId } });
+    const sponsor = await prisma.sponsor.findUnique({ where: { sponsorId }, include: { sponsorTasks: true } });
     if (!sponsor) throw new NotFoundException('Sponsor', sponsorId);
-    if (sponsor.dateCreated) throw new DeletedException('Sponsor', sponsorId);
+    if (sponsor.dateDeleted) throw new DeletedException('Sponsor', sponsorId);
 
     if (assigneeUserId) {
       const assignee = await prisma.user.findUnique({ where: { userId: assigneeUserId } });
@@ -207,21 +207,21 @@ export default class FinanceServices {
       data: {
         dueDate,
         notifyDate,
-        assignee: { connect: { userId: assigneeUserId } },
+        assignee: assigneeUserId ? { connect: { userId: assigneeUserId } } : undefined,
         notes,
         sponsor: { connect: { sponsorId } }
       },
-      include: {
-        assignee: {
-          include: {
-            organizations: true,
-            roles: true
-          }
-        },
-        sponsor: true
-      }
+      ...getSponsorTaskQueryArgs(organization.organizationId)
     });
 
-    return sponsorTaskTransformer(createdSponsorTask);
+    const updatedSponsor = await prisma.sponsor.findUnique({
+      where: { sponsorId },
+      include: { sponsorTasks: true }
+    });
+
+    return {
+      ...sponsorTaskTransformer(createdSponsorTask),
+      updatedSponsor
+    };
   }
 }

--- a/src/backend/src/services/finance.services.ts
+++ b/src/backend/src/services/finance.services.ts
@@ -193,7 +193,7 @@ export default class FinanceServices {
       throw new AccessDeniedException('Only heads can create a sponsor task');
     }
 
-    const sponsor = await prisma.sponsor.findUnique({ where: { sponsorId }, include: { sponsorTasks: true } });
+    const sponsor = await prisma.sponsor.findUnique({ where: { sponsorId, organizationId: organization.organizationId } });
     if (!sponsor) throw new NotFoundException('Sponsor', sponsorId);
     if (sponsor.dateDeleted) throw new DeletedException('Sponsor', sponsorId);
 

--- a/src/backend/src/services/finance.services.ts
+++ b/src/backend/src/services/finance.services.ts
@@ -49,7 +49,7 @@ export default class FinanceServices {
     discountCode?: string
   ) {
     if (!(await userHasPermission(submitter.userId, organization.organizationId, isHead)))
-      throw new AccessDeniedAdminOnlyException('create a sponsor');
+      throw new AccessDeniedAdminOnlyException('Only heads can create a sponsor');
 
     const sponsor = await prisma.sponsor.create({
       data: {
@@ -122,11 +122,19 @@ export default class FinanceServices {
     return deletedSponsor;
   }
 
+  /**
+   * Creates a sponsor tier.
+   * @param submitter current user creating the sponsor tier
+   * @param name tier name
+   * @param organization current organization of the current user
+   * @param colorHexCode tier color
+   * @returns newly created sponsor tier
+   */
   static async createSponsorTier(submitter: User, name: string, organization: Organization, colorHexCode: string) {
     if (!(await userHasPermission(submitter.userId, organization.organizationId, isHead)))
       throw new AccessDeniedAdminOnlyException('create a sponsor tier');
 
-    const sponsor = await prisma.sponsor_Tier.create({
+    const sponsorTier = await prisma.sponsor_Tier.create({
       data: {
         name,
         organizationId: organization.organizationId,
@@ -137,7 +145,7 @@ export default class FinanceServices {
       }
     });
 
-    return sponsor;
+    return sponsorTier;
   }
 
   /**
@@ -157,5 +165,63 @@ export default class FinanceServices {
     }
 
     return sponsor.sponsorTasks.map(sponsorTaskTransformer);
+  }
+
+  /**
+   * Creates a sponsor task for the given sponsorId.
+   * @param submitter current user creating the sponsor task
+   * @param organization current organization of the user
+   * @param dueDate sponsor task's due date
+   * @param notes notes for the sponsor task
+   * @param sponsorId the sponsor associated with this sponsor task
+   * @param notifyDate notification date for this sponsor tasks
+   * @param assigneeUserId assignee of this sponsor task
+   * @returns newly created sponsor task
+   * @throws AccessDeniedAdminOnlyException if the user lacks permissions.
+   * @throws NotFoundException if the sponsor or assignee is not found.
+   * @throws DeletedException if the sponsor is marked as deleted.
+   */
+  static async createSponsorTask(
+    submitter: User,
+    organization: Organization,
+    dueDate: Date,
+    notes: string,
+    sponsorId: string,
+    notifyDate?: Date,
+    assigneeUserId?: string
+  ) {
+    if (!(await userHasPermission(submitter.userId, organization.organizationId, isHead))) {
+      throw new AccessDeniedAdminOnlyException('Only heads can create a sponsor task');
+    }
+
+    const sponsor = await prisma.sponsor.findUnique({ where: { sponsorId } });
+    if (!sponsor) throw new NotFoundException('Sponsor', sponsorId);
+    if (sponsor.dateCreated) throw new DeletedException('Sponsor', sponsorId);
+
+    if (assigneeUserId) {
+      const assignee = await prisma.user.findUnique({ where: { userId: assigneeUserId } });
+      if (!assignee) throw new NotFoundException('User', assigneeUserId);
+    }
+
+    const createdSponsorTask = await prisma.sponsor_Task.create({
+      data: {
+        dueDate,
+        notifyDate,
+        assignee: { connect: { userId: assigneeUserId } },
+        notes,
+        sponsor: { connect: { sponsorId } }
+      },
+      include: {
+        assignee: {
+          include: {
+            organizations: true,
+            roles: true
+          }
+        },
+        sponsor: true
+      }
+    });
+
+    return sponsorTaskTransformer(createdSponsorTask);
   }
 }

--- a/src/backend/tests/unit/finance.test.ts
+++ b/src/backend/tests/unit/finance.test.ts
@@ -1,11 +1,6 @@
 import { Organization } from '@prisma/client';
 import FinanceServices from '../../src/services/finance.services';
-import {
-  AccessDeniedAdminOnlyException,
-  AccessDeniedException,
-  DeletedException,
-  NotFoundException
-} from '../../src/utils/errors.utils';
+import { AccessDeniedException, DeletedException, NotFoundException } from '../../src/utils/errors.utils';
 import { batmanAppAdmin, wonderwomanGuest, supermanAdmin, theVisitorGuest } from '../test-data/users.test-data';
 import { createTestOrganization, createTestUser, resetUsers } from '../test-utils';
 import prisma from '../../src/prisma/prisma';
@@ -50,7 +45,7 @@ describe('Finance Tests', () => {
             organization,
             'googlecode'
           )
-      ).rejects.toThrow(new AccessDeniedAdminOnlyException('Only heads can create a sponsor'));
+      ).rejects.toThrow(new AccessDeniedException('Only heads can create a sponsor'));
     });
 
     it('Succeeds and creates a sponsor', async () => {
@@ -202,7 +197,7 @@ describe('Finance Tests', () => {
             organization,
             'C0C0C0'
           )
-      ).rejects.toThrow(new AccessDeniedAdminOnlyException('Only heads can create a sponsor tier'));
+      ).rejects.toThrow(new AccessDeniedException('Only heads can create a sponsor tier'));
     });
 
     it('Succeeds and creates a sponsor tier', async () => {
@@ -272,7 +267,7 @@ describe('Finance Tests', () => {
       const user = await createTestUser(wonderwomanGuest, orgId);
       await expect(
         FinanceServices.createSponsorTask(user, organization, new Date(1, 1, 25), 'notes', 'sponsorId')
-      ).rejects.toThrow(new AccessDeniedAdminOnlyException('Only heads can create a sponsor task'));
+      ).rejects.toThrow(new AccessDeniedException('Only heads can create a sponsor task'));
     });
 
     it('Fails when assigned user is not found', async () => {
@@ -330,9 +325,6 @@ describe('Finance Tests', () => {
         'telsaCode'
       );
 
-      // sponsor has no sponsor tasks pre createSponsorTask call
-      expect(sponsor.sponsorTasks.length).toEqual(0);
-
       const result = await FinanceServices.createSponsorTask(
         user,
         organization,
@@ -346,9 +338,7 @@ describe('Finance Tests', () => {
       expect(result.assignee?.userId).toEqual(user.userId);
       expect(result.notes).toEqual('hello notes');
       expect(result.dueDate).toEqual(new Date(1, 2, 3));
-
-      // sponsor has one sponsor tasks pre createSponsorTask call
-      expect(result.updatedSponsor?.sponsorTasks.length).toEqual(1);
+      expect(result.assignee?.userId).toEqual(user.userId);
     });
   });
 });

--- a/src/backend/tests/unit/finance.test.ts
+++ b/src/backend/tests/unit/finance.test.ts
@@ -50,7 +50,7 @@ describe('Finance Tests', () => {
             organization,
             'googlecode'
           )
-      ).rejects.toThrow(new AccessDeniedAdminOnlyException('create a sponsor'));
+      ).rejects.toThrow(new AccessDeniedAdminOnlyException('Only heads can create a sponsor'));
     });
 
     it('Succeeds and creates a sponsor', async () => {
@@ -202,7 +202,7 @@ describe('Finance Tests', () => {
             organization,
             'C0C0C0'
           )
-      ).rejects.toThrow(new AccessDeniedAdminOnlyException('create a sponsor tier'));
+      ).rejects.toThrow(new AccessDeniedAdminOnlyException('Only heads can create a sponsor tier'));
     });
 
     it('Succeeds and creates a sponsor tier', async () => {
@@ -264,6 +264,91 @@ describe('Finance Tests', () => {
       );
 
       await prisma.sponsor_Task.deleteMany();
+    });
+  });
+
+  describe('Create Sponsor Tasks', () => {
+    it('Fails when user is not a head or above', async () => {
+      const user = await createTestUser(wonderwomanGuest, orgId);
+      await expect(
+        FinanceServices.createSponsorTask(user, organization, new Date(1, 1, 25), 'notes', 'sponsorId')
+      ).rejects.toThrow(new AccessDeniedAdminOnlyException('Only heads can create a sponsor task'));
+    });
+
+    it('Fails when assigned user is not found', async () => {
+      const user = await createTestUser(supermanAdmin, orgId);
+      const newSponsor = await FinanceServices.createSponsor(
+        user,
+        'Telsa',
+        true,
+        5000,
+        new Date(12, 1, 24),
+        [2024],
+        sponsorTierId,
+        true,
+        'Bill Gates',
+        [],
+        organization,
+        'telsaCode'
+      );
+
+      await expect(
+        FinanceServices.createSponsorTask(
+          user,
+          organization,
+          new Date(1, 2, 3),
+          'hello notes',
+          newSponsor.sponsorId,
+          new Date(1, 2, 3),
+          'USERID'
+        )
+      ).rejects.toThrow(new NotFoundException('User', 'USERID'));
+    });
+
+    it('Fails when associated sponsor is not found', async () => {
+      const user = await createTestUser(supermanAdmin, orgId);
+
+      await expect(
+        FinanceServices.createSponsorTask(user, organization, new Date(1, 2, 3), 'hello notes', 'NOT FOUND')
+      ).rejects.toThrow(new NotFoundException('Sponsor', 'NOT FOUND'));
+    });
+
+    it('Succeeds in creating a sponsor task', async () => {
+      const user = await createTestUser(supermanAdmin, orgId);
+      const sponsor = await FinanceServices.createSponsor(
+        user,
+        'Telsa',
+        true,
+        5000,
+        new Date(12, 1, 24),
+        [2024],
+        sponsorTierId,
+        true,
+        'Bill Gates',
+        [],
+        organization,
+        'telsaCode'
+      );
+
+      // sponsor has no sponsor tasks pre createSponsorTask call
+      expect(sponsor.sponsorTasks.length).toEqual(0);
+
+      const result = await FinanceServices.createSponsorTask(
+        user,
+        organization,
+        new Date(1, 2, 3),
+        'hello notes',
+        sponsor.sponsorId,
+        new Date(1, 2, 3),
+        user.userId
+      );
+
+      expect(result.assignee?.userId).toEqual(user.userId);
+      expect(result.notes).toEqual('hello notes');
+      expect(result.dueDate).toEqual(new Date(1, 2, 3));
+
+      // sponsor has one sponsor tasks pre createSponsorTask call
+      expect(result.updatedSponsor?.sponsorTasks.length).toEqual(1);
     });
   });
 });


### PR DESCRIPTION
## Changes

route, controller, service + transformer for creating a sponsor task

added seed data and tests 

made some minor cleanups to other finance endpoints 

## Notes

for this endpoint i thought it would be best for the service to return the newly created sponsor task and the sponsor that has its tasks updated but let me know what you think

## Test Cases

- user is below a head
- assignee can't be found
- sponsor can't be found
- sponsor is deleted 
<img width="669" alt="Screenshot 2025-03-28 at 8 47 43 PM" src="https://github.com/user-attachments/assets/2641bb00-b0a0-4f7d-a87a-3bbf5dad74e7" />



## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3296 
