### PR TITLE
#2424: hide completed projects from projects page

### DIFF
--- a/src/frontend/src/pages/ProjectsPage/ProjectsOverview.tsx
+++ b/src/frontend/src/pages/ProjectsPage/ProjectsOverview.tsx
@@ -9,6 +9,7 @@ import ErrorPage from '../ErrorPage';
 import { useCurrentUser, useUsersFavoriteProjects } from '../../hooks/users.hooks';
 import ProjectsOverviewCards from './ProjectsOverviewCards';
 import { useGetUsersLeadingProjects, useGetUsersTeamsProjects } from '../../hooks/projects.hooks';
+import { WbsElementStatus } from 'shared';
 
 /**
  * Cards of all projects this user has favorited
@@ -47,6 +48,14 @@ const ProjectsOverview: React.FC = () => {
 
   const favoriteProjectsSet: Set<string> = new Set(favoriteProjects.map((project) => project.id));
 
+  // Keeps only favorite team/leading projects (even when completed) or incomplete projects
+  const filteredTeamsProjects = teamsProjects.filter(
+    (project) => project.status !== WbsElementStatus.Complete || favoriteProjectsSet.has(project.id)
+  );
+  const filteredLeadingProjects = leadingProjects.filter(
+    (project) => project.status !== WbsElementStatus.Complete || favoriteProjectsSet.has(project.id)
+  );
+
   return (
     <Box>
       <ProjectsOverviewCards
@@ -56,16 +65,16 @@ const ProjectsOverview: React.FC = () => {
         emptyMessage="You have no favorite projects. Click the star on a project's page to add one!"
       />
 
-      {teamsProjects.length > 0 && (
+      {filteredTeamsProjects.length > 0 && (
         <ProjectsOverviewCards
-          projects={teamsProjects}
+          projects={filteredTeamsProjects}
           title="My Team's Projects"
           favoriteProjectsSet={favoriteProjectsSet}
         />
       )}
-      {leadingProjects.length > 0 && (
+      {filteredLeadingProjects.length > 0 && (
         <ProjectsOverviewCards
-          projects={leadingProjects}
+          projects={filteredLeadingProjects}
           title="Projects I'm Leading"
           favoriteProjectsSet={favoriteProjectsSet}
         />

--- a/src/frontend/src/pages/ProjectsPage/ProjectsTable.tsx
+++ b/src/frontend/src/pages/ProjectsPage/ProjectsTable.tsx
@@ -155,7 +155,7 @@ const ProjectsTable: React.FC = () => {
         rows={
           // flatten some complex data to allow MUI to sort/filter yet preserve the original data being available to the front-end
           data
-            ?.filter((project) => project.status !== 'COMPLETE')
+            ?.filter((project) => project.status !== WbsElementStatus.Complete)
             .map((v) => ({
               ...v,
               carNumber: v.wbsNum.carNumber,

--- a/src/frontend/src/pages/ProjectsPage/ProjectsTable.tsx
+++ b/src/frontend/src/pages/ProjectsPage/ProjectsTable.tsx
@@ -24,17 +24,10 @@ const ProjectsTable: React.FC = () => {
   const [pageSize, setPageSize] = useState(localStorage.getItem('projectsTableRowCount'));
   const [windowSize, setWindowSize] = useState(window.innerWidth);
 
-  const baseColDef: GridColDefStyle = {
-    flex: 1,
-    align: 'center',
-    headerAlign: 'center'
-  };
+  const baseColDef: GridColDefStyle = { flex: 1, align: 'center', headerAlign: 'center' };
 
   const dollars = (amount: number) => {
-    const formatter = new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: 'USD'
-    });
+    const formatter = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' });
     return formatter.format(amount);
   };
 
@@ -64,11 +57,7 @@ const ProjectsTable: React.FC = () => {
     }
   };
 
-  const projectNameColumn: GridColDef = {
-    ...baseColDef,
-    field: 'name',
-    headerName: 'Project Name'
-  };
+  const projectNameColumn: GridColDef = { ...baseColDef, field: 'name', headerName: 'Project Name' };
 
   const durationColumn: GridColDef = {
     ...baseColDef,
@@ -103,24 +92,9 @@ const ProjectsTable: React.FC = () => {
     { ...baseColDef, field: 'carNumber', headerName: 'Car #', type: 'number', maxWidth: 50 },
     wbsNumColumn,
     projectNameColumn,
-    {
-      ...baseColDef,
-      field: 'lead',
-      headerName: 'Lead',
-      maxWidth: 250
-    },
-    {
-      ...baseColDef,
-      field: 'manager',
-      headerName: 'Manager',
-      maxWidth: 250
-    },
-    {
-      ...baseColDef,
-      field: 'team',
-      headerName: 'Team',
-      maxWidth: 200
-    },
+    { ...baseColDef, field: 'lead', headerName: 'Lead', maxWidth: 250 },
+    { ...baseColDef, field: 'manager', headerName: 'Manager', maxWidth: 250 },
+    { ...baseColDef, field: 'team', headerName: 'Team', maxWidth: 200 },
     durationColumn,
     budgetColumn,
     {
@@ -180,30 +154,26 @@ const ProjectsTable: React.FC = () => {
         error={error}
         rows={
           // flatten some complex data to allow MUI to sort/filter yet preserve the original data being available to the front-end
-          data?.map((v) => ({
-            ...v,
-            carNumber: v.wbsNum.carNumber,
-            lead: fullNamePipe(v.lead),
-            manager: fullNamePipe(v.manager),
-            team: getProjectTeamsName(v)
-          })) || []
+          data
+            ?.filter((project) => project.status !== 'COMPLETE')
+            .map((v) => ({
+              ...v,
+              carNumber: v.wbsNum.carNumber,
+              lead: fullNamePipe(v.lead),
+              manager: fullNamePipe(v.manager),
+              team: getProjectTeamsName(v)
+            })) || []
         }
         columns={windowSize < 900 ? smallColumns : columns}
         sx={{
           border: 0,
-          '& .MuiDataGrid-row:hover': {
-            backgroundColor: 'rgba(239, 67, 69, 0.6)'
-          },
+          '& .MuiDataGrid-row:hover': { backgroundColor: 'rgba(239, 67, 69, 0.6)' },
           '& .MuiDataGrid-columnHeader': {
             borderRight: `1px solid ${theme.palette.mode === 'light' ? '#f0f0f0' : '#303030'}`,
             borderLeft: `1px solid ${theme.palette.mode === 'light' ? '#f0f0f0' : '#303030'}`
           },
-          '& .MuiDataGrid-columnHeaders': {
-            border: `1px solid ${theme.palette.mode === 'light' ? '#f0f0f0' : '#303030'}`
-          },
-          '.MuiDataGrid-columnSeparator': {
-            display: 'none'
-          }
+          '& .MuiDataGrid-columnHeaders': { border: `1px solid ${theme.palette.mode === 'light' ? '#f0f0f0' : '#303030'}` },
+          '.MuiDataGrid-columnSeparator': { display: 'none' }
         }}
         getRowClassName={(params) => (params.indexRelativeToCurrentPage % 2 === 0 ? 'Mui-even' : 'Mui-odd')}
         components={{
@@ -221,12 +191,7 @@ const ProjectsTable: React.FC = () => {
             );
           }
         }}
-        componentsProps={{
-          toolbar: {
-            showQuickFilter: true,
-            quickFilterProps: { debounceMs: 500 }
-          }
-        }}
+        componentsProps={{ toolbar: { showQuickFilter: true, quickFilterProps: { debounceMs: 500 } } }}
         onFilterModelChange={(filterModel: GridFilterModel) => {
           const [filterItems] = filterModel.items;
           if (filterItems) localStorage.setItem('projectsTableFilter', JSON.stringify(filterItems));
@@ -243,15 +208,8 @@ const ProjectsTable: React.FC = () => {
               ]
             }
           },
-          sorting: {
-            sortModel: [{ field: 'status', sort: 'asc' }]
-          },
-          columns: {
-            columnVisibilityModel: {
-              carNumber: false,
-              workPackages: false
-            }
-          }
+          sorting: { sortModel: [{ field: 'status', sort: 'asc' }] },
+          columns: { columnVisibilityModel: { carNumber: false, workPackages: false } }
         }}
       />
     </Box>

--- a/src/frontend/src/pages/ProjectsPage/ProjectsTable.tsx
+++ b/src/frontend/src/pages/ProjectsPage/ProjectsTable.tsx
@@ -24,10 +24,17 @@ const ProjectsTable: React.FC = () => {
   const [pageSize, setPageSize] = useState(localStorage.getItem('projectsTableRowCount'));
   const [windowSize, setWindowSize] = useState(window.innerWidth);
 
-  const baseColDef: GridColDefStyle = { flex: 1, align: 'center', headerAlign: 'center' };
+  const baseColDef: GridColDefStyle = {
+    flex: 1,
+    align: 'center',
+    headerAlign: 'center'
+  };
 
   const dollars = (amount: number) => {
-    const formatter = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' });
+    const formatter = new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD'
+    });
     return formatter.format(amount);
   };
 
@@ -57,7 +64,11 @@ const ProjectsTable: React.FC = () => {
     }
   };
 
-  const projectNameColumn: GridColDef = { ...baseColDef, field: 'name', headerName: 'Project Name' };
+  const projectNameColumn: GridColDef = {
+    ...baseColDef,
+    field: 'name',
+    headerName: 'Project Name'
+  };
 
   const durationColumn: GridColDef = {
     ...baseColDef,
@@ -92,9 +103,24 @@ const ProjectsTable: React.FC = () => {
     { ...baseColDef, field: 'carNumber', headerName: 'Car #', type: 'number', maxWidth: 50 },
     wbsNumColumn,
     projectNameColumn,
-    { ...baseColDef, field: 'lead', headerName: 'Lead', maxWidth: 250 },
-    { ...baseColDef, field: 'manager', headerName: 'Manager', maxWidth: 250 },
-    { ...baseColDef, field: 'team', headerName: 'Team', maxWidth: 200 },
+    {
+      ...baseColDef,
+      field: 'lead',
+      headerName: 'Lead',
+      maxWidth: 250
+    },
+    {
+      ...baseColDef,
+      field: 'manager',
+      headerName: 'Manager',
+      maxWidth: 250
+    },
+    {
+      ...baseColDef,
+      field: 'team',
+      headerName: 'Team',
+      maxWidth: 200
+    },
     durationColumn,
     budgetColumn,
     {
@@ -154,26 +180,30 @@ const ProjectsTable: React.FC = () => {
         error={error}
         rows={
           // flatten some complex data to allow MUI to sort/filter yet preserve the original data being available to the front-end
-          data
-            ?.filter((project) => project.status !== WbsElementStatus.Complete)
-            .map((v) => ({
-              ...v,
-              carNumber: v.wbsNum.carNumber,
-              lead: fullNamePipe(v.lead),
-              manager: fullNamePipe(v.manager),
-              team: getProjectTeamsName(v)
-            })) || []
+          data?.map((v) => ({
+            ...v,
+            carNumber: v.wbsNum.carNumber,
+            lead: fullNamePipe(v.lead),
+            manager: fullNamePipe(v.manager),
+            team: getProjectTeamsName(v)
+          })) || []
         }
         columns={windowSize < 900 ? smallColumns : columns}
         sx={{
           border: 0,
-          '& .MuiDataGrid-row:hover': { backgroundColor: 'rgba(239, 67, 69, 0.6)' },
+          '& .MuiDataGrid-row:hover': {
+            backgroundColor: 'rgba(239, 67, 69, 0.6)'
+          },
           '& .MuiDataGrid-columnHeader': {
             borderRight: `1px solid ${theme.palette.mode === 'light' ? '#f0f0f0' : '#303030'}`,
             borderLeft: `1px solid ${theme.palette.mode === 'light' ? '#f0f0f0' : '#303030'}`
           },
-          '& .MuiDataGrid-columnHeaders': { border: `1px solid ${theme.palette.mode === 'light' ? '#f0f0f0' : '#303030'}` },
-          '.MuiDataGrid-columnSeparator': { display: 'none' }
+          '& .MuiDataGrid-columnHeaders': {
+            border: `1px solid ${theme.palette.mode === 'light' ? '#f0f0f0' : '#303030'}`
+          },
+          '.MuiDataGrid-columnSeparator': {
+            display: 'none'
+          }
         }}
         getRowClassName={(params) => (params.indexRelativeToCurrentPage % 2 === 0 ? 'Mui-even' : 'Mui-odd')}
         components={{
@@ -191,7 +221,12 @@ const ProjectsTable: React.FC = () => {
             );
           }
         }}
-        componentsProps={{ toolbar: { showQuickFilter: true, quickFilterProps: { debounceMs: 500 } } }}
+        componentsProps={{
+          toolbar: {
+            showQuickFilter: true,
+            quickFilterProps: { debounceMs: 500 }
+          }
+        }}
         onFilterModelChange={(filterModel: GridFilterModel) => {
           const [filterItems] = filterModel.items;
           if (filterItems) localStorage.setItem('projectsTableFilter', JSON.stringify(filterItems));
@@ -208,8 +243,15 @@ const ProjectsTable: React.FC = () => {
               ]
             }
           },
-          sorting: { sortModel: [{ field: 'status', sort: 'asc' }] },
-          columns: { columnVisibilityModel: { carNumber: false, workPackages: false } }
+          sorting: {
+            sortModel: [{ field: 'status', sort: 'asc' }]
+          },
+          columns: {
+            columnVisibilityModel: {
+              carNumber: false,
+              workPackages: false
+            }
+          }
         }}
       />
     </Box>


### PR DESCRIPTION
## Changes

Removed completed projects from the projects page


## Screenshots
<img width="1431" alt="Screenshot 2025-04-16 at 6 58 03 PM" src="https://github.com/user-attachments/assets/2482653c-d714-4749-9553-d431c12a9f2c" />

<img width="1433" alt="Screenshot 2025-04-16 at 6 58 31 PM" src="https://github.com/user-attachments/assets/11a7fb29-041e-46ec-b53f-5de4f8764050" />

## Notes
See new comment below about new updated changes to Project Overiew tab instead of All Projects tab.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x ] All commits are tagged with the ticket number
- [ x] No linting errors / newline at end of file warnings
- [ x] All code follows repository-configured prettier formatting
- [ x] No merge conflicts
- [ x] All checks passing
- [ x] Screenshots of UI changes (see Screenshots section)
- [ x] Remove any non-applicable sections of this template
- [ x] Assign the PR to yourself
- [ x] No `yarn.lock` changes (unless dependencies have changed)
- [ x] Request reviewers & ping on Slack
- [ x] PR is linked to the ticket (fill in the closes line below)

Closes #2424
