### PR TITLE
CAD Part History Component

### DIFF
--- a/src/frontend/src/pages/PartPage/Components/PartHistoryView.tsx
+++ b/src/frontend/src/pages/PartPage/Components/PartHistoryView.tsx
@@ -2,8 +2,6 @@ import { Grid } from '@mui/system';
 import { Part } from 'shared';
 import { completePartHistory } from '../../../utils/part.utils';
 
-// Take in part shared type
-// and then to test it you can make your own test part and pass it into your component.
 interface PartHistoryViewProps {
   part: Part;
 }

--- a/src/frontend/src/pages/PartPage/Components/PartHistoryView.tsx
+++ b/src/frontend/src/pages/PartPage/Components/PartHistoryView.tsx
@@ -1,0 +1,17 @@
+import { Grid } from '@mui/system';
+import { Part } from 'shared';
+import { completePartHistory } from '../../../utils/part.utils';
+
+// Take in part shared type
+// and then to test it you can make your own test part and pass it into your component.
+interface PartHistoryViewProps {
+  part: Part;
+}
+
+const PartHistoryView: React.FC<PartHistoryViewProps> = ({ part }: PartHistoryViewProps) => {
+  const historyEntries = completePartHistory(part);
+
+  return <Grid> /* History Entries */ </Grid>;
+};
+
+export default PartHistoryView;

--- a/src/frontend/src/pages/PartPage/Components/PartHistoryView.tsx
+++ b/src/frontend/src/pages/PartPage/Components/PartHistoryView.tsx
@@ -7,7 +7,7 @@ interface PartHistoryViewProps {
 }
 
 const PartHistoryView: React.FC<PartHistoryViewProps> = ({ part }: PartHistoryViewProps) => {
-  const historyEntries = completePartHistory(part);
+  const historyEntries: string[] = completePartHistory(part);
 
   return <Grid> /* History Entries */ </Grid>;
 };

--- a/src/frontend/src/pages/PartPage/Components/PartHistoryView.tsx
+++ b/src/frontend/src/pages/PartPage/Components/PartHistoryView.tsx
@@ -1,6 +1,7 @@
 import { Grid } from '@mui/system';
 import { Part } from 'shared';
 import { completePartHistory } from '../../../utils/part.utils';
+import ScrollablePageBlock from '../../HomePage/components/ScrollablePageBlock';
 
 interface PartHistoryViewProps {
   part: Part;
@@ -10,11 +11,13 @@ const PartHistoryView: React.FC<PartHistoryViewProps> = ({ part }: PartHistoryVi
   const historyEntries: string[] = completePartHistory(part);
 
   return (
-    <Grid>
-      {historyEntries.map((entry, index) => (
-        <Grid key={index}>{entry}</Grid>
-      ))}
-    </Grid>
+    <ScrollablePageBlock>
+      <Grid>
+        {historyEntries.map((entry, index) => (
+          <Grid key={index}>{entry}</Grid>
+        ))}
+      </Grid>
+    </ScrollablePageBlock>
   );
 };
 

--- a/src/frontend/src/pages/PartPage/Components/PartHistoryView.tsx
+++ b/src/frontend/src/pages/PartPage/Components/PartHistoryView.tsx
@@ -9,7 +9,13 @@ interface PartHistoryViewProps {
 const PartHistoryView: React.FC<PartHistoryViewProps> = ({ part }: PartHistoryViewProps) => {
   const historyEntries: string[] = completePartHistory(part);
 
-  return <Grid> /* History Entries */ </Grid>;
+  return (
+    <Grid>
+      {historyEntries.map((entry, index) => (
+        <Grid key={index}>{entry}</Grid>
+      ))}
+    </Grid>
+  );
 };
 
 export default PartHistoryView;

--- a/src/frontend/src/pages/PartPage/PartPage.tsx
+++ b/src/frontend/src/pages/PartPage/PartPage.tsx
@@ -1,4 +1,71 @@
 import { Box, Typography, Grid, Breadcrumbs } from '@mui/material';
+import PartHistoryView from './Components/PartHistoryView';
+import { Part, PartReview, PartReviewRequest, PartSubmission, Review_Status, RoleEnum, User } from 'shared';
+
+const creator: User = {
+  userId: '05',
+  firstName: 'Mohit',
+  lastName: 'Singhal',
+  email: 'email',
+  emailId: '',
+  role: RoleEnum.ADMIN,
+  permissions: []
+};
+
+const reviewer1: User = {
+  userId: '04',
+  firstName: 'Peter',
+  lastName: 'Desnoyers',
+  email: 'email',
+  emailId: '',
+  role: RoleEnum.ADMIN,
+  permissions: []
+};
+
+const partReview1: PartReview = {
+  partReviewId: '001',
+  fileIds: [],
+  notes: '',
+  submissionId: '02',
+  popUps: [],
+  createdAt: new Date('2024-01-04T01:00:00Z'),
+  completedAt: new Date('2024-01-05T01:00:00Z'),
+  userCreated: reviewer1
+};
+
+const partSubmission1: PartSubmission = {
+  partSubmissionId: '01',
+  fileIds: [],
+  name: 'Submission #1',
+  notes: 'First Submission',
+  partId: '00A',
+  userCreated: creator,
+  reviews: [partReview1],
+  createdAt: new Date('2024-01-02T01:00:00Z')
+};
+
+const reviewReq1: PartReviewRequest = {
+  partReviewRequestId: '000',
+  partId: '00A',
+  requester: creator,
+  reviewerRequested: reviewer1,
+  createdAt: new Date('2024-01-03T01:00:00Z')
+};
+
+const part1: Part = {
+  partId: '00A',
+  index: 1,
+  commonName: 'PROJ_PartName_0000-00A',
+  description: '',
+  status: Review_Status.APPROVED,
+  tags: [],
+  projectId: '001',
+  assignees: [],
+  reviewRequests: [reviewReq1],
+  createdAt: new Date('2024-01-01T01:00:00Z'),
+  userCreated: creator,
+  submissions: [partSubmission1]
+};
 
 const PartPage: React.FC = () => {
   return (
@@ -74,6 +141,7 @@ const PartPage: React.FC = () => {
                 }}
               >
                 <Typography>History</Typography>
+                <PartHistoryView part={part1}></PartHistoryView>
               </Box>
             </Grid>
           </Grid>

--- a/src/frontend/src/tests/utils/part.utils.test.ts
+++ b/src/frontend/src/tests/utils/part.utils.test.ts
@@ -1,0 +1,109 @@
+import { Part, PartReview, PartSubmission, Permission, Review_Status, RoleEnum, User } from 'shared';
+import { completePartHistory } from '../../utils/part.utils';
+
+const user1: User = {
+  userId: '5',
+  firstName: 'Chris',
+  lastName: 'Pyle',
+  email: 'email',
+  emailId: '',
+  role: RoleEnum.ADMIN,
+  permissions: []
+};
+const user2: User = {
+  userId: '8',
+  firstName: 'Griffin',
+  lastName: 'Cooper',
+  email: 'email',
+  emailId: '',
+  role: RoleEnum.ADMIN,
+  permissions: []
+};
+const user3: User = {
+  userId: '3',
+  firstName: 'Zachary',
+  lastName: 'Wen',
+  email: 'email',
+  emailId: '',
+  role: RoleEnum.ADMIN,
+  permissions: []
+};
+
+const partReviewUncomplete: PartReview = {
+  partReviewId: '001',
+  fileIds: [],
+  notes: 'NOTES FOR A REVIEW',
+  submissionId: '02',
+  popUps: [],
+  createdAt: new Date('2022-01-01T00:00:00Z'),
+  userCreated: user2
+};
+
+const partReviewComplete: PartReview = {
+  partReviewId: '002',
+  fileIds: [],
+  notes: 'NOTES FOR A REVIEW',
+  submissionId: '02',
+  popUps: [],
+  createdAt: new Date('2022-01-03T00:00:00Z'),
+  completedAt: new Date('2022-01-03T00:00:00Z'),
+  userCreated: user2
+};
+
+const partSubmission1: PartSubmission = {
+  partSubmissionId: '02',
+  fileIds: [],
+  name: 'PROJ_PartName_0000-00A',
+  notes: 'NOTES FOR A SUBMISSION!',
+  partId: '002',
+  userCreated: user1,
+  reviews: [partReviewUncomplete],
+  createdAt: new Date('2000-01-02T00:00:00Z')
+};
+
+const partInProgress: Part = {
+  partId: '00A',
+  index: 1,
+  commonName: 'Wheel',
+  description: 'A wheel part',
+  status: Review_Status.IN_PROGRESS,
+  tags: [],
+  projectId: '001',
+  assignees: [user1],
+  reviewRequests: [],
+  createdAt: new Date('2000-01-01T00:00:00Z'),
+  userCreated: user1,
+  submissions: [partSubmission1]
+};
+
+describe('Part Submission History', () => {
+  it('Part created history', () => {
+    const response: String = '';
+    expect(completePartHistory(partInProgress)).toEqual(response);
+    // [01/01/24] - PROJ_PartName_0000-00A was created.
+  });
+  it('User uploaded first submission includes part name', () => {
+    // [01/01/24] - Joseph Aoun uploaded Submission #1 for PROJ_PartName_0000-00A.
+  });
+  it('User uploaded second submission w/o part name', () => {
+    // [01/01/24] - Joseph Aoun uploaded Submission #2
+  });
+  it('User requested review', () => {
+    // [01/01/24] - Joseph Aoun requested a review from Jacob Brown.
+  });
+  it('User re-requested review', () => {
+    // [01/03/24] - Joseph Aoun re-requested a review from Jacob Brown.
+  });
+  it('User requested review from two people combined', () => {
+    // [01/01/24] - Joseph Aoun requested a review from Jacob Brown and George Miller.
+  });
+  it('Reviewer began reviewing submission', () => {
+    // [01/01/24] - George Miller began reviewing Submission #1
+  });
+  it('Reviewer reviewed submission', () => {
+    // [01/03/24] - George Miller reviewed Submission #1 (in Submission #1 Review)
+  });
+  it('Reviewer approved last submission', () => {
+    // [01/05/24] - George Miller approved Submission #3
+  });
+});

--- a/src/frontend/src/tests/utils/part.utils.test.ts
+++ b/src/frontend/src/tests/utils/part.utils.test.ts
@@ -1,7 +1,7 @@
-import { Part, PartReview, PartSubmission, Permission, Review_Status, RoleEnum, User } from 'shared';
+import { Part, PartReview, PartSubmission, Review_Status, RoleEnum, User } from 'shared';
 import { completePartHistory } from '../../utils/part.utils';
 
-const user1: User = {
+const creator: User = {
   userId: '5',
   firstName: 'Chris',
   lastName: 'Pyle',
@@ -10,7 +10,7 @@ const user1: User = {
   role: RoleEnum.ADMIN,
   permissions: []
 };
-const user2: User = {
+const reviewer1: User = {
   userId: '8',
   firstName: 'Griffin',
   lastName: 'Cooper',
@@ -19,7 +19,7 @@ const user2: User = {
   role: RoleEnum.ADMIN,
   permissions: []
 };
-const user3: User = {
+const reviewer2: User = {
   userId: '3',
   firstName: 'Zachary',
   lastName: 'Wen',
@@ -29,81 +29,141 @@ const user3: User = {
   permissions: []
 };
 
-const partReviewUncomplete: PartReview = {
+const partReview1: PartReview = {
   partReviewId: '001',
   fileIds: [],
   notes: 'NOTES FOR A REVIEW',
   submissionId: '02',
   popUps: [],
-  createdAt: new Date('2022-01-01T00:00:00Z'),
-  userCreated: user2
+  createdAt: new Date('2024-01-02T12:00:00Z'),
+  completedAt: new Date('2024-01-03T12:00:00Z'),
+  userCreated: reviewer1
 };
 
-const partReviewComplete: PartReview = {
+const partReview2: PartReview = {
   partReviewId: '002',
   fileIds: [],
   notes: 'NOTES FOR A REVIEW',
   submissionId: '02',
   popUps: [],
-  createdAt: new Date('2022-01-03T00:00:00Z'),
-  completedAt: new Date('2022-01-03T00:00:00Z'),
-  userCreated: user2
+  createdAt: new Date('2024-01-04T12:00:00Z'),
+  userCreated: reviewer1
+};
+
+const partReview3: PartReview = {
+  partReviewId: '003',
+  fileIds: [],
+  notes: 'NOTES FOR A REVIEW',
+  submissionId: '02',
+  popUps: [],
+  createdAt: new Date('2024-01-04T12:00:00Z'),
+  userCreated: reviewer2
+};
+
+const partReviewComplete: PartReview = {
+  partReviewId: '004',
+  fileIds: [],
+  notes: 'NOTES FOR A REVIEW',
+  submissionId: '02',
+  popUps: [],
+  createdAt: new Date('2024-01-07T00:00:00Z'),
+  completedAt: new Date('2024-01-07T00:12:00Z'),
+  userCreated: reviewer1
 };
 
 const partSubmission1: PartSubmission = {
-  partSubmissionId: '02',
+  partSubmissionId: '01',
   fileIds: [],
-  name: 'PROJ_PartName_0000-00A',
-  notes: 'NOTES FOR A SUBMISSION!',
-  partId: '002',
-  userCreated: user1,
-  reviews: [partReviewUncomplete],
-  createdAt: new Date('2000-01-02T00:00:00Z')
+  name: 'Submission #1',
+  notes: 'First Submission',
+  partId: '00A',
+  userCreated: creator,
+  reviews: [partReview1],
+  createdAt: new Date('2024-01-02T00:00:00Z')
 };
 
-const partInProgress: Part = {
+const partSubmission2: PartSubmission = {
+  partSubmissionId: '02',
+  fileIds: [],
+  name: 'Submission #2',
+  notes: 'Second submission',
+  partId: '00A',
+  userCreated: creator,
+  reviews: [partReview2, partReview3],
+  createdAt: new Date('2024-01-04T00:00:00Z')
+};
+
+const partSubmission3: PartSubmission = {
+  partSubmissionId: '03',
+  fileIds: [],
+  name: 'Submission #3',
+  notes: 'Final submission',
+  partId: '00A',
+  userCreated: creator,
+  reviews: [partReviewComplete],
+  createdAt: new Date('2024-01-06T00:00:00Z')
+};
+
+const part1: Part = {
   partId: '00A',
   index: 1,
-  commonName: 'Wheel',
+  commonName: 'PROJ_PartName_0000-00A',
   description: 'A wheel part',
-  status: Review_Status.IN_PROGRESS,
+  status: Review_Status.APPROVED,
   tags: [],
   projectId: '001',
-  assignees: [user1],
+  assignees: [creator],
   reviewRequests: [],
-  createdAt: new Date('2000-01-01T00:00:00Z'),
-  userCreated: user1,
-  submissions: [partSubmission1]
+  createdAt: new Date('2024-01-01T00:00:00Z'),
+  userCreated: reviewer2, //any other user
+  submissions: [partSubmission1, partSubmission2, partSubmission3]
 };
 
 describe('Part Submission History', () => {
   it('Part created history', () => {
-    const response: String = '';
-    expect(completePartHistory(partInProgress)).toEqual(response);
-    // [01/01/24] - PROJ_PartName_0000-00A was created.
+    const response: string = '[01/01/24] - PROJ_PartName_0000-00A was created';
+    expect(completePartHistory(part1)[0]).toBe(response);
+
+    //Received: "[12/31/23] - PROJ_PartName_0000-00A was created"
   });
   it('User uploaded first submission includes part name', () => {
-    // [01/01/24] - Joseph Aoun uploaded Submission #1 for PROJ_PartName_0000-00A.
+    const response: string = '[01/02/24] - Chris Pyle uploaded Submission #1 for PROJ_PartName_0000-00A';
+    expect(completePartHistory(part1)[1]).toBe(response);
+
+    //Received: "[12/31/23] - Griffin Cooper began reviewing Submission #1"
   });
-  it('User uploaded second submission w/o part name', () => {
-    // [01/01/24] - Joseph Aoun uploaded Submission #2
+  it('User requested single review', () => {
+    const response: string = '[01/02/24] - Chris Pyle requested a review from Griffin Cooper';
+    expect(completePartHistory(part1)[2]).toBe(response);
   });
-  it('User requested review', () => {
-    // [01/01/24] - Joseph Aoun requested a review from Jacob Brown.
+  it('Reviewer began reviewing submission', () => {
+    const response: string = '[01/02/24] - Griffin Cooper began reviewing Submission #1';
+    expect(completePartHistory(part1)[3]).toBe(response);
   });
-  it('User re-requested review', () => {
-    // [01/03/24] - Joseph Aoun re-requested a review from Jacob Brown.
+  it('Reviewer finished reviewing submission', () => {
+    const response: string = '[01/02/24] - Griffin Cooper reviewed Submission #1 (in Submission #1 Review)';
+    expect(completePartHistory(part1)[4]).toBe(response);
   });
   it('User requested review from two people combined', () => {
     // [01/01/24] - Joseph Aoun requested a review from Jacob Brown and George Miller.
+    const response: string = '?';
+    expect(completePartHistory(part1)[5]).toBe(response);
   });
   it('Reviewer began reviewing submission', () => {
     // [01/01/24] - George Miller began reviewing Submission #1
+    const response: string = '?';
+    expect(completePartHistory(part1)[6]).toBe(response);
   });
   it('Reviewer reviewed submission', () => {
     // [01/03/24] - George Miller reviewed Submission #1 (in Submission #1 Review)
+    const response: string = '?';
+    expect(completePartHistory(part1)[7]).toBe(response);
   });
   it('Reviewer approved last submission', () => {
     // [01/05/24] - George Miller approved Submission #3
+    const response: string = '[01/01/24] - name approved Submission #3';
+    expect(completePartHistory(part1)[8]).toBe(response);
+
+    //undefined
   });
 });

--- a/src/frontend/src/tests/utils/part.utils.test.ts
+++ b/src/frontend/src/tests/utils/part.utils.test.ts
@@ -1,4 +1,4 @@
-import { Part, PartReview, PartSubmission, Review_Status, RoleEnum, User } from 'shared';
+import { Part, PartReview, PartReviewRequest, PartSubmission, Review_Status, RoleEnum, User } from 'shared';
 import { completePartHistory } from '../../utils/part.utils';
 
 const creator: User = {
@@ -32,43 +32,34 @@ const reviewer2: User = {
 const partReview1: PartReview = {
   partReviewId: '001',
   fileIds: [],
-  notes: 'NOTES FOR A REVIEW',
+  notes: '',
   submissionId: '02',
   popUps: [],
-  createdAt: new Date('2024-01-02T12:00:00Z'),
-  completedAt: new Date('2024-01-03T12:00:00Z'),
+  createdAt: new Date('2024-01-04T01:00:00Z'),
+  completedAt: new Date('2024-01-05T01:00:00Z'),
   userCreated: reviewer1
 };
 
 const partReview2: PartReview = {
   partReviewId: '002',
   fileIds: [],
-  notes: 'NOTES FOR A REVIEW',
+  notes: '',
   submissionId: '02',
   popUps: [],
-  createdAt: new Date('2024-01-04T12:00:00Z'),
-  userCreated: reviewer1
-};
-
-const partReview3: PartReview = {
-  partReviewId: '003',
-  fileIds: [],
-  notes: 'NOTES FOR A REVIEW',
-  submissionId: '02',
-  popUps: [],
-  createdAt: new Date('2024-01-04T12:00:00Z'),
+  createdAt: new Date('2024-01-08T01:00:00Z'),
+  completedAt: new Date('2024-01-09T01:01:00Z'),
   userCreated: reviewer2
 };
 
 const partReviewComplete: PartReview = {
   partReviewId: '004',
   fileIds: [],
-  notes: 'NOTES FOR A REVIEW',
+  notes: '',
   submissionId: '02',
   popUps: [],
-  createdAt: new Date('2024-01-07T00:00:00Z'),
-  completedAt: new Date('2024-01-07T00:12:00Z'),
-  userCreated: reviewer1
+  createdAt: new Date('2024-01-12T01:00:00Z'),
+  completedAt: new Date('2024-01-13T02:00:00Z'),
+  userCreated: reviewer2
 };
 
 const partSubmission1: PartSubmission = {
@@ -79,7 +70,7 @@ const partSubmission1: PartSubmission = {
   partId: '00A',
   userCreated: creator,
   reviews: [partReview1],
-  createdAt: new Date('2024-01-02T00:00:00Z')
+  createdAt: new Date('2024-01-02T01:00:00Z')
 };
 
 const partSubmission2: PartSubmission = {
@@ -89,8 +80,8 @@ const partSubmission2: PartSubmission = {
   notes: 'Second submission',
   partId: '00A',
   userCreated: creator,
-  reviews: [partReview2, partReview3],
-  createdAt: new Date('2024-01-04T00:00:00Z')
+  reviews: [partReview2],
+  createdAt: new Date('2024-01-06T01:00:00Z')
 };
 
 const partSubmission3: PartSubmission = {
@@ -101,69 +92,112 @@ const partSubmission3: PartSubmission = {
   partId: '00A',
   userCreated: creator,
   reviews: [partReviewComplete],
-  createdAt: new Date('2024-01-06T00:00:00Z')
+  createdAt: new Date('2024-01-10T01:00:00Z')
+};
+
+const reviewReq1: PartReviewRequest = {
+  partReviewRequestId: '000',
+  partId: '00A',
+  requester: creator,
+  reviewerRequested: reviewer1,
+  createdAt: new Date('2024-01-03T01:00:00Z')
+};
+
+const reviewReq2: PartReviewRequest = {
+  partReviewRequestId: '001',
+  partId: '00A',
+  requester: creator,
+  reviewerRequested: reviewer1,
+  createdAt: new Date('2024-01-07T01:00:00Z')
+};
+
+const reviewReq3: PartReviewRequest = {
+  partReviewRequestId: '002',
+  partId: '00A',
+  requester: creator,
+  reviewerRequested: reviewer2,
+  createdAt: new Date('2024-01-07T01:00:00Z')
+};
+
+const reviewReq4: PartReviewRequest = {
+  partReviewRequestId: '003',
+  partId: '00A',
+  requester: creator,
+  reviewerRequested: reviewer2,
+  createdAt: new Date('2024-01-11T01:00:00Z')
 };
 
 const part1: Part = {
   partId: '00A',
   index: 1,
   commonName: 'PROJ_PartName_0000-00A',
-  description: 'A wheel part',
+  description: '',
   status: Review_Status.APPROVED,
   tags: [],
   projectId: '001',
-  assignees: [creator],
-  reviewRequests: [],
-  createdAt: new Date('2024-01-01T00:00:00Z'),
-  userCreated: reviewer2, //any other user
+  assignees: [],
+  reviewRequests: [reviewReq1, reviewReq2, reviewReq3, reviewReq4],
+  createdAt: new Date('2024-01-01T01:00:00Z'),
+  userCreated: creator,
   submissions: [partSubmission1, partSubmission2, partSubmission3]
 };
 
 describe('Part Submission History', () => {
   it('Part created history', () => {
-    const response: string = '[01/01/24] - PROJ_PartName_0000-00A was created';
+    const response: string = '[01/01/24] - PROJ_PartName_0000-00A was created.';
     expect(completePartHistory(part1)[0]).toBe(response);
-
-    //Received: "[12/31/23] - PROJ_PartName_0000-00A was created"
   });
   it('User uploaded first submission includes part name', () => {
-    const response: string = '[01/02/24] - Chris Pyle uploaded Submission #1 for PROJ_PartName_0000-00A';
+    // userCreated or assignees???
+    const response: string = '[01/02/24] - Chris Pyle uploaded Submission #1 for PROJ_PartName_0000-00A.';
     expect(completePartHistory(part1)[1]).toBe(response);
-
-    //Received: "[12/31/23] - Griffin Cooper began reviewing Submission #1"
   });
   it('User requested single review', () => {
-    const response: string = '[01/02/24] - Chris Pyle requested a review from Griffin Cooper';
+    const response: string = '[01/03/24] - Chris Pyle requested a review from Griffin Cooper.';
     expect(completePartHistory(part1)[2]).toBe(response);
   });
   it('Reviewer began reviewing submission', () => {
-    const response: string = '[01/02/24] - Griffin Cooper began reviewing Submission #1';
+    const response: string = '[01/04/24] - Griffin Cooper began reviewing Submission #1.';
     expect(completePartHistory(part1)[3]).toBe(response);
   });
   it('Reviewer finished reviewing submission', () => {
-    const response: string = '[01/02/24] - Griffin Cooper reviewed Submission #1 (in Submission #1 Review)';
+    const response: string = '[01/05/24] - Griffin Cooper reviewed Submission #1 (in Submission #1 Review).';
     expect(completePartHistory(part1)[4]).toBe(response);
   });
-  it('User requested review from two people combined', () => {
-    // [01/01/24] - Joseph Aoun requested a review from Jacob Brown and George Miller.
-    const response: string = '?';
+  it('User uploaded second submission w/o part name', () => {
+    const response: string = '[01/06/24] - Chris Pyle uploaded Submission #2.';
     expect(completePartHistory(part1)[5]).toBe(response);
   });
-  it('Reviewer began reviewing submission', () => {
-    // [01/01/24] - George Miller began reviewing Submission #1
-    const response: string = '?';
+  it('User requested review from two people combined', () => {
+    const response: string = '[01/07/24] - Chris Pyle requested a review from Griffin Cooper and Zachary Wen.';
     expect(completePartHistory(part1)[6]).toBe(response);
   });
   it('Reviewer reviewed submission', () => {
-    // [01/03/24] - George Miller reviewed Submission #1 (in Submission #1 Review)
-    const response: string = '?';
+    const response: string = '[01/08/24] - Zachary Wen began reviewing Submission #2.';
     expect(completePartHistory(part1)[7]).toBe(response);
   });
-  it('Reviewer approved last submission', () => {
-    // [01/05/24] - George Miller approved Submission #3
-    const response: string = '[01/01/24] - name approved Submission #3';
+  it('Reviewer approved submission', () => {
+    const response: string = '[01/09/24] - Zachary Wen reviewed Submission #2 (in Submission #2 Review).';
     expect(completePartHistory(part1)[8]).toBe(response);
-
-    //undefined
+  });
+  it('Sub 3', () => {
+    const response: string = '[01/10/24] - Chris Pyle uploaded Submission #3.';
+    expect(completePartHistory(part1)[9]).toBe(response);
+  });
+  it('Re-Request Review', () => {
+    const response: string = '[01/11/24] - Chris Pyle re-requested a review from Zachary Wen.';
+    expect(completePartHistory(part1)[10]).toBe(response);
+  });
+  it('Began Reviewing', () => {
+    const response: string = '[01/12/24] - Zachary Wen began reviewing Submission #3.';
+    expect(completePartHistory(part1)[11]).toBe(response);
+  });
+  it('Last Review Approves?', () => {
+    const response: string = '[01/13/24] - Zachary Wen reviewed Submission #3 (in Submission #3 Review).';
+    expect(completePartHistory(part1)[12]).toBe(response);
+  });
+  it('Complete History for viewing', () => {
+    const response: string = '...';
+    expect(completePartHistory(part1)).toBe(response);
   });
 });

--- a/src/frontend/src/tests/utils/part.utils.test.ts
+++ b/src/frontend/src/tests/utils/part.utils.test.ts
@@ -148,7 +148,6 @@ describe('Part Submission History', () => {
     expect(completePartHistory(part1)[0]).toBe(response);
   });
   it('User uploaded first submission includes part name', () => {
-    // userCreated or assignees???
     const response: string = '[01/02/24] - Chris Pyle uploaded Submission #1 for PROJ_PartName_0000-00A.';
     expect(completePartHistory(part1)[1]).toBe(response);
   });
@@ -172,15 +171,15 @@ describe('Part Submission History', () => {
     const response: string = '[01/07/24] - Chris Pyle requested a review from Griffin Cooper and Zachary Wen.';
     expect(completePartHistory(part1)[6]).toBe(response);
   });
-  it('Reviewer reviewed submission', () => {
+  it('Reviewer began reviewing submission', () => {
     const response: string = '[01/08/24] - Zachary Wen began reviewing Submission #2.';
     expect(completePartHistory(part1)[7]).toBe(response);
   });
-  it('Reviewer approved submission', () => {
+  it('Reviewer finished reviewing submission', () => {
     const response: string = '[01/09/24] - Zachary Wen reviewed Submission #2 (in Submission #2 Review).';
     expect(completePartHistory(part1)[8]).toBe(response);
   });
-  it('Sub 3', () => {
+  it('Submission 3', () => {
     const response: string = '[01/10/24] - Chris Pyle uploaded Submission #3.';
     expect(completePartHistory(part1)[9]).toBe(response);
   });
@@ -192,7 +191,7 @@ describe('Part Submission History', () => {
     const response: string = '[01/12/24] - Zachary Wen began reviewing Submission #3.';
     expect(completePartHistory(part1)[11]).toBe(response);
   });
-  it('Last Review Approves?', () => {
+  it('Last Review', () => {
     const response: string = '[01/13/24] - Zachary Wen reviewed Submission #3 (in Submission #3 Review).';
     expect(completePartHistory(part1)[12]).toBe(response);
   });

--- a/src/frontend/src/tests/utils/part.utils.test.ts
+++ b/src/frontend/src/tests/utils/part.utils.test.ts
@@ -168,10 +168,10 @@ describe('Part Submission History', () => {
       '[01/07/24] - Chris Pyle re-requested a review from Griffin Cooper and requested a review from Zachary Wen.'
     );
   });
-  it('Reviewer began reviewing submission', () => {
+  it('Reviewer began reviewing Submission #2', () => {
     expect(completePartHistory(part1)[7]).toBe('[01/08/24] - Zachary Wen began reviewing Submission #2.');
   });
-  it('Reviewer finished reviewing submission', () => {
+  it('Reviewer finished reviewing Submission #2', () => {
     expect(completePartHistory(part1)[8]).toBe('[01/09/24] - Zachary Wen reviewed Submission #2 (in Submission #2 Review).');
   });
   it('Submission 3', () => {

--- a/src/frontend/src/tests/utils/part.utils.test.ts
+++ b/src/frontend/src/tests/utils/part.utils.test.ts
@@ -144,59 +144,48 @@ const part1: Part = {
 
 describe('Part Submission History', () => {
   it('Part created history', () => {
-    const response: string = '[01/01/24] - PROJ_PartName_0000-00A was created.';
-    expect(completePartHistory(part1)[0]).toBe(response);
+    expect(completePartHistory(part1)[0]).toBe('[01/01/24] - PROJ_PartName_0000-00A was created.');
   });
   it('User uploaded first submission includes part name', () => {
-    const response: string = '[01/02/24] - Chris Pyle uploaded Submission #1 for PROJ_PartName_0000-00A.';
-    expect(completePartHistory(part1)[1]).toBe(response);
+    expect(completePartHistory(part1)[1]).toBe('[01/02/24] - Chris Pyle uploaded Submission #1 for PROJ_PartName_0000-00A.');
   });
   it('User requested single review', () => {
-    const response: string = '[01/03/24] - Chris Pyle requested a review from Griffin Cooper.';
-    expect(completePartHistory(part1)[2]).toBe(response);
+    expect(completePartHistory(part1)[2]).toBe('[01/03/24] - Chris Pyle requested a review from Griffin Cooper.');
   });
   it('Reviewer began reviewing submission', () => {
-    const response: string = '[01/04/24] - Griffin Cooper began reviewing Submission #1.';
-    expect(completePartHistory(part1)[3]).toBe(response);
+    expect(completePartHistory(part1)[3]).toBe('[01/04/24] - Griffin Cooper began reviewing Submission #1.');
   });
   it('Reviewer finished reviewing submission', () => {
-    const response: string = '[01/05/24] - Griffin Cooper reviewed Submission #1 (in Submission #1 Review).';
-    expect(completePartHistory(part1)[4]).toBe(response);
+    expect(completePartHistory(part1)[4]).toBe(
+      '[01/05/24] - Griffin Cooper reviewed Submission #1 (in Submission #1 Review).'
+    );
   });
   it('User uploaded second submission w/o part name', () => {
-    const response: string = '[01/06/24] - Chris Pyle uploaded Submission #2.';
-    expect(completePartHistory(part1)[5]).toBe(response);
+    expect(completePartHistory(part1)[5]).toBe('[01/06/24] - Chris Pyle uploaded Submission #2.');
   });
   it('User requested review from two people combined', () => {
-    const response: string = '[01/07/24] - Chris Pyle requested a review from Griffin Cooper and Zachary Wen.';
-    expect(completePartHistory(part1)[6]).toBe(response);
+    expect(completePartHistory(part1)[6]).toBe(
+      '[01/07/24] - Chris Pyle re-requested a review from Griffin Cooper and requested a review from Zachary Wen.'
+    );
   });
   it('Reviewer began reviewing submission', () => {
-    const response: string = '[01/08/24] - Zachary Wen began reviewing Submission #2.';
-    expect(completePartHistory(part1)[7]).toBe(response);
+    expect(completePartHistory(part1)[7]).toBe('[01/08/24] - Zachary Wen began reviewing Submission #2.');
   });
   it('Reviewer finished reviewing submission', () => {
-    const response: string = '[01/09/24] - Zachary Wen reviewed Submission #2 (in Submission #2 Review).';
-    expect(completePartHistory(part1)[8]).toBe(response);
+    expect(completePartHistory(part1)[8]).toBe('[01/09/24] - Zachary Wen reviewed Submission #2 (in Submission #2 Review).');
   });
   it('Submission 3', () => {
-    const response: string = '[01/10/24] - Chris Pyle uploaded Submission #3.';
-    expect(completePartHistory(part1)[9]).toBe(response);
+    expect(completePartHistory(part1)[9]).toBe('[01/10/24] - Chris Pyle uploaded Submission #3.');
   });
   it('Re-Request Review', () => {
-    const response: string = '[01/11/24] - Chris Pyle re-requested a review from Zachary Wen.';
-    expect(completePartHistory(part1)[10]).toBe(response);
+    expect(completePartHistory(part1)[10]).toBe('[01/11/24] - Chris Pyle re-requested a review from Zachary Wen.');
   });
   it('Began Reviewing', () => {
-    const response: string = '[01/12/24] - Zachary Wen began reviewing Submission #3.';
-    expect(completePartHistory(part1)[11]).toBe(response);
+    expect(completePartHistory(part1)[11]).toBe('[01/12/24] - Zachary Wen began reviewing Submission #3.');
   });
   it('Last Review', () => {
-    const response: string = '[01/13/24] - Zachary Wen reviewed Submission #3 (in Submission #3 Review).';
-    expect(completePartHistory(part1)[12]).toBe(response);
-  });
-  it('Complete History for viewing', () => {
-    const response: string = '...';
-    expect(completePartHistory(part1)).toBe(response);
+    expect(completePartHistory(part1)[12]).toBe(
+      '[01/13/24] - Zachary Wen reviewed Submission #3 (in Submission #3 Review).'
+    );
   });
 });

--- a/src/frontend/src/utils/part.utils.ts
+++ b/src/frontend/src/utils/part.utils.ts
@@ -2,16 +2,12 @@ import { Part, PartReview, PartReviewRequest, PartSubmission, User } from 'share
 
 type HistoryEntry = [Date, string];
 
-/* [01/01/24] - PROJ_PartName_0000-00A was created. */
 export const getPartCreationHistory = (createdAt: Date, name: String): HistoryEntry[] => {
   return [[new Date(createdAt), `${name} was created`]];
 };
 
-/* [01/01/24] - Joseph Aoun uploaded Submission #1 for PROJ_PartName_0000-00A. */
-/* [01/01/24] - Joseph Aoun uploaded Submission #2 */
 export const getSubmissionHistory = (user: User, submissions: PartSubmission[], name: String): HistoryEntry[] => {
   if (submissions.length === 0) return [];
-
   const firstSubmission = [...submissions]
     .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
     .at(0);
@@ -21,57 +17,61 @@ export const getSubmissionHistory = (user: User, submissions: PartSubmission[], 
     const isFirstSubmission = firstSubmission && sub.createdAt === firstSubmission.createdAt;
     const message = isFirstSubmission
       ? `${user.firstName} ${user.lastName} uploaded ${sub.name} for ${name}`
-      : `${user} uploaded ${sub.name}`;
+      : `${user.firstName} ${user.lastName} uploaded ${sub.name}`;
 
     return [new Date(sub.createdAt), message];
   });
 };
 
-/* [01/01/24] - Joseph Aoun requested a review from Jacob Brown and George Miller. */
-/* [01/03/24] - Joseph Aoun re-requested a review from George Miller. */
 export const getReviewRequestHistory = (reviewRequests: PartReviewRequest[]): HistoryEntry[] => {
   if (reviewRequests.length === 0) return [];
 
   const historyEntries: HistoryEntry[] = [];
-  const combinedRequests = new Map<Date, Map<User, Set<string>>>();
+  // Tracking for ' and ' concatenation
+  const combinedRequests = new Map<string, Map<User, Set<string>>>();
+  // Tracking for re-request vs request
+  const previousRequests = new Map<User, Set<User>>();
 
   reviewRequests.forEach(({ createdAt, requester, reviewerRequested }) => {
-    const date = new Date(createdAt);
+    // Reformatted date for comparisons
+    const formattedDate = new Date(createdAt).toISOString().split('T')[0];
 
-    if (!combinedRequests.has(date)) combinedRequests.set(date, new Map());
-    const requesters = combinedRequests.get(date)!;
+    if (!combinedRequests.has(formattedDate)) combinedRequests.set(formattedDate, new Map());
+    const requesters = combinedRequests.get(formattedDate)!;
 
     if (!requesters.has(requester)) requesters.set(requester, new Set());
-
     const messages = requesters.get(requester)!;
-    const isReRequest = [...messages].some((msg) => msg.includes(reviewerRequested.userId));
 
-    // Re-request if already requested from the specific reviewerRequested
-    messages.add(`${isReRequest ? 're-requested' : 'requested'} a review from ${reviewerRequested.userId}`);
+    if (!previousRequests.has(requester)) previousRequests.set(requester, new Set());
+    const pastReviewers = previousRequests.get(requester)!;
+
+    const isReRequest = pastReviewers.has(reviewerRequested);
+
+    const action = isReRequest ? 're-requested a review from' : 'requested a review from';
+    messages.add(`${action} ${reviewerRequested.firstName} ${reviewerRequested.lastName}`);
+
+    pastReviewers.add(reviewerRequested);
   });
 
-  // Two different requests on the same date from the same User should be combined
-  combinedRequests.forEach((requesters, date) => {
-    const messages = Array.from(requesters.entries()).map(
-      ([requester, reviews]) => `${requester} ${Array.from(reviews).join(' and ')}.`
-    );
+  // Combine multiple requests from the same requester on the same date
+  combinedRequests.forEach((requesters, formattedDate) => {
+    const date = new Date(formattedDate);
+    const messages = Array.from(requesters.entries()).map(([requester, reviews]) => {
+      const reviewMessages = Array.from(reviews);
+      return `${requester.firstName} ${requester.lastName} ${reviewMessages.join(' and ')}`;
+    });
     historyEntries.push([date, messages.join(' ')]);
   });
 
-  // Sort the history entries by date
   return historyEntries.sort((a, b) => a[0].getTime() - b[0].getTime());
 };
 
-/* [01/01/24] - George Miller began reviewing Submission #1 */
-/* [01/03/24] - George Miller reviewed Submission #1 (in Submission #1 Review)*/
-/* [01/03/24] - George Miller reviewed Submission #2(added comments) */
-/* [01/05/24] - George Miller approved Submission #3 */
 export const getReviewHistory = (submissions: PartSubmission[]): HistoryEntry[] => {
   if (submissions.length === 0) return [];
   const historyEntries: HistoryEntry[] = [];
 
   submissions.forEach((sub) => {
-    // Each reviewer gets a separate "began" and "approved"
+    // Each reviewer gets a separate "began reviewing" and "reviewed"
     const reviewsForReviewer = new Map<User, PartReview[]>();
     sub.reviews.forEach((review) => {
       const reviewer = review.userCreated;
@@ -81,7 +81,6 @@ export const getReviewHistory = (submissions: PartSubmission[]): HistoryEntry[] 
       reviewsForReviewer.get(reviewer)!.push(review);
     });
 
-    // Process each reviewer individually
     reviewsForReviewer.forEach((reviews, reviewer) => {
       processReviewerHistory(reviews, reviewer, sub.name, historyEntries);
     });
@@ -100,25 +99,15 @@ export const processReviewerHistory = (
   reviews.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
   if (reviews.length === 0) return;
 
-  // Began reviewing first review by this reviewer
   const firstReview = reviews[0];
   historyEntries.push([new Date(firstReview.createdAt), `${reviewerName} began reviewing ${subName}`]);
 
   reviews.forEach((review) => {
-    let message = ``;
     if (review.completedAt) {
-      message += `${reviewerName} reviewed ${subName} `;
+      let message = `${reviewerName} reviewed ${subName} (in ${subName} Review)`;
+      historyEntries.push([new Date(review.completedAt), message]);
     }
-    message += `(in ${subName} Review)`;
-
-    historyEntries.push([new Date(review.createdAt), message]);
   });
-
-  // Check if last review was approved
-  const lastreview = reviews.at(-1);
-  if (lastreview?.completedAt) {
-    historyEntries.push([new Date(lastreview.completedAt), `${reviewerName} approved ${subName}`]);
-  }
 };
 
 export const completePartHistory = (part: Part): string[] => {
@@ -132,10 +121,13 @@ export const completePartHistory = (part: Part): string[] => {
   history
     .sort((a, b) => a[0].getTime() - b[0].getTime())
     .map(([date, message]) => {
-      const formattedDate = date.toLocaleDateString('en-US', { year: '2-digit', month: '2-digit', day: '2-digit' });
-      result.push(`[${formattedDate}] - ${message}`);
+      const formattedDate = date.toLocaleDateString('en-US', {
+        timeZone: 'UTC',
+        year: '2-digit',
+        month: '2-digit',
+        day: '2-digit'
+      });
+      result.push(`[${formattedDate}] - ${message}.`);
     });
   return result;
 };
-
-// Part createdAt goes back by 1 day??? 2024-01-01 vs 12/31/23

--- a/src/frontend/src/utils/part.utils.ts
+++ b/src/frontend/src/utils/part.utils.ts
@@ -1,0 +1,56 @@
+import { Part, Review_Status } from 'shared';
+
+// return tuples of [date, data] for each of the
+// different actions that need to be processed
+type HistoryEntry = [Date, string];
+
+/* [01/01/24] - PROJ_PartName_0000-00A was created. */
+// [Date] - [PartPreview.commonName] was created
+export const getPartCreationHistory = (part: Part): HistoryEntry[] => {
+  return [[new Date(part.createdAt), `${part.commonName} was created`]];
+};
+
+/* [01/01/24] - Joseph Aoun uploaded Submission #1 for PROJ_PartName_0000-00A. */
+// [Date] - [User] uploaded [PartSubmission.name] for [Part Project Name]
+/* [01/01/24] - Joseph Aoun uploaded Submission #2 */
+export const getSubmissionHistory = (part: Part): HistoryEntry[] => {
+  return; // all uploads as tuples
+};
+
+/* [01/01/24] - Joseph Aoun requested a review from Jacob Brown and George Miller. */
+// [Date] - [User] requested a review from [PartReviewRequest.reviewerRequested] and [PartReviewRequest.reviewerRequested]
+// Two different PartReviewRequests on the same date from the same User should be combined
+
+/* [01/03/24] - Joseph Aoun re-requested a review from George Miller. */
+// [Date] -
+export const getReviewRequestHistory = (part: Part): HistoryEntry[] => {
+  return;
+};
+
+/* [01/01/24] - George Miller began reviewing Submission #1 */
+// [Date] - [User/PartReviewRequest.reviewerRequested] began reviewing [PartSubmission.name]
+
+/* [01/03/24] - George Miller reviewed Submission #2(added comments) */
+// [Date] -  [User/PartReviewRequest.reviewerRequested] reviewed [PartSubmission.name](added comments)
+// Check for 'added commends' by checking PartReview.notes?
+
+/* [01/01/24] - George Miller reviewed Submission #1 (in Submission #1 Review)*/
+// [Date] - [User/PartReviewRequest.reviewerRequested] reviewed [PartSubmission.name] (in [PartReview.submissionId?])
+export const getReviewHistory = (part: Part): HistoryEntry[] => {
+  Review_Status;
+  return;
+};
+
+/* [01/05/24] - George Miller approved Submission #3 */
+// [Date] - [User/PartReviewRequest.reviewerRequested] approved [PartSubmission.name]
+// Check for PartPreview.status.APPROVED
+
+export const completePartHistory = (part: Part): HistoryEntry[] => {
+  const history = [
+    ...getPartCreationHistory(part),
+    ...getSubmissionHistory(part),
+    ...getReviewRequestHistory(part),
+    ...getReviewHistory(part)
+  ];
+  return history.sort((a, b) => a[0].getTime() - b[0].getTime());
+};

--- a/src/frontend/src/utils/part.utils.ts
+++ b/src/frontend/src/utils/part.utils.ts
@@ -1,4 +1,4 @@
-import { Part, PartReview, PartReviewRequest, PartSubmission, Review_Status, User } from 'shared';
+import { Part, PartReview, PartReviewRequest, PartSubmission, User } from 'shared';
 
 type HistoryEntry = [Date, string];
 
@@ -121,12 +121,21 @@ export const processReviewerHistory = (
   }
 };
 
-export const completePartHistory = (part: Part): HistoryEntry[] => {
+export const completePartHistory = (part: Part): string[] => {
   const history = [
     ...getPartCreationHistory(part.createdAt, part.commonName),
     ...getSubmissionHistory(part.userCreated, part.submissions, part.commonName),
     ...getReviewRequestHistory(part.reviewRequests),
     ...getReviewHistory(part.submissions)
   ];
-  return history.sort((a, b) => a[0].getTime() - b[0].getTime());
+  const result: string[] = [];
+  history
+    .sort((a, b) => a[0].getTime() - b[0].getTime())
+    .map(([date, message]) => {
+      const formattedDate = date.toLocaleDateString('en-US', { year: '2-digit', month: '2-digit', day: '2-digit' });
+      result.push(`[${formattedDate}] - ${message}`);
+    });
+  return result;
 };
+
+// Part createdAt goes back by 1 day??? 2024-01-01 vs 12/31/23

--- a/src/frontend/src/utils/part.utils.ts
+++ b/src/frontend/src/utils/part.utils.ts
@@ -1,4 +1,4 @@
-import { Part, PartReviewRequest, PartSubmission, Review_Status, User } from 'shared';
+import { Part, PartReview, PartReviewRequest, PartSubmission, Review_Status, User } from 'shared';
 
 type HistoryEntry = [Date, string];
 
@@ -16,56 +16,117 @@ export const getSubmissionHistory = (user: User, submissions: PartSubmission[], 
     .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
     .at(0);
 
+  // Includes part name if first submission upload
   return submissions.map((sub) => {
     const isFirstSubmission = firstSubmission && sub.createdAt === firstSubmission.createdAt;
-    const message = isFirstSubmission ? `${user} uploaded ${sub.name} for ${name}` : `${user} uploaded ${sub.name}`;
+    const message = isFirstSubmission
+      ? `${user.firstName} ${user.lastName} uploaded ${sub.name} for ${name}`
+      : `${user} uploaded ${sub.name}`;
 
     return [new Date(sub.createdAt), message];
   });
 };
 
 /* [01/01/24] - Joseph Aoun requested a review from Jacob Brown and George Miller. */
-// [Date] - [User] requested a review from [PartReviewRequest.reviewerRequested] and [PartReviewRequest.reviewerRequested]
-// Two different PartReviewRequests on the same date from the same User should be combined
 /* [01/03/24] - Joseph Aoun re-requested a review from George Miller. */
-export const getReviewRequestHistory = (user: User, reviewRequests: PartReviewRequest[]): HistoryEntry[] => {
-  if(reviewRequests.length === 0) return [];
+export const getReviewRequestHistory = (reviewRequests: PartReviewRequest[]): HistoryEntry[] => {
+  if (reviewRequests.length === 0) return [];
 
-  reviewRequests.forEach((req) => {});
+  const historyEntries: HistoryEntry[] = [];
+  const combinedRequests = new Map<Date, Map<User, Set<string>>>();
 
-  return [[new Date(reviewRequests[0].createdAt), `?`]]; // repeat for all review requests and combine if on the same date
+  reviewRequests.forEach(({ createdAt, requester, reviewerRequested }) => {
+    const date = new Date(createdAt);
+
+    if (!combinedRequests.has(date)) combinedRequests.set(date, new Map());
+    const requesters = combinedRequests.get(date)!;
+
+    if (!requesters.has(requester)) requesters.set(requester, new Set());
+
+    const messages = requesters.get(requester)!;
+    const isReRequest = [...messages].some((msg) => msg.includes(reviewerRequested.userId));
+
+    // Re-request if already requested from the specific reviewerRequested
+    messages.add(`${isReRequest ? 're-requested' : 'requested'} a review from ${reviewerRequested.userId}`);
+  });
+
+  // Two different requests on the same date from the same User should be combined
+  combinedRequests.forEach((requesters, date) => {
+    const messages = Array.from(requesters.entries()).map(
+      ([requester, reviews]) => `${requester} ${Array.from(reviews).join(' and ')}.`
+    );
+    historyEntries.push([date, messages.join(' ')]);
+  });
+
+  // Sort the history entries by date
+  return historyEntries.sort((a, b) => a[0].getTime() - b[0].getTime());
 };
 
 /* [01/01/24] - George Miller began reviewing Submission #1 */
-// [Date] - [User/PartReviewRequest.reviewerRequested] began reviewing [PartSubmission.name]
-
+/* [01/03/24] - George Miller reviewed Submission #1 (in Submission #1 Review)*/
 /* [01/03/24] - George Miller reviewed Submission #2(added comments) */
-// [Date] -  [User/PartReviewRequest.reviewerRequested] reviewed [PartSubmission.name](added comments)
-
-/* [01/01/24] - George Miller reviewed Submission #1 (in Submission #1 Review)*/
-// [Date] - [User/PartReviewRequest.reviewerRequested] reviewed [PartSubmission.name] (in [PartReview.submissionId?])
-
 /* [01/05/24] - George Miller approved Submission #3 */
-// [Date] - [User/PartReviewRequest.reviewerRequested] approved [PartSubmission.name]
-// Check for PartPreview.status.APPROVED
-
-export const getReviewHistory = (reviewer: User, submissions: PartSubmission[]): HistoryEntry[] => {
+export const getReviewHistory = (submissions: PartSubmission[]): HistoryEntry[] => {
   if (submissions.length === 0) return [];
+  const historyEntries: HistoryEntry[] = [];
 
-  submissions.forEach(sub => {
-    // figure out the status using submission id? NOT PartPreview.status
-    // using completed at (check if approved),
-    // using notes? ("added comments")
+  submissions.forEach((sub) => {
+    // Each reviewer gets a separate "began" and "approved"
+    const reviewsForReviewer = new Map<User, PartReview[]>();
+    sub.reviews.forEach((review) => {
+      const reviewer = review.userCreated;
+      if (!reviewsForReviewer.has(reviewer)) {
+        reviewsForReviewer.set(reviewer, []);
+      }
+      reviewsForReviewer.get(reviewer)!.push(review);
+    });
+
+    // Process each reviewer individually
+    reviewsForReviewer.forEach((reviews, reviewer) => {
+      processReviewerHistory(reviews, reviewer, sub.name, historyEntries);
+    });
   });
-  return [[new Date(submissions[0].createdAt), `?`]]; // repeat for all submissions
+  return historyEntries;
+};
+
+// Processes an individual reviewer's history in a submission
+export const processReviewerHistory = (
+  reviews: PartReview[],
+  reviewer: User,
+  subName: string,
+  historyEntries: HistoryEntry[]
+) => {
+  const reviewerName = `${reviewer.firstName} ${reviewer.lastName}`;
+  reviews.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+  if (reviews.length === 0) return;
+
+  // Began reviewing first review by this reviewer
+  const firstReview = reviews[0];
+  historyEntries.push([new Date(firstReview.createdAt), `${reviewerName} began reviewing ${subName}`]);
+
+  reviews.forEach((review) => {
+    let message = ``;
+    if (review.completedAt) {
+      message += `${reviewerName} reviewed ${subName} `;
+    }
+    message += `(in ${subName} Review)`;
+
+    historyEntries.push([new Date(review.createdAt), message]);
+  });
+
+  // Check if last review was approved
+  const lastreview = reviews.at(-1);
+  if (lastreview?.completedAt) {
+    historyEntries.push([new Date(lastreview.completedAt), `${reviewerName} approved ${subName}`]);
+  }
 };
 
 export const completePartHistory = (part: Part): HistoryEntry[] => {
   const history = [
     ...getPartCreationHistory(part.createdAt, part.commonName),
     ...getSubmissionHistory(part.userCreated, part.submissions, part.commonName),
-    ...getReviewRequestHistory(part.userCreated, part.reviewRequests),
-    ...getReviewHistory(part.userCreated, part.submissions)
+    ...getReviewRequestHistory(part.reviewRequests),
+    ...getReviewHistory(part.submissions)
   ];
   return history.sort((a, b) => a[0].getTime() - b[0].getTime());
 };

--- a/src/frontend/src/utils/part.utils.ts
+++ b/src/frontend/src/utils/part.utils.ts
@@ -6,7 +6,7 @@ export const getPartCreationHistory = (createdAt: Date, name: String): HistoryEn
   return [[new Date(createdAt), `${name} was created`]];
 };
 
-export const getSubmissionHistory = (user: User, submissions: PartSubmission[], name: String): HistoryEntry[] => {
+export const getSubmissionHistory = (submissions: PartSubmission[], name: String): HistoryEntry[] => {
   if (submissions.length === 0) return [];
   const firstSubmission = [...submissions]
     .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
@@ -16,8 +16,8 @@ export const getSubmissionHistory = (user: User, submissions: PartSubmission[], 
   return submissions.map((sub) => {
     const isFirstSubmission = firstSubmission && sub.createdAt === firstSubmission.createdAt;
     const message = isFirstSubmission
-      ? `${user.firstName} ${user.lastName} uploaded ${sub.name} for ${name}`
-      : `${user.firstName} ${user.lastName} uploaded ${sub.name}`;
+      ? `${sub.userCreated.firstName} ${sub.userCreated.lastName} uploaded ${sub.name} for ${name}`
+      : `${sub.userCreated.firstName} ${sub.userCreated.lastName} uploaded ${sub.name}`;
 
     return [new Date(sub.createdAt), message];
   });
@@ -113,7 +113,7 @@ export const processReviewerHistory = (
 export const completePartHistory = (part: Part): string[] => {
   const history = [
     ...getPartCreationHistory(part.createdAt, part.commonName),
-    ...getSubmissionHistory(part.userCreated, part.submissions, part.commonName),
+    ...getSubmissionHistory(part.submissions, part.commonName),
     ...getReviewRequestHistory(part.reviewRequests),
     ...getReviewHistory(part.submissions)
   ];

--- a/src/frontend/src/utils/part.utils.ts
+++ b/src/frontend/src/utils/part.utils.ts
@@ -34,7 +34,7 @@ export const getReviewRequestHistory = (reviewRequests: PartReviewRequest[]): Hi
 
   reviewRequests.forEach(({ createdAt, requester, reviewerRequested }) => {
     // Reformatted date for comparisons
-    const formattedDate = new Date(createdAt).toISOString().split('T')[0];
+    const [formattedDate] = new Date(createdAt).toISOString().split('T');
 
     if (!combinedRequests.has(formattedDate)) combinedRequests.set(formattedDate, new Map());
     const requesters = combinedRequests.get(formattedDate)!;
@@ -99,12 +99,12 @@ export const processReviewerHistory = (
   reviews.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
   if (reviews.length === 0) return;
 
-  const firstReview = reviews[0];
+  const [firstReview] = reviews;
   historyEntries.push([new Date(firstReview.createdAt), `${reviewerName} began reviewing ${subName}`]);
 
   reviews.forEach((review) => {
     if (review.completedAt) {
-      let message = `${reviewerName} reviewed ${subName} (in ${subName} Review)`;
+      const message = `${reviewerName} reviewed ${subName} (in ${subName} Review)`;
       historyEntries.push([new Date(review.completedAt), message]);
     }
   });
@@ -120,7 +120,7 @@ export const completePartHistory = (part: Part): string[] => {
   const result: string[] = [];
   history
     .sort((a, b) => a[0].getTime() - b[0].getTime())
-    .map(([date, message]) => {
+    .forEach(([date, message]) => {
       const formattedDate = date.toLocaleDateString('en-US', {
         timeZone: 'UTC',
         year: '2-digit',

--- a/src/frontend/src/utils/part.utils.ts
+++ b/src/frontend/src/utils/part.utils.ts
@@ -1,30 +1,39 @@
-import { Part, Review_Status } from 'shared';
+import { Part, PartReviewRequest, PartSubmission, Review_Status, User } from 'shared';
 
-// return tuples of [date, data] for each of the
-// different actions that need to be processed
 type HistoryEntry = [Date, string];
 
 /* [01/01/24] - PROJ_PartName_0000-00A was created. */
-// [Date] - [PartPreview.commonName] was created
-export const getPartCreationHistory = (part: Part): HistoryEntry[] => {
-  return [[new Date(part.createdAt), `${part.commonName} was created`]];
+export const getPartCreationHistory = (createdAt: Date, name: String): HistoryEntry[] => {
+  return [[new Date(createdAt), `${name} was created`]];
 };
 
 /* [01/01/24] - Joseph Aoun uploaded Submission #1 for PROJ_PartName_0000-00A. */
-// [Date] - [User] uploaded [PartSubmission.name] for [Part Project Name]
 /* [01/01/24] - Joseph Aoun uploaded Submission #2 */
-export const getSubmissionHistory = (part: Part): HistoryEntry[] => {
-  return; // all uploads as tuples
+export const getSubmissionHistory = (user: User, submissions: PartSubmission[], name: String): HistoryEntry[] => {
+  if (submissions.length === 0) return [];
+
+  const firstSubmission = [...submissions]
+    .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+    .at(0);
+
+  return submissions.map((sub) => {
+    const isFirstSubmission = firstSubmission && sub.createdAt === firstSubmission.createdAt;
+    const message = isFirstSubmission ? `${user} uploaded ${sub.name} for ${name}` : `${user} uploaded ${sub.name}`;
+
+    return [new Date(sub.createdAt), message];
+  });
 };
 
 /* [01/01/24] - Joseph Aoun requested a review from Jacob Brown and George Miller. */
 // [Date] - [User] requested a review from [PartReviewRequest.reviewerRequested] and [PartReviewRequest.reviewerRequested]
 // Two different PartReviewRequests on the same date from the same User should be combined
-
 /* [01/03/24] - Joseph Aoun re-requested a review from George Miller. */
-// [Date] -
-export const getReviewRequestHistory = (part: Part): HistoryEntry[] => {
-  return;
+export const getReviewRequestHistory = (user: User, reviewRequests: PartReviewRequest[]): HistoryEntry[] => {
+  if(reviewRequests.length === 0) return [];
+
+  reviewRequests.forEach((req) => {});
+
+  return [[new Date(reviewRequests[0].createdAt), `?`]]; // repeat for all review requests and combine if on the same date
 };
 
 /* [01/01/24] - George Miller began reviewing Submission #1 */
@@ -32,25 +41,31 @@ export const getReviewRequestHistory = (part: Part): HistoryEntry[] => {
 
 /* [01/03/24] - George Miller reviewed Submission #2(added comments) */
 // [Date] -  [User/PartReviewRequest.reviewerRequested] reviewed [PartSubmission.name](added comments)
-// Check for 'added commends' by checking PartReview.notes?
 
 /* [01/01/24] - George Miller reviewed Submission #1 (in Submission #1 Review)*/
 // [Date] - [User/PartReviewRequest.reviewerRequested] reviewed [PartSubmission.name] (in [PartReview.submissionId?])
-export const getReviewHistory = (part: Part): HistoryEntry[] => {
-  Review_Status;
-  return;
-};
 
 /* [01/05/24] - George Miller approved Submission #3 */
 // [Date] - [User/PartReviewRequest.reviewerRequested] approved [PartSubmission.name]
 // Check for PartPreview.status.APPROVED
 
+export const getReviewHistory = (reviewer: User, submissions: PartSubmission[]): HistoryEntry[] => {
+  if (submissions.length === 0) return [];
+
+  submissions.forEach(sub => {
+    // figure out the status using submission id? NOT PartPreview.status
+    // using completed at (check if approved),
+    // using notes? ("added comments")
+  });
+  return [[new Date(submissions[0].createdAt), `?`]]; // repeat for all submissions
+};
+
 export const completePartHistory = (part: Part): HistoryEntry[] => {
   const history = [
-    ...getPartCreationHistory(part),
-    ...getSubmissionHistory(part),
-    ...getReviewRequestHistory(part),
-    ...getReviewHistory(part)
+    ...getPartCreationHistory(part.createdAt, part.commonName),
+    ...getSubmissionHistory(part.userCreated, part.submissions, part.commonName),
+    ...getReviewRequestHistory(part.userCreated, part.reviewRequests),
+    ...getReviewHistory(part.userCreated, part.submissions)
   ];
   return history.sort((a, b) => a[0].getTime() - b[0].getTime());
 };


### PR DESCRIPTION
## Changes

Component to display the full history of a given part. Created utils functions that return date and data for part creation, submission history, review request history, and review history. All entries sorted by date and returned as strings.

## Notes

Submission links will eventually go to corresponding submissions part page

## Test Cases

- Requested vs re-requested
- Combining two review reqs on the same day

## Screenshots

<img width="578" alt="Screenshot 2025-04-09 at 7 14 30 PM" src="https://github.com/user-attachments/assets/562dc9d9-0f15-489e-9333-efd445b26b65" />

------------- 

<img width="735" alt="Screenshot 2025-04-09 at 7 16 24 PM" src="https://github.com/user-attachments/assets/82ed6003-7fee-4b27-8a81-062f2df65850" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3339
