### PR TITLE
#3290 Created getPart endpoint

### DIFF
--- a/src/backend/src/controllers/part-review.controllers.ts
+++ b/src/backend/src/controllers/part-review.controllers.ts
@@ -4,12 +4,12 @@ import { WbsNumber, validateWBS } from 'shared';
 import { HttpException } from '../utils/errors.utils';
 
 export default class PartReviewController {
-  
   static async getPart(req: Request, res: Response, next: NextFunction) {
     try {
-      const organizationId = req.organization.organizationId;
-      const { partId } = req.params;
-      const part = await PartReviewService.getPart(organizationId, partId);
+      const { wbsNum, indexNum } = req.params;
+
+      const wbsNumber: WbsNumber = validateWBS(wbsNum);
+      const part = await PartReviewService.getPart(req.organization, wbsNumber, indexNum);
       res.status(200).json(part);
     } catch (error: unknown) {
       next(error);

--- a/src/backend/src/controllers/part-review.controllers.ts
+++ b/src/backend/src/controllers/part-review.controllers.ts
@@ -1,26 +1,30 @@
 import { NextFunction, Request, Response } from 'express';
 import PartReviewService from '../services/part-review.services';
+import { WbsNumber, validateWBS } from 'shared';
 
 export default class PartReviewController {
   static async getPart(req: Request, res: Response, next: NextFunction) {
     try {
+      const organizationId = req.organization.organizationId;
       const { partId } = req.params;
-      const part = await PartReviewService.getPart(partId);
+      const part = await PartReviewService.getPart(organizationId, partId);
       res.status(200).json(part);
     } catch (error: unknown) {
       next(error);
     }
   }
 
-  static async getPartPreviews(req: Request, res: Response, next: NextFunction) {
-    try {
-      const { projectId } = req.params;
-      const partPreviews = await PartReviewService.getPartPreviews(projectId);
-      res.status(200).json(partPreviews);
-    } catch (error: unknown) {
-      next(error);
-    }
-  }
+  // static async getPartPreviews(req: Request, res: Response, next: NextFunction) {
+  //   try {
+  //     const organization = req.organization;
+  //     const wbsNumber: WbsNumber = validateWBS(req.params.wbsNum);
+
+  //     const partPreviews = await PartReviewService.getPartPreviews(organization, wbsNumber);
+  //     res.status(200).json(partPreviews);
+  //   } catch (error: unknown) {
+  //     next(error);
+  //   }
+  // }
 
   static async getAllPartTags(req: Request, res: Response, next: NextFunction) {
     try {

--- a/src/backend/src/controllers/part-review.controllers.ts
+++ b/src/backend/src/controllers/part-review.controllers.ts
@@ -2,6 +2,26 @@ import { NextFunction, Request, Response } from 'express';
 import PartReviewService from '../services/part-review.services';
 
 export default class PartReviewController {
+  static async getPart(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { partId } = req.params;
+      const part = await PartReviewService.getPart(partId);
+      res.status(200).json(part);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
+  static async getPartPreviews(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { projectId } = req.params;
+      const partPreviews = await PartReviewService.getPartPreviews(projectId);
+      res.status(200).json(partPreviews);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
   static async getAllPartTags(req: Request, res: Response, next: NextFunction) {
     try {
       const tags = await PartReviewService.getAllPartTags(req.organization.organizationId);

--- a/src/backend/src/prisma/migrations/20250124235046_cad_part_file_review/migration.sql
+++ b/src/backend/src/prisma/migrations/20250124235046_cad_part_file_review/migration.sql
@@ -33,6 +33,7 @@ CREATE TABLE "Part" (
     "userCreatedId" TEXT NOT NULL,
     "userDeletedId" TEXT,
 
+    CONSTRAINT "ProjectId_and_index" UNIQUE ("projectId", "index"),
     CONSTRAINT "Part_pkey" PRIMARY KEY ("partId")
 );
 

--- a/src/backend/src/prisma/schema.prisma
+++ b/src/backend/src/prisma/schema.prisma
@@ -1128,32 +1128,34 @@ model Contact {
 }
 
 model Part {
-  partId           String              @id @default(uuid())
-  index            Int
-  commonName       String
-  description      String?
+  partId         String              @id @default(uuid())
+  index          Int
+  commonName     String
+  description    String?
   previewImageId String?
-  status           Review_Status       @default(IN_PROGRESS)
-  tags             PartTag[]
-  submissions      PartSubmission[]
-  reviewRequests   PartReviewRequest[]
-  project          Project             @relation(fields: [projectId], references: [projectId])
-  projectId        String
-  assignees        User[]              @relation("partAssignees")
-  createdAt        DateTime            @default(now())
-  updatedAt        DateTime            @updatedAt
-  dateDeleted      DateTime?
-  userCreatedId    String
-  userCreated      User                @relation(fields: [userCreatedId], references: [userId], name: "partCreator")
-  userDeletedId    String?
-  userDeleted      User?               @relation(fields: [userDeletedId], references: [userId], name: "partDeleter")
+  status         Review_Status       @default(IN_PROGRESS)
+  tags           PartTag[]
+  submissions    PartSubmission[]
+  reviewRequests PartReviewRequest[]
+  project        Project             @relation(fields: [projectId], references: [projectId])
+  projectId      String
+  assignees      User[]              @relation("partAssignees")
+  createdAt      DateTime            @default(now())
+  updatedAt      DateTime            @updatedAt
+  dateDeleted    DateTime?
+  userCreatedId  String
+  userCreated    User                @relation(fields: [userCreatedId], references: [userId], name: "partCreator")
+  userDeletedId  String?
+  userDeleted    User?               @relation(fields: [userDeletedId], references: [userId], name: "partDeleter")
+
+  @@unique([projectId, index], name: "ProjectId_and_index")
 }
 
 model PartTag {
-  partTagId      String        @id @default(uuid())
+  partTagId      String       @id @default(uuid())
   name           String
   colorHexCode   String
-  dateCreated    DateTime      @default(now())
+  dateCreated    DateTime     @default(now())
   dateDeleted    DateTime?
   parts          Part[]
   organization   Organization @relation(fields: [organizationId], references: [organizationId])
@@ -1178,14 +1180,14 @@ model PartSubmission {
 }
 
 model PartReviewRequest {
-  partReviewRequestId String   @id @default(uuid())
+  partReviewRequestId String    @id @default(uuid())
   partId              String
-  part                Part     @relation(fields: [partId], references: [partId])
+  part                Part      @relation(fields: [partId], references: [partId])
   requesterId         String
-  requester           User     @relation(fields: [requesterId], references: [userId], name: "PartReviewRequestor")
+  requester           User      @relation(fields: [requesterId], references: [userId], name: "PartReviewRequestor")
   reviewerId          String
-  reviewerRequested   User     @relation(fields: [reviewerId], references: [userId], name: "PartReviewRequested")
-  createdAt           DateTime @default(now())
+  reviewerRequested   User      @relation(fields: [reviewerId], references: [userId], name: "PartReviewRequested")
+  createdAt           DateTime  @default(now())
   dateDeleted         DateTime?
 }
 

--- a/src/backend/src/prisma/seed.ts
+++ b/src/backend/src/prisma/seed.ts
@@ -2198,7 +2198,7 @@ const performSeed: () => Promise<void> = async () => {
   const part1Example = await prisma.part.create({
     data: {
       partId: '001',
-      index: 0,
+      index: 100,
       commonName: 'tire',
       project: {
         connect: { projectId: project1Id }
@@ -2213,7 +2213,7 @@ const performSeed: () => Promise<void> = async () => {
   const part2Example = await prisma.part.create({
     data: {
       partId: '002',
-      index: 0,
+      index: 100,
       commonName: 'engine',
       project: {
         connect: { projectId: project2Id }
@@ -2228,7 +2228,7 @@ const performSeed: () => Promise<void> = async () => {
   const part3Example = await prisma.part.create({
     data: {
       partId: '003',
-      index: 0,
+      index: 100,
       commonName: 'door',
       project: {
         connect: { projectId: project3Id }

--- a/src/backend/src/routes/parts.routes.ts
+++ b/src/backend/src/routes/parts.routes.ts
@@ -7,6 +7,8 @@ const partsRouter = express.Router();
 
 partsRouter.get('/tags', PartsReviewController.getAllPartTags);
 partsRouter.get('/faqs', PartsReviewController.getAllPartReviewFAQS);
+partsRouter.get('/:partId', PartsReviewController.getPart);
+partsRouter.get('/projectId/parts', PartsReviewController.getPartPreviews);
 
 partsRouter.post(
   '/faq/create',

--- a/src/backend/src/routes/parts.routes.ts
+++ b/src/backend/src/routes/parts.routes.ts
@@ -9,9 +9,9 @@ const upload = multer({ limits: { fileSize: 30000000 }, storage: memoryStorage()
 
 const partsRouter = express.Router();
 
-partsRouter.get('/tags', PartsReviewController.getAllPartTags);
-partsRouter.get('/faqs', PartsReviewController.getAllPartReviewFAQS);
-partsRouter.get('/:partId', PartsReviewController.getPart);
+partsRouter.get('/tags', PartReviewController.getAllPartTags);
+partsRouter.get('/faqs', PartReviewController.getAllPartReviewFAQS);
+partsRouter.get('/:wbsNum/:indexNum', PartReviewController.getPart);
 partsRouter.get('/:wbsNum', PartReviewController.getAllPartsForProject);
 
 partsRouter.post(

--- a/src/backend/src/routes/parts.routes.ts
+++ b/src/backend/src/routes/parts.routes.ts
@@ -8,7 +8,7 @@ const partsRouter = express.Router();
 partsRouter.get('/tags', PartsReviewController.getAllPartTags);
 partsRouter.get('/faqs', PartsReviewController.getAllPartReviewFAQS);
 partsRouter.get('/:partId', PartsReviewController.getPart);
-partsRouter.get('/projectId/parts', PartsReviewController.getPartPreviews);
+// partsRouter.get('/projectId/parts', PartsReviewController.getPartPreviews);
 
 partsRouter.post(
   '/faq/create',

--- a/src/backend/src/routes/parts.routes.ts
+++ b/src/backend/src/routes/parts.routes.ts
@@ -12,7 +12,7 @@ const partsRouter = express.Router();
 partsRouter.get('/tags', PartReviewController.getAllPartTags);
 partsRouter.get('/faqs', PartReviewController.getAllPartReviewFAQS);
 partsRouter.get('/:wbsNum/:indexNum', PartReviewController.getPart);
-partsRouter.get('/:wbsNum', PartReviewController.getAllPartsForProject);
+partsRouter.get('/byProject/:wbsNum', PartReviewController.getAllPartsForProject);
 
 partsRouter.post(
   '/create',

--- a/src/backend/src/services/part-review.services.ts
+++ b/src/backend/src/services/part-review.services.ts
@@ -42,17 +42,26 @@ import ProjectsService from './projects.services';
 export default class PartReviewService {
   /**
    * Uses the given partId to get the specific part and all of its constituent data
-   * @param partId the id of the part
+   * @param wbsNumber the wbsNum of the project this part is under
+   * @param indexNum the index number of the part on this project
    * @returns a single Part
    */
-  static async getPart(organizationId: string, partId: string) {
+  static async getPart(organization: Organization, wbsNumber: WbsNumber, indexNum: string) {
+    const project: Project = await ProjectsService.getSingleProject(wbsNumber, organization);
+    const index = Number(indexNum);
     const part = await prisma.part.findUnique({
-      where: { partId: partId, dateDeleted: null },
-      ...partQueryArgs(organizationId)
+      where: {
+        ProjectId_and_index: {
+          projectId: project.id,
+          index
+        },
+        dateDeleted: null
+      },
+      ...getPartQueryArgs(organization.organizationId)
     });
 
-    if (!part) throw new NotFoundException('Part', partId)
-    
+    if (!part) throw new HttpException(404, `could not find a part with projectId: ${project.id} and index number: ${indexNum}`);
+
     return partTransformer(part);
   }
   /**

--- a/src/backend/src/services/part-review.services.ts
+++ b/src/backend/src/services/part-review.services.ts
@@ -5,9 +5,46 @@ import { AccessDeniedAdminOnlyException, DeletedException, NotFoundException } f
 import prisma from '../prisma/prisma';
 import { getFaqQueryArgs } from '../prisma-query-args/faq.query-args';
 import { faqTransformer } from '../transformers/faq.transformer';
-import { partsReviewCommonMistakeTransformer } from '../transformers/part-review.transformer';
+import { partsReviewCommonMistakeTransformer, partTransformer } from '../transformers/part-review.transformer';
 
 export default class PartReviewService {
+  /**
+   * Uses the given partId to get the specific part and all of its constituent data
+   * @param partId the id of the part
+   * @returns a single Part
+   */
+  static async getPart(partId: string) {
+    const part = await prisma.part.findUnique({
+      where: { partId: partId, dateDeleted: null },
+      include: {
+        tags: true,
+        submissions: true,
+        assignees: true,
+        userCreated: true
+      }
+    });
+    return partTransformer(part);
+  }
+
+  /**
+   * Uses the given project ID to fetch the respective part preview
+   * @param projectId the id of the project
+   * @returns a part preview
+   */
+  static async getPartPreviews(projectId: string) {
+    const part = await prisma.part.findUnique({
+      where: { projectId: projectId, dateDeleted: null },
+      include: {
+        tags: true,
+        submissions: true,
+        assignees: true,
+        userCreated: true
+      }
+    })
+
+    part.
+  }
+
   /**
    * Uses the given organizationID to and returns an array of part tags
    * @param organizationId the organization to get the parts for

--- a/src/backend/src/services/part-review.services.ts
+++ b/src/backend/src/services/part-review.services.ts
@@ -60,8 +60,7 @@ export default class PartReviewService {
       ...getPartQueryArgs(organization.organizationId)
     });
 
-    if (!part)
-      throw new HttpException(404, `could not find a part with projectId: ${project.id} and index number: ${indexNum}`);
+    if (!part) throw new NotFoundException('Part', `projectId: ${project.id} and index number: ${indexNum}`);
 
     return partTransformer(part);
   }
@@ -621,11 +620,11 @@ export default class PartReviewService {
     });
 
     if (!commonMistake) {
-      throw new NotFoundException('common mistake', commonMistakeId);
+      throw new NotFoundException('Common Mistake', commonMistakeId);
     }
 
     if (commonMistake.dateDeleted) {
-      throw new DeletedException('common mistake', commonMistakeId);
+      throw new DeletedException('Common Mistake', commonMistakeId);
     }
 
     if (!(await userHasPermission(updater.userId, organizationId, isAdmin))) {
@@ -665,7 +664,7 @@ export default class PartReviewService {
     });
 
     if (!commonMistake) {
-      throw new NotFoundException('common mistake', commonMistakeId);
+      throw new NotFoundException('Common Mistake', commonMistakeId);
     }
 
     if (!(await userHasPermission(deleter.userId, organizationId, isAdmin))) {
@@ -748,11 +747,11 @@ export default class PartReviewService {
     });
 
     if (!reviewRequest) {
-      throw new NotFoundException('Review request', reviewRequestId);
+      throw new NotFoundException('Review Request', reviewRequestId);
     }
 
     if (reviewRequest.dateDeleted) {
-      throw new DeletedException('Review request', reviewRequestId);
+      throw new DeletedException('Review Request', reviewRequestId);
     }
 
     const isRequester = reviewRequest.requesterId === user.userId;

--- a/src/backend/src/services/part-review.services.ts
+++ b/src/backend/src/services/part-review.services.ts
@@ -60,7 +60,8 @@ export default class PartReviewService {
       ...getPartQueryArgs(organization.organizationId)
     });
 
-    if (!part) throw new HttpException(404, `could not find a part with projectId: ${project.id} and index number: ${indexNum}`);
+    if (!part)
+      throw new HttpException(404, `could not find a part with projectId: ${project.id} and index number: ${indexNum}`);
 
     return partTransformer(part);
   }

--- a/src/backend/src/services/part-review.services.ts
+++ b/src/backend/src/services/part-review.services.ts
@@ -1,11 +1,13 @@
-import { User } from '@prisma/client';
+import { Organization, User } from '@prisma/client';
 import { userHasPermission } from '../utils/users.utils';
-import { FrequentlyAskedQuestion, isAdmin, PartReviewCommonMistake } from 'shared';
+import { FrequentlyAskedQuestion, isAdmin, PartReviewCommonMistake, Project, WbsNumber } from 'shared';
 import { AccessDeniedAdminOnlyException, DeletedException, NotFoundException } from '../utils/errors.utils';
 import prisma from '../prisma/prisma';
 import { getFaqQueryArgs } from '../prisma-query-args/faq.query-args';
 import { faqTransformer } from '../transformers/faq.transformer';
 import { partsReviewCommonMistakeTransformer, partTransformer } from '../transformers/part-review.transformer';
+import { partQueryArgs } from '../prisma-query-args/part-review.query-args';
+import ProjectsService from './projects.services';
 
 export default class PartReviewService {
   /**
@@ -13,37 +15,29 @@ export default class PartReviewService {
    * @param partId the id of the part
    * @returns a single Part
    */
-  static async getPart(partId: string) {
+  static async getPart(organizationId: string, partId: string) {
     const part = await prisma.part.findUnique({
       where: { partId: partId, dateDeleted: null },
-      include: {
-        tags: true,
-        submissions: true,
-        assignees: true,
-        userCreated: true
-      }
+      ...partQueryArgs(organizationId)
     });
+
+    if (!part) throw new NotFoundException('Part', partId)
+
     return partTransformer(part);
   }
 
-  /**
-   * Uses the given project ID to fetch the respective part preview
-   * @param projectId the id of the project
-   * @returns a part preview
-   */
-  static async getPartPreviews(projectId: string) {
-    const part = await prisma.part.findUnique({
-      where: { projectId: projectId, dateDeleted: null },
-      include: {
-        tags: true,
-        submissions: true,
-        assignees: true,
-        userCreated: true
-      }
-    })
+  // /**
+  //  * Uses the given project ID to fetch the respective part preview
+  //  * @param projectId the id of the project
+  //  * @returns the previews of all parts related to the given project
+  //  */
+  // static async getPartPreviews(organization: Organization, wbsNum: WbsNumber) {
+  //   const project: Project = await ProjectsService.getSingleProject(wbsNum, organization);
 
-    part.
-  }
+  //   const partPreviews = await prisma.
+
+  //   if (!part) throw new NotFoundException('Part', partId)
+  // }
 
   /**
    * Uses the given organizationID to and returns an array of part tags

--- a/src/backend/src/utils/errors.utils.ts
+++ b/src/backend/src/utils/errors.utils.ts
@@ -145,4 +145,5 @@ export type ExceptionObjectNames =
   | 'Announcement'
   | 'Graph'
   | 'Graph Collection'
-  | 'common mistake';
+  | 'common mistake'
+  | 'Part';

--- a/src/backend/src/utils/errors.utils.ts
+++ b/src/backend/src/utils/errors.utils.ts
@@ -148,5 +148,5 @@ export type ExceptionObjectNames =
   | 'Part Review'
   | 'Part'
   | 'Part Tag'
-  | 'common mistake'
-  | 'Review request';
+  | 'Common Mistake'
+  | 'Review Request';

--- a/src/backend/tests/unit/part-review.test.ts
+++ b/src/backend/tests/unit/part-review.test.ts
@@ -464,7 +464,7 @@ describe('part review tests', () => {
             batman,
             orgId
           )
-      ).rejects.toThrow(new DeletedException('common mistake', commonMistake.partReviewCommonMistakeId));
+      ).rejects.toThrow(new DeletedException('Common Mistake', commonMistake.partReviewCommonMistakeId));
     });
   });
 
@@ -732,7 +732,7 @@ describe('part review tests', () => {
       const fakePartId = 'non-existent-part-id';
 
       await expect(PartReviewService.deletePartReviewRequest(fakePartId, batman, orgId)).rejects.toThrow(
-        new NotFoundException('Review request', fakePartId)
+        new NotFoundException('Review Request', fakePartId)
       );
     });
   });

--- a/src/backend/tests/unit/part-review.test.ts
+++ b/src/backend/tests/unit/part-review.test.ts
@@ -735,6 +735,42 @@ describe('part review tests', () => {
       );
     });
   });
+
+  describe('Get a singular part', () => {
+    it('successfully gets the part corresponding to the partId', async () => {
+      const division = await createTestTeamType(undefined, orgId);
+      const team = await createTestTeam(batman.userId, division.teamTypeId, orgId);
+      const car = await createTestCar(orgId, batman.userId);
+
+      const project = await createTestProject(batman, orgId, team.teamId, car.carId, 1);
+
+      const part = await createTestPart(superman, 'door', '1', 1, project.projectId);
+
+      const testPart = await PartReviewService.getPart(orgId, '1');
+
+      expect(testPart.userCreated.userId).toEqual(part.userCreatedId);
+      expect(testPart.commonName).toBe(part.commonName);
+      expect(testPart.partId).toBe(part.partId);
+      expect(testPart.index).toBe(part.index);
+      expect(testPart.projectId).toBe(part.projectId);
+    });
+
+    it('throws an error when a part cannot be found with the given partId'),
+      async () => {
+        const division = await createTestTeamType(undefined, orgId);
+        const team = await createTestTeam(batman.userId, division.teamTypeId, orgId);
+        const car = await createTestCar(orgId, batman.userId);
+
+        const project = await createTestProject(batman, orgId, team.teamId, car.carId, 1);
+
+        const part1 = await createTestPart(superman, 'door', '-1', 1, project.projectId);
+        const part2 = await createTestPart(superman, 'door', '23', 1, project.projectId);
+        const part3 = await createTestPart(superman, 'door', '29', 1, project.projectId);
+
+        await expect(PartReviewService.getPart(orgId, '1')).rejects.toThrow(new NotFoundException('Part', '-1'));
+      };
+  });
+
   describe('Get all parts', () => {
     it('getting all parts from a project with no parts successfully returns empty array', async () => {
       const division = await createTestTeamType(undefined, orgId);

--- a/src/backend/tests/unit/part-review.test.ts
+++ b/src/backend/tests/unit/part-review.test.ts
@@ -18,9 +18,10 @@ import {
   AccessDeniedAdminOnlyException,
   AccessDeniedException,
   DeletedException,
+  HttpException,
   NotFoundException
 } from '../../src/utils/errors.utils';
-import { validateWBS } from 'shared';
+import { validateWBS, WbsNumber } from 'shared';
 import { Review_Status } from 'shared';
 
 describe('part review tests', () => {
@@ -743,10 +744,16 @@ describe('part review tests', () => {
       const car = await createTestCar(orgId, batman.userId);
 
       const project = await createTestProject(batman, orgId, team.teamId, car.carId, 1);
+      const project1 = await prisma.project.findUnique({
+        where: { projectId: project.projectId },
+        include: {
+          wbsElement: true
+        }
+      });
 
       const part = await createTestPart(superman, 'door', '1', 1, project.projectId);
 
-      const testPart = await PartReviewService.getPart(orgId, '1');
+      const testPart = await PartReviewService.getPart(organization, project1?.wbsElement as WbsNumber, '1');
 
       expect(testPart.userCreated.userId).toEqual(part.userCreatedId);
       expect(testPart.commonName).toBe(part.commonName);
@@ -755,20 +762,24 @@ describe('part review tests', () => {
       expect(testPart.projectId).toBe(part.projectId);
     });
 
-    it('throws an error when a part cannot be found with the given partId'),
-      async () => {
-        const division = await createTestTeamType(undefined, orgId);
-        const team = await createTestTeam(batman.userId, division.teamTypeId, orgId);
-        const car = await createTestCar(orgId, batman.userId);
+    it('throws an error when a part cannot be found with the given partId', async () => {
+      const division = await createTestTeamType(undefined, orgId);
+      const team = await createTestTeam(batman.userId, division.teamTypeId, orgId);
+      const car = await createTestCar(orgId, batman.userId);
 
-        const project = await createTestProject(batman, orgId, team.teamId, car.carId, 1);
+      const project = await createTestProject(batman, orgId, team.teamId, car.carId, 1);
+      const project1 = await prisma.project.findUnique({
+        where: { projectId: project.projectId },
+        include: {
+          wbsElement: true
+        }
+      });
+      const wbsNum = project1?.wbsElement as WbsNumber;
 
-        const part1 = await createTestPart(superman, 'door', '-1', 1, project.projectId);
-        const part2 = await createTestPart(superman, 'door', '23', 1, project.projectId);
-        const part3 = await createTestPart(superman, 'door', '29', 1, project.projectId);
-
-        await expect(PartReviewService.getPart(orgId, '1')).rejects.toThrow(new NotFoundException('Part', '-1'));
-      };
+      await expect(PartReviewService.getPart(organization, wbsNum, '1')).rejects.toThrow(
+        new HttpException(404, `could not find a part with projectId: ${project.projectId} and index number: 1`)
+      );
+    });
   });
 
   describe('Get all parts', () => {

--- a/src/backend/tests/unit/part-review.test.ts
+++ b/src/backend/tests/unit/part-review.test.ts
@@ -18,7 +18,6 @@ import {
   AccessDeniedAdminOnlyException,
   AccessDeniedException,
   DeletedException,
-  HttpException,
   NotFoundException
 } from '../../src/utils/errors.utils';
 import { validateWBS, WbsNumber } from 'shared';
@@ -777,7 +776,7 @@ describe('part review tests', () => {
       const wbsNum = project1?.wbsElement as WbsNumber;
 
       await expect(PartReviewService.getPart(organization, wbsNum, '1')).rejects.toThrow(
-        new HttpException(404, `could not find a part with projectId: ${project.projectId} and index number: 1`)
+        new NotFoundException('Part', `projectId: ${project.projectId} and index number: 1`)
       );
     });
   });

--- a/src/frontend/src/apis/part-review.api.ts
+++ b/src/frontend/src/apis/part-review.api.ts
@@ -10,196 +10,29 @@ import {
 } from 'shared';
 import axios from '../utils/axios';
 import { apiUrls } from '../utils/urls';
+import { partPreviewTransformer, partTransformer } from './transformers/part-review.transformers';
 
 /**
  * Fetches all parts acosiated with the given project as part previews
  *
- * @param projectId the id of the project
+ * @param wbsNum the wbsNum of the project
  */
-export const getPartsFromProject = (/*projectId: string*/): { data: PartPreview[] } => {
-  return {
-    data: [
-      {
-        partId: '1',
-        index: 1,
-        commonName: 'wheels',
-        description: 'we need wheels for the car to go, because no wheels means no rolly means no car go',
-        previewImageId: 'jqoi34ghpwadjkog5qh3',
-        status: 'IN_PROGRESS' as Review_Status,
-        tags: [],
-        projectId: '1',
-        assignees: [],
-        reviewRequests: [
-          {
-            partReviewRequestId: '1',
-            partId: '1',
-            requester: {
-              userId: '1',
-              firstName: 'fred',
-              lastName: 'bellinger',
-              email: 'test@test.com',
-              role: 'ADMIN',
-              emailId: 'test@test.com',
-              permissions: []
-            },
-            reviewerRequested: {
-              userId: '2',
-              firstName: 'albert',
-              lastName: 'stetson',
-              email: 'reviewer@test.com',
-              role: 'ADMIN',
-              emailId: 'reviewer@test.com',
-              permissions: []
-            },
-            createdAt: new Date()
-          }
-        ],
-        createdAt: new Date(),
-        userCreated: {
-          userId: '1',
-          firstName: 'allen',
-          lastName: 'bean',
-          email: 'test@test.com',
-          role: 'ADMIN',
-          emailId: 'test@test.com',
-          permissions: []
-        }
-      },
-      {
-        partId: '2',
-        index: 2,
-        commonName: 'Test Part 2',
-        description: 'Test Description 2',
-        previewImageId: 'qogi43tbiohrj3q2jntfpi',
-        status: 'READY_FOR_REVIEW' as Review_Status,
-        tags: [],
-        projectId: '1',
-        assignees: [],
-        reviewRequests: [],
-        createdAt: new Date(),
-        userCreated: {
-          userId: '1',
-          firstName: 'will',
-          lastName: 'atwater',
-          email: 'test@test.com',
-          role: 'ADMIN',
-          emailId: 'test@test.com',
-          permissions: []
-        }
-      }
-    ]
-  };
-
-  //   return axios.get<PartPreview[]>(apiUrls.partsByProject(projectId), {
-  //     transformResponse: (data) => data.map(partPreviewTransformer)
-  //   });
+export const getPartsFromProject = async (wbsNum: string) => {
+  return axios.get<PartPreview[]>(apiUrls.partsByProject(wbsNum), {
+    transformResponse: (data) => data.map(partPreviewTransformer)
+  });
 };
 
 /**
  * Fetches a single part
  *
- * @param partId the id of the part
+ * @param wbsNum the wbsNum of the project
+ * @param index the index number of the part
  */
-export const getSinglePart = (/*partId: string*/): { data: Part } => {
-  return {
-    data: {
-      partId: '1',
-      index: 1,
-      commonName: 'Suspension',
-      description: 'Test description for a suspension part, which could be a fairly lon sentence',
-      previewImageId: 'qogi43tbiohrj3q2jntfpi',
-      status: 'IN_REVIEW' as Review_Status,
-      tags: [],
-      projectId: '1',
-      assignees: [],
-      reviewRequests: [
-        {
-          partReviewRequestId: '1',
-          partId: '1',
-          requester: {
-            userId: '1',
-            firstName: 'fred',
-            lastName: 'bellinger',
-            email: 'test@test.com',
-            role: 'ADMIN',
-            emailId: 'test@test.com',
-            permissions: []
-          },
-          reviewerRequested: {
-            userId: '2',
-            firstName: 'albert',
-            lastName: 'stetson',
-            email: 'reviewer@test.com',
-            role: 'ADMIN',
-            emailId: 'reviewer@test.com',
-            permissions: []
-          },
-          createdAt: new Date()
-        }
-      ],
-      createdAt: new Date(),
-      userCreated: {
-        userId: '1',
-        firstName: 'john',
-        lastName: 'doe',
-        email: 'test@test.com',
-        role: 'ADMIN',
-        emailId: '1234567',
-        permissions: []
-      },
-      submissions: [
-        {
-          partSubmissionId: '1',
-          fileIds: ['file1', 'file2'],
-          name: 'Initial Submission',
-          notes: 'Please review these changes',
-          partId: '1',
-          userCreated: {
-            userId: '1',
-            firstName: 'jane',
-            lastName: 'plane',
-            email: 'test@test.com',
-            role: 'ADMIN',
-            emailId: 'test@test.com',
-            permissions: []
-          },
-          reviews: [
-            {
-              partReviewId: '1',
-              fileIds: ['reviewFile1'],
-              notes: 'Looks good, just a few minor changes needed',
-              submissionId: '1',
-              popUps: [
-                {
-                  partReviewPopupId: '1',
-                  xCoord: 0.5,
-                  yCoord: 0.25,
-                  title: 'Dimension Issue',
-                  description: 'Please check this measurement',
-                  reviewId: '1'
-                }
-              ],
-              completedAt: new Date(),
-              createdAt: new Date(),
-              userCreated: {
-                userId: '2',
-                firstName: 'albert',
-                lastName: 'stetson',
-                email: 'reviewer@test.com',
-                role: 'ADMIN',
-                emailId: 'reviewer@test.com',
-                permissions: []
-              }
-            }
-          ],
-          createdAt: new Date()
-        }
-      ]
-    }
-  };
-  //   return axios.get<Part>(apiUrls.partById(partId), {
-  //     transformResponse: (data) => partTransformer(JSON.parse(data))
-  //   });
+export const getSinglePart = (wbsNum: string, index: number) => {
+  return axios.get<Part>(apiUrls.partByIndex(wbsNum, index), {
+    transformResponse: (data) => partTransformer(JSON.parse(data))
+  });
 };
 
 /**

--- a/src/frontend/src/apis/part-review.api.ts
+++ b/src/frontend/src/apis/part-review.api.ts
@@ -1,7 +1,6 @@
 import { PartPayload, PartSubmissionPayload, PartReviewRequestPayload, PartReviewPayload } from '../hooks/part-review.hooks';
 import {
   PartPreview,
-  Review_Status,
   Part,
   PartSubmission,
   PartReviewRequest,

--- a/src/frontend/src/apis/part-review.api.ts
+++ b/src/frontend/src/apis/part-review.api.ts
@@ -1,12 +1,5 @@
 import { PartPayload, PartSubmissionPayload, PartReviewRequestPayload, PartReviewPayload } from '../hooks/part-review.hooks';
-import {
-  PartPreview,
-  Part,
-  PartSubmission,
-  PartReviewRequest,
-  PartReview,
-  PartReviewCommonMistake
-} from 'shared';
+import { PartPreview, Part, PartSubmission, PartReviewRequest, PartReview, PartReviewCommonMistake } from 'shared';
 import axios from '../utils/axios';
 import { apiUrls } from '../utils/urls';
 import { partPreviewTransformer, partTransformer } from './transformers/part-review.transformers';

--- a/src/frontend/src/hooks/part-review.hooks.ts
+++ b/src/frontend/src/hooks/part-review.hooks.ts
@@ -53,11 +53,11 @@ export interface PartReviewPayload {
 /**
  * Custom React Hook to fetch all parts associated with the given project as part previews
  *
- * @param projectId the id of the project
+ * @param wbsNum the wbs number of the project
  */
-export const usePartsFromProject = (/*projectId: string*/) => {
-  return useQuery<PartPreview[], Error>(['parts', 'byProject'], async () => {
-    const { data } = await getPartsFromProject(/*projectId*/);
+export const usePartsFromProject = (wbsNum: string) => {
+  return useQuery<PartPreview[], Error>(['parts'], async () => {
+    const { data } = await getPartsFromProject(wbsNum);
     return data;
   });
 };
@@ -65,11 +65,12 @@ export const usePartsFromProject = (/*projectId: string*/) => {
 /**
  * Custom React Hook to fetch a single part
  *
- * @param partId the id of the part
+ * @param wbsNum the wbs number of the project
+ * @param index the index number of the part
  */
-export const useSinglePart = (/*partId: string*/) => {
-  return useQuery<Part, Error>(['parts', 'byId' /*partId*/], async () => {
-    const { data } = await getSinglePart(/*partId*/);
+export const useSinglePart = (wbsNum: string, index: number) => {
+  return useQuery<Part, Error>(['parts'], async () => {
+    const { data } = await getSinglePart(wbsNum, index);
     return data;
   });
 };
@@ -87,7 +88,7 @@ export const useCreatePart = () => {
     },
     {
       onSuccess: () => {
-        queryClient.invalidateQueries(['parts', 'byProject']);
+        queryClient.invalidateQueries(['parts']);
       }
     }
   );
@@ -108,8 +109,7 @@ export const useEditPart = (partId: string) => {
     },
     {
       onSuccess: () => {
-        queryClient.invalidateQueries(['parts', 'byProject']);
-        queryClient.invalidateQueries(['parts', 'byId', partId]);
+        queryClient.invalidateQueries(['parts']);
       }
     }
   );
@@ -124,8 +124,7 @@ export const useUploadPreviewImage = (partId: string) => {
     },
     {
       onSuccess: () => {
-        queryClient.invalidateQueries(['parts', 'byProject']);
-        queryClient.invalidateQueries(['parts', 'byId', partId]);
+        queryClient.invalidateQueries(['parts']);
       }
     }
   );
@@ -146,8 +145,7 @@ export const useDeletePart = (partId: string) => {
     },
     {
       onSuccess: () => {
-        queryClient.invalidateQueries(['parts', 'byProject']);
-        queryClient.invalidateQueries(['parts', 'byId', partId]);
+        queryClient.invalidateQueries(['parts']);
       }
     }
   );
@@ -168,8 +166,7 @@ export const useCreatePartSubmission = (partId: string) => {
     },
     {
       onSuccess: () => {
-        queryClient.invalidateQueries(['parts', 'byProject']);
-        queryClient.invalidateQueries(['parts', 'byId', partId]);
+        queryClient.invalidateQueries(['parts']);
       }
     }
   );
@@ -190,7 +187,7 @@ export const useEditPartSubmission = (submissionId: string) => {
     },
     {
       onSuccess: () => {
-        queryClient.invalidateQueries(['parts', 'byId']);
+        queryClient.invalidateQueries(['parts']);
       }
     }
   );

--- a/src/frontend/src/utils/urls.ts
+++ b/src/frontend/src/utils/urls.ts
@@ -43,8 +43,8 @@ const projectsEditLinkTypes = (linkTypeName: string) => `${projects()}/link-type
 
 /**************** Part Review Endpoints ********************/
 const parts = () => `${API_URL}/parts`;
-const partsByProject = (projectId: string) => `${parts()}/${projectId}/parts`;
-const partsById = (partId: string) => `${parts()}/${partId}`;
+const partsByProject = (wbsNum: string) => `${parts()}/byProject/${wbsNum}`;
+const partByIndex = (wbsNum: string, partIndex: number) => `${parts()}/${wbsNum}/${partIndex}`;
 const partsCreate = () => `${parts()}/create`;
 const partsUploadPreviewImage = (partId: string) => `${parts()}/${partId}/upload-preview`;
 const partsEdit = (partId: string) => `${parts()}/${partId}/update`;
@@ -295,7 +295,7 @@ export const apiUrls = {
 
   parts,
   partsByProject,
-  partsById,
+  partByIndex,
   partsCreate,
   partsUploadPreviewImage,
   partsEdit,

--- a/src/shared/src/types/part-review.types.ts
+++ b/src/shared/src/types/part-review.types.ts
@@ -34,6 +34,7 @@ export interface PartSubmission {
   notes?: string;
   partId: string;
   userCreated: User;
+  createdAt: Date;
   reviewRequests: PartReviewRequest[];
   reviews: PartReview[];
 }


### PR DESCRIPTION
## Changes

Added an endpoint to get a singular part given a `partId`

## Test Cases

- Part is successfully found
- Part cannot be found because there is no part with the given partId

## Screenshots
![Screenshot 2025-04-10 at 1 41 38 AM](https://github.com/user-attachments/assets/a05f56b7-2026-4cbd-a7f2-10a88a04ad43)


## To Do


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #3290 
