### PR TITLE
Fixed date conversion to 1 index dates

### DIFF
--- a/src/backend/src/utils/datetime.utils.ts
+++ b/src/backend/src/utils/datetime.utils.ts
@@ -10,6 +10,6 @@
  */
 export const transformDate = (date: Date) => {
   const month = date.getMonth() + 1 < 10 ? `0${date.getMonth() + 1}` : (date.getMonth() + 1).toString();
-  const day = date.getDate() + 1 < 10 ? `0${date.getDate() + 1}` : (date.getDate() + 1).toString();
+  const day = date.getDate() < 10 ? `0${date.getDate()}` : date.getDate().toString();
   return `${date.getFullYear().toString()}-${month}-${day}`;
 };


### PR DESCRIPTION
## Changes

transformDate no longer adds 1 to getDate() from the input date, as getDate() already returns the 1 indexed value (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getDate)