### PR TITLE
3157 get all parts endpoint

### DIFF
--- a/src/backend/src/controllers/part-review.controllers.ts
+++ b/src/backend/src/controllers/part-review.controllers.ts
@@ -4,7 +4,6 @@ import { Project, validateWBS, WbsNumber } from 'shared';
 import ProjectsService from '../services/projects.services';
 
 export default class PartReviewController {
-  
   static async getAllParts(req: Request, res: Response, next: NextFunction) {
     try {
       const wbsNumber: WbsNumber = validateWBS(req.params.wbsNum);
@@ -17,8 +16,7 @@ export default class PartReviewController {
       next(error);
     }
   }
-  
-  
+
   static async getAllPartTags(req: Request, res: Response, next: NextFunction) {
     try {
       const tags = await PartReviewService.getAllPartTags(req.organization.organizationId);

--- a/src/backend/src/controllers/part-review.controllers.ts
+++ b/src/backend/src/controllers/part-review.controllers.ts
@@ -1,7 +1,24 @@
 import { NextFunction, Request, Response } from 'express';
 import PartReviewService from '../services/part-review.services';
+import { Project, validateWBS, WbsNumber } from 'shared';
+import ProjectsService from '../services/projects.services';
 
 export default class PartReviewController {
+  
+  static async getAllParts(req: Request, res: Response, next: NextFunction) {
+    try {
+      const wbsNumber: WbsNumber = validateWBS(req.params.wbsNum);
+
+      const project: Project = await ProjectsService.getSingleProject(wbsNumber, req.organization);
+
+      const parts = await PartReviewService.getAllParts(project.id, req.organization.organizationId);
+      res.status(200).json(parts);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+  
+  
   static async getAllPartTags(req: Request, res: Response, next: NextFunction) {
     try {
       const tags = await PartReviewService.getAllPartTags(req.organization.organizationId);

--- a/src/backend/src/controllers/part-review.controllers.ts
+++ b/src/backend/src/controllers/part-review.controllers.ts
@@ -1,16 +1,13 @@
 import { NextFunction, Request, Response } from 'express';
 import PartReviewService from '../services/part-review.services';
-import { Project, validateWBS, WbsNumber } from 'shared';
-import ProjectsService from '../services/projects.services';
+import { validateWBS, WbsNumber } from 'shared';
 
 export default class PartReviewController {
   static async getAllParts(req: Request, res: Response, next: NextFunction) {
     try {
       const wbsNumber: WbsNumber = validateWBS(req.params.wbsNum);
 
-      const project: Project = await ProjectsService.getSingleProject(wbsNumber, req.organization);
-
-      const parts = await PartReviewService.getAllParts(project.id, req.organization.organizationId);
+      const parts = await PartReviewService.getAllPartsForProject(wbsNumber, req.organization);
       res.status(200).json(parts);
     } catch (error: unknown) {
       next(error);

--- a/src/backend/src/controllers/part-review.controllers.ts
+++ b/src/backend/src/controllers/part-review.controllers.ts
@@ -3,7 +3,7 @@ import PartReviewService from '../services/part-review.services';
 import { validateWBS, WbsNumber } from 'shared';
 
 export default class PartReviewController {
-  static async getAllParts(req: Request, res: Response, next: NextFunction) {
+  static async getAllPartsForProject(req: Request, res: Response, next: NextFunction) {
     try {
       const wbsNumber: WbsNumber = validateWBS(req.params.wbsNum);
 

--- a/src/backend/src/prisma-query-args/part-review.query-args.ts
+++ b/src/backend/src/prisma-query-args/part-review.query-args.ts
@@ -1,31 +1,31 @@
 import { Prisma } from '@prisma/client';
 import { getUserQueryArgs } from './user.query-args';
 
-export type PartQueryArgs = ReturnType<typeof partQueryArgs>;
-export type PartSubmissionQueryArgs = ReturnType<typeof partSubmissionQueryArgs>;
-export type PartReviewQueryArgs = ReturnType<typeof partReviewQueryArgs>;
-export type PartReviewRequestQueryArgs = ReturnType<typeof partReviewRequestQueryArgs>;
+export type PartQueryArgs = ReturnType<typeof getPartQueryArgs>;
+export type PartSubmissionQueryArgs = ReturnType<typeof getPartSubmissionQueryArgs>;
+export type PartReviewQueryArgs = ReturnType<typeof getPartReviewQueryArgs>;
+export type PartReviewRequestQueryArgs = ReturnType<typeof getPartReviewRequestQueryArgs>;
 
-export const partQueryArgs = (organizationId: string) =>
+export const getPartQueryArgs = (organizationId: string) =>
   Prisma.validator<Prisma.PartDefaultArgs>()({
     include: {
       tags: true,
-      submissions: partSubmissionQueryArgs(organizationId),
-      reviewRequests: partReviewRequestQueryArgs(organizationId),
+      submissions: getPartSubmissionQueryArgs(organizationId),
+      reviewRequests: getPartReviewRequestQueryArgs(organizationId),
       assignees: getUserQueryArgs(organizationId),
       userCreated: getUserQueryArgs(organizationId)
     }
   });
 
-export const partSubmissionQueryArgs = (organizationId: string) =>
+export const getPartSubmissionQueryArgs = (organizationId: string) =>
   Prisma.validator<Prisma.PartSubmissionDefaultArgs>()({
     include: {
       userCreated: getUserQueryArgs(organizationId),
-      reviews: partReviewQueryArgs(organizationId)
+      reviews: getPartReviewQueryArgs(organizationId)
     }
   });
 
-export const partReviewRequestQueryArgs = (organizationId: string) =>
+export const getPartReviewRequestQueryArgs = (organizationId: string) =>
   Prisma.validator<Prisma.PartReviewRequestDefaultArgs>()({
     include: {
       requester: getUserQueryArgs(organizationId),
@@ -33,7 +33,7 @@ export const partReviewRequestQueryArgs = (organizationId: string) =>
     }
   });
 
-export const partReviewQueryArgs = (organizationId: string) =>
+export const getPartReviewQueryArgs = (organizationId: string) =>
   Prisma.validator<Prisma.PartReviewDefaultArgs>()({
     include: {
       popUps: true,

--- a/src/backend/src/routes/parts.routes.ts
+++ b/src/backend/src/routes/parts.routes.ts
@@ -5,7 +5,7 @@ import PartReviewController from '../controllers/part-review.controllers';
 
 const partsRouter = express.Router();
 
-partsRouter.get('/:wbsNum', PartReviewController.getAllParts);
+partsRouter.get('/:wbsNum', PartReviewController.getAllPartsForProject);
 
 partsRouter.get('/tags', PartReviewController.getAllPartTags);
 partsRouter.get('/faqs', PartReviewController.getAllPartReviewFAQS);

--- a/src/backend/src/routes/parts.routes.ts
+++ b/src/backend/src/routes/parts.routes.ts
@@ -5,6 +5,8 @@ import PartReviewController from '../controllers/part-review.controllers';
 
 const partsRouter = express.Router();
 
+partsRouter.get('/:wbsNum', PartReviewController.getAllParts);
+
 partsRouter.get('/tags', PartReviewController.getAllPartTags);
 partsRouter.get('/faqs', PartReviewController.getAllPartReviewFAQS);
 

--- a/src/backend/src/services/part-review.services.ts
+++ b/src/backend/src/services/part-review.services.ts
@@ -1,13 +1,35 @@
 import { User } from '@prisma/client';
 import { userHasPermission } from '../utils/users.utils';
-import { FrequentlyAskedQuestion, isAdmin, PartReviewCommonMistake, PartTag } from 'shared';
+import { FrequentlyAskedQuestion, isAdmin, PartReviewCommonMistake, PartTag, Project } from 'shared';
 import { AccessDeniedAdminOnlyException, DeletedException, HttpException, NotFoundException } from '../utils/errors.utils';
 import prisma from '../prisma/prisma';
 import { getFaqQueryArgs } from '../prisma-query-args/faq.query-args';
+import { getPartQueryArgs } from '../prisma-query-args/part-review.query-args';
 import { faqTransformer } from '../transformers/faq.transformer';
+import { partPreviewTransformer } from '../transformers/part-review.transformer';
 import { partsReviewCommonMistakeTransformer } from '../transformers/part-review.transformer';
 
 export default class PartReviewService {
+
+  /**
+   * Gets all parts for the given project Id
+   * @param projectId project Id of the Project that the parts are associated with
+   * @param organizationId organization Id of the Project
+   * @returns all the parts from the given project
+   */
+  static async getAllParts(projectId: string, organizationId: string) {
+    const parts = await prisma.part.findMany({
+      where: {
+        projectId,
+        dateDeleted: null
+      },
+      ...getPartQueryArgs(organizationId)
+    });
+
+    return parts.map(partPreviewTransformer);
+  }
+
+
   /**
    * Uses the given organizationID to and returns an array of part tags
    * @param organizationId the organization to get the parts for

--- a/src/backend/src/services/part-review.services.ts
+++ b/src/backend/src/services/part-review.services.ts
@@ -1,6 +1,6 @@
-import { User } from '@prisma/client';
+import { Organization, User } from '@prisma/client';
 import { userHasPermission } from '../utils/users.utils';
-import { FrequentlyAskedQuestion, isAdmin, PartReviewCommonMistake, PartTag } from 'shared';
+import { FrequentlyAskedQuestion, isAdmin, PartReviewCommonMistake, PartTag, Project, WbsNumber } from 'shared';
 import { AccessDeniedAdminOnlyException, DeletedException, HttpException, NotFoundException } from '../utils/errors.utils';
 import prisma from '../prisma/prisma';
 import { getFaqQueryArgs } from '../prisma-query-args/faq.query-args';
@@ -8,21 +8,24 @@ import { getPartQueryArgs } from '../prisma-query-args/part-review.query-args';
 import { faqTransformer } from '../transformers/faq.transformer';
 import { partPreviewTransformer } from '../transformers/part-review.transformer';
 import { partsReviewCommonMistakeTransformer } from '../transformers/part-review.transformer';
+import ProjectsService from '../services/projects.services';
 
 export default class PartReviewService {
   /**
-   * Gets all parts for the given project Id
-   * @param projectId project Id of the Project that the parts are associated with
-   * @param organizationId organization Id of the Project
+   * Gets all parts for the given project
+   * @param wbsNumber the wbs number of the project
+   * @param organization the organization to get the parts for
    * @returns all the parts from the given project
    */
-  static async getAllParts(projectId: string, organizationId: string) {
+  static async getAllPartsForProject(wbsNumber: WbsNumber, organization: Organization) {
+    const project: Project = await ProjectsService.getSingleProject(wbsNumber, organization);
+
     const parts = await prisma.part.findMany({
       where: {
-        projectId,
+        projectId: project.id,
         dateDeleted: null
       },
-      ...getPartQueryArgs(organizationId)
+      ...getPartQueryArgs(organization.organizationId)
     });
 
     return parts.map(partPreviewTransformer);

--- a/src/backend/src/services/part-review.services.ts
+++ b/src/backend/src/services/part-review.services.ts
@@ -10,7 +10,6 @@ import { partPreviewTransformer } from '../transformers/part-review.transformer'
 import { partsReviewCommonMistakeTransformer } from '../transformers/part-review.transformer';
 
 export default class PartReviewService {
-
   /**
    * Gets all parts for the given project Id
    * @param projectId project Id of the Project that the parts are associated with
@@ -28,7 +27,6 @@ export default class PartReviewService {
 
     return parts.map(partPreviewTransformer);
   }
-
 
   /**
    * Uses the given organizationID to and returns an array of part tags

--- a/src/backend/src/services/part-review.services.ts
+++ b/src/backend/src/services/part-review.services.ts
@@ -1,6 +1,6 @@
 import { User } from '@prisma/client';
 import { userHasPermission } from '../utils/users.utils';
-import { FrequentlyAskedQuestion, isAdmin, PartReviewCommonMistake, PartTag, Project } from 'shared';
+import { FrequentlyAskedQuestion, isAdmin, PartReviewCommonMistake, PartTag } from 'shared';
 import { AccessDeniedAdminOnlyException, DeletedException, HttpException, NotFoundException } from '../utils/errors.utils';
 import prisma from '../prisma/prisma';
 import { getFaqQueryArgs } from '../prisma-query-args/faq.query-args';

--- a/src/backend/src/services/part-review.services.ts
+++ b/src/backend/src/services/part-review.services.ts
@@ -4,7 +4,7 @@ import { FrequentlyAskedQuestion, isAdmin, PartReviewCommonMistake, PartTag, Pro
 import { AccessDeniedAdminOnlyException, DeletedException, HttpException, NotFoundException } from '../utils/errors.utils';
 import prisma from '../prisma/prisma';
 import { getFaqQueryArgs } from '../prisma-query-args/faq.query-args';
-import { getPartQueryArgs, partReviewQueryArgs } from '../prisma-query-args/part-review.query-args';
+import { getPartQueryArgs, getPartReviewQueryArgs } from '../prisma-query-args/part-review.query-args';
 import { faqTransformer } from '../transformers/faq.transformer';
 import { partPreviewTransformer } from '../transformers/part-review.transformer';
 import { partsReviewCommonMistakeTransformer } from '../transformers/part-review.transformer';
@@ -505,7 +505,7 @@ export default class PartReviewService {
         title,
         description
       },
-      ...partReviewQueryArgs
+      ...getPartReviewQueryArgs
     });
     return newPopup;
   }
@@ -557,7 +557,7 @@ export default class PartReviewService {
         description,
         updatedAt: new Date()
       },
-      ...partReviewQueryArgs
+      ...getPartReviewQueryArgs
     });
   }
 
@@ -588,7 +588,7 @@ export default class PartReviewService {
       data: {
         deletedAt: new Date()
       },
-      ...partReviewQueryArgs
+      ...getPartReviewQueryArgs
     });
 
     return deletedPopup;

--- a/src/backend/tests/test-utils.ts
+++ b/src/backend/tests/test-utils.ts
@@ -683,7 +683,6 @@ export const createSlackMessageEvent = (
   };
 };
 
-
 export const createTestPart = async (
   user: User,
   name: string,
@@ -692,7 +691,6 @@ export const createTestPart = async (
   projectId?: string,
   dateDeleted?: Date
 ): Promise<Part> => {
-
   const part = await prisma.part.create({
     data: {
       partId,
@@ -710,7 +708,6 @@ export const createTestPart = async (
 
   return part;
 };
-
 
 export const CreatePartTag = async (organizationId: string, name: string, colorHexCode: string) => {
   return await prisma.partTag.create({

--- a/src/backend/tests/test-utils.ts
+++ b/src/backend/tests/test-utils.ts
@@ -2,6 +2,7 @@
 import {
   Club_Accounts,
   Organization,
+  Part,
   PartReview,
   PartSubmission,
   Part_Review_Popup,
@@ -100,6 +101,7 @@ export const createTestUser = async (
 export const resetUsers = async () => {
   await prisma.frequentlyAskedQuestion.deleteMany();
   await prisma.work_Package.deleteMany();
+  await prisma.part.deleteMany();
   await prisma.project.deleteMany();
   await prisma.material.deleteMany();
   await prisma.manufacturer.deleteMany();
@@ -680,6 +682,35 @@ export const createSlackMessageEvent = (
     ]
   };
 };
+
+
+export const createTestPart = async (
+  user: User,
+  name: string,
+  partId: string,
+  index: number,
+  projectId?: string,
+  dateDeleted?: Date
+): Promise<Part> => {
+
+  const part = await prisma.part.create({
+    data: {
+      partId,
+      index,
+      commonName: name,
+      project: {
+        connect: { projectId }
+      },
+      userCreated: {
+        connect: { userId: user.userId }
+      },
+      dateDeleted: dateDeleted ?? null
+    }
+  });
+
+  return part;
+};
+
 
 export const CreatePartTag = async (organizationId: string, name: string, colorHexCode: string) => {
   return await prisma.partTag.create({

--- a/src/backend/tests/unit/part-review.test.ts
+++ b/src/backend/tests/unit/part-review.test.ts
@@ -1,5 +1,5 @@
 import { Organization, User } from '@prisma/client';
-import { createTestOrganization, createTestUser, resetUsers } from '../test-utils';
+import { createTestCar, createTestOrganization, createTestPart, createTestProject, createTestTeam, createTestTeamType, createTestUser, resetUsers } from '../test-utils';
 import PartReviewService from '../../src/services/part-review.services';
 import { batmanAppAdmin, supermanAdmin, aquamanLeadership, flashAdmin } from '../test-data/users.test-data';
 import prisma from '../../src/prisma/prisma';
@@ -451,4 +451,61 @@ describe('part review tests', () => {
     expect(commonMistakes[1].starred).toBe(true);
     expect(commonMistakes[2].starred).toBe(false);
   });
+
+  describe('Get all parts', () => {
+    it('getting all parts from a project with no parts successfully returns empty array', async () => {
+
+      const division = await createTestTeamType(undefined, orgId);
+      const team1 = await createTestTeam(batman.userId, division.teamTypeId, orgId);
+      const car = await createTestCar(orgId, batman.userId);
+
+      const project = await createTestProject(batman, orgId, team1.teamId, car.carId);
+
+      const parts = await PartReviewService.getAllParts(project.projectId, orgId);
+      
+      expect(parts).toBeInstanceOf(Array);
+      expect(parts.length).toEqual(0);
+    });
+
+    it('gets all parts for the correct project', async () => {
+
+      const division = await createTestTeamType(undefined, orgId);
+      const team1 = await createTestTeam(batman.userId, division.teamTypeId, orgId);
+      const team2 = await createTestTeam(superman.userId, division.teamTypeId, orgId);
+      const car = await createTestCar(orgId, batman.userId);
+
+      const project1 = await createTestProject(batman, orgId, team1.teamId, car.carId);
+      const project2 = await createTestProject(superman, orgId, team2.teamId, car.carId, 2);
+
+      const part1 = await createTestPart(batman, 'part1', "1", 1, project1.projectId);
+      const part2 = await createTestPart(batman, 'part2', "2", 2, project1.projectId);
+
+      const part3 = await createTestPart(superman, 'part3', "3", 3, project2.projectId);
+
+      const parts1 = await PartReviewService.getAllParts(project1.projectId, orgId);
+      expect(parts1).toHaveLength(2);
+      expect(parts1[0].userCreated.userId).toEqual(part1.userCreatedId);
+      expect(parts1[0].commonName).toBe(part1.commonName);
+      expect(parts1[0].partId).toBe(part1.partId);
+      expect(parts1[0].index).toBe(part1.index);
+      expect(parts1[0].projectId).toBe(part1.projectId);
+
+      expect(parts1[1].commonName).toBe(part2.commonName);
+      expect(parts1[1].commonName).toBe(part2.commonName);
+      expect(parts1[1].partId).toBe(part2.partId);
+      expect(parts1[1].index).toBe(part2.index);
+      expect(parts1[1].projectId).toBe(part2.projectId);
+      
+
+      const parts2 = await PartReviewService.getAllParts(project2.projectId, orgId);
+      expect(parts2).toHaveLength(1);
+      expect(parts2[0].userCreated.userId).toEqual(part3.userCreatedId);
+      expect(parts2[0].commonName).toBe(part3.commonName);
+      expect(parts2[0].partId).toBe(part3.partId);
+      expect(parts2[0].index).toBe(part3.index);
+      expect(parts2[0].projectId).toBe(part3.projectId);
+    }
+    );
+  });
+
 });

--- a/src/backend/tests/unit/part-review.test.ts
+++ b/src/backend/tests/unit/part-review.test.ts
@@ -1,5 +1,14 @@
 import { Organization, User } from '@prisma/client';
-import { createTestCar, createTestOrganization, createTestPart, createTestProject, createTestTeam, createTestTeamType, createTestUser, resetUsers } from '../test-utils';
+import {
+  createTestCar,
+  createTestOrganization,
+  createTestPart,
+  createTestProject,
+  createTestTeam,
+  createTestTeamType,
+  createTestUser,
+  resetUsers
+} from '../test-utils';
 import PartReviewService from '../../src/services/part-review.services';
 import { batmanAppAdmin, supermanAdmin, aquamanLeadership, flashAdmin } from '../test-data/users.test-data';
 import prisma from '../../src/prisma/prisma';
@@ -454,7 +463,6 @@ describe('part review tests', () => {
 
   describe('Get all parts', () => {
     it('getting all parts from a project with no parts successfully returns empty array', async () => {
-
       const division = await createTestTeamType(undefined, orgId);
       const team1 = await createTestTeam(batman.userId, division.teamTypeId, orgId);
       const car = await createTestCar(orgId, batman.userId);
@@ -462,13 +470,12 @@ describe('part review tests', () => {
       const project = await createTestProject(batman, orgId, team1.teamId, car.carId);
 
       const parts = await PartReviewService.getAllParts(project.projectId, orgId);
-      
+
       expect(parts).toBeInstanceOf(Array);
       expect(parts.length).toEqual(0);
     });
 
     it('gets all parts for the correct project', async () => {
-
       const division = await createTestTeamType(undefined, orgId);
       const team1 = await createTestTeam(batman.userId, division.teamTypeId, orgId);
       const team2 = await createTestTeam(superman.userId, division.teamTypeId, orgId);
@@ -477,10 +484,10 @@ describe('part review tests', () => {
       const project1 = await createTestProject(batman, orgId, team1.teamId, car.carId);
       const project2 = await createTestProject(superman, orgId, team2.teamId, car.carId, 2);
 
-      const part1 = await createTestPart(batman, 'part1', "1", 1, project1.projectId);
-      const part2 = await createTestPart(batman, 'part2', "2", 2, project1.projectId);
+      const part1 = await createTestPart(batman, 'part1', '1', 1, project1.projectId);
+      const part2 = await createTestPart(batman, 'part2', '2', 2, project1.projectId);
 
-      const part3 = await createTestPart(superman, 'part3', "3", 3, project2.projectId);
+      const part3 = await createTestPart(superman, 'part3', '3', 3, project2.projectId);
 
       const parts1 = await PartReviewService.getAllParts(project1.projectId, orgId);
       expect(parts1).toHaveLength(2);
@@ -495,7 +502,6 @@ describe('part review tests', () => {
       expect(parts1[1].partId).toBe(part2.partId);
       expect(parts1[1].index).toBe(part2.index);
       expect(parts1[1].projectId).toBe(part2.projectId);
-      
 
       const parts2 = await PartReviewService.getAllParts(project2.projectId, orgId);
       expect(parts2).toHaveLength(1);
@@ -504,8 +510,6 @@ describe('part review tests', () => {
       expect(parts2[0].partId).toBe(part3.partId);
       expect(parts2[0].index).toBe(part3.index);
       expect(parts2[0].projectId).toBe(part3.projectId);
-    }
-    );
+    });
   });
-
 });

--- a/src/backend/tests/unit/part-review.test.ts
+++ b/src/backend/tests/unit/part-review.test.ts
@@ -13,6 +13,7 @@ import PartReviewService from '../../src/services/part-review.services';
 import { batmanAppAdmin, supermanAdmin, aquamanLeadership, flashAdmin } from '../test-data/users.test-data';
 import prisma from '../../src/prisma/prisma';
 import { AccessDeniedAdminOnlyException, DeletedException } from '../../src/utils/errors.utils';
+import { validateWBS } from 'shared';
 
 describe('part review tests', () => {
   let orgId: string;
@@ -467,9 +468,12 @@ describe('part review tests', () => {
       const team1 = await createTestTeam(batman.userId, division.teamTypeId, orgId);
       const car = await createTestCar(orgId, batman.userId);
 
-      const project = await createTestProject(batman, orgId, team1.teamId, car.carId);
+      // Create a project with no parts
+      await createTestProject(batman, orgId, team1.teamId, car.carId, 4);
 
-      const parts = await PartReviewService.getAllParts(project.projectId, orgId);
+      const proj1WbsNum = validateWBS('0.4.0');
+
+      const parts = await PartReviewService.getAllPartsForProject(proj1WbsNum, organization);
 
       expect(parts).toBeInstanceOf(Array);
       expect(parts.length).toEqual(0);
@@ -481,15 +485,18 @@ describe('part review tests', () => {
       const team2 = await createTestTeam(superman.userId, division.teamTypeId, orgId);
       const car = await createTestCar(orgId, batman.userId);
 
-      const project1 = await createTestProject(batman, orgId, team1.teamId, car.carId);
+      const project1 = await createTestProject(batman, orgId, team1.teamId, car.carId, 1);
       const project2 = await createTestProject(superman, orgId, team2.teamId, car.carId, 2);
+
+      const proj1WbsNum = validateWBS('0.1.0');
+      const proj2WbsNum = validateWBS('0.2.0');
 
       const part1 = await createTestPart(batman, 'part1', '1', 1, project1.projectId);
       const part2 = await createTestPart(batman, 'part2', '2', 2, project1.projectId);
 
       const part3 = await createTestPart(superman, 'part3', '3', 3, project2.projectId);
 
-      const parts1 = await PartReviewService.getAllParts(project1.projectId, orgId);
+      const parts1 = await PartReviewService.getAllPartsForProject(proj1WbsNum, organization);
       expect(parts1).toHaveLength(2);
       expect(parts1[0].userCreated.userId).toEqual(part1.userCreatedId);
       expect(parts1[0].commonName).toBe(part1.commonName);
@@ -503,7 +510,7 @@ describe('part review tests', () => {
       expect(parts1[1].index).toBe(part2.index);
       expect(parts1[1].projectId).toBe(part2.projectId);
 
-      const parts2 = await PartReviewService.getAllParts(project2.projectId, orgId);
+      const parts2 = await PartReviewService.getAllPartsForProject(proj2WbsNum, organization);
       expect(parts2).toHaveLength(1);
       expect(parts2[0].userCreated.userId).toEqual(part3.userCreatedId);
       expect(parts2[0].commonName).toBe(part3.commonName);


### PR DESCRIPTION
## Changes

Created getAllParts endpoints that retrieves all the parts for a specified project, so that the parts can be displayed on the Parts Review page. The information that the endpoint returns includes information about tags, project, assignees, and reviewe requests, but not submissions or reviews.

GET /parts/:wbsNum


## Test Cases

- getting all parts from a project with no parts successfully returns empty array
- getting all parts for the correct project (two different created projects)

## Screenshots

<img width="838" alt="Screenshot 2025-03-26 at 7 54 04 PM" src="https://github.com/user-attachments/assets/1a1dc680-8ed3-4b3a-a663-7644414ce0f4" />

<img width="841" alt="Screenshot 2025-03-26 at 7 55 18 PM" src="https://github.com/user-attachments/assets/b4a83860-1b3c-464c-a6ec-c09689a4e670" />

<img width="850" alt="Screenshot 2025-03-26 at 7 55 49 PM" src="https://github.com/user-attachments/assets/587416dd-ccb6-4107-b05d-d0264f965b61" />


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3157 