### PR TITLE
#3338 details for part submission

### DIFF
--- a/src/frontend/src/pages/PartPage/Components/PartSubmissionDetails.tsx
+++ b/src/frontend/src/pages/PartPage/Components/PartSubmissionDetails.tsx
@@ -8,19 +8,19 @@ interface PartSubmissionProps {
 
 const PartSubmissionDetails = ({ submission }: PartSubmissionProps) => {
   return (
-    <Stack spacing={'4%'} alignItems="center" width="100%">
+    <Stack spacing={'4%'} alignItems="left" width="100%">
       <Typography sx={{ fontWeight: 'normal' }} variant="h5">
-        Details for ${submission.name}:
+        Details for {submission.name}:
       </Typography>
 
       <Typography variant="body1">
-        Uploader: ${submission.userCreated.firstName} {submission.userCreated.lastName}
+        Uploader: {submission.userCreated.firstName} {submission.userCreated.lastName}
       </Typography>
 
       <Typography variant="body1">Uploader Notes: {submission.notes || 'There are no notes.'}</Typography>
 
       <Typography variant="body1">
-        Reviewer Notes:
+        Reviewer Notes:{' '}
         {submission.reviews.length !== 0
           ? submission.reviews.map((review) => review.notes).join('\n')
           : 'There are no notes.'}

--- a/src/frontend/src/pages/PartPage/Components/PartSubmissionDetails.tsx
+++ b/src/frontend/src/pages/PartPage/Components/PartSubmissionDetails.tsx
@@ -8,7 +8,7 @@ interface PartSubmissionProps {
 
 const PartSubmissionDetails = ({ submission }: PartSubmissionProps) => {
   return (
-    <Box display="flex" alignItems="center" width="50%" padding={2}>
+    <Box display="flex" alignItems="center" width="50%" padding={2} sx={{ flexDirection: 'column' }}>
       <Typography variant="h4">Details for Submission #{submission.partSubmissionId}:</Typography>
 
       <Typography variant="h6">

--- a/src/frontend/src/pages/PartPage/Components/PartSubmissionDetails.tsx
+++ b/src/frontend/src/pages/PartPage/Components/PartSubmissionDetails.tsx
@@ -8,7 +8,7 @@ interface PartSubmissionProps {
 
 const PartSubmissionDetails = ({ submission }: PartSubmissionProps) => {
   return (
-    <Box display="flex" alignItems="center" width="50%" padding={2} sx={{ flexDirection: 'column' }}>
+    <Box display="flex" alignItems="center" width="100%" padding={2} sx={{ flexDirection: 'column' }}>
       <Typography variant="h4">Details for Submission #{submission.partSubmissionId}:</Typography>
 
       <Typography variant="h6">

--- a/src/frontend/src/pages/PartPage/Components/PartSubmissionDetails.tsx
+++ b/src/frontend/src/pages/PartPage/Components/PartSubmissionDetails.tsx
@@ -9,9 +9,8 @@ interface PartSubmissionProps {
 const reviewNotes = (reviews: PartReview[]): string => {
   if (reviews.length === 0) {
     return 'There are no notes.';
-  } else {
-    return '\n' + reviews.map((review) => '- ' + review.notes).join('\n');
   }
+  return '\n' + reviews.map((review) => '- ' + review.notes).join('\n');
 };
 
 const PartSubmissionDetails = ({ submission }: PartSubmissionProps) => {

--- a/src/frontend/src/pages/PartPage/Components/PartSubmissionDetails.tsx
+++ b/src/frontend/src/pages/PartPage/Components/PartSubmissionDetails.tsx
@@ -1,5 +1,5 @@
 import { Typography } from '@mui/material';
-import { Box } from '@mui/system';
+import { Stack } from '@mui/system';
 import { PartSubmission } from 'shared';
 
 interface PartSubmissionProps {
@@ -8,26 +8,24 @@ interface PartSubmissionProps {
 
 const PartSubmissionDetails = ({ submission }: PartSubmissionProps) => {
   return (
-    <Box display="left" alignItems="center" width="100%" sx={{ flexDirection: 'column'}}>
-      <Typography sx = {{fontWeight: "normal", marginBottom: '4%'}} variant="h5">Details for Submission #{submission.partSubmissionId}:</Typography>
-
-      <Typography variant="body1" sx = {{marginBottom: '4%'}}>
-        Uploader:
-        {' ' + submission.userCreated.firstName + ' ' + submission.userCreated.lastName}
+    <Stack spacing={'4%'} alignItems="center" width="100%">
+      <Typography sx={{ fontWeight: 'normal' }} variant="h5">
+        Details for ${submission.name}:
       </Typography>
 
-      <Typography variant="body1" sx = {{marginBottom: '4%'}}>
-        Uploader Notes:
-        {' ' + submission.notes || 'There are no notes.'}
+      <Typography variant="body1">
+        Uploader: ${submission.userCreated.firstName} {submission.userCreated.lastName}
       </Typography>
 
-      <Typography variant="body1" sx = {{marginBottom: '4%'}}>
-        Reviewer Notes:{' '}
+      <Typography variant="body1">Uploader Notes: {submission.notes || 'There are no notes.'}</Typography>
+
+      <Typography variant="body1">
+        Reviewer Notes:
         {submission.reviews.length !== 0
-          ? submission.reviews.map((review) => review.notes).join('  ')
+          ? submission.reviews.map((review) => review.notes).join('\n')
           : 'There are no notes.'}
       </Typography>
-    </Box>
+    </Stack>
   );
 };
 

--- a/src/frontend/src/pages/PartPage/Components/PartSubmissionDetails.tsx
+++ b/src/frontend/src/pages/PartPage/Components/PartSubmissionDetails.tsx
@@ -1,6 +1,6 @@
 import { Typography } from '@mui/material';
 import { Stack } from '@mui/system';
-import { Part_Review_Popup, PartSubmission } from 'shared';
+import { PartSubmission, PartReview, RoleEnum } from 'shared';
 
 interface PartSubmissionProps {
   submission: PartSubmission;
@@ -31,60 +31,38 @@ const PartSubmissionDetails = ({ submission }: PartSubmissionProps) => {
 
 export default PartSubmissionDetails;
 
-// mock examples for testing
-
-const partReviewPopUp1: Part_Review_Popup = {
-  partReviewPopupId: '1',
-  xCoord: 0.0,
-  yCoord: 0.0,
-  title: 'review 1 popup',
-  description: 'description1',
-  reviewId: '1'
-};
-
-const partReviewPopUp2: Part_Review_Popup = {
-  partReviewPopupId: '2',
-  xCoord: 0.0,
-  yCoord: 0.0,
-  title: 'review 2 popup',
-  description: 'description2',
-  reviewId: '1'
-};
-
-export const partReviewExample1 = {
-  partReviewId: 'reviewId003',
-  fileIds: ['file5', 'file6'],
+export const partReviewExample1: PartReview = {
+  partReviewId: 'reviewId001',
+  fileIds: ['file1', 'file2'],
   notes: 'this part submission is decent!!',
-  submission: {
-    connect: {
-      partSubmissionId: '1'
-    }
-  },
+  submissionId: '1',
   userCreated: {
-    connect: { userId: '123' }
+    userId: '124',
+    email: 'mark.andrews@example.com',
+    emailId: 'mark.andrews@example.com',
+    role: RoleEnum.MEMBER,
+    permissions: [],
+    firstName: 'Mark',
+    lastName: 'Andrews'
   },
-  popUps: {
-    connect: [partReviewPopUp1]
-  },
-  submissionId: '123',
+  popUps: [],
   createdAt: new Date(2025, 6, 4)
 };
 
-export const partReviewExample2 = {
-  partReviewId: 'reviewId004',
-  fileIds: ['file7', 'file8'],
+export const partReviewExample2: PartReview = {
+  partReviewId: 'reviewId002',
+  fileIds: ['file3', 'file4'],
   notes: 'this part submission is terrible!!',
-  submission: {
-    connect: {
-      partSubmissionId: '1'
-    }
-  },
+  submissionId: '1',
   userCreated: {
-    connect: { userId: '32' }
+    userId: '125',
+    email: 'julia.williams@example.com',
+    emailId: 'julia.williams@example.com',
+    role: RoleEnum.MEMBER,
+    permissions: [],
+    firstName: 'Julia',
+    lastName: 'Williams'
   },
-  popUps: {
-    connect: [partReviewPopUp2]
-  },
-  submissionId: '123',
-  createdAt: new Date(2025, 5, 4)
+  popUps: [],
+  createdAt: new Date(2025, 3, 4)
 };

--- a/src/frontend/src/pages/PartPage/Components/PartSubmissionDetails.tsx
+++ b/src/frontend/src/pages/PartPage/Components/PartSubmissionDetails.tsx
@@ -8,23 +8,23 @@ interface PartSubmissionProps {
 
 const PartSubmissionDetails = ({ submission }: PartSubmissionProps) => {
   return (
-    <Box display="flex" alignItems="center" width="100%" padding={2} sx={{ flexDirection: 'column' }}>
-      <Typography variant="h4">Details for Submission #{submission.partSubmissionId}:</Typography>
+    <Box display="left" alignItems="center" width="100%" sx={{ flexDirection: 'column'}}>
+      <Typography sx = {{fontWeight: "normal", marginBottom: '4%'}} variant="h5">Details for Submission #{submission.partSubmissionId}:</Typography>
 
-      <Typography variant="h6">
+      <Typography variant="body1" sx = {{marginBottom: '4%'}}>
         Uploader:
-        {submission.userCreated.firstName} {submission.userCreated.lastName}
+        {' ' + submission.userCreated.firstName + ' ' + submission.userCreated.lastName}
       </Typography>
 
-      <Typography variant="h6">
+      <Typography variant="body1" sx = {{marginBottom: '4%'}}>
         Uploader Notes:
-        {submission.notes || 'There are no notes.'}
+        {' ' + submission.notes || 'There are no notes.'}
       </Typography>
 
-      <Typography variant="h6">
-        Reviewer Notes:
+      <Typography variant="body1" sx = {{marginBottom: '4%'}}>
+        Reviewer Notes:{' '}
         {submission.reviews.length !== 0
-          ? submission.reviews.map((review) => review.notes).join(' ')
+          ? submission.reviews.map((review) => review.notes).join('  ')
           : 'There are no notes.'}
       </Typography>
     </Box>

--- a/src/frontend/src/pages/PartPage/Components/PartSubmissionDetails.tsx
+++ b/src/frontend/src/pages/PartPage/Components/PartSubmissionDetails.tsx
@@ -6,24 +6,34 @@ interface PartSubmissionProps {
   submission: PartSubmission;
 }
 
+const reviewNotes = (reviews: PartReview[]): string => {
+  if (reviews.length === 0) {
+    return 'There are no notes.';
+  } else {
+    return '\n' + reviews.map((review) => '- ' + review.notes).join('\n');
+  }
+};
+
 const PartSubmissionDetails = ({ submission }: PartSubmissionProps) => {
   return (
-    <Stack spacing={'4%'} alignItems="left" width="100%">
+    <Stack spacing={'1%'} alignItems="left" width="100%">
       <Typography sx={{ fontWeight: 'normal' }} variant="h5">
         Details for {submission.name}:
       </Typography>
 
       <Typography variant="body1">
-        Uploader: {submission.userCreated.firstName} {submission.userCreated.lastName}
+        <b>Uploader: </b>
+        {submission.userCreated.firstName} {submission.userCreated.lastName}
       </Typography>
 
-      <Typography variant="body1">Uploader Notes: {submission.notes || 'There are no notes.'}</Typography>
-
       <Typography variant="body1">
-        Reviewer Notes:{' '}
-        {submission.reviews.length !== 0
-          ? submission.reviews.map((review) => review.notes).join('\n')
-          : 'There are no notes.'}
+        <b>Uploader Notes: </b>
+        {submission.notes || 'There are no notes.'}
+      </Typography>
+
+      <Typography variant="body1" sx={{ whiteSpace: 'pre-line' }}>
+        <b>Reviewer Notes: </b>
+        {reviewNotes(submission.reviews)}
       </Typography>
     </Stack>
   );

--- a/src/frontend/src/pages/PartPage/Components/PartSubmissionDetails.tsx
+++ b/src/frontend/src/pages/PartPage/Components/PartSubmissionDetails.tsx
@@ -1,6 +1,6 @@
 import { Typography } from '@mui/material';
 import { Stack } from '@mui/system';
-import { PartSubmission } from 'shared';
+import { Part_Review_Popup, PartSubmission } from 'shared';
 
 interface PartSubmissionProps {
   submission: PartSubmission;
@@ -30,3 +30,61 @@ const PartSubmissionDetails = ({ submission }: PartSubmissionProps) => {
 };
 
 export default PartSubmissionDetails;
+
+// mock examples for testing
+
+const partReviewPopUp1: Part_Review_Popup = {
+  partReviewPopupId: '1',
+  xCoord: 0.0,
+  yCoord: 0.0,
+  title: 'review 1 popup',
+  description: 'description1',
+  reviewId: '1'
+};
+
+const partReviewPopUp2: Part_Review_Popup = {
+  partReviewPopupId: '2',
+  xCoord: 0.0,
+  yCoord: 0.0,
+  title: 'review 2 popup',
+  description: 'description2',
+  reviewId: '1'
+};
+
+export const partReviewExample1 = {
+  partReviewId: 'reviewId003',
+  fileIds: ['file5', 'file6'],
+  notes: 'this part submission is decent!!',
+  submission: {
+    connect: {
+      partSubmissionId: '1'
+    }
+  },
+  userCreated: {
+    connect: { userId: '123' }
+  },
+  popUps: {
+    connect: [partReviewPopUp1]
+  },
+  submissionId: '123',
+  createdAt: new Date(2025, 6, 4)
+};
+
+export const partReviewExample2 = {
+  partReviewId: 'reviewId004',
+  fileIds: ['file7', 'file8'],
+  notes: 'this part submission is terrible!!',
+  submission: {
+    connect: {
+      partSubmissionId: '1'
+    }
+  },
+  userCreated: {
+    connect: { userId: '32' }
+  },
+  popUps: {
+    connect: [partReviewPopUp2]
+  },
+  submissionId: '123',
+  createdAt: new Date(2025, 5, 4)
+};

--- a/src/frontend/src/pages/PartPage/Components/PartSubmissionDetails.tsx
+++ b/src/frontend/src/pages/PartPage/Components/PartSubmissionDetails.tsx
@@ -1,0 +1,34 @@
+import { Typography } from '@mui/material';
+import { Box } from '@mui/system';
+import { PartSubmission } from 'shared';
+
+interface PartSubmissionProps {
+  submission: PartSubmission;
+}
+
+const PartSubmissionDetails = ({ submission }: PartSubmissionProps) => {
+  return (
+    <Box display="flex" alignItems="center" width="50%" padding={2}>
+      <Typography variant="h4">Details for Submission #{submission.partSubmissionId}:</Typography>
+
+      <Typography variant="h6">
+        Uploader:
+        {submission.userCreated.firstName} {submission.userCreated.lastName}
+      </Typography>
+
+      <Typography variant="h6">
+        Uploader Notes:
+        {submission.notes || 'There are no notes.'}
+      </Typography>
+
+      <Typography variant="h6">
+        Reviewer Notes:
+        {submission.reviews.length !== 0
+          ? submission.reviews.map((review) => review.notes).join(' ')
+          : 'There are no notes.'}
+      </Typography>
+    </Box>
+  );
+};
+
+export default PartSubmissionDetails;

--- a/src/frontend/src/pages/PartPage/PartPage.tsx
+++ b/src/frontend/src/pages/PartPage/PartPage.tsx
@@ -60,22 +60,8 @@ const PartPage: React.FC = () => {
                   justifyContent: 'center',
                   mb: 2
                 }}
-              >
-                <Typography>Details for Submission</Typography>
-              </Box>
-              <Box
-                sx={{
-                  backgroundColor: 'transparent',
-                  height: '24vh',
-                  width: '50%',
-                  borderRadius: 2,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  mb: 2
-                }}
-              >
-                {/*Add part submission details here*/}
+              ></Box>
+              <Box>
                 <PartSubmissionDetails
                   submission={{
                     partSubmissionId: '1',
@@ -89,7 +75,7 @@ const PartPage: React.FC = () => {
                       lastName: 'Doe'
                     },
                     notes: 'This is a test note.',
-                    reviews: [partReviewExample1, partReviewExample2],
+                    reviews: [],
                     fileIds: [],
                     name: 'Test Part Submission',
                     partId: '456',

--- a/src/frontend/src/pages/PartPage/PartPage.tsx
+++ b/src/frontend/src/pages/PartPage/PartPage.tsx
@@ -73,6 +73,7 @@ const PartPage: React.FC = () => {
                   mb: 2
                 }}
               >
+                <PartSubmissionDetails></PartSubmissionDetails>
                 <Typography>History</Typography>
               </Box>
             </Grid>

--- a/src/frontend/src/pages/PartPage/PartPage.tsx
+++ b/src/frontend/src/pages/PartPage/PartPage.tsx
@@ -75,7 +75,7 @@ const PartPage: React.FC = () => {
                       lastName: 'Doe'
                     },
                     notes: 'This is a test note.',
-                    reviews: [],
+                    reviews: [partReviewExample1, partReviewExample2],
                     fileIds: [],
                     name: 'Test Part Submission',
                     partId: '456',

--- a/src/frontend/src/pages/PartPage/PartPage.tsx
+++ b/src/frontend/src/pages/PartPage/PartPage.tsx
@@ -1,6 +1,6 @@
 import { Box, Typography, Grid, Breadcrumbs } from '@mui/material';
 import { RoleEnum } from 'shared';
-import PartSubmissionDetails from './Components/PartSubmissionDetails';
+import PartSubmissionDetails, { partReviewExample1, partReviewExample2 } from './Components/PartSubmissionDetails';
 
 const PartPage: React.FC = () => {
   return (
@@ -89,7 +89,7 @@ const PartPage: React.FC = () => {
                       lastName: 'Doe'
                     },
                     notes: 'This is a test note.',
-                    reviews: [],
+                    reviews: [partReviewExample1, partReviewExample2],
                     fileIds: [],
                     name: 'Test Part Submission',
                     partId: '456',

--- a/src/frontend/src/pages/PartPage/PartPage.tsx
+++ b/src/frontend/src/pages/PartPage/PartPage.tsx
@@ -1,4 +1,6 @@
 import { Box, Typography, Grid, Breadcrumbs } from '@mui/material';
+import { RoleEnum } from 'shared';
+import PartSubmissionDetails from './Components/PartSubmissionDetails';
 
 const PartPage: React.FC = () => {
   return (
@@ -73,7 +75,27 @@ const PartPage: React.FC = () => {
                   mb: 2
                 }}
               >
-                <PartSubmissionDetails></PartSubmissionDetails>
+                Add part submission details here
+                <PartSubmissionDetails
+                  submission={{
+                    partSubmissionId: '1',
+                    userCreated: {
+                      userId: '123',
+                      email: 'john.doe@example.com',
+                      emailId: 'john.doe@example.com',
+                      role: RoleEnum.MEMBER,
+                      permissions: [],
+                      firstName: 'John',
+                      lastName: 'Doe'
+                    },
+                    notes: 'This is a test note.',
+                    reviews: [],
+                    fileIds: [],
+                    name: 'Test Part Submission',
+                    partId: '456',
+                    createdAt: new Date()
+                  }}
+                />
                 <Typography>History</Typography>
               </Box>
             </Grid>

--- a/src/frontend/src/pages/PartPage/PartPage.tsx
+++ b/src/frontend/src/pages/PartPage/PartPage.tsx
@@ -20,7 +20,7 @@ const PartPage: React.FC = () => {
             sx={{
               backgroundColor: 'black',
               height: '75vh',
-              width: '100%',
+              width: '50%',
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
@@ -39,7 +39,7 @@ const PartPage: React.FC = () => {
                 sx={{
                   backgroundColor: 'gray',
                   height: '24vh',
-                  width: '100%',
+                  width: '50%',
                   borderRadius: 2,
                   display: 'flex',
                   alignItems: 'center',
@@ -53,7 +53,7 @@ const PartPage: React.FC = () => {
                 sx={{
                   backgroundColor: 'gray',
                   height: '24vh',
-                  width: '100%',
+                  width: '50%',
                   borderRadius: 2,
                   display: 'flex',
                   alignItems: 'center',
@@ -65,9 +65,9 @@ const PartPage: React.FC = () => {
               </Box>
               <Box
                 sx={{
-                  backgroundColor: 'gray',
+                  backgroundColor: 'transparent',
                   height: '24vh',
-                  width: '100%',
+                  width: '50%',
                   borderRadius: 2,
                   display: 'flex',
                   alignItems: 'center',
@@ -75,7 +75,7 @@ const PartPage: React.FC = () => {
                   mb: 2
                 }}
               >
-                Add part submission details here
+                {/*Add part submission details here*/}
                 <PartSubmissionDetails
                   submission={{
                     partSubmissionId: '1',
@@ -96,8 +96,8 @@ const PartPage: React.FC = () => {
                     createdAt: new Date()
                   }}
                 />
-                <Typography>History</Typography>
               </Box>
+              <Typography>History</Typography>
             </Grid>
           </Grid>
         </Grid>


### PR DESCRIPTION
## Changes

Added PartSubmissionDetails.tsx component in Components folder under PartPage.  Example PartSubmission was manually added to PartPage.tsx to test what it looked like.

## Notes

Slightly changed alignment of existing components from 100% to 50% in PartPage.tsx to test what PartSubmissionDetails component looked like.

## Test Cases

None

## Screenshots

![partsubmissiondetails2](https://github.com/user-attachments/assets/3ba4c03d-0fdb-4e73-863e-a0794ac6cbcd)
![partsubmissiondetails1](https://github.com/user-attachments/assets/fab311e2-af0e-4f50-9d1f-88f41d3979a7)


## To Do

None

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #3338 
