### PR TITLE
#3282 edit abbreviation table

### DIFF
--- a/src/backend/src/controllers/projects.controllers.ts
+++ b/src/backend/src/controllers/projects.controllers.ts
@@ -109,6 +109,27 @@ export default class ProjectsController {
     }
   }
 
+  static async setAbbreviation(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { abbreviation } = req.body;
+      const wbsNum: WbsNumber = validateWBS(req.body.wbsNum);
+      const updatedProject = await ProjectsService.setAbbreviation(wbsNum, req.currentUser, req.organization, abbreviation);
+      res.status(200).json(updatedProject);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
+  static async deleteAbbreviation(req: Request, res: Response, next: NextFunction) {
+    try {
+      const wbsNum: WbsNumber = validateWBS(req.params.wbsNum);
+      await ProjectsService.deleteAbbreviation(wbsNum, req.currentUser, req.organization);
+      res.status(200).json({ message: `Project ${wbsPipe(wbsNum)}'s abbreviation was successfully deleted.` });
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
   static async getAllLinkTypes(req: Request, res: Response, next: NextFunction) {
     try {
       const linkTypes = await ProjectsService.getAllLinkTypes(req.organization);

--- a/src/backend/src/routes/projects.routes.ts
+++ b/src/backend/src/routes/projects.routes.ts
@@ -55,6 +55,17 @@ projectRouter.get('/:wbsNum', ProjectsController.getSingleProject);
 projectRouter.post('/:wbsNum/set-team', nonEmptyString(body('teamId')), validateInputs, ProjectsController.setProjectTeam);
 projectRouter.delete('/:wbsNum/delete', ProjectsController.deleteProject);
 projectRouter.post('/:wbsNum/favorite', ProjectsController.toggleFavorite);
+projectRouter.post(
+  '/set-abbreviation',
+  nonEmptyString(body('wbsNum')),
+  nonEmptyString(body('abbreviation')),
+  validateInputs,
+  ProjectsController.setAbbreviation
+);
+projectRouter.post(
+  '/:wbsNum/delete-abbreviation',
+  ProjectsController.deleteAbbreviation
+);
 
 /**************** BOM Section ****************/
 projectRouter.post(

--- a/src/backend/src/routes/projects.routes.ts
+++ b/src/backend/src/routes/projects.routes.ts
@@ -62,10 +62,7 @@ projectRouter.post(
   validateInputs,
   ProjectsController.setAbbreviation
 );
-projectRouter.post(
-  '/:wbsNum/delete-abbreviation',
-  ProjectsController.deleteAbbreviation
-);
+projectRouter.post('/:wbsNum/delete-abbreviation', ProjectsController.deleteAbbreviation);
 
 /**************** BOM Section ****************/
 projectRouter.post(

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -473,6 +473,8 @@ export default class ProjectsService {
   static async setAbbreviation(wbsNum: WbsNumber, user: User, organization: Organization, abbreviation: string) {
     const project = await ProjectsService.getSingleProjectWithQueryArgs(wbsNum, organization);
 
+    if (!project) throw new NotFoundException('Project', wbsPipe(wbsNum));
+
     if (!(await userHasPermission(user.userId, organization.organizationId, isAdmin))) {
       throw new AccessDeniedAdminOnlyException('set Abbreviation');
     }
@@ -489,7 +491,7 @@ export default class ProjectsService {
   }
 
   /**
-   * Revomves the abbreviation from a given project
+   * Removes the abbreviation from a given project
    * @param wbsNum the project
    * @param user the user making the change
    * @param organization the organization
@@ -498,8 +500,10 @@ export default class ProjectsService {
   static async deleteAbbreviation(wbsNum: WbsNumber, user: User, organization: Organization) {
     const project = await ProjectsService.getSingleProjectWithQueryArgs(wbsNum, organization);
 
+    if (!project) throw new NotFoundException('Project', wbsPipe(wbsNum));
+
     if (!(await userHasPermission(user.userId, organization.organizationId, isAdmin))) {
-      throw new AccessDeniedAdminOnlyException('delete Abbreviation');
+      throw new AccessDeniedAdminOnlyException('delete abbreviation');
     }
 
     await prisma.project.update({

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -476,7 +476,7 @@ export default class ProjectsService {
     if (!project) throw new NotFoundException('Project', wbsPipe(wbsNum));
 
     if (!(await userHasPermission(user.userId, organization.organizationId, isAdmin))) {
-      throw new AccessDeniedAdminOnlyException('set Abbreviation');
+      throw new AccessDeniedAdminOnlyException('set abbreviation');
     }
 
     const updatedProject = await prisma.project.update({

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -463,6 +463,54 @@ export default class ProjectsService {
   }
 
   /**
+   * Sets an abbreviation for this project
+   * @param wbsNum the project
+   * @param user the user making the change
+   * @param organization the organization
+   * @param abbreviation the new abbreviation
+   * @returns the updated project
+   */
+  static async setAbbreviation(wbsNum: WbsNumber, user: User, organization: Organization, abbreviation: string) {
+    const project = await ProjectsService.getSingleProjectWithQueryArgs(wbsNum, organization);
+
+    if (!(await userHasPermission(user.userId, organization.organizationId, isAdmin))) {
+      throw new AccessDeniedAdminOnlyException('set Abbreviation');
+    }
+
+    const updatedProject = await prisma.project.update({
+      where: { projectId: project.projectId },
+      data: {
+        abbreviation
+      },
+      ...getProjectQueryArgs(organization.organizationId)
+    });
+
+    return projectTransformer(updatedProject);
+  }
+
+  /**
+   * Revomves the abbreviation from a given project
+   * @param wbsNum the project
+   * @param user the user making the change
+   * @param organization the organization
+   * @returns the updated project
+   */
+  static async deleteAbbreviation(wbsNum: WbsNumber, user: User, organization: Organization) {
+    const project = await ProjectsService.getSingleProjectWithQueryArgs(wbsNum, organization);
+
+    if (!(await userHasPermission(user.userId, organization.organizationId, isAdmin))) {
+      throw new AccessDeniedAdminOnlyException('delete Abbreviation');
+    }
+
+    await prisma.project.update({
+      where: { projectId: project.projectId },
+      data: {
+        abbreviation: null
+      }
+    });
+  }
+
+  /**
    * Gets all the link types in the users organization
    * @param organizationId The organization the user is currently in
    * @returns all the link types in the users organization

--- a/src/backend/src/transformers/projects.transformer.ts
+++ b/src/backend/src/transformers/projects.transformer.ts
@@ -56,6 +56,7 @@ const projectTransformer = (project: Prisma.ProjectGetPayload<ProjectQueryArgs>)
     tasks: wbsElement.tasks.map(taskTransformer),
     materials: wbsElement.materials.map(materialTransformer),
     assemblies: wbsElement.assemblies.map(assemblyTransformer),
+    abbreviation: project.abbreviation ?? undefined,
     workPackages: project.workPackages.map((workPackage) => {
       const endDate = calculateEndDate(workPackage.startDate, workPackage.duration);
 

--- a/src/backend/tests/unit/part-review.test.ts
+++ b/src/backend/tests/unit/part-review.test.ts
@@ -828,7 +828,7 @@ describe('part review tests', () => {
 
     await ProjectsService.deleteAbbreviation(wbsNum, batman, organization);
     const projectWithNoAbbrev = await ProjectsService.getSingleProject(wbsNum, organization);
-    expect(projectWithNoAbbrev.abbreviation).toBeNull();
+    expect(projectWithNoAbbrev.abbreviation).toBeUndefined();
   });
 });
 

--- a/src/backend/tests/unit/part-review.test.ts
+++ b/src/backend/tests/unit/part-review.test.ts
@@ -813,7 +813,7 @@ describe('part review tests', () => {
     await ProjectsService.deleteAbbreviation(wbsNum, batman, organization);
 
     await expect(ProjectsService.setAbbreviation(wbsNum, nonAdmin, organization, 'new abbreviation')).rejects.toThrow(
-      new AccessDeniedAdminOnlyException('set Abbreviation')
+      new AccessDeniedAdminOnlyException('set abbreviation')
     );
 
     const updatedProject = await ProjectsService.setAbbreviation(wbsNum, batman, organization, 'new abbreviation');
@@ -823,7 +823,7 @@ describe('part review tests', () => {
     expect(updatedProject2.abbreviation).toBe('diff');
 
     await expect(ProjectsService.deleteAbbreviation(wbsNum, nonAdmin, organization)).rejects.toThrow(
-      new AccessDeniedAdminOnlyException('delete Abbreviation')
+      new AccessDeniedAdminOnlyException('delete abbreviation')
     );
 
     await ProjectsService.deleteAbbreviation(wbsNum, batman, organization);

--- a/src/backend/tests/unit/part-review.test.ts
+++ b/src/backend/tests/unit/part-review.test.ts
@@ -20,8 +20,9 @@ import {
   DeletedException,
   NotFoundException
 } from '../../src/utils/errors.utils';
-import { validateWBS } from 'shared';
+import { validateWBS, WbsNumber } from 'shared';
 import { Review_Status } from 'shared';
+import ProjectsService from '../../src/services/projects.services';
 
 describe('part review tests', () => {
   let orgId: string;
@@ -791,6 +792,43 @@ describe('part review tests', () => {
       expect(parts2[0].index).toBe(part3.index);
       expect(parts2[0].projectId).toBe(part3.projectId);
     });
+  });
+
+  it('updates the abbreviation on a project and then deletes it', async () => {
+    const project = await createTestProject(batman, orgId);
+
+    const projectWithWbs = await prisma.project.findUnique({
+      where: { projectId: project.projectId },
+      include: {
+        wbsElement: true
+      }
+    });
+
+    expect(projectWithWbs?.abbreviation).toBeNull();
+
+    const wbsNum: WbsNumber = validateWBS(
+      `${projectWithWbs?.wbsElement.carNumber}.${projectWithWbs?.wbsElement.projectNumber}.${projectWithWbs?.wbsElement.workPackageNumber}`
+    );
+
+    await ProjectsService.deleteAbbreviation(wbsNum, batman, organization);
+
+    await expect(ProjectsService.setAbbreviation(wbsNum, nonAdmin, organization, 'new abbreviation')).rejects.toThrow(
+      new AccessDeniedAdminOnlyException('set Abbreviation')
+    );
+
+    const updatedProject = await ProjectsService.setAbbreviation(wbsNum, batman, organization, 'new abbreviation');
+    expect(updatedProject.abbreviation).toBe('new abbreviation');
+
+    const updatedProject2 = await ProjectsService.setAbbreviation(wbsNum, batman, organization, 'diff');
+    expect(updatedProject2.abbreviation).toBe('diff');
+
+    await expect(ProjectsService.deleteAbbreviation(wbsNum, nonAdmin, organization)).rejects.toThrow(
+      new AccessDeniedAdminOnlyException('delete Abbreviation')
+    );
+
+    await ProjectsService.deleteAbbreviation(wbsNum, batman, organization);
+    const projectWithNoAbbrev = await ProjectsService.getSingleProject(wbsNum, organization);
+    expect(projectWithNoAbbrev.abbreviation).toBeNull();
   });
 });
 

--- a/src/frontend/src/apis/projects.api.ts
+++ b/src/frontend/src/apis/projects.api.ts
@@ -81,6 +81,22 @@ export const toggleProjectFavorite = (wbsNum: WbsNumber) => {
 };
 
 /**
+ * Set the abbreviation of a project
+ */
+export const setAbbreviation = (payload: { wbsNum: string; abbreviation: string }) => {
+  return axios.post<Project>(apiUrls.projectsSetAbbreviation(), {
+    ...payload
+  });
+};
+
+/**
+ * Delete the abbreviation of a project
+ */
+export const deleteAbbreviation = (wbsNum: string) => {
+  return axios.post<{ message: string }>(apiUrls.projectsDeleteAbbreviation(wbsNum));
+};
+
+/**
  * gets all the link types from the database
  * @returns gets all the link types
  */

--- a/src/frontend/src/hooks/projects.hooks.ts
+++ b/src/frontend/src/hooks/projects.hooks.ts
@@ -18,7 +18,9 @@ import {
   getAllWorkPackageTemplates,
   editLinkType,
   getAllUsefulLinks,
-  setUsefulLinks
+  setUsefulLinks,
+  deleteAbbreviation,
+  setAbbreviation
 } from '../apis/projects.api';
 import { CreateSingleProjectPayload, EditSingleProjectPayload } from '../utils/types';
 import { useCurrentUser } from './users.hooks';
@@ -136,6 +138,44 @@ export const useToggleProjectFavorite = (wbsNumber: WbsNumber) => {
       onSuccess: () => {
         queryClient.invalidateQueries(['projects', wbsNumber]);
         queryClient.invalidateQueries(['users', user.userId, 'favorite projects']);
+      }
+    }
+  );
+};
+
+/**
+ * Custom react hook to set the abbreviation of a project
+ */
+export const useSetProjectAbbreviation = () => {
+  const queryClient = useQueryClient();
+  return useMutation<Project, Error, any>(
+    ['projects', 'abbreviation', 'set'],
+    async (payload: { wbsNum: string; abbreviation: string }) => {
+      const { data } = await setAbbreviation(payload);
+      return data;
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(['projects']);
+      }
+    }
+  );
+};
+
+/**
+ * Custom react hook to delete the abbreviation of a project
+ */
+export const useDeleteProjectAbbreviation = () => {
+  const queryClient = useQueryClient();
+  return useMutation<{ message: string }, Error, any>(
+    ['projects', 'abbreviation', 'delete'],
+    async (wbsNumber: string) => {
+      const { data } = await deleteAbbreviation(wbsNumber);
+      return data;
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(['projects']);
       }
     }
   );

--- a/src/frontend/src/pages/AdminToolsPage/ProjectsConfig/AbbreviationsTable.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/ProjectsConfig/AbbreviationsTable.tsx
@@ -4,7 +4,7 @@ import { NERButton } from '../../../components/NERButton';
 import { useAllProjects, useDeleteProjectAbbreviation } from '../../../hooks/projects.hooks';
 import LoadingIndicator from '../../../components/LoadingIndicator';
 import ErrorPage from '../../ErrorPage';
-import SetAbbreviationModel from './SetAbbreviationModel';
+import SetAbbreviationModal from './SetAbbreviationModal';
 import { useState } from 'react';
 import { Project, wbsPipe } from 'shared';
 import { Delete } from '@mui/icons-material';
@@ -46,14 +46,14 @@ const AbbreviationsTable: React.FC = () => {
 
   return (
     <Box>
-      <SetAbbreviationModel
+      <SetAbbreviationModal
         open={openModal}
         handleClose={() => {
           setOpenModal(false);
         }}
       />
       <Typography variant="subtitle1">Project Name Abbreviations</Typography>
-      <AdminToolTable columns={[{ name: 'Project Name' }, { name: 'Abbreviation' }]} rows={projectTableRows} />
+      <AdminToolTable columns={[{ name: 'Project Name' }, { name: 'Abbreviation' }, { name: '' }]} rows={projectTableRows} />
       <Box sx={{ display: 'flex', justifyContent: 'right', marginTop: '10px' }}>
         <NERButton
           variant="contained"

--- a/src/frontend/src/pages/AdminToolsPage/ProjectsConfig/AbbreviationsTable.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/ProjectsConfig/AbbreviationsTable.tsx
@@ -1,12 +1,20 @@
-import { Box, Typography } from '@mui/material';
+import { Box, IconButton, TableCell, TableRow, Typography } from '@mui/material';
 import AdminToolTable from '../AdminToolTable';
 import { NERButton } from '../../../components/NERButton';
-import { useAllProjects } from '../../../hooks/projects.hooks';
+import { useAllProjects, useDeleteProjectAbbreviation } from '../../../hooks/projects.hooks';
 import LoadingIndicator from '../../../components/LoadingIndicator';
 import ErrorPage from '../../ErrorPage';
+import SetAbbreviationModel from './SetAbbreviationModel';
+import { useState } from 'react';
+import { Project, wbsPipe } from 'shared';
+import { Delete } from '@mui/icons-material';
+import NERModal from '../../../components/NERModal';
 
 const AbbreviationsTable: React.FC = () => {
   const { data: projects, isLoading: projectsIsLoading, isError: projectsIsError, error: projectsError } = useAllProjects();
+  const { mutateAsync } = useDeleteProjectAbbreviation();
+  const [openModal, setOpenModal] = useState(false);
+  const [abbreviationToDelete, setAbbreviationToDelete] = useState<Project>();
 
   if (!projects || projectsIsLoading) {
     return <LoadingIndicator />;
@@ -15,15 +23,59 @@ const AbbreviationsTable: React.FC = () => {
     return <ErrorPage message={projectsError?.message} />;
   }
 
+  const projectTableRows = projects
+    .filter((project) => !!project.abbreviation)
+    .map((project) => (
+      <TableRow>
+        <TableCell align="left" sx={{ border: '2px solid black' }}>
+          {`${wbsPipe(project.wbsNum)} - ${project.name}`}
+        </TableCell>
+        <TableCell sx={{ border: '2px solid black' }}>{project.abbreviation}</TableCell>
+        <TableCell align="center" sx={{ border: '2px solid black', verticalAlign: 'middle' }}>
+          <IconButton
+            onClick={(event) => {
+              event.stopPropagation();
+              setAbbreviationToDelete(project);
+            }}
+          >
+            <Delete />
+          </IconButton>
+        </TableCell>
+      </TableRow>
+    ));
+
   return (
     <Box>
+      <SetAbbreviationModel
+        open={openModal}
+        handleClose={() => {
+          setOpenModal(false);
+        }}
+      />
       <Typography variant="subtitle1">Project Name Abbreviations</Typography>
-      <AdminToolTable columns={[{ name: 'Project Name' }, { name: 'Abbreviation' }]} rows={[]} />
+      <AdminToolTable columns={[{ name: 'Project Name' }, { name: 'Abbreviation' }]} rows={projectTableRows} />
       <Box sx={{ display: 'flex', justifyContent: 'right', marginTop: '10px' }}>
-        <NERButton variant="contained" onClick={() => {}}>
-          New Abbreviation
+        <NERButton
+          variant="contained"
+          onClick={() => {
+            setOpenModal(true);
+          }}
+        >
+          Set Abbreviation
         </NERButton>
       </Box>
+      <NERModal
+        open={!!abbreviationToDelete}
+        title="Warning!"
+        onHide={() => setAbbreviationToDelete(undefined)}
+        submitText="Delete"
+        onSubmit={() => {
+          mutateAsync(wbsPipe(abbreviationToDelete!.wbsNum));
+          setAbbreviationToDelete(undefined);
+        }}
+      >
+        <Typography gutterBottom>Are you sure you want to delete this project's abbreviaiton?</Typography>
+      </NERModal>
     </Box>
   );
 };

--- a/src/frontend/src/pages/AdminToolsPage/ProjectsConfig/SetAbbreviationModal.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/ProjectsConfig/SetAbbreviationModal.tsx
@@ -19,7 +19,7 @@ interface SetAbbreviation {
   handleClose: () => void;
 }
 
-const SetAbbreviationModel: React.FC<SetAbbreviation> = ({ open, handleClose }) => {
+const SetAbbreviationModal: React.FC<SetAbbreviation> = ({ open, handleClose }) => {
   const { data: projects, isLoading: projectsIsLoading, isError: projectsIsError, error: projectsError } = useAllProjects();
   const { mutateAsync } = useSetProjectAbbreviation();
 
@@ -104,4 +104,4 @@ const SetAbbreviationModel: React.FC<SetAbbreviation> = ({ open, handleClose }) 
   );
 };
 
-export default SetAbbreviationModel;
+export default SetAbbreviationModal;

--- a/src/frontend/src/pages/AdminToolsPage/ProjectsConfig/SetAbbreviationModel.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/ProjectsConfig/SetAbbreviationModel.tsx
@@ -1,0 +1,107 @@
+import { useForm, Controller } from 'react-hook-form';
+import NERFormModal from '../../../components/NERFormModal';
+import { FormControl, FormLabel, FormHelperText, Autocomplete, TextField } from '@mui/material';
+import ReactHookTextField from '../../../components/ReactHookTextField';
+import * as yup from 'yup';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { wbsPipe } from 'shared';
+import { useAllProjects, useSetProjectAbbreviation } from '../../../hooks/projects.hooks';
+import LoadingIndicator from '../../../components/LoadingIndicator';
+import ErrorPage from '../../ErrorPage';
+
+const schema = yup.object().shape({
+  wbsNum: yup.string().required('Project is Required'),
+  abbreviation: yup.string().required('Abbreviation is Required')
+});
+
+interface SetAbbreviation {
+  open: boolean;
+  handleClose: () => void;
+}
+
+const SetAbbreviationModel: React.FC<SetAbbreviation> = ({ open, handleClose }) => {
+  const { data: projects, isLoading: projectsIsLoading, isError: projectsIsError, error: projectsError } = useAllProjects();
+  const { mutateAsync } = useSetProjectAbbreviation();
+
+  const onFormSubmit = async (data: { wbsNum: string; abbreviation: string }) => {
+    handleClose();
+    await mutateAsync(data);
+  };
+
+  const {
+    handleSubmit,
+    control,
+    reset,
+    setValue,
+    formState: { errors }
+  } = useForm({
+    resolver: yupResolver(schema),
+    defaultValues: {
+      wbsNum: '',
+      abbreviation: ''
+    }
+  });
+
+  const handleCancel = () => {
+    reset({ wbsNum: '', abbreviation: '' });
+    handleClose();
+  };
+
+  if (!projects || projectsIsLoading) {
+    return <LoadingIndicator />;
+  }
+  if (projectsIsError) {
+    return <ErrorPage message={projectsError?.message} />;
+  }
+
+  return (
+    <NERFormModal
+      open={open}
+      onHide={handleCancel}
+      title={`Set Project Abbreviation`}
+      reset={() => reset({ wbsNum: '', abbreviation: '' })}
+      handleUseFormSubmit={handleSubmit}
+      onFormSubmit={onFormSubmit}
+      formId="set project abbreviation"
+      showCloseButton
+    >
+      <FormControl fullWidth required>
+        <FormLabel>Project</FormLabel>
+        <Controller
+          name="wbsNum"
+          control={control}
+          render={({ field }) => (
+            <Autocomplete
+              options={projects}
+              getOptionLabel={(option) => {
+                return option.name;
+              }}
+              value={field.value ? projects.find((project) => wbsPipe(project.wbsNum) === field.value) || null : null}
+              onChange={(_, newValue) => {
+                if (newValue) {
+                  setValue('wbsNum', wbsPipe(newValue.wbsNum));
+                  setValue('abbreviation', newValue.abbreviation ?? '');
+                }
+              }}
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  placeholder="Select a project"
+                  error={!!errors.wbsNum}
+                  helperText={errors.wbsNum?.message}
+                />
+              )}
+            />
+          )}
+        />
+      </FormControl>
+      <FormControl fullWidth>
+        <FormLabel>Abbreviation</FormLabel>
+        <ReactHookTextField name="abbreviation" control={control} sx={{ width: 1 }} />
+        <FormHelperText error>{errors.abbreviation?.message}</FormHelperText>
+      </FormControl>
+    </NERFormModal>
+  );
+};
+
+export default SetAbbreviationModel;

--- a/src/frontend/src/pages/AdminToolsPage/ProjectsConfig/WorkPackageTemplateTable.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/ProjectsConfig/WorkPackageTemplateTable.tsx
@@ -56,7 +56,7 @@ const WorkPackageTemplateTable = () => {
 
   return (
     <Box>
-      <AdminToolTable columns={[{ name: 'Name' }, { name: 'Description' }]} rows={workPackageTemplateRows} />
+      <AdminToolTable columns={[{ name: 'Name' }, { name: 'Description' }, { name: '' }]} rows={workPackageTemplateRows} />
       <Box sx={{ display: 'flex', justifyContent: 'right', marginTop: '10px' }}>
         {isAdmin(currentUser.role) && (
           <NERButton variant="contained" size="small" onClick={() => history.push(routes.WORK_PACKAGE_TEMPLATE_NEW)}>

--- a/src/frontend/src/utils/urls.ts
+++ b/src/frontend/src/utils/urls.ts
@@ -37,6 +37,8 @@ const projectsEdit = () => `${projects()}/edit`;
 const projectsSetTeam = (wbsNum: string) => `${projects()}/${wbsNum}/set-team`;
 const projectsDelete = (wbsNum: string) => projectsByWbsNum(wbsNum) + '/delete';
 const projectsToggleFavorite = (wbsNum: string) => projectsByWbsNum(wbsNum) + '/favorite';
+const projectsSetAbbreviation = () => `${projects()}/set-abbreviation`;
+const projectsDeleteAbbreviation = (wbsNum: string) => projectsByWbsNum(wbsNum) + '/delete-abbreviation';
 const projectsLinkTypes = () => `${projects()}/link-types`;
 const projectsCreateLinkTypes = () => `${projects()}/link-types/create`;
 const projectsEditLinkTypes = (linkTypeName: string) => `${projects()}/link-types/${linkTypeName}/edit`;
@@ -289,6 +291,8 @@ export const apiUrls = {
   projectsSetTeam,
   projectsDelete,
   projectsToggleFavorite,
+  projectsSetAbbreviation,
+  projectsDeleteAbbreviation,
   projectsLinkTypes,
   projectsCreateLinkTypes,
   projectsEditLinkTypes,

--- a/src/shared/src/types/project-types.ts
+++ b/src/shared/src/types/project-types.ts
@@ -48,6 +48,7 @@ export interface Project extends WbsElement {
   teams: TeamPreview[];
   tasks: Task[];
   favoritedBy: UserPreview[];
+  abbreviation?: string;
 }
 
 export type ProjectPreview = Pick<


### PR DESCRIPTION
## Changes

Added features to the abbreviation table to set abbreviations (existing and new), using set and delete endpoints

## Test Cases

- create a new abbreviation
- update an existing abbreviation
- delete an abbreviation
- only admins can do these things

## Screenshots
<img width="720" alt="Screenshot 2025-04-11 at 2 35 30 PM" src="https://github.com/user-attachments/assets/e791a533-0083-4fd4-aacc-6884b0152022" />

Postman testing not done because you can test it with the table (add something and then refresh)

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #3282
