### PR TITLE
#3371 add sponsor tier in getAllSponsor Endpoint

### DIFF
--- a/src/backend/src/prisma-query-args/sponsor.query.args.ts
+++ b/src/backend/src/prisma-query-args/sponsor.query.args.ts
@@ -5,6 +5,8 @@ export type SponsorQueryArgs = ReturnType<typeof getSponsorQueryArgs>;
 
 export type SponsorTaskQueryArgs = ReturnType<typeof getSponsorTaskQueryArgs>;
 
+export type SponsorTierQueryArgs = ReturnType<typeof getSponsorTierQueryArgs>; 
+
 export const getSponsorQueryArgs = (organizationId: string) =>
   Prisma.validator<Prisma.SponsorDefaultArgs>()({
     include: {
@@ -18,3 +20,10 @@ export const getSponsorTaskQueryArgs = (organizationId: string) =>
       assignee: getUserQueryArgs(organizationId)
     }
   });
+
+  export const getSponsorTierQueryArgs = (organizationId: string) =>
+    Prisma.validator<Prisma.Sponsor_TierDefaultArgs>()({
+      include: {
+        sponsors: getSponsorQueryArgs(organizationId)
+      }
+    })

--- a/src/backend/src/prisma-query-args/sponsor.query.args.ts
+++ b/src/backend/src/prisma-query-args/sponsor.query.args.ts
@@ -5,12 +5,11 @@ export type SponsorQueryArgs = ReturnType<typeof getSponsorQueryArgs>;
 
 export type SponsorTaskQueryArgs = ReturnType<typeof getSponsorTaskQueryArgs>;
 
-export type SponsorTierQueryArgs = ReturnType<typeof getSponsorTierQueryArgs>; 
-
 export const getSponsorQueryArgs = (organizationId: string) =>
   Prisma.validator<Prisma.SponsorDefaultArgs>()({
     include: {
-      sponsorTasks: getSponsorTaskQueryArgs(organizationId)
+      sponsorTasks: getSponsorTaskQueryArgs(organizationId),
+      tier: true
     }
   });
 
@@ -20,10 +19,3 @@ export const getSponsorTaskQueryArgs = (organizationId: string) =>
       assignee: getUserQueryArgs(organizationId)
     }
   });
-
-  export const getSponsorTierQueryArgs = (organizationId: string) =>
-    Prisma.validator<Prisma.Sponsor_TierDefaultArgs>()({
-      include: {
-        sponsors: getSponsorQueryArgs(organizationId)
-      }
-    })

--- a/src/backend/src/transformers/finance.transformer.ts
+++ b/src/backend/src/transformers/finance.transformer.ts
@@ -6,10 +6,8 @@ import { userTransformer } from './user.transformer';
 export const sponsorTransformer = (sponsor: Prisma.SponsorGetPayload<SponsorQueryArgs>): Sponsor => {
   return {
     ...sponsor,
-    tierId: sponsor.sponsorTierId,
     discountCode: sponsor.discountCode ?? undefined,
-    sponsorTasks: sponsor.sponsorTasks.map(sponsorTaskTranformer),
-    tier: sponsor.tier
+    sponsorTasks: sponsor.sponsorTasks.map(sponsorTaskTranformer)
   };
 };
 

--- a/src/backend/src/transformers/finance.transformer.ts
+++ b/src/backend/src/transformers/finance.transformer.ts
@@ -1,6 +1,6 @@
 import { Prisma } from '@prisma/client';
-import { Sponsor, SponsorTask, SponsorTier } from 'shared';
-import { SponsorQueryArgs, SponsorTaskQueryArgs, SponsorTierQueryArgs } from '../prisma-query-args/sponsor.query.args';
+import { Sponsor, SponsorTask } from 'shared';
+import { SponsorQueryArgs, SponsorTaskQueryArgs } from '../prisma-query-args/sponsor.query.args';
 import { userTransformer } from './user.transformer';
 
 export const sponsorTransformer = (sponsor: Prisma.SponsorGetPayload<SponsorQueryArgs>): Sponsor => {
@@ -9,7 +9,7 @@ export const sponsorTransformer = (sponsor: Prisma.SponsorGetPayload<SponsorQuer
     tierId: sponsor.sponsorTierId,
     discountCode: sponsor.discountCode ?? undefined,
     sponsorTasks: sponsor.sponsorTasks.map(sponsorTaskTranformer),
-    sponsorTier: sponsor.sponsorTierId ? sponsorTierTransformer(sponsor.sponsorTierId) : undefined
+    tier: sponsor.tier
   };
 };
 
@@ -20,12 +20,3 @@ export const sponsorTaskTranformer = (sponsorTask: Prisma.Sponsor_TaskGetPayload
     assignee: sponsorTask.assignee ? userTransformer(sponsorTask.assignee) : undefined
   };
 };
-
-export const sponsorTierTransformer = (sponsorTier: Prisma.Sponsor_TierGetPayload<SponsorTierQueryArgs>): SponsorTier => {
-  return {
-    ...sponsorTier,
-    sponsorTierId: sponsorTier.sponsorTierId,
-    name: sponsorTier.name,
-    colorHexCode: sponsorTier.colorHexCode
-  }
-}

--- a/src/backend/src/transformers/finance.transformer.ts
+++ b/src/backend/src/transformers/finance.transformer.ts
@@ -1,6 +1,6 @@
 import { Prisma } from '@prisma/client';
-import { Sponsor, SponsorTask } from 'shared';
-import { SponsorQueryArgs, SponsorTaskQueryArgs } from '../prisma-query-args/sponsor.query.args';
+import { Sponsor, SponsorTask, SponsorTier } from 'shared';
+import { SponsorQueryArgs, SponsorTaskQueryArgs, SponsorTierQueryArgs } from '../prisma-query-args/sponsor.query.args';
 import { userTransformer } from './user.transformer';
 
 export const sponsorTransformer = (sponsor: Prisma.SponsorGetPayload<SponsorQueryArgs>): Sponsor => {
@@ -8,7 +8,8 @@ export const sponsorTransformer = (sponsor: Prisma.SponsorGetPayload<SponsorQuer
     ...sponsor,
     tierId: sponsor.sponsorTierId,
     discountCode: sponsor.discountCode ?? undefined,
-    sponsorTasks: sponsor.sponsorTasks.map(sponsorTaskTranformer)
+    sponsorTasks: sponsor.sponsorTasks.map(sponsorTaskTranformer),
+    sponsorTier: sponsor.sponsorTierId ? sponsorTierTransformer(sponsor.sponsorTierId) : undefined
   };
 };
 
@@ -19,3 +20,12 @@ export const sponsorTaskTranformer = (sponsorTask: Prisma.Sponsor_TaskGetPayload
     assignee: sponsorTask.assignee ? userTransformer(sponsorTask.assignee) : undefined
   };
 };
+
+export const sponsorTierTransformer = (sponsorTier: Prisma.Sponsor_TierGetPayload<SponsorTierQueryArgs>): SponsorTier => {
+  return {
+    ...sponsorTier,
+    sponsorTierId: sponsorTier.sponsorTierId,
+    name: sponsorTier.name,
+    colorHexCode: sponsorTier.colorHexCode
+  }
+}

--- a/src/backend/tests/unit/finance.test.ts
+++ b/src/backend/tests/unit/finance.test.ts
@@ -69,7 +69,7 @@ describe('Finance Tests', () => {
       expect(result.sponsorValue).toBe(5000);
       expect(result.joinDate).toEqual(new Date(12, 1, 24));
       expect(result.activeYears).toEqual([2024, 2025]);
-      expect(result.tierId).toEqual(sponsorTierId);
+      expect(result.tier.sponsorTierId).toEqual(sponsorTierId);
       expect(result.taxExempt).toBe(true);
       expect(result.discountCode).toEqual('googlecode');
       expect(result.vendorContact).toEqual('Bill Gates');

--- a/src/shared/src/types/finance-types.ts
+++ b/src/shared/src/types/finance-types.ts
@@ -12,7 +12,7 @@ export interface Sponsor {
   taxExempt: boolean;
   discountCode?: string;
   sponsorTasks: SponsorTask[];
-  sponsorTier?: SponsorTier;
+  tier?: SponsorTier;
 }
 
 export interface SponsorTask {

--- a/src/shared/src/types/finance-types.ts
+++ b/src/shared/src/types/finance-types.ts
@@ -12,6 +12,7 @@ export interface Sponsor {
   taxExempt: boolean;
   discountCode?: string;
   sponsorTasks: SponsorTask[];
+  sponsorTier?: SponsorTier;
 }
 
 export interface SponsorTask {

--- a/src/shared/src/types/finance-types.ts
+++ b/src/shared/src/types/finance-types.ts
@@ -5,14 +5,13 @@ export interface Sponsor {
   name: string;
   activeStatus: boolean;
   vendorContact: string;
-  tierId: string;
   sponsorValue: number;
   joinDate: Date;
   activeYears: number[];
   taxExempt: boolean;
   discountCode?: string;
   sponsorTasks: SponsorTask[];
-  tier?: SponsorTier;
+  tier: SponsorTier;
 }
 
 export interface SponsorTask {


### PR DESCRIPTION
## Changes

Updated the getAllSponsor endpoint where now each sponsor also returns its according SponsorTier 

## Screenshots
<img width="478" alt="Screenshot 2025-04-14 at 11 42 56 AM" src="https://github.com/user-attachments/assets/26939335-3000-4a3d-84a3-bb30b83a119e" />


## To Do

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #3371
