### PR TITLE
#3380 reimbursement request comments endpoints

### DIFF
--- a/src/backend/src/controllers/reimbursement-requests.controllers.ts
+++ b/src/backend/src/controllers/reimbursement-requests.controllers.ts
@@ -574,7 +574,7 @@ export default class ReimbursementRequestsController {
   static async createReimbursementRequestComment(req: Request, res: Response, next: NextFunction) {
     try {
       const { comment } = req.body;
-      const { reimbursementRequestId } = req.params;
+      const { requestId: reimbursementRequestId } = req.params;
 
       const createdComment = await ReimbursementRequestService.createReimbursementRequestComment(
         req.currentUser,
@@ -593,12 +593,12 @@ export default class ReimbursementRequestsController {
       const { comment } = req.body;
       const { commentId } = req.params;
 
-      const createdComment = await ReimbursementRequestService.editReimbursementRequestComment(
+      const editedComment = await ReimbursementRequestService.editReimbursementRequestComment(
         req.organization,
         comment,
         commentId
       );
-      res.status(200).json(createdComment);
+      res.status(200).json(editedComment);
     } catch (error: unknown) {
       next(error);
     }
@@ -608,11 +608,11 @@ export default class ReimbursementRequestsController {
     try {
       const { commentId } = req.params;
 
-      const createdComment = await ReimbursementRequestService.deleteReimbursementRequestComment(
+      const deletedComment = await ReimbursementRequestService.deleteReimbursementRequestComment(
         req.organization,
         commentId
       );
-      res.status(200).json(createdComment);
+      res.status(200).json(deletedComment);
     } catch (error: unknown) {
       next(error);
     }

--- a/src/backend/src/controllers/reimbursement-requests.controllers.ts
+++ b/src/backend/src/controllers/reimbursement-requests.controllers.ts
@@ -593,7 +593,11 @@ export default class ReimbursementRequestsController {
       const { comment } = req.body;
       const { commentId } = req.params;
 
-      const createdComment = await ReimbursementRequestService.editReimbursementRequestComment(comment, commentId);
+      const createdComment = await ReimbursementRequestService.editReimbursementRequestComment(
+        req.organization,
+        comment,
+        commentId
+      );
       res.status(200).json(createdComment);
     } catch (error: unknown) {
       next(error);
@@ -604,7 +608,10 @@ export default class ReimbursementRequestsController {
     try {
       const { commentId } = req.params;
 
-      const createdComment = await ReimbursementRequestService.deleteReimbursementRequestComment(commentId);
+      const createdComment = await ReimbursementRequestService.deleteReimbursementRequestComment(
+        req.organization,
+        commentId
+      );
       res.status(200).json(createdComment);
     } catch (error: unknown) {
       next(error);

--- a/src/backend/src/controllers/reimbursement-requests.controllers.ts
+++ b/src/backend/src/controllers/reimbursement-requests.controllers.ts
@@ -607,12 +607,8 @@ export default class ReimbursementRequestsController {
   static async deleteReimbursementRequestComment(req: Request, res: Response, next: NextFunction) {
     try {
       const { commentId } = req.params;
-
-      const deletedComment = await ReimbursementRequestService.deleteReimbursementRequestComment(
-        req.organization,
-        commentId
-      );
-      res.status(200).json(deletedComment);
+      await ReimbursementRequestService.deleteReimbursementRequestComment(req.organization, commentId);
+      res.status(200).json({ message: `Successfully deleted Comment with id ${commentId}` });
     } catch (error: unknown) {
       next(error);
     }

--- a/src/backend/src/controllers/reimbursement-requests.controllers.ts
+++ b/src/backend/src/controllers/reimbursement-requests.controllers.ts
@@ -570,4 +570,44 @@ export default class ReimbursementRequestsController {
       next(error);
     }
   }
+
+  static async createReimbursementRequestComment(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { comment } = req.body;
+      const { reimbursementRequestId } = req.params;
+
+      const createdComment = await ReimbursementRequestService.createReimbursementRequestComment(
+        req.currentUser,
+        req.organization,
+        comment,
+        reimbursementRequestId
+      );
+      res.status(200).json(createdComment);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
+  static async editReimbursementRequestComment(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { comment } = req.body;
+      const { commentId } = req.params;
+
+      const createdComment = await ReimbursementRequestService.editReimbursementRequestComment(comment, commentId);
+      res.status(200).json(createdComment);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
+  static async deleteReimbursementRequestComment(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { commentId } = req.params;
+
+      const createdComment = await ReimbursementRequestService.deleteReimbursementRequestComment(commentId);
+      res.status(200).json(createdComment);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
 }

--- a/src/backend/src/prisma-query-args/reimbursement-comment.query-args.ts
+++ b/src/backend/src/prisma-query-args/reimbursement-comment.query-args.ts
@@ -1,0 +1,11 @@
+import { Prisma } from '@prisma/client';
+import { getUserQueryArgs } from './user.query-args';
+
+export type ReimbursementRequestCommentQueryArgs = ReturnType<typeof getReimbursementRequestCommentQueryArgs>;
+
+export const getReimbursementRequestCommentQueryArgs = (organizationId: string) =>
+  Prisma.validator<Prisma.Reimbursement_Request_CommentDefaultArgs>()({
+    include: {
+      userCreated: getUserQueryArgs(organizationId)
+    }
+  });

--- a/src/backend/src/prisma-query-args/reimbursement-requests.query-args.ts
+++ b/src/backend/src/prisma-query-args/reimbursement-requests.query-args.ts
@@ -6,6 +6,7 @@ import { getReceiptQueryArgs } from './receipt-query.args';
 import { getReimbursementProductQueryArgs } from './reimbursement-products.query-args';
 import { getIndexCodeQueryArgs } from './index-code.query-args';
 import { getAccountCodeQueryArgs } from './account-code.query-args';
+import { getReimbursementRequestCommentQueryArgs } from './reimbursement-comment.query-args';
 
 export type ReimbursementRequestQueryArgs = ReturnType<typeof getReimbursementRequestQueryArgs>;
 
@@ -24,6 +25,12 @@ export const getReimbursementRequestQueryArgs = (organizationId: string) =>
         },
         ...getReimbursementProductQueryArgs(organizationId)
       },
-      notificationSlackThreads: true
+      notificationSlackThreads: true,
+      reimbursementComments: {
+        where: {
+          dateDeleted: null
+        },
+        ...getReimbursementRequestCommentQueryArgs(organizationId)
+      }
     }
   });

--- a/src/backend/src/prisma/migrations/20250402021534_finance_redesign/migration.sql
+++ b/src/backend/src/prisma/migrations/20250402021534_finance_redesign/migration.sql
@@ -254,3 +254,6 @@ ALTER TABLE "Reimbursement_Request_Comment" ADD CONSTRAINT "Reimbursement_Reques
 
 -- AddForeignKey
 ALTER TABLE "Reimbursement_Request_Comment" ADD CONSTRAINT "Reimbursement_Request_Comment_reimbursementRequestId_fkey" FOREIGN KEY ("reimbursementRequestId") REFERENCES "Reimbursement_Request"("reimbursementRequestId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AlterTable
+ALTER TABLE "Reimbursement_Request_Comment" ADD COLUMN     "dateDeleted" TIMESTAMP(3);

--- a/src/backend/src/prisma/schema.prisma
+++ b/src/backend/src/prisma/schema.prisma
@@ -1192,9 +1192,10 @@ model Reimbursement_Product_Other_Reason {
 model Reimbursement_Request_Comment {
   reimbursementRequestCommentId String                @id @default(uuid())
   dateCreated                   DateTime              @default(now())
+  dateDeleted                   DateTime?
   userCreated                   User                  @relation(fields: [userCreatedId], references: [userId], name: "createdReimbursementRequestComments")
   userCreatedId                 String
   comment                       String
   reimbursementRequestId        String
-  reimbursementRequuest         Reimbursement_Request @relation(fields: [reimbursementRequestId], references: [reimbursementRequestId])
+  reimbursementRequest          Reimbursement_Request @relation(fields: [reimbursementRequestId], references: [reimbursementRequestId])
 }

--- a/src/backend/src/prisma/seed.ts
+++ b/src/backend/src/prisma/seed.ts
@@ -1805,6 +1805,27 @@ const performSeed: () => Promise<void> = async () => {
     new Date()
   );
 
+  ReimbursementRequestService.createReimbursementRequestComment(
+    thomasEmrax,
+    ner,
+    'Thomas Followed up - "Please upload reciept"',
+    reimbursement1.reimbursementRequestId
+  );
+
+  ReimbursementRequestService.createReimbursementRequestComment(
+    batman,
+    ner,
+    'Batman Uploaded Receipt',
+    reimbursement1.reimbursementRequestId
+  );
+
+  ReimbursementRequestService.createReimbursementRequestComment(
+    thomasEmrax,
+    ner,
+    'Thomas Submmited to SABO',
+    reimbursement1.reimbursementRequestId
+  );
+
   const otherProductReasonConsumables = await ReimbursementRequestService.createOtherReimbursementProductReason(
     'CONSUMABLES',
     10,

--- a/src/backend/src/routes/reimbursement-requests.routes.ts
+++ b/src/backend/src/routes/reimbursement-requests.routes.ts
@@ -226,9 +226,6 @@ reimbursementRequestsRouter.post(
   ReimbursementRequestController.editReimbursementRequestComment
 );
 
-reimbursementRequestsRouter.delete(
-  '/comments/commentId/delete',
-  ReimbursementRequestController.deleteReimbursementRequestComment
-);
+reimbursementRequestsRouter.delete('/comments/:commentId', ReimbursementRequestController.deleteReimbursementRequestComment);
 
 export default reimbursementRequestsRouter;

--- a/src/backend/src/routes/reimbursement-requests.routes.ts
+++ b/src/backend/src/routes/reimbursement-requests.routes.ts
@@ -212,4 +212,23 @@ reimbursementRequestsRouter.post(
   ReimbursementRequestController.markReimbursementRequestAsPendingFinance
 );
 
+reimbursementRequestsRouter.post(
+  '/:requestId/comments',
+  nonEmptyString(body('comment')),
+  validateInputs,
+  ReimbursementRequestController.createReimbursementRequestComment
+);
+
+reimbursementRequestsRouter.post(
+  '/comments/:commentId/edit',
+  nonEmptyString(body('comment')),
+  validateInputs,
+  ReimbursementRequestController.editReimbursementRequestComment
+);
+
+reimbursementRequestsRouter.delete(
+  '/comments/commentId/delete',
+  ReimbursementRequestController.deleteReimbursementRequestComment
+);
+
 export default reimbursementRequestsRouter;

--- a/src/backend/src/services/reimbursement-requests.services.ts
+++ b/src/backend/src/services/reimbursement-requests.services.ts
@@ -72,7 +72,6 @@ import { encryptPassword } from '../utils/encryption.utils';
 import { getAccountCodeQueryArgs } from '../prisma-query-args/account-code.query-args';
 import { getIndexCodeQueryArgs } from '../prisma-query-args/index-code.query-args';
 import { getReimbursementProductOtherReasonQueryArgs } from '../prisma-query-args/reimbursement-product-other-reason.query-args';
-import { Or } from '@prisma/client/runtime/library';
 import { getReimbursementRequestCommentQueryArgs } from '../prisma-query-args/reimbursement-comment.query-args';
 
 export default class ReimbursementRequestService {
@@ -1542,7 +1541,7 @@ export default class ReimbursementRequestService {
     reimbursementRequestId: string
   ) {
     const reimbursementRequest = await prisma.reimbursement_Request.findUnique({
-      where: { reimbursementRequestId, organizationId: organization.organizationId }
+      where: { reimbursementRequestId, organizationId: organization.organizationId, dateDeleted: null }
     });
 
     if (!reimbursementRequest) {
@@ -1573,7 +1572,7 @@ export default class ReimbursementRequestService {
    */
   static async editReimbursementRequestComment(organization: Organization, comment: string, commentId: string) {
     const reimbursementRequestComment = await prisma.reimbursement_Request_Comment.findUnique({
-      where: { reimbursementRequestCommentId: commentId }
+      where: { reimbursementRequestCommentId: commentId, dateDeleted: null }
     });
 
     if (!reimbursementRequestComment) {
@@ -1603,7 +1602,7 @@ export default class ReimbursementRequestService {
    */
   static async deleteReimbursementRequestComment(organization: Organization, commentId: string) {
     const reimbursementRequestComment = await prisma.reimbursement_Request_Comment.findUnique({
-      where: { reimbursementRequestCommentId: commentId }
+      where: { reimbursementRequestCommentId: commentId, dateDeleted: null }
     });
 
     if (!reimbursementRequestComment) {

--- a/src/backend/src/services/reimbursement-requests.services.ts
+++ b/src/backend/src/services/reimbursement-requests.services.ts
@@ -71,6 +71,7 @@ import { encryptPassword } from '../utils/encryption.utils';
 import { getAccountCodeQueryArgs } from '../prisma-query-args/account-code.query-args';
 import { getIndexCodeQueryArgs } from '../prisma-query-args/index-code.query-args';
 import { getReimbursementProductOtherReasonQueryArgs } from '../prisma-query-args/reimbursement-product-other-reason.query-args';
+import { Or } from '@prisma/client/runtime/library';
 
 export default class ReimbursementRequestService {
   /**
@@ -1520,5 +1521,94 @@ export default class ReimbursementRequestService {
     });
 
     return otherProductReasonTransformer(deletedOtherProductReason);
+  }
+
+  /**
+   * Creates a new comment for a reimbursement request
+   *
+   * @param currentUser The user creating the comment
+   * @param organization The organization context for the request
+   * @param comment The comment text content
+   * @param reimbursementRequestId The ID of the reimbursement request to comment on
+   * @returns The newly created reimbursement request comment
+   * @throws NotFoundException if the reimbursement request doesn't exist in the organization
+   */
+  static async createReimbursementRequestComment(
+    currentUser: User,
+    organization: Organization,
+    comment: string,
+    reimbursementRequestId: string
+  ) {
+    const reimbursementRequest = await prisma.reimbursement_Request.findUnique({
+      where: { reimbursementRequestId, organizationId: organization.organizationId }
+    });
+
+    if (!reimbursementRequest) {
+      throw new NotFoundException('Reimbursement Request', reimbursementRequestId);
+    }
+
+    const reimbursementRequestComment = await prisma.reimbursement_Request_Comment.create({
+      data: {
+        userCreatedId: currentUser.userId,
+        reimbursementRequestId,
+        comment
+      }
+    });
+
+    return reimbursementRequestComment;
+  }
+
+  /**
+   * Updates the comment for an existing new comment on a reimbursement request
+   *
+   * @param comment The comment text content
+   * @param commentId The ID of the reimbursement request comment
+   * @returns The updated reimbursement request comment
+   * @throws NotFoundException if the comment doesn't exist
+   * @throws HttpException if the comment is the same as the current comment
+   */
+  static async editReimbursementRequestComment(comment: string, commentId: string) {
+    const reimbursementRequestComment = await prisma.reimbursement_Request_Comment.findUnique({
+      where: { reimbursementRequestCommentId: commentId }
+    });
+
+    if (!reimbursementRequestComment) {
+      throw new NotFoundException('Reimbursement Request Comment', commentId);
+    }
+
+    if (reimbursementRequestComment.comment === comment) {
+      throw new HttpException(400, 'New comment matches existing content');
+    }
+
+    const editedComment = await prisma.reimbursement_Request_Comment.update({
+      where: { reimbursementRequestCommentId: commentId },
+      data: { comment }
+    });
+
+    return editedComment;
+  }
+
+  /**
+   * Deletes the comment for an existing comment on a reimbursement request
+   *
+   * @param commentId The ID of the reimbursement request comment
+   * @returns The deleted reimbursement request comment
+   * @throws NotFoundException if the comment doesn't exist
+   */
+  static async deleteReimbursementRequestComment(commentId: string) {
+    const reimbursementRequestComment = await prisma.reimbursement_Request_Comment.findUnique({
+      where: { reimbursementRequestCommentId: commentId }
+    });
+
+    if (!reimbursementRequestComment) {
+      throw new NotFoundException('Reimbursement Request Comment', commentId);
+    }
+
+    const deletedComment = await prisma.reimbursement_Request_Comment.update({
+      where: { reimbursementRequestCommentId: commentId },
+      data: { dateDeleted: new Date() }
+    });
+
+    return deletedComment;
   }
 }

--- a/src/backend/src/services/reimbursement-requests.services.ts
+++ b/src/backend/src/services/reimbursement-requests.services.ts
@@ -48,6 +48,7 @@ import {
   accountCodeTransformer,
   indexCodeTransformer,
   otherProductReasonTransformer,
+  reimbursementRequestCommentTransformer,
   reimbursementRequestTransformer,
   reimbursementStatusTransformer,
   reimbursementTransformer,
@@ -72,6 +73,7 @@ import { getAccountCodeQueryArgs } from '../prisma-query-args/account-code.query
 import { getIndexCodeQueryArgs } from '../prisma-query-args/index-code.query-args';
 import { getReimbursementProductOtherReasonQueryArgs } from '../prisma-query-args/reimbursement-product-other-reason.query-args';
 import { Or } from '@prisma/client/runtime/library';
+import { getReimbursementRequestCommentQueryArgs } from '../prisma-query-args/reimbursement-comment.query-args';
 
 export default class ReimbursementRequestService {
   /**
@@ -1547,27 +1549,29 @@ export default class ReimbursementRequestService {
       throw new NotFoundException('Reimbursement Request', reimbursementRequestId);
     }
 
-    const reimbursementRequestComment = await prisma.reimbursement_Request_Comment.create({
+    const createdComment = await prisma.reimbursement_Request_Comment.create({
       data: {
         userCreatedId: currentUser.userId,
         reimbursementRequestId,
         comment
-      }
+      },
+      ...getReimbursementRequestCommentQueryArgs(organization.organizationId)
     });
 
-    return reimbursementRequestComment;
+    return reimbursementRequestCommentTransformer(createdComment);
   }
 
   /**
    * Updates the comment for an existing new comment on a reimbursement request
    *
+   * @param organization The organization context for the request
    * @param comment The comment text content
    * @param commentId The ID of the reimbursement request comment
    * @returns The updated reimbursement request comment
    * @throws NotFoundException if the comment doesn't exist
    * @throws HttpException if the comment is the same as the current comment
    */
-  static async editReimbursementRequestComment(comment: string, commentId: string) {
+  static async editReimbursementRequestComment(organization: Organization, comment: string, commentId: string) {
     const reimbursementRequestComment = await prisma.reimbursement_Request_Comment.findUnique({
       where: { reimbursementRequestCommentId: commentId }
     });
@@ -1582,20 +1586,22 @@ export default class ReimbursementRequestService {
 
     const editedComment = await prisma.reimbursement_Request_Comment.update({
       where: { reimbursementRequestCommentId: commentId },
-      data: { comment }
+      data: { comment },
+      ...getReimbursementRequestCommentQueryArgs(organization.organizationId)
     });
 
-    return editedComment;
+    return reimbursementRequestCommentTransformer(editedComment);
   }
 
   /**
    * Deletes the comment for an existing comment on a reimbursement request
    *
+   * @param organization The organization context for the request
    * @param commentId The ID of the reimbursement request comment
    * @returns The deleted reimbursement request comment
    * @throws NotFoundException if the comment doesn't exist
    */
-  static async deleteReimbursementRequestComment(commentId: string) {
+  static async deleteReimbursementRequestComment(organization: Organization, commentId: string) {
     const reimbursementRequestComment = await prisma.reimbursement_Request_Comment.findUnique({
       where: { reimbursementRequestCommentId: commentId }
     });
@@ -1606,9 +1612,10 @@ export default class ReimbursementRequestService {
 
     const deletedComment = await prisma.reimbursement_Request_Comment.update({
       where: { reimbursementRequestCommentId: commentId },
-      data: { dateDeleted: new Date() }
+      data: { dateDeleted: new Date() },
+      ...getReimbursementRequestCommentQueryArgs(organization.organizationId)
     });
 
-    return deletedComment;
+    return reimbursementRequestCommentTransformer(deletedComment);
   }
 }

--- a/src/backend/src/transformers/reimbursement-requests.transformer.ts
+++ b/src/backend/src/transformers/reimbursement-requests.transformer.ts
@@ -62,7 +62,8 @@ export const reimbursementRequestTransformer = (
     receiptPictures: reimbursementRequest.receiptPictures.filter((receipt) => !receipt.dateDeleted).map(receiptTransformer),
     reimbursementProducts: reimbursementRequest.reimbursementProducts.map(reimbursementProductTransformer),
     dateDelivered: reimbursementRequest.dateDelivered ?? undefined,
-    accountCode: accountCodeTransformer(reimbursementRequest.accountCode)
+    accountCode: accountCodeTransformer(reimbursementRequest.accountCode),
+    comments: reimbursementRequest.reimbursementComments.map(reimbursementRequestCommentTransformer)
   };
 };
 

--- a/src/backend/src/transformers/reimbursement-requests.transformer.ts
+++ b/src/backend/src/transformers/reimbursement-requests.transformer.ts
@@ -13,6 +13,7 @@ import {
   ReimbursementProduct,
   ReimbursementProductReason,
   ReimbursementRequest,
+  ReimbursementRequestComment,
   ReimbursementStatus,
   ReimbursementStatusType,
   Vendor
@@ -34,6 +35,7 @@ import { NotFoundException } from '../utils/errors.utils';
 import { AccountCodeQueryArgs } from '../prisma-query-args/account-code.query-args';
 import { IndexCodeQueryArgs } from '../prisma-query-args/index-code.query-args';
 import { ReimbursementProductOtherReasonQueryArgs } from '../prisma-query-args/reimbursement-product-other-reason.query-args';
+import { ReimbursementRequestCommentQueryArgs } from '../prisma-query-args/reimbursement-comment.query-args';
 
 export const receiptTransformer = (receipt: Prisma.ReceiptGetPayload<ReceiptQueryArgs>): Receipt => {
   return {
@@ -150,5 +152,14 @@ export const otherProductReasonTransformer = (
     dateCreated: otherProductReason.dateCreated,
     budget: otherProductReason.budget,
     indexCode: indexCodeTransformer(otherProductReason.indexCode)
+  };
+};
+
+export const reimbursementRequestCommentTransformer = (
+  reimbursementRequestComment: Prisma.Reimbursement_Request_CommentGetPayload<ReimbursementRequestCommentQueryArgs>
+): ReimbursementRequestComment => {
+  return {
+    ...reimbursementRequestComment,
+    userCreated: userTransformer(reimbursementRequestComment.userCreated)
   };
 };

--- a/src/backend/src/utils/errors.utils.ts
+++ b/src/backend/src/utils/errors.utils.ts
@@ -149,4 +149,5 @@ export type ExceptionObjectNames =
   | 'SponsorTask'
   | 'Index Code'
   | 'Reimbursement Product Other Reason'
-  | 'Encryption Key';
+  | 'Encryption Key'
+  | 'Reimbursement Request Comment';

--- a/src/backend/tests/test-utils.ts
+++ b/src/backend/tests/test-utils.ts
@@ -105,6 +105,7 @@ export const resetUsers = async () => {
   await prisma.user_Secure_Settings.deleteMany();
   await prisma.reimbursement_Product.deleteMany();
   await prisma.reimbursement_Status.deleteMany();
+  await prisma.reimbursement_Request_Comment.deleteMany();
   await prisma.reimbursement_Request.deleteMany();
   await prisma.vendor.deleteMany();
   await prisma.account_Code.deleteMany();

--- a/src/backend/tests/unit/reimbursement-requests.test.ts
+++ b/src/backend/tests/unit/reimbursement-requests.test.ts
@@ -553,4 +553,97 @@ describe('Reimbursement Requests', () => {
       );
     });
   });
+
+  describe('Creating a reimbursement request comment', () => {
+    test('Successfully creating a RR comment', async () => {
+      const comment = await ReimbursementRequestService.createReimbursementRequestComment(
+        createdUser,
+        org,
+        'Test comment!',
+        reimbursementRequest.reimbursementRequestId
+      );
+
+      expect(comment.comment).toEqual('Test comment!');
+      expect(comment.reimbursementRequestId).toEqual(reimbursementRequest.reimbursementRequestId);
+      expect(comment.userCreated.userId).toEqual(createdUser.userId);
+    });
+    test('Fails when RR id is not found', async () => {
+      await expect(
+        async () =>
+          await ReimbursementRequestService.createReimbursementRequestComment(createdUser, org, 'Test comment!', 'bad ID')
+      ).rejects.toThrow(new NotFoundException('Reimbursement Request', 'bad ID'));
+    });
+  });
+
+  describe('Editing a reimbursement request comment', () => {
+    test('Successfully editing a RR comment', async () => {
+      const comment = await ReimbursementRequestService.createReimbursementRequestComment(
+        createdUser,
+        org,
+        'Test comment!',
+        reimbursementRequest.reimbursementRequestId
+      );
+      const editedComment = await ReimbursementRequestService.editReimbursementRequestComment(
+        org,
+        'Edited',
+        comment.reimbursementRequestCommentId
+      );
+
+      expect(editedComment.comment).toEqual('Edited');
+      expect(comment.reimbursementRequestId).toEqual(editedComment.reimbursementRequestId);
+      expect(editedComment.userCreated.userId).toEqual(comment.userCreated.userId);
+    });
+    test('Fails when RRComment id is not found', async () => {
+      await expect(
+        async () => await ReimbursementRequestService.editReimbursementRequestComment(org, 'Test comment!', 'bad ID')
+      ).rejects.toThrow(new NotFoundException('Reimbursement Request Comment', 'bad ID'));
+    });
+    test('Fails when new comment is the same as existing comment', async () => {
+      const comment = await ReimbursementRequestService.createReimbursementRequestComment(
+        createdUser,
+        org,
+        'Test comment!',
+        reimbursementRequest.reimbursementRequestId
+      );
+      await expect(
+        async () =>
+          await ReimbursementRequestService.editReimbursementRequestComment(
+            org,
+            'Test comment!',
+            comment.reimbursementRequestCommentId
+          )
+      ).rejects.toThrow(new HttpException(400, 'New comment matches existing content'));
+    });
+  });
+
+  describe('Deleting a reimbursement request comment', () => {
+    test('Successfully deleting a RR comment', async () => {
+      const comment = await ReimbursementRequestService.createReimbursementRequestComment(
+        createdUser,
+        org,
+        'Test comment!',
+        reimbursementRequest.reimbursementRequestId
+      );
+      const deletedComment = await ReimbursementRequestService.deleteReimbursementRequestComment(
+        org,
+        comment.reimbursementRequestCommentId
+      );
+      // checking its not found after deleting
+      await expect(
+        async () =>
+          await ReimbursementRequestService.editReimbursementRequestComment(
+            org,
+            'Test comment!',
+            deletedComment.reimbursementRequestCommentId
+          )
+      ).rejects.toThrow(
+        new NotFoundException('Reimbursement Request Comment', deletedComment.reimbursementRequestCommentId)
+      );
+    });
+    test('Fails when RRComment id is not found', async () => {
+      await expect(
+        async () => await ReimbursementRequestService.deleteReimbursementRequestComment(org, 'bad ID')
+      ).rejects.toThrow(new NotFoundException('Reimbursement Request Comment', 'bad ID'));
+    });
+  });
 });

--- a/src/shared/src/types/reimbursement-requests-types.ts
+++ b/src/shared/src/types/reimbursement-requests-types.ts
@@ -139,3 +139,10 @@ export interface Reimbursement {
   amount: number;
   userSubmitted: User;
 }
+
+export interface ReimbursementRequestComment {
+  reimbursementRequestId: string;
+  dateCreated: Date;
+  comment: string;
+  userCreated: User;
+}

--- a/src/shared/src/types/reimbursement-requests-types.ts
+++ b/src/shared/src/types/reimbursement-requests-types.ts
@@ -60,6 +60,7 @@ export interface ReimbursementRequest {
   reimbursementProducts: ReimbursementProduct[];
   dateDelivered?: Date;
   accountCode: AccountCode;
+  comments: ReimbursementRequestComment[];
 }
 
 export interface OtherProductReason {

--- a/src/shared/src/types/reimbursement-requests-types.ts
+++ b/src/shared/src/types/reimbursement-requests-types.ts
@@ -142,6 +142,7 @@ export interface Reimbursement {
 }
 
 export interface ReimbursementRequestComment {
+  reimbursementRequestCommentId: string;
   reimbursementRequestId: string;
   dateCreated: Date;
   comment: string;


### PR DESCRIPTION
## Changes

- modified the schema for RRComment to add a date deleted field and resolve a typo 
- createdRRComment endpoint
- editRRComment endpoint
- deleteRRComment endpoint
- modified RR type, query args, and transformer to include its comments

## Notes

When I read over the epic, it seemed like every user should have access to the RR Timeline so I haven't added any user constraints on the endpoints but lmk if I should

## Screenshots
RR includes comments:
<img width="1133" alt="Screenshot 2025-04-05 at 9 02 50 PM" src="https://github.com/user-attachments/assets/d629c965-8623-44c5-a7ff-a7fd3f361a68" />

Creating RR comment: 
<img width="713" alt="Screenshot 2025-04-05 at 9 09 10 PM" src="https://github.com/user-attachments/assets/ffe24cb6-8ed6-4ee1-a467-21c83b32afed" />

Editing:
<img width="993" alt="Screenshot 2025-04-05 at 9 10 23 PM" src="https://github.com/user-attachments/assets/e52d1116-8946-4ab0-8bee-45b0aaa8963e" />

Deleting:
<img width="974" alt="Screenshot 2025-04-05 at 9 22 49 PM" src="https://github.com/user-attachments/assets/d361b9ea-2ddc-4e65-9932-a1e410d16ed5" />


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3380
