### PR TITLE
#3202 cadproject file reviews create part card component

### DIFF
--- a/devContainerization/Dockerfile.frontend.dev
+++ b/devContainerization/Dockerfile.frontend.dev
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:20
 WORKDIR /base
 
 COPY package.json tsconfig.build.json ./

--- a/src/frontend/src/components/PartPreviewCard.tsx
+++ b/src/frontend/src/components/PartPreviewCard.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { Review_Status, PartPreview } from 'shared';
+import { yellow, blue, purple, green, grey } from '@mui/material/colors';
+import DownloadIcon from '@mui/icons-material/Download';
+import { Card, CardContent, CardMedia, Typography, Button, Box, Chip } from '@mui/material';
+
+// fills status pill with color based on review status
+function getStatusColor(status: Review_Status) {
+  switch (status) {
+    case Review_Status.IN_PROGRESS:
+      return yellow[700];
+    case Review_Status.READY_FOR_REVIEW:
+      return blue[600];
+    case Review_Status.IN_REVIEW:
+      return purple[600];
+    case Review_Status.REVIEWED:
+      return green[600];
+    case Review_Status.APPROVED:
+      return green[800];
+    default:
+      return grey[600];
+  }
+}
+
+// converts statuses from ALL CAPS to Title Case
+function formatStatus(status: Review_Status): string {
+  return status
+    .toLowerCase()
+    .split('_')
+    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+    .join(' ');
+}
+
+interface PartPreviewCardProps {
+  partPreview: PartPreview;
+}
+
+export function PartPreviewCard({ partPreview }: PartPreviewCardProps) {
+  const { commonName, previewImageId, status, assignees, reviewRequests } = partPreview;
+  return (
+    <Card
+      sx={{
+        maxWidth: 400,
+        border: '1px solid white',
+        borderRadius: '8px',
+        bgcolor: grey[800],
+        overflow: 'hidden'
+      }}
+    >
+      <Box sx={{ px: 2, pt: 2, bgcolor: grey[800] }}>
+        {previewImageId ? (
+          <CardMedia
+            component="img"
+            height="200"
+            image={`/api/files/${previewImageId}`}
+            alt="Part Preview"
+            sx={{
+              border: '1px solid white'
+            }}
+          />
+        ) : (
+          <Box
+            sx={{
+              height: 200,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              border: '1px solid white'
+            }}
+          >
+            <Typography variant="body2" sx={{ color: grey[400] }}>
+              No Preview Available
+            </Typography>
+          </Box>
+        )}
+      </Box>
+      <CardContent sx={{ bgcolor: grey[800], color: 'white', px: 2, py: 1 }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
+          <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
+            {commonName}
+          </Typography>
+          <Chip
+            label={formatStatus(status)}
+            size="small"
+            sx={{
+              bgcolor: getStatusColor(status),
+              color: 'white',
+              borderRadius: '16px',
+              fontWeight: 500,
+              px: 1,
+              py: 0.5
+            }}
+          />
+        </Box>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <Box>
+            <Typography variant="body2" sx={{ color: grey[300] }}>
+              <strong>Assignees:</strong>{' '}
+              {assignees && assignees.length
+                ? assignees.map((a) => `${a.firstName} ${a.lastName}`).join(', ')
+                : 'None assigned'}
+            </Typography>
+            <Typography variant="body2" sx={{ color: grey[300] }}>
+              <strong>Reviewers:</strong>{' '}
+              {reviewRequests && reviewRequests.length
+                ? reviewRequests.map((r) => `${r.reviewerRequested.firstName} ${r.reviewerRequested.lastName}`).join(', ')
+                : 'No reviewers'}
+            </Typography>
+          </Box>
+
+          <Button
+            size="small"
+            startIcon={<DownloadIcon />}
+            sx={{
+              minWidth: 0,
+              width: 32,
+              height: 32,
+              p: 0,
+              borderRadius: '50%',
+              bgcolor: grey[900],
+              color: 'white',
+              '&:hover': {
+                bgcolor: grey[800]
+              },
+              '& .MuiButton-startIcon': {
+                margin: 0
+              }
+            }}
+          />
+        </Box>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/PartReview/PartsReviewPage.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/PartReview/PartsReviewPage.tsx
@@ -1,4 +1,3 @@
-import LoadingIndicator from '../../../../components/LoadingIndicator';
 import { Box } from '@mui/system';
 import { Grid, FormGroup, FormControlLabel, Typography } from '@mui/material';
 import { useState } from 'react';

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/PartReview/PartsReviewPage.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/PartReview/PartsReviewPage.tsx
@@ -3,9 +3,115 @@ import { Box } from '@mui/system';
 import { Grid, FormGroup, FormControlLabel, Typography } from '@mui/material';
 import { useState } from 'react';
 import { useCurrentUser } from '../../../../hooks/users.hooks';
-import { rankUserRole } from 'shared';
+import { rankUserRole, Review_Status, PartTag, PartReviewRequest, User } from 'shared';
 import NERSwitch from '../../../../components/NERSwitch';
 import CommonMistakes from './CommonMistakes';
+import { PartPreviewCard } from '../../../../components/PartPreviewCard';
+
+const emptyUser: User = {
+  userId: '',
+  firstName: '',
+  lastName: '',
+  email: '',
+  emailId: null,
+  role: 'MEMBER',
+  permissions: []
+};
+
+const emptyPartPreview = {
+  partId: '',
+  index: 0,
+  commonName: '',
+  description: '',
+  status: Review_Status.IN_PROGRESS,
+  tags: [],
+  projectId: '',
+  assignees: [],
+  reviewRequests: [],
+  createdAt: new Date(),
+  userCreated: emptyUser,
+  previewImageId: undefined
+};
+
+const fullUser: User = {
+  userId: 'user1',
+  firstName: 'John',
+  lastName: 'Doe',
+  email: 'john@example.com',
+  emailId: 'john@example.com',
+  role: 'MEMBER',
+  permissions: []
+};
+
+const fullPartPreview = {
+  partId: '123',
+  index: 1,
+  commonName: 'Motor Mount',
+  description: 'A sturdy mount for securing the motor in place',
+  status: Review_Status.IN_REVIEW,
+  tags: [
+    {
+      partTagId: '1',
+      name: 'Mechanical',
+      colorHexCode: '#FF0000'
+    },
+    {
+      partTagId: '2',
+      name: 'Critical',
+      colorHexCode: '#00FF00'
+    }
+  ] as PartTag[],
+  projectId: 'project-1',
+  assignees: [
+    {
+      userId: 'user1',
+      firstName: 'John',
+      lastName: 'Doe',
+      email: 'john@example.com',
+      emailId: 'john@example.com',
+      role: 'MEMBER',
+      permissions: []
+    },
+    {
+      userId: 'user2',
+      firstName: 'Jane',
+      lastName: 'Smith',
+      email: 'jane@example.com',
+      emailId: 'jane@example.com',
+      role: 'LEADERSHIP',
+      permissions: []
+    }
+  ] as User[],
+  reviewRequests: [
+    {
+      partReviewRequestId: 'req1',
+      partId: '123',
+      requester: {
+        userId: 'user1',
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'john@example.com',
+        emailId: 'john@example.com',
+        role: 'MEMBER',
+        permissions: []
+      },
+      reviewerRequested: {
+        userId: 'user3',
+        firstName: 'Bob',
+        lastName: 'Johnson',
+        email: 'bob@example.com',
+        emailId: 'bob@example.com',
+        role: 'HEAD',
+        permissions: []
+      },
+      createdAt: new Date(),
+      dateDeleted: undefined
+    }
+  ] as PartReviewRequest[],
+  createdAt: new Date(),
+  userCreated: fullUser,
+  previewImageId: undefined
+};
 
 const PartsReviewPage = () => {
   const currentUser = useCurrentUser();
@@ -32,20 +138,29 @@ const PartsReviewPage = () => {
           </FormGroup>
         </Grid>
         <Grid item xs={12}>
-          {/* The guide should be toggled off by default for admins, heads, and leads and toggled on for all other roles */}
-
           {showSubmissionGuide ? (
             <Grid container spacing={3}>
               <Grid item xs={12}>
                 <Typography variant="h4">Submission Guide</Typography>
                 <CommonMistakes />
-                {/* Submission Guide components will go here */}
-                <LoadingIndicator />
-                {/* Loading indicator will be replaced by a grid of all the part cards */}
+                <PartPreviewCard partPreview={emptyPartPreview} />
               </Grid>
             </Grid>
           ) : (
-            <LoadingIndicator /> /* Loading indicator will be replaced by a grid of all the part cards */
+            <Grid container spacing={3}>
+              <Grid item xs={12} md={6}>
+                <Typography variant="h6" gutterBottom>
+                  Empty Part Preview
+                </Typography>
+                <PartPreviewCard partPreview={emptyPartPreview} />
+              </Grid>
+              <Grid item xs={12} md={6}>
+                <Typography variant="h6" gutterBottom>
+                  Full Part Preview
+                </Typography>
+                <PartPreviewCard partPreview={fullPartPreview} />
+              </Grid>
+            </Grid>
           )}
         </Grid>
       </Grid>


### PR DESCRIPTION
## Changes

Made a part preview card in frontend/src/components/PartPreviewCard.tsx that takes in a PartPreview from the shared folder. Didn't alter any other file, so no current UI changes, just added the component.

## Notes

- each status type has a corresponding color (feel free to tell me to change the colors)
- all info fields have default texts if no input is found (i.e, if no reviewers, the 'Reviewers' field will say 'No reviewers')
- if preview image is missing, resort to a gray box
- download button's icon is filled which is different from the outlined icon in the mockup

## Test Cases

- Missing all fields: resorts to default text and gray box for image

## Screenshots

Normal Sized Window:
<img width="1458" alt="Screenshot 2025-04-11 at 7 51 47 PM" src="https://github.com/user-attachments/assets/37a84204-2c5e-4baa-b389-0d9e1346e039" />

Smallest Possible Window:
<img width="487" alt="Screenshot 2025-04-11 at 7 52 15 PM" src="https://github.com/user-attachments/assets/26c834c0-d168-477e-920c-9f1155a93191" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ x ] All commits are tagged with the ticket number
- [ x ] No linting errors / newline at end of file warnings
- [ x ] All code follows repository-configured prettier formatting
- [ x ] No merge conflicts
- [ x ] All checks passing
- [ x ] Screenshots of UI changes (see Screenshots section)
- [ x  ] Remove any non-applicable sections of this template
- [ x ] Assign the PR to yourself
- [ x ] No `yarn.lock` changes (unless dependencies have changed)
- [ x ] Request reviewers & ping on Slack
- [ x ] PR is linked to the ticket (fill in the closes line below)

Closes #3202
