### PR TITLE
#3311 cud endpoints for parts

### DIFF
--- a/src/backend/src/controllers/part-review.controllers.ts
+++ b/src/backend/src/controllers/part-review.controllers.ts
@@ -6,10 +6,10 @@ export default class PartReviewController {
   static async createPart(req: Request, res: Response, next: NextFunction) {
     try {
       const { index, commonName, description, reviewStatus, tagIds, assigneeIds } = req.body;
-      const { projectId } = req.params;
+      const { wbsNum } = req.params;
       const part = await PartReviewService.createPart(
-        req.organization.organizationId,
-        projectId,
+        req.organization,
+        wbsNum,
         req.currentUser,
         index,
         commonName,

--- a/src/backend/src/controllers/part-review.controllers.ts
+++ b/src/backend/src/controllers/part-review.controllers.ts
@@ -5,8 +5,7 @@ import { HttpException } from '../utils/errors.utils';
 export default class PartReviewController {
   static async createPart(req: Request, res: Response, next: NextFunction) {
     try {
-      const { index, commonName, description, reviewStatus, tagIds, assigneeIds } = req.body;
-      const { wbsNum } = req.params;
+      const { wbsNum, index, commonName, description, reviewStatus, tagIds, assigneeIds } = req.body;
       const part = await PartReviewService.createPart(
         req.organization,
         wbsNum,
@@ -30,7 +29,7 @@ export default class PartReviewController {
       const { partId } = req.params;
       if (!file) throw new HttpException(400, 'Invalid or undefined image data');
 
-      const newPreviewImage = await PartReviewService.uploadPreview(
+      const newPreviewImage = await PartReviewService.uploadPartPreviewImage(
         file,
         partId,
         req.currentUser,
@@ -67,8 +66,8 @@ export default class PartReviewController {
   static async deletePart(req: Request, res: Response, next: NextFunction) {
     try {
       const { partId } = req.params;
-      const deletedPart = await PartReviewService.deletePart(partId, req.currentUser, req.organization.organizationId);
-      res.status(200).json(deletedPart);
+      await PartReviewService.deletePart(partId, req.currentUser, req.organization.organizationId);
+      res.status(200).json({ message: `Successfully deleted part #${partId}` });
     } catch (error: unknown) {
       next(error);
     }

--- a/src/backend/src/controllers/part-review.controllers.ts
+++ b/src/backend/src/controllers/part-review.controllers.ts
@@ -1,7 +1,74 @@
 import { NextFunction, Request, Response } from 'express';
 import PartReviewService from '../services/part-review.services';
+import { HttpException } from '../utils/errors.utils';
 
 export default class PartReviewController {
+  static async createPart(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { index, commonName, description, reviewStatus, tagIds, assigneeIds } = req.body;
+      const { projectId } = req.params;
+      const part = await PartReviewService.createPart(
+        req.organization.organizationId,
+        projectId,
+        req.currentUser,
+        index,
+        commonName,
+        description,
+        reviewStatus,
+        tagIds,
+        assigneeIds
+      );
+      res.status(200).json(part);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
+  static async uploadPreview(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { file } = req;
+      const { partId } = req.params;
+      if (!file) throw new HttpException(400, 'Invalid or undefined image data');
+
+      const newPreviewImage = await PartReviewService.uploadPreview(file, partId, req.currentUser, req.organization);
+
+      res.status(200).json(newPreviewImage);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
+  static async updatePart(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { index, commonName, description, previewImageLink, reviewStatus, tagIds, assigneeIds } = req.body;
+      const { partId } = req.params;
+      const part = await PartReviewService.updatePart(
+        req.organization.organizationId,
+        partId,
+        req.currentUser,
+        index,
+        commonName,
+        description,
+        reviewStatus,
+        tagIds,
+        assigneeIds
+      );
+      res.status(200).json(part);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
+  static async deletePart(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { partId } = req.params;
+      const deletedPart = await PartReviewService.deletePart(partId, req.currentUser, req.organization.organizationId);
+      res.status(200).json(deletedPart);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
   static async getAllPartTags(req: Request, res: Response, next: NextFunction) {
     try {
       const tags = await PartReviewService.getAllPartTags(req.organization.organizationId);

--- a/src/backend/src/controllers/part-review.controllers.ts
+++ b/src/backend/src/controllers/part-review.controllers.ts
@@ -30,7 +30,12 @@ export default class PartReviewController {
       const { partId } = req.params;
       if (!file) throw new HttpException(400, 'Invalid or undefined image data');
 
-      const newPreviewImage = await PartReviewService.uploadPreview(file, partId, req.currentUser, req.organization);
+      const newPreviewImage = await PartReviewService.uploadPreview(
+        file,
+        partId,
+        req.currentUser,
+        req.organization.organizationId
+      );
 
       res.status(200).json(newPreviewImage);
     } catch (error: unknown) {
@@ -40,7 +45,7 @@ export default class PartReviewController {
 
   static async updatePart(req: Request, res: Response, next: NextFunction) {
     try {
-      const { index, commonName, description, previewImageLink, reviewStatus, tagIds, assigneeIds } = req.body;
+      const { index, commonName, description, reviewStatus, tagIds, assigneeIds } = req.body;
       const { partId } = req.params;
       const part = await PartReviewService.updatePart(
         req.organization.organizationId,

--- a/src/backend/src/prisma-query-args/part-review.query-args.ts
+++ b/src/backend/src/prisma-query-args/part-review.query-args.ts
@@ -1,31 +1,31 @@
 import { Prisma } from '@prisma/client';
 import { getUserQueryArgs } from './user.query-args';
 
-export type PartQueryArgs = ReturnType<typeof partQueryArgs>;
-export type PartSubmissionQueryArgs = ReturnType<typeof partSubmissionQueryArgs>;
-export type PartReviewQueryArgs = ReturnType<typeof partReviewQueryArgs>;
-export type PartReviewRequestQueryArgs = ReturnType<typeof partReviewRequestQueryArgs>;
+export type PartQueryArgs = ReturnType<typeof getPartQueryArgs>;
+export type PartSubmissionQueryArgs = ReturnType<typeof getPartSubmissionQueryArgs>;
+export type PartReviewQueryArgs = ReturnType<typeof getPartReviewQueryArgs>;
+export type PartReviewRequestQueryArgs = ReturnType<typeof getPartReviewRequestQueryArgs>;
 
-export const partQueryArgs = (organizationId: string) =>
+export const getPartQueryArgs = (organizationId: string) =>
   Prisma.validator<Prisma.PartDefaultArgs>()({
     include: {
       tags: true,
-      submissions: partSubmissionQueryArgs(organizationId),
-      reviewRequests: partReviewRequestQueryArgs(organizationId),
+      submissions: getPartSubmissionQueryArgs(organizationId),
+      reviewRequests: getPartReviewRequestQueryArgs(organizationId),
       assignees: getUserQueryArgs(organizationId),
       userCreated: getUserQueryArgs(organizationId)
     }
   });
 
-export const partSubmissionQueryArgs = (organizationId: string) =>
+export const getPartSubmissionQueryArgs = (organizationId: string) =>
   Prisma.validator<Prisma.PartSubmissionDefaultArgs>()({
     include: {
       userCreated: getUserQueryArgs(organizationId),
-      reviews: partReviewQueryArgs(organizationId)
+      reviews: getPartReviewQueryArgs(organizationId)
     }
   });
 
-export const partReviewRequestQueryArgs = (organizationId: string) =>
+export const getPartReviewRequestQueryArgs = (organizationId: string) =>
   Prisma.validator<Prisma.PartReviewRequestDefaultArgs>()({
     include: {
       requester: getUserQueryArgs(organizationId),
@@ -33,7 +33,7 @@ export const partReviewRequestQueryArgs = (organizationId: string) =>
     }
   });
 
-export const partReviewQueryArgs = (organizationId: string) =>
+export const getPartReviewQueryArgs = (organizationId: string) =>
   Prisma.validator<Prisma.PartReviewDefaultArgs>()({
     include: {
       popUps: true,

--- a/src/backend/src/prisma/migrations/20250124235046_cad_part_file_review/migration.sql
+++ b/src/backend/src/prisma/migrations/20250124235046_cad_part_file_review/migration.sql
@@ -24,7 +24,7 @@ CREATE TABLE "Part" (
     "index" INTEGER NOT NULL,
     "commonName" TEXT NOT NULL,
     "description" TEXT,
-    "previewImageLink" TEXT,
+    "previewImageId" TEXT,
     "status" "Review_Status" NOT NULL DEFAULT 'IN_PROGRESS',
     "projectId" TEXT NOT NULL,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/src/backend/src/prisma/schema.prisma
+++ b/src/backend/src/prisma/schema.prisma
@@ -1132,7 +1132,7 @@ model Part {
   index            Int
   commonName       String
   description      String?
-  previewImageLink String?
+  previewImageId String?
   status           Review_Status       @default(IN_PROGRESS)
   tags             PartTag[]
   submissions      PartSubmission[]

--- a/src/backend/src/prisma/seed-data/parts.seed.ts
+++ b/src/backend/src/prisma/seed-data/parts.seed.ts
@@ -11,7 +11,7 @@ const basicPart = (projectId: string, userCreatedId: string, assigneeIds: string
       index: 1,
       commonName: 'Basic Part',
       description: 'Basic part with all fields populated',
-      previewImageLink: 'https://NER.com/basicpart.jpg',
+      previewImageId: 'https://NER.com/basicpart.jpg',
       status: 'IN_PROGRESS',
       createdAt: new Date('2025-01-01T10:00:00Z'),
       project: {
@@ -32,7 +32,7 @@ const partWithoutDescription = (projectId: string, userCreatedId: string, assign
     data: {
       index: 2,
       commonName: 'Part without description',
-      previewImageLink: 'https://NER.com/partwithoutdes.jpg',
+      previewImageId: 'https://NER.com/partwithoutdes.jpg',
       status: 'IN_PROGRESS',
       createdAt: new Date('2025-01-01T10:00:00Z'),
       project: {
@@ -74,7 +74,7 @@ const partWithEmptyHistory = (projectId: string, userCreatedId: string, assignee
       index: 4,
       commonName: 'Part with empty history',
       description: 'Basic part but with empty history',
-      previewImageLink: 'https://NER.com/partemptyhistory.jpg',
+      previewImageId: 'https://NER.com/partemptyhistory.jpg',
       status: 'IN_PROGRESS',
       createdAt: new Date('2025-01-01T10:00:00Z'),
       project: {
@@ -95,7 +95,7 @@ const partWithLongName = (projectId: string, userCreatedId: string, assigneeIds:
       index: 5,
       commonName: 'ThisPartHasANameThatIsWayTooLongAndMightCauseProblemsWithVisibilityOnTheWebsiteMaybeIDK',
       description: 'part with super long name',
-      previewImageLink: 'https://NER.com/partwithlongname.jpg',
+      previewImageId: 'https://NER.com/partwithlongname.jpg',
       status: 'IN_PROGRESS',
       createdAt: new Date('2025-01-01T10:00:00Z'),
       project: {
@@ -116,7 +116,7 @@ const partIndexNegative = (projectId: string, userCreatedId: string, assigneeIds
       index: -1,
       commonName: 'Part with negative index',
       description: 'This parts index is negative',
-      previewImageLink: 'https://NER.com/negativeindexpart.jpg',
+      previewImageId: 'https://NER.com/negativeindexpart.jpg',
       status: 'IN_PROGRESS',
       createdAt: new Date('2025-01-01T10:00:00Z'),
       project: {
@@ -137,7 +137,7 @@ const partIndexZero = (projectId: string, userCreatedId: string, assigneeIds: st
       index: 0,
       commonName: 'Part with index 0',
       description: 'This parts index is 0',
-      previewImageLink: 'https://NER.com/zeroindexpart.jpg',
+      previewImageId: 'https://NER.com/zeroindexpart.jpg',
       status: 'IN_PROGRESS',
       createdAt: new Date('2025-01-01T10:00:00Z'),
       project: {
@@ -158,7 +158,7 @@ const partIndexLarge = (projectId: string, userCreatedId: string, assigneeIds: s
       index: 99999999,
       commonName: 'Part with very large index',
       description: 'This part index is very large',
-      previewImageLink: 'https://NER.com/largeindexpart.jpg',
+      previewImageId: 'https://NER.com/largeindexpart.jpg',
       status: 'IN_PROGRESS',
       createdAt: new Date('2025-01-01T10:00:00Z'),
       project: {
@@ -179,7 +179,7 @@ const partReadyForReview = (projectId: string, userCreatedId: string, assigneeId
       index: 9,
       commonName: 'Part with READY_FOR_REVIEW status',
       description: 'This part is ready for review',
-      previewImageLink: 'https://NER.com/testimage.jpg',
+      previewImageId: 'https://NER.com/testimage.jpg',
       status: 'READY_FOR_REVIEW',
       createdAt: new Date('2025-01-01T10:00:00Z'),
       project: {
@@ -200,7 +200,7 @@ const partInReview = (projectId: string, userCreatedId: string, assigneeIds: str
       index: 10,
       commonName: 'Part with IN_REVIEW status',
       description: 'This part is in review',
-      previewImageLink: 'https://NER.com/testimage.jpg',
+      previewImageId: 'https://NER.com/testimage.jpg',
       status: 'IN_REVIEW',
       createdAt: new Date('2025-01-01T10:00:00Z'),
       project: {
@@ -221,7 +221,7 @@ const partReviewed = (projectId: string, userCreatedId: string, assigneeIds: str
       index: 11,
       commonName: 'Part with REVIEWED status',
       description: 'This part is reviewed.',
-      previewImageLink: 'https://NER.com/testimage.jpg',
+      previewImageId: 'https://NER.com/testimage.jpg',
       status: 'REVIEWED',
       createdAt: new Date('2025-01-01T10:00:00Z'),
       project: {
@@ -242,7 +242,7 @@ const partApproved = (projectId: string, userCreatedId: string, assigneeIds: str
       index: 12,
       commonName: 'Part with APPROVED status',
       description: 'This part is approved.',
-      previewImageLink: 'https://NER.com/testimage.jpg',
+      previewImageId: 'https://NER.com/testimage.jpg',
       status: 'APPROVED',
       createdAt: new Date('2025-01-01T10:00:00Z'),
       project: {
@@ -263,7 +263,7 @@ const partCurrentDate = (projectId: string, userCreatedId: string, assigneeIds: 
       index: 13,
       commonName: 'Part with current date',
       description: 'This part has the current date.',
-      previewImageLink: 'https://NER.com/testimage.jpg',
+      previewImageId: 'https://NER.com/testimage.jpg',
       status: 'APPROVED',
       createdAt: new Date(),
       project: {
@@ -284,7 +284,7 @@ const partPastDate = (projectId: string, userCreatedId: string, assigneeIds: str
       index: 14,
       commonName: 'Part with past date',
       description: 'This part is old.',
-      previewImageLink: 'https://NER.com/testimage.jpg',
+      previewImageId: 'https://NER.com/testimage.jpg',
       status: 'APPROVED',
       createdAt: new Date('2000-01-01T00:00:00Z'),
       project: {
@@ -305,7 +305,7 @@ const partUnixEpochDate = (projectId: string, userCreatedId: string, assigneeIds
       index: 15,
       commonName: 'Part with date of Unix Epoch',
       description: 'This part is was made at the unix epoch.',
-      previewImageLink: 'https://NER.com/testimage.jpg',
+      previewImageId: 'https://NER.com/testimage.jpg',
       status: 'APPROVED',
       createdAt: new Date('1970-01-01T00:00:00Z'),
       project: {
@@ -326,7 +326,7 @@ const partFutureDate = (projectId: string, userCreatedId: string, assigneeIds: s
       index: 16,
       commonName: 'Part with date of future',
       description: 'This part is was made in the future.',
-      previewImageLink: 'https://NER.com/testimage.jpg',
+      previewImageId: 'https://NER.com/testimage.jpg',
       status: 'APPROVED',
       createdAt: new Date('2100-12-31T23:59:59Z'),
       project: {
@@ -347,7 +347,7 @@ const partLeapYearDate = (projectId: string, userCreatedId: string, assigneeIds:
       index: 17,
       commonName: 'Part with date with a leap year',
       description: 'This part is was during a leap year.',
-      previewImageLink: 'https://NER.com/testimage.jpg',
+      previewImageId: 'https://NER.com/testimage.jpg',
       status: 'APPROVED',
       createdAt: new Date('2024-02-29T12:00:00Z'),
       project: {

--- a/src/backend/src/routes/parts.routes.ts
+++ b/src/backend/src/routes/parts.routes.ts
@@ -21,11 +21,7 @@ partsRouter.post(
   PartReviewController.createPart
 );
 
-partsRouter.post(
-  '/:partId/upload-preview',
-  upload.single('image'),
-  PartReviewController.uploadPreview
-);
+partsRouter.post('/:partId/upload-preview', upload.single('image'), PartReviewController.uploadPreview);
 
 partsRouter.post(
   '/:partId/update',

--- a/src/backend/src/routes/parts.routes.ts
+++ b/src/backend/src/routes/parts.routes.ts
@@ -29,10 +29,9 @@ partsRouter.post(
 
 partsRouter.post(
   '/:partId/update',
-  nonEmptyString(body('index')),
+  intMinZero(body('index')),
   nonEmptyString(body('commonName')),
   body('description').optional().isString(),
-  body('previewImageLink').isString(),
   body('reviewStatus').custom((value) => Object.values(Review_Status).includes(value)),
   body('tagIds').isArray(),
   body('assigneeIds').isArray(),

--- a/src/backend/src/routes/parts.routes.ts
+++ b/src/backend/src/routes/parts.routes.ts
@@ -1,9 +1,46 @@
 import express from 'express';
-import { nonEmptyString, validateInputs } from '../utils/validation.utils';
+import { intMinZero, nonEmptyString, validateInputs } from '../utils/validation.utils';
 import { body } from 'express-validator';
 import PartReviewController from '../controllers/part-review.controllers';
+import { Review_Status } from 'shared';
+import multer, { memoryStorage } from 'multer';
+
+const upload = multer({ limits: { fileSize: 30000000 }, storage: memoryStorage() });
 
 const partsRouter = express.Router();
+
+partsRouter.post(
+  '/:projectId/create',
+  intMinZero(body('index')),
+  nonEmptyString(body('commonName')),
+  body('description').optional().isString(),
+  body('reviewStatus').custom((value) => Object.values(Review_Status).includes(value)),
+  body('tagIds').isArray(),
+  body('assigneeIds').isArray(),
+  validateInputs,
+  PartReviewController.createPart
+);
+
+partsRouter.post(
+  '/:partId/upload-preview',
+  upload.single('image'),
+  PartReviewController.uploadPreview
+);
+
+partsRouter.post(
+  '/:partId/update',
+  nonEmptyString(body('index')),
+  nonEmptyString(body('commonName')),
+  body('description').isString(),
+  body('previewImageLink').isString(),
+  body('reviewStatus').custom((value) => Object.values(Review_Status).includes(value)),
+  body('tagIds').isArray(),
+  body('assigneeIds').isArray(),
+  validateInputs,
+  PartReviewController.updatePart
+);
+
+partsRouter.post('/:partId/delete', PartReviewController.deletePart);
 
 partsRouter.get('/tags', PartReviewController.getAllPartTags);
 partsRouter.get('/faqs', PartReviewController.getAllPartReviewFAQS);

--- a/src/backend/src/routes/parts.routes.ts
+++ b/src/backend/src/routes/parts.routes.ts
@@ -10,7 +10,7 @@ const upload = multer({ limits: { fileSize: 30000000 }, storage: memoryStorage()
 const partsRouter = express.Router();
 
 partsRouter.post(
-  '/:projectId/create',
+  '/:wbsNum/create',
   intMinZero(body('index')),
   nonEmptyString(body('commonName')),
   body('description').optional().isString(),
@@ -31,7 +31,7 @@ partsRouter.post(
   '/:partId/update',
   nonEmptyString(body('index')),
   nonEmptyString(body('commonName')),
-  body('description').isString(),
+  body('description').optional().isString(),
   body('previewImageLink').isString(),
   body('reviewStatus').custom((value) => Object.values(Review_Status).includes(value)),
   body('tagIds').isArray(),

--- a/src/backend/src/routes/parts.routes.ts
+++ b/src/backend/src/routes/parts.routes.ts
@@ -10,7 +10,8 @@ const upload = multer({ limits: { fileSize: 30000000 }, storage: memoryStorage()
 const partsRouter = express.Router();
 
 partsRouter.post(
-  '/:wbsNum/create',
+  '/create',
+  nonEmptyString(body('wbsNum')),
   intMinZero(body('index')),
   nonEmptyString(body('commonName')),
   body('description').optional().isString(),

--- a/src/backend/src/services/part-review.services.ts
+++ b/src/backend/src/services/part-review.services.ts
@@ -36,7 +36,7 @@ export default class PartReviewService {
    * @param index the index of the part
    * @param commonName the name of the part
    * @param description the description of the part
-   * @param previewImageLink
+   * @param previewImageId
    * @param reviewStatus
    * @param tagIds
    * @param assigneeIds
@@ -93,7 +93,12 @@ export default class PartReviewService {
    * @param submitter the user making the update
    * @param organization the organization
    */
-  static async uploadPreview(previewImage: Express.Multer.File, partId: string, submitter: User, organizationId: string) {
+  static async uploadPartPreviewImage(
+    previewImage: Express.Multer.File,
+    partId: string,
+    submitter: User,
+    organizationId: string
+  ) {
     const part = await prisma.part.findUnique({
       where: {
         partId
@@ -104,17 +109,19 @@ export default class PartReviewService {
 
     if (part.dateDeleted) throw new DeletedException('Part', partId);
 
+    if (previewImage.size > 1000000) throw new HttpException(413, 'files bust be less than 1 mb');
+
     const hasPermission =
       (await userHasPermission(submitter.userId, organizationId, isLeadership)) ||
       submitter.userId === part.userCreated.userId;
     if (!hasPermission) throw new AccessDeniedException('Only leadership and part creators can add a preview image');
 
-    const previewImageData = await uploadFile(previewImage);
+    const { id } = await uploadFile(previewImage);
 
     const updatedPart = await prisma.part.update({
       where: { partId },
       data: {
-        previewImageLink: previewImageData.id
+        previewImageId: id
       },
       ...getPartQueryArgs(organizationId)
     });
@@ -185,7 +192,12 @@ export default class PartReviewService {
     const deletedPart = await prisma.part.update({
       where: { partId },
       data: {
-        dateDeleted: new Date()
+        dateDeleted: new Date(),
+        userDeleted: {
+          connect: {
+            userId: deleter.userId
+          }
+        }
       },
       ...getPartQueryArgs(organizationId)
     });

--- a/src/backend/src/services/part-review.services.ts
+++ b/src/backend/src/services/part-review.services.ts
@@ -63,7 +63,7 @@ export default class PartReviewService {
       (await userHasPermission(creator.userId, organization.organizationId, isLeadership)) ||
       isUserPartOfTeams(project.teams, creator);
 
-    if (!perms) throw new AccessDeniedException('create materials');
+    if (!perms) throw new AccessDeniedException('Only leadership and team members can create a part');
 
     const part = await prisma.part.create({
       data: {
@@ -155,10 +155,10 @@ export default class PartReviewService {
         description,
         status: reviewStatus,
         tags: {
-          connect: tagIds.map((partTagId) => ({ partTagId }))
+          set: tagIds.map((partTagId) => ({ partTagId }))
         },
         assignees: {
-          connect: assigneeIds.map((userId) => ({ userId }))
+          set: assigneeIds.map((userId) => ({ userId }))
         }
       },
       ...getPartQueryArgs(organizationId)

--- a/src/backend/src/services/part-review.services.ts
+++ b/src/backend/src/services/part-review.services.ts
@@ -1,4 +1,4 @@
-import { User } from '@prisma/client';
+import { Organization, User } from '@prisma/client';
 import { userHasPermission } from '../utils/users.utils';
 import {
   FrequentlyAskedQuestion,
@@ -6,7 +6,9 @@ import {
   isLeadership,
   PartReviewCommonMistake,
   PartTag,
-  Review_Status
+  Review_Status,
+  validateWBS,
+  WbsNumber
 } from 'shared';
 import {
   AccessDeniedAdminOnlyException,
@@ -19,17 +21,17 @@ import prisma from '../prisma/prisma';
 import { getFaqQueryArgs } from '../prisma-query-args/faq.query-args';
 import { faqTransformer } from '../transformers/faq.transformer';
 import { partsReviewCommonMistakeTransformer, partTransformer } from '../transformers/part-review.transformer';
-import { getProjectQueryArgs } from '../prisma-query-args/projects.query-args';
 import { isUserPartOfTeams } from '../utils/teams.utils';
 import { getPartQueryArgs } from '../prisma-query-args/part-review.query-args';
 import { uploadFile } from '../utils/google-integration.utils';
+import ProjectsService from './projects.services';
 
 export default class PartReviewService {
   /**
    * Creates a part on the given project id,
    * with no submissions and no review requests
    * @param organization the organization
-   * @param projectId project that the part will be added too
+   * @param wbsNum project that the part will be added too
    * @param creator the user creating the part
    * @param index the index of the part
    * @param commonName the name of the part
@@ -41,8 +43,8 @@ export default class PartReviewService {
    * @returns
    */
   static async createPart(
-    organizationId: string,
-    projectId: string,
+    organization: Organization,
+    wbsNum: string,
     creator: User,
     index: number,
     commonName: string,
@@ -51,17 +53,15 @@ export default class PartReviewService {
     tagIds: string[],
     assigneeIds: string[]
   ) {
-    const project = await prisma.project.findUnique({
-      where: {
-        projectId
-      },
-      ...getProjectQueryArgs(organizationId)
-    });
+    const wbsNumber: WbsNumber = validateWBS(wbsNum);
 
-    if (!project) throw new NotFoundException('Project', projectId);
+    const project = await ProjectsService.getSingleProjectWithQueryArgs(wbsNumber, organization);
+
+    if (!project) throw new NotFoundException('Project', wbsNum);
 
     const perms =
-      (await userHasPermission(creator.userId, organizationId, isLeadership)) || isUserPartOfTeams(project.teams, creator);
+      (await userHasPermission(creator.userId, organization.organizationId, isLeadership)) ||
+      isUserPartOfTeams(project.teams, creator);
 
     if (!perms) throw new AccessDeniedException('create materials');
 
@@ -74,13 +74,13 @@ export default class PartReviewService {
         tags: {
           connect: tagIds.map((partTagId) => ({ partTagId }))
         },
-        project: { connect: { projectId } },
+        project: { connect: { projectId: project.projectId } },
         assignees: {
           connect: assigneeIds.map((userId) => ({ userId }))
         },
         userCreated: { connect: { userId: creator.userId } }
       },
-      ...getPartQueryArgs(organizationId)
+      ...getPartQueryArgs(organization.organizationId)
     });
 
     return partTransformer(part);

--- a/src/backend/src/services/part-review.services.ts
+++ b/src/backend/src/services/part-review.services.ts
@@ -4,7 +4,6 @@ import {
   FrequentlyAskedQuestion,
   isAdmin,
   isLeadership,
-  Organization,
   PartReviewCommonMistake,
   PartTag,
   Review_Status
@@ -94,24 +93,19 @@ export default class PartReviewService {
    * @param submitter the user making the update
    * @param organization the organization
    */
-  static async uploadPreview(
-    previewImage: Express.Multer.File,
-    partId: string,
-    submitter: User,
-    organization: Organization
-  ) {
+  static async uploadPreview(previewImage: Express.Multer.File, partId: string, submitter: User, organizationId: string) {
     const part = await prisma.part.findUnique({
       where: {
         partId
       },
-      ...getPartQueryArgs(organization.organizationId)
+      ...getPartQueryArgs(organizationId)
     });
     if (!part) throw new NotFoundException('Part', partId);
 
     if (part.dateDeleted) throw new DeletedException('Part', partId);
 
     const hasPermission =
-      (await userHasPermission(submitter.userId, organization.organizationId, isLeadership)) ||
+      (await userHasPermission(submitter.userId, organizationId, isLeadership)) ||
       submitter.userId === part.userCreated.userId;
     if (!hasPermission) throw new AccessDeniedException('Only leadership and part creators can add a preview image');
 
@@ -122,7 +116,7 @@ export default class PartReviewService {
       data: {
         previewImageLink: previewImageData.id
       },
-      ...getPartQueryArgs(organization.organizationId)
+      ...getPartQueryArgs(organizationId)
     });
 
     return partTransformer(updatedPart);

--- a/src/backend/src/services/part-review.services.ts
+++ b/src/backend/src/services/part-review.services.ts
@@ -1,13 +1,204 @@
 import { User } from '@prisma/client';
 import { userHasPermission } from '../utils/users.utils';
-import { FrequentlyAskedQuestion, isAdmin, PartReviewCommonMistake, PartTag } from 'shared';
-import { AccessDeniedAdminOnlyException, DeletedException, HttpException, NotFoundException } from '../utils/errors.utils';
+import {
+  FrequentlyAskedQuestion,
+  isAdmin,
+  isLeadership,
+  Organization,
+  PartReviewCommonMistake,
+  PartTag,
+  Review_Status
+} from 'shared';
+import {
+  AccessDeniedAdminOnlyException,
+  AccessDeniedException,
+  DeletedException,
+  HttpException,
+  NotFoundException
+} from '../utils/errors.utils';
 import prisma from '../prisma/prisma';
 import { getFaqQueryArgs } from '../prisma-query-args/faq.query-args';
 import { faqTransformer } from '../transformers/faq.transformer';
-import { partsReviewCommonMistakeTransformer } from '../transformers/part-review.transformer';
+import { partsReviewCommonMistakeTransformer, partTransformer } from '../transformers/part-review.transformer';
+import { getProjectQueryArgs } from '../prisma-query-args/projects.query-args';
+import { isUserPartOfTeams } from '../utils/teams.utils';
+import { getPartQueryArgs } from '../prisma-query-args/part-review.query-args';
+import { uploadFile } from '../utils/google-integration.utils';
 
 export default class PartReviewService {
+  /**
+   * Creates a part on the given project id,
+   * with no submissions and no review requests
+   * @param organization the organization
+   * @param projectId project that the part will be added too
+   * @param creator the user creating the part
+   * @param index the index of the part
+   * @param commonName the name of the part
+   * @param description the description of the part
+   * @param previewImageLink
+   * @param reviewStatus
+   * @param tagIds
+   * @param assigneeIds
+   * @returns
+   */
+  static async createPart(
+    organizationId: string,
+    projectId: string,
+    creator: User,
+    index: number,
+    commonName: string,
+    description: string,
+    reviewStatus: Review_Status,
+    tagIds: string[],
+    assigneeIds: string[]
+  ) {
+    const project = await prisma.project.findUnique({
+      where: {
+        projectId
+      },
+      ...getProjectQueryArgs(organizationId)
+    });
+
+    if (!project) throw new NotFoundException('Project', projectId);
+
+    const perms =
+      (await userHasPermission(creator.userId, organizationId, isLeadership)) || isUserPartOfTeams(project.teams, creator);
+
+    if (!perms) throw new AccessDeniedException('create materials');
+
+    const part = await prisma.part.create({
+      data: {
+        index,
+        commonName,
+        description,
+        status: reviewStatus,
+        tags: {
+          connect: tagIds.map((partTagId) => ({ partTagId }))
+        },
+        project: { connect: { projectId } },
+        assignees: {
+          connect: assigneeIds.map((userId) => ({ userId }))
+        },
+        userCreated: { connect: { userId: creator.userId } }
+      },
+      ...getPartQueryArgs(organizationId)
+    });
+
+    return partTransformer(part);
+  }
+
+  /**
+   * Uploads an image to g drive and sets the parts preview image id to that image
+   * @param previewImage the image to upload
+   * @param partId the id of the part for which the preview image is being updated
+   * @param submitter the user making the update
+   * @param organization the organization
+   */
+  static async uploadPreview(
+    previewImage: Express.Multer.File,
+    partId: string,
+    submitter: User,
+    organization: Organization
+  ) {
+    const part = await prisma.part.findUnique({
+      where: {
+        partId
+      },
+      ...getPartQueryArgs(organization.organizationId)
+    });
+    if (!part) throw new NotFoundException('Part', partId);
+
+    if (part.dateDeleted) throw new DeletedException('Part', partId);
+
+    const hasPermission =
+      (await userHasPermission(submitter.userId, organization.organizationId, isLeadership)) ||
+      submitter.userId === part.userCreated.userId;
+    if (!hasPermission) throw new AccessDeniedException('Only leadership and part creators can add a preview image');
+
+    const previewImageData = await uploadFile(previewImage);
+
+    const updatedPart = await prisma.part.update({
+      where: { partId },
+      data: {
+        previewImageLink: previewImageData.id
+      },
+      ...getPartQueryArgs(organization.organizationId)
+    });
+
+    return partTransformer(updatedPart);
+  }
+
+  static async updatePart(
+    organizationId: string,
+    partId: string,
+    updater: User,
+    index: number,
+    commonName: string,
+    description: string,
+    reviewStatus: Review_Status,
+    tagIds: string[],
+    assigneeIds: string[]
+  ) {
+    const part = await prisma.part.findUnique({
+      where: { partId },
+      ...getPartQueryArgs(organizationId)
+    });
+
+    if (!part) throw new NotFoundException('Part', partId);
+
+    if (part.dateDeleted) throw new DeletedException('Part', partId);
+
+    const hasPermission =
+      (await userHasPermission(updater.userId, organizationId, isLeadership)) || updater.userId === part.userCreated.userId;
+
+    if (!hasPermission) throw new AccessDeniedException('Only leadership and the part creator can update part data');
+
+    const updatedPart = await prisma.part.update({
+      where: { partId },
+      data: {
+        index,
+        commonName,
+        description,
+        status: reviewStatus,
+        tags: {
+          connect: tagIds.map((partTagId) => ({ partTagId }))
+        },
+        assignees: {
+          connect: assigneeIds.map((userId) => ({ userId }))
+        }
+      },
+      ...getPartQueryArgs(organizationId)
+    });
+
+    return partTransformer(updatedPart);
+  }
+
+  static async deletePart(partId: string, deleter: User, organizationId: string) {
+    const part = await prisma.part.findUnique({
+      where: { partId },
+      ...getPartQueryArgs(organizationId)
+    });
+
+    if (!part) throw new NotFoundException('Part', partId);
+
+    if (part.dateDeleted) throw new DeletedException('Part', partId);
+
+    const hasPermission =
+      (await userHasPermission(deleter.userId, organizationId, isLeadership)) || deleter.userId === part.userCreated.userId;
+
+    if (!hasPermission) throw new AccessDeniedException('Only leadership and the part creator can delete a part');
+
+    const deletedPart = await prisma.part.update({
+      where: { partId },
+      data: {
+        dateDeleted: new Date()
+      },
+      ...getPartQueryArgs(organizationId)
+    });
+
+    return partTransformer(deletedPart);
+  }
+
   /**
    * Uses the given organizationID to and returns an array of part tags
    * @param organizationId the organization to get the parts for

--- a/src/backend/src/transformers/part-review.transformer.ts
+++ b/src/backend/src/transformers/part-review.transformer.ts
@@ -33,7 +33,7 @@ export const partPreviewTransformer = (part: Prisma.PartGetPayload<PartQueryArgs
     index: part.index,
     commonName: part.commonName,
     description: part.description ?? undefined,
-    previewImageLink: part.previewImageLink ?? undefined,
+    previewImageId: part.previewImageId ?? undefined,
     status: part.status as Review_Status,
     tags: part.tags,
     projectId: part.projectId,

--- a/src/backend/src/utils/errors.utils.ts
+++ b/src/backend/src/utils/errors.utils.ts
@@ -145,5 +145,6 @@ export type ExceptionObjectNames =
   | 'Announcement'
   | 'Graph'
   | 'Graph Collection'
+  | 'Part'
   | 'Part Tag'
   | 'common mistake';

--- a/src/backend/tests/test-utils.ts
+++ b/src/backend/tests/test-utils.ts
@@ -100,6 +100,12 @@ export const createTestUser = async (
 export const resetUsers = async () => {
   await prisma.frequentlyAskedQuestion.deleteMany();
   await prisma.work_Package.deleteMany();
+  await prisma.partReviewCommonMistake.deleteMany();
+  await prisma.partTag.deleteMany();
+  await prisma.part_Review_Popup.deleteMany();
+  await prisma.partReview.deleteMany();
+  await prisma.partSubmission.deleteMany();
+  await prisma.part.deleteMany();
   await prisma.project.deleteMany();
   await prisma.material.deleteMany();
   await prisma.manufacturer.deleteMany();
@@ -140,12 +146,6 @@ export const resetUsers = async () => {
   await prisma.graph_Collection.deleteMany();
   await prisma.announcement.deleteMany();
   await prisma.popUp.deleteMany();
-  await prisma.partReviewCommonMistake.deleteMany();
-  await prisma.partTag.deleteMany();
-  await prisma.part_Review_Popup.deleteMany();
-  await prisma.partReview.deleteMany();
-  await prisma.partSubmission.deleteMany();
-  await prisma.part.deleteMany();
   await prisma.organization.deleteMany();
   await prisma.user.deleteMany();
 };

--- a/src/backend/tests/unit/part-review.test.ts
+++ b/src/backend/tests/unit/part-review.test.ts
@@ -3,7 +3,12 @@ import { createTestOrganization, createTestProject, createTestUser, resetUsers }
 import PartReviewService from '../../src/services/part-review.services';
 import { batmanAppAdmin, supermanAdmin, aquamanLeadership, flashAdmin, financeMember } from '../test-data/users.test-data';
 import prisma from '../../src/prisma/prisma';
-import { AccessDeniedAdminOnlyException, AccessDeniedException, DeletedException } from '../../src/utils/errors.utils';
+import {
+  AccessDeniedAdminOnlyException,
+  AccessDeniedException,
+  DeletedException,
+  NotFoundException
+} from '../../src/utils/errors.utils';
 import { Review_Status } from 'shared';
 
 describe('part review tests', () => {
@@ -167,6 +172,45 @@ describe('part review tests', () => {
           [superman.userId, nonAdmin.userId]
         )
     ).rejects.toThrow(new AccessDeniedException('Only leadership and the part creator can update part data'));
+  });
+
+  it('Does not allow non-leadership to delete parts, or non-existant/deleted parts to be deleted', async () => {
+    const project = await createTestProject(batman, orgId);
+
+    const project1 = await prisma.project.findUnique({
+      where: { projectId: project.projectId },
+      include: {
+        wbsElement: true
+      }
+    });
+
+    const wbsNum = `${project1?.wbsElement.carNumber}.${project1?.wbsElement.projectNumber}.${project1?.wbsElement.workPackageNumber}`;
+
+    const part = await PartReviewService.createPart(
+      organization,
+      wbsNum,
+      batman,
+      1,
+      'part1',
+      'here is a description',
+      Review_Status.IN_PROGRESS,
+      [],
+      [nonAdmin.userId, batman.userId]
+    );
+
+    await expect(async () => await PartReviewService.deletePart(part.partId, nonLeadership, orgId)).rejects.toThrow(
+      new AccessDeniedException('Only leadership and the part creator can delete a part')
+    );
+
+    await PartReviewService.deletePart(part.partId, superman, orgId);
+
+    await expect(async () => await PartReviewService.deletePart(part.partId, batman, orgId)).rejects.toThrow(
+      new DeletedException('Part', part.partId)
+    );
+
+    await expect(
+      async () => await PartReviewService.deletePart('some id that does not exist', batman, orgId)
+    ).rejects.toThrow(new NotFoundException('Part', 'some id that does not exist'));
   });
 
   it('creates a part tag, edits it, and deletes it', async () => {

--- a/src/backend/tests/unit/part-review.test.ts
+++ b/src/backend/tests/unit/part-review.test.ts
@@ -1,9 +1,10 @@
 import { Organization, User } from '@prisma/client';
-import { createTestOrganization, createTestUser, resetUsers } from '../test-utils';
+import { createTestOrganization, createTestProject, createTestUser, resetUsers } from '../test-utils';
 import PartReviewService from '../../src/services/part-review.services';
-import { batmanAppAdmin, supermanAdmin, aquamanLeadership, flashAdmin } from '../test-data/users.test-data';
+import { batmanAppAdmin, supermanAdmin, aquamanLeadership, flashAdmin, financeMember } from '../test-data/users.test-data';
 import prisma from '../../src/prisma/prisma';
-import { AccessDeniedAdminOnlyException, DeletedException } from '../../src/utils/errors.utils';
+import { AccessDeniedAdminOnlyException, AccessDeniedException, DeletedException } from '../../src/utils/errors.utils';
+import { Review_Status } from 'shared';
 
 describe('part review tests', () => {
   let orgId: string;
@@ -11,16 +12,161 @@ describe('part review tests', () => {
   let batman: User;
   let superman: User;
   let nonAdmin: User;
+  let nonLeadership: User;
   beforeEach(async () => {
     organization = await createTestOrganization();
     orgId = organization.organizationId;
     batman = await createTestUser(batmanAppAdmin, orgId);
     superman = await createTestUser(supermanAdmin, orgId);
     nonAdmin = await createTestUser(aquamanLeadership, orgId);
+    nonLeadership = await createTestUser(financeMember, orgId);
   });
 
   afterEach(async () => {
     await resetUsers();
+  });
+
+  it('creates a part, updates it, and deletes it', async () => {
+    const project = await createTestProject(batman, orgId);
+
+    const project1 = await prisma.project.findUnique({
+      where: { projectId: project.projectId },
+      include: {
+        wbsElement: true
+      }
+    });
+
+    const wbsNum = `${project1?.wbsElement.carNumber}.${project1?.wbsElement.projectNumber}.${project1?.wbsElement.workPackageNumber}`;
+
+    const tag = await PartReviewService.createPartTag('practice', '#000000', superman, orgId);
+    const tag2 = await PartReviewService.createPartTag('practice1', '#000001', superman, orgId);
+    const tag3 = await PartReviewService.createPartTag('practice2', '#000002', superman, orgId);
+
+    const part = await PartReviewService.createPart(
+      organization,
+      wbsNum,
+      batman,
+      1,
+      'part1',
+      'here is a description',
+      Review_Status.IN_PROGRESS,
+      [tag.partTagId, tag3.partTagId],
+      [nonAdmin.userId, batman.userId]
+    );
+
+    expect(part.commonName).toBe('part1');
+    expect(part.description).toBe('here is a description');
+    expect(part.userCreated.userId).toBe(batman.userId);
+    expect(part.status).toBe('IN_PROGRESS');
+    expect(part.tags.map((tag) => tag.partTagId)).toHaveLength(2);
+    expect(part.tags.map((tag) => tag.partTagId)).toContain(tag.partTagId);
+    expect(part.tags.map((tag) => tag.partTagId)).toContain(tag3.partTagId);
+    expect(part.assignees).toHaveLength(2);
+    expect(part.assignees.map((user) => user.userId)).toContain(nonAdmin.userId);
+    expect(part.assignees.map((user) => user.userId)).toContain(batman.userId);
+
+    const updatedPart = await PartReviewService.updatePart(
+      orgId,
+      part.partId,
+      superman,
+      2,
+      'part2',
+      'new description',
+      Review_Status.IN_REVIEW,
+      [tag2.partTagId],
+      [superman.userId, nonAdmin.userId]
+    );
+
+    expect(updatedPart.commonName).toBe('part2');
+    expect(updatedPart.description).toBe('new description');
+    expect(updatedPart.userCreated.userId).toBe(batman.userId);
+    expect(updatedPart.status).toBe('IN_REVIEW');
+    expect(updatedPart.tags.map((tag) => tag.partTagId)).toHaveLength(1);
+    expect(updatedPart.tags.map((tag) => tag.partTagId)).toContain(tag2.partTagId);
+    expect(updatedPart.assignees).toHaveLength(2);
+    expect(updatedPart.assignees.map((user) => user.userId)).toContain(superman.userId);
+    expect(updatedPart.assignees.map((user) => user.userId)).toContain(nonAdmin.userId);
+
+    const deletedPart = await PartReviewService.deletePart(updatedPart.partId, batman, orgId);
+    expect(deletedPart.commonName).toBe('part2');
+    expect(deletedPart.description).toBe('new description');
+    expect(deletedPart.userCreated.userId).toBe(batman.userId);
+    expect(deletedPart.status).toBe('IN_REVIEW');
+    expect(deletedPart.tags.map((tag) => tag.partTagId)).toHaveLength(1);
+    expect(deletedPart.tags.map((tag) => tag.partTagId)).toContain(tag2.partTagId);
+    expect(deletedPart.assignees).toHaveLength(2);
+    expect(deletedPart.assignees.map((user) => user.userId)).toContain(superman.userId);
+    expect(deletedPart.assignees.map((user) => user.userId)).toContain(nonAdmin.userId);
+
+    await expect(
+      async () =>
+        await PartReviewService.updatePart(
+          orgId,
+          part.partId,
+          superman,
+          2,
+          'part2',
+          'new description',
+          Review_Status.IN_REVIEW,
+          [tag2.partTagId],
+          [superman.userId, nonAdmin.userId]
+        )
+    ).rejects.toThrow(new DeletedException('Part', part.partId));
+  });
+
+  it('Does not allow non-leadership or non-team members to create or update a part', async () => {
+    const project = await createTestProject(batman, orgId);
+
+    const project1 = await prisma.project.findUnique({
+      where: { projectId: project.projectId },
+      include: {
+        wbsElement: true
+      }
+    });
+
+    const wbsNum = `${project1?.wbsElement.carNumber}.${project1?.wbsElement.projectNumber}.${project1?.wbsElement.workPackageNumber}`;
+
+    await expect(
+      async () =>
+        await PartReviewService.createPart(
+          organization,
+          wbsNum,
+          nonLeadership,
+          1,
+          'part1',
+          'here is a description',
+          Review_Status.IN_PROGRESS,
+          [],
+          [nonAdmin.userId, batman.userId]
+        )
+    ).rejects.toThrow(new AccessDeniedException('Only leadership and team members can create a part'));
+
+    const part = await PartReviewService.createPart(
+      organization,
+      wbsNum,
+      batman,
+      1,
+      'part1',
+      'here is a description',
+      Review_Status.IN_PROGRESS,
+      [],
+      [nonAdmin.userId, batman.userId]
+    );
+
+    await expect(
+      async () =>
+        await PartReviewService.updatePart(
+          orgId,
+          part.partId,
+          nonLeadership,
+          2,
+          'part2',
+          'new description',
+          Review_Status.IN_REVIEW,
+          [],
+          [superman.userId, nonAdmin.userId]
+        )
+    ).rejects.toThrow(new AccessDeniedException('Only leadership and the part creator can update part data'));
   });
 
   it('creates a part tag, edits it, and deletes it', async () => {

--- a/src/frontend/src/apis/part-review.api.ts
+++ b/src/frontend/src/apis/part-review.api.ts
@@ -16,7 +16,7 @@ export const getPartsFromProject = (/*projectId: string*/): { data: PartPreview[
         index: 1,
         commonName: 'wheels',
         description: 'we need wheels for the car to go, because no wheels means no rolly means no car go',
-        previewImageLink: 'jqoi34ghpwadjkog5qh3',
+        previewImageId: 'jqoi34ghpwadjkog5qh3',
         status: 'IN_PROGRESS' as Review_Status,
         tags: [],
         projectId: '1',
@@ -62,7 +62,7 @@ export const getPartsFromProject = (/*projectId: string*/): { data: PartPreview[
         index: 2,
         commonName: 'Test Part 2',
         description: 'Test Description 2',
-        previewImageLink: 'qogi43tbiohrj3q2jntfpi',
+        previewImageId: 'qogi43tbiohrj3q2jntfpi',
         status: 'READY_FOR_REVIEW' as Review_Status,
         tags: [],
         projectId: '1',
@@ -99,7 +99,7 @@ export const getSinglePart = (/*partId: string*/): { data: Part } => {
       index: 1,
       commonName: 'Suspension',
       description: 'Test description for a suspension part, which could be a fairly lon sentence',
-      previewImageLink: 'qogi43tbiohrj3q2jntfpi',
+      previewImageId: 'qogi43tbiohrj3q2jntfpi',
       status: 'IN_REVIEW' as Review_Status,
       tags: [],
       projectId: '1',
@@ -199,8 +199,8 @@ export const getSinglePart = (/*partId: string*/): { data: Part } => {
  *
  * @param payload the payload of the part
  */
-export const createPart = (projectId: string, payload: PartPayload) => {
-  return axios.post<Part>(apiUrls.partsCreate(projectId), {
+export const createPart = (payload: PartPayload) => {
+  return axios.post<Part>(apiUrls.partsCreate(), {
     ...payload
   });
 };
@@ -234,7 +234,7 @@ export const editPart = (partId: string, payload: PartPayload) => {
  * @param partId the id of the part to delete
  */
 export const deletePart = (partId: string) => {
-  return axios.post<Part>(apiUrls.partsDelete(partId));
+  return axios.post<{ message: string }>(apiUrls.partsDelete(partId));
 };
 
 /**

--- a/src/frontend/src/apis/part-review.api.ts
+++ b/src/frontend/src/apis/part-review.api.ts
@@ -210,7 +210,7 @@ export const createPart = (projectId: string, payload: PartPayload) => {
  * @param file the preview image
  * @param partId the id of the part that will display this image
  */
-export const useUploadPreviewImage = (file: File, partId: string) => {
+export const uploadPreviewImage = (file: File, partId: string) => {
   const formData = new FormData();
   formData.append('image', file);
   return axios.post(apiUrls.partsUploadPreviewImage(partId), formData);

--- a/src/frontend/src/apis/part-review.api.ts
+++ b/src/frontend/src/apis/part-review.api.ts
@@ -199,10 +199,21 @@ export const getSinglePart = (/*partId: string*/): { data: Part } => {
  *
  * @param payload the payload of the part
  */
-export const createPart = (payload: PartPayload) => {
-  return axios.post<Part>(apiUrls.partsCreate(), {
+export const createPart = (projectId: string, payload: PartPayload) => {
+  return axios.post<Part>(apiUrls.partsCreate(projectId), {
     ...payload
   });
+};
+
+/**
+ * Uploads a preview image for a given part
+ * @param file the preview image
+ * @param partId the id of the part that will display this image
+ */
+export const useUploadPreviewImage = (file: File, partId: string) => {
+  const formData = new FormData();
+  formData.append('image', file);
+  return axios.post(apiUrls.partsUploadPreviewImage(partId), formData);
 };
 
 /**

--- a/src/frontend/src/hooks/part-review.hooks.ts
+++ b/src/frontend/src/hooks/part-review.hooks.ts
@@ -38,7 +38,6 @@ export interface PartReviewRequestPayload {
 export interface PartReviewPayload {
   fileIds: string[];
   notes?: string;
-  commonMistakeIds: string[];
 }
 
 /**

--- a/src/frontend/src/hooks/part-review.hooks.ts
+++ b/src/frontend/src/hooks/part-review.hooks.ts
@@ -16,6 +16,7 @@ import {
 } from '../apis/part-review.api';
 
 export interface PartPayload {
+  wbsNum: string;
   index: number;
   commonName: string;
   description?: string;
@@ -67,12 +68,12 @@ export const useSinglePart = (/*partId: string*/) => {
 /**
  * Custom React Hook to create a new part
  */
-export const useCreatePart = (projectId: string) => {
+export const useCreatePart = () => {
   const queryClient = useQueryClient();
   return useMutation<Part, Error, PartPayload>(
     ['parts', 'create'],
     async (part: PartPayload) => {
-      const { data } = await createPart(projectId, part);
+      const { data } = await createPart(part);
       return data;
     },
     {
@@ -128,7 +129,7 @@ export const useUploadPreviewImage = (partId: string) => {
  */
 export const useDeletePart = (partId: string) => {
   const queryClient = useQueryClient();
-  return useMutation<Part, Error, any>(
+  return useMutation<{ message: string }, Error, any>(
     ['parts', 'delete'],
     async () => {
       const { data } = await deletePart(partId);

--- a/src/frontend/src/hooks/part-review.hooks.ts
+++ b/src/frontend/src/hooks/part-review.hooks.ts
@@ -13,15 +13,14 @@ import {
   getPartsFromProject,
   getSinglePart
 } from '../apis/part-review.api';
+import { apiUrls } from '../utils/urls';
 
 export interface PartPayload {
   index: number;
   commonName: string;
   description?: string;
-  previewImageLink?: string;
   reviewStatus: Review_Status;
   tagIds: string[];
-  projectId: string;
   assigneeIds: string[];
 }
 
@@ -69,12 +68,12 @@ export const useSinglePart = (/*partId: string*/) => {
 /**
  * Custom React Hook to create a new part
  */
-export const useCreatePart = () => {
+export const useCreatePart = (projectId: string) => {
   const queryClient = useQueryClient();
   return useMutation<Part, Error, PartPayload>(
     ['parts', 'create'],
     async (part: PartPayload) => {
-      const { data } = await createPart(part);
+      const { data } = await createPart(projectId, part);
       return data;
     },
     {
@@ -84,6 +83,7 @@ export const useCreatePart = () => {
     }
   );
 };
+
 
 /**
  * Custom React Hook to edit a part

--- a/src/frontend/src/hooks/part-review.hooks.ts
+++ b/src/frontend/src/hooks/part-review.hooks.ts
@@ -11,9 +11,9 @@ import {
   editPartReview,
   editPartSubmission,
   getPartsFromProject,
-  getSinglePart
+  getSinglePart,
+  uploadPreviewImage
 } from '../apis/part-review.api';
-import { apiUrls } from '../utils/urls';
 
 export interface PartPayload {
   index: number;
@@ -84,7 +84,6 @@ export const useCreatePart = (projectId: string) => {
   );
 };
 
-
 /**
  * Custom React Hook to edit a part
  *
@@ -96,6 +95,22 @@ export const useEditPart = (partId: string) => {
     ['parts', 'edit'],
     async (part: PartPayload) => {
       const { data } = await editPart(partId, part);
+      return data;
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(['parts', 'byProject']);
+        queryClient.invalidateQueries(['parts', 'byId', partId]);
+      }
+    }
+  );
+};
+
+export const useUploadPreviewImage = (partId: string) => {
+  const queryClient = useQueryClient();
+  return useMutation<any, unknown, File>(
+    async (image: File) => {
+      const { data } = await uploadPreviewImage(image, partId);
       return data;
     },
     {

--- a/src/frontend/src/utils/urls.ts
+++ b/src/frontend/src/utils/urls.ts
@@ -45,7 +45,7 @@ const projectsEditLinkTypes = (linkTypeName: string) => `${projects()}/link-type
 const parts = () => `${API_URL}/parts`;
 const partsByProject = (projectId: string) => `${parts()}/${projectId}/parts`;
 const partsById = (partId: string) => `${parts()}/${partId}`;
-const partsCreate = (projectId: string) => `${parts()}/${projectId}/create`;
+const partsCreate = () => `${parts()}/create`;
 const partsUploadPreviewImage = (partId: string) => `${parts()}/${partId}/upload-preview`;
 const partsEdit = (partId: string) => `${parts()}/${partId}/update`;
 const partsDelete = (partId: string) => `${parts()}/${partId}/delete`;

--- a/src/frontend/src/utils/urls.ts
+++ b/src/frontend/src/utils/urls.ts
@@ -45,7 +45,8 @@ const projectsEditLinkTypes = (linkTypeName: string) => `${projects()}/link-type
 const parts = () => `${API_URL}/parts`;
 const partsByProject = (projectId: string) => `${parts()}/${projectId}/parts`;
 const partsById = (partId: string) => `${parts()}/${partId}`;
-const partsCreate = () => `${parts()}/create`;
+const partsCreate = (projectId: string) => `${parts()}/${projectId}/create`;
+const partsUploadPreviewImage = (partId: string) => `${parts()}/${partId}/upload-preview`;
 const partsEdit = (partId: string) => `${parts()}/${partId}/update`;
 const partsDelete = (partId: string) => `${parts()}/${partId}/delete`;
 const partsCreateSubmission = (partId: string) => `${parts()}/submission/${partId}/create`;
@@ -293,8 +294,9 @@ export const apiUrls = {
 
   parts,
   partsByProject,
-  partById: partsById,
+  partsById,
   partsCreate,
+  partsUploadPreviewImage,
   partsEdit,
   partsDelete,
   partsCreateSubmission,

--- a/src/shared/src/types/part-review.types.ts
+++ b/src/shared/src/types/part-review.types.ts
@@ -13,7 +13,7 @@ export interface PartPreview {
   index: number;
   commonName: string;
   description?: string;
-  previewImageLink?: string;
+  previewImageId?: string;
   status: Review_Status;
   tags: PartTag[];
   projectId: string;


### PR DESCRIPTION
## Changes

Create, update, and delete endpoints for parts, along with an upload preview image endpoint to upload an image as the preview for a part

## Test Cases

- creating a part works
- updating a part works
- deleting a part works
- non-leadership cannot create part
- non-leadership cannot update part
- cannot update deleted part

## Screenshots
<img width="1219" alt="Screenshot 2025-03-29 at 2 17 35 PM" src="https://github.com/user-attachments/assets/89322d92-7f6c-46a8-bd20-9f7694e6bf66" />
<img width="1182" alt="Screenshot 2025-03-29 at 2 25 36 PM" src="https://github.com/user-attachments/assets/6752030e-c368-4c53-bbce-135b94896c1c" />
<img width="1163" alt="Screenshot 2025-03-29 at 2 26 03 PM" src="https://github.com/user-attachments/assets/2ca088d9-7a52-42b2-bac9-aab2b9008197" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #3311
