### PR TITLE
Get Set Part Review Sample Image Hooks and Endpoints

### DIFF
--- a/src/backend/src/controllers/part-review.controllers.ts
+++ b/src/backend/src/controllers/part-review.controllers.ts
@@ -387,4 +387,29 @@ export default class PartReviewController {
       next(error);
     }
   }
+
+  static async setPartReviewSampleImage(req: Request, res: Response, next: NextFunction) {
+    try {
+      if (!req.file) {
+        throw new HttpException(400, 'Invalid or undefined image data');
+      }
+
+      const updatedOrg = await PartReviewService.setPartReviewSampleImage(req.file, req.currentUser, req.organization);
+
+      res.status(200).json(updatedOrg);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
+  static async getPartReviewSampleImage(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { organization } = req;
+
+      const partReviewSampleImageId = await PartReviewService.getPartReviewSampleImage(organization.organizationId);
+      res.status(200).json(partReviewSampleImageId);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
 }

--- a/src/backend/src/prisma/migrations/20250422002550_tes/migration.sql
+++ b/src/backend/src/prisma/migrations/20250422002550_tes/migration.sql
@@ -1,0 +1,11 @@
+-- DropForeignKey
+ALTER TABLE "PartReviewCommonMistake" DROP CONSTRAINT "PartReviewCommonMistake_organizationId_fkey";
+
+-- AlterTable
+ALTER TABLE "PartReviewCommonMistake" ALTER COLUMN "organizationId" DROP NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "PartReviewCommonMistake" ADD CONSTRAINT "PartReviewCommonMistake_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("organizationId") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- RenameIndex
+ALTER INDEX "ProjectId_and_index" RENAME TO "Part_projectId_index_key";

--- a/src/backend/src/routes/parts.routes.ts
+++ b/src/backend/src/routes/parts.routes.ts
@@ -158,4 +158,11 @@ partsRouter.get('/:wbsNum', PartReviewController.getAllPartsForProject);
 
 partsRouter.post('/reviewRequest/:reviewRequestId/delete', PartReviewController.deletePartReviewRequest);
 
+partsRouter.post(
+  '/partReviewSampleImage/update',
+  upload.single('partReviewSampleImage'),
+  PartReviewController.setPartReviewSampleImage
+);
+partsRouter.get('/partReviewSampleImage', PartReviewController.getPartReviewSampleImage);
+
 export default partsRouter;

--- a/src/backend/src/services/part-review.services.ts
+++ b/src/backend/src/services/part-review.services.ts
@@ -1056,4 +1056,54 @@ export default class PartReviewService {
 
     return deletedPopup;
   }
+
+  /**
+   * Sets the part review sample image for an organization, User must be admin
+   * @param image the image which will be uploaded and have its id stored in the org
+   * @param submitter the user submitting the sample image
+   * @param organization the organization who's sample image is being set
+   * @returns the updated organization
+   * @throws if the user is not an admin
+   */
+  static async setPartReviewSampleImage(
+    image: Express.Multer.File,
+    submitter: User,
+    organization: Organization
+  ): Promise<Organization> {
+    if (!(await userHasPermission(submitter.userId, organization.organizationId, isAdmin))) {
+      throw new AccessDeniedAdminOnlyException('update part review sample image');
+    }
+
+    const previewImageData = await uploadFile(image);
+
+    if (!previewImageData?.name) {
+      throw new HttpException(500, 'Image Name not found');
+    }
+
+    const updatedOrg = await prisma.organization.update({
+      where: { organizationId: organization.organizationId },
+      data: {
+        partReviewSampleImageId: previewImageData.id
+      }
+    });
+
+    return updatedOrg;
+  }
+
+  /**
+   * Gets the part review sample image of the organization
+   * @param organizationId the id of the organization
+   * @returns the id of the image
+   */
+  static async getPartReviewSampleImage(organizationId: string): Promise<string | null> {
+    const organization = await prisma.organization.findUnique({
+      where: { organizationId }
+    });
+
+    if (!organization) {
+      throw new NotFoundException('Organization', organizationId);
+    }
+
+    return organization.partReviewSampleImageId;
+  }
 }

--- a/src/backend/tests/unit/part-review.test.ts
+++ b/src/backend/tests/unit/part-review.test.ts
@@ -1093,6 +1093,7 @@ describe('Part Review Popups', () => {
       await resetUsers();
       organization = await createTestOrganization();
       orgId = organization.organizationId;
+      batman = await createTestUser(batmanAppAdmin, orgId);
     });
 
     it('Fails if user is not an admin', async () => {
@@ -1102,12 +1103,11 @@ describe('Part Review Popups', () => {
     });
 
     it('Succeeds and updates the sample image', async () => {
-      const testBatman = batman;
       (uploadFile as Mock).mockImplementation((file) => {
         return Promise.resolve({ name: `${file.originalname}`, id: `uploaded-${file.originalname}` });
       });
 
-      await PartReviewService.setPartReviewSampleImage(file1, testBatman, organization);
+      await PartReviewService.setPartReviewSampleImage(file1, batman, organization);
 
       const oldOrganization = await prisma.organization.findUnique({
         where: {
@@ -1118,7 +1118,7 @@ describe('Part Review Popups', () => {
       expect(oldOrganization).not.toBeNull();
       expect(oldOrganization?.partReviewSampleImageId).toBe('uploaded-image1.png');
 
-      await PartReviewService.setPartReviewSampleImage(file2, testBatman, organization);
+      await PartReviewService.setPartReviewSampleImage(file2, batman, organization);
 
       const updatedOrganization = await prisma.organization.findUnique({
         where: {
@@ -1138,6 +1138,7 @@ describe('Part Review Popups', () => {
       await resetUsers();
       organization = await createTestOrganization();
       orgId = organization.organizationId;
+      batman = await createTestUser(batmanAppAdmin, orgId);
     });
 
     it('Fails if an organization does not exist', async () => {
@@ -1147,10 +1148,9 @@ describe('Part Review Popups', () => {
     });
 
     it('Succeeds and gets the image', async () => {
-      const testBatman = batman;
       await PartReviewService.setPartReviewSampleImage(
         { originalname: 'image1.png' } as Express.Multer.File,
-        testBatman,
+        batman,
         organization
       );
       const image = await PartReviewService.getPartReviewSampleImage(orgId);

--- a/src/backend/tests/unit/part-review.test.ts
+++ b/src/backend/tests/unit/part-review.test.ts
@@ -1094,6 +1094,10 @@ describe('Part Review Popups', () => {
       orgId = organization.organizationId;
     });
 
+    afterEach(async () => {
+      await resetUsers();
+    });  
+
     it('Fails if user is not an admin', async () => {
       await expect(
         PartReviewService.setPartReviewSampleImage(file1, await createTestUser(wonderwomanGuest, orgId), organization)
@@ -1137,6 +1141,10 @@ describe('Part Review Popups', () => {
       organization = await createTestOrganization();
       orgId = organization.organizationId;
     });
+
+    afterEach(async () => {
+      await resetUsers();
+    });  
 
     it('Fails if an organization does not exist', async () => {
       await expect(async () => await PartReviewService.getPartReviewSampleImage('1')).rejects.toThrow(

--- a/src/backend/tests/unit/part-review.test.ts
+++ b/src/backend/tests/unit/part-review.test.ts
@@ -36,6 +36,10 @@ vi.mock('../../src/utils/google-integration.utils', () => ({
   uploadFile: vi.fn()
 }));
 
+beforeEach(async () => {
+  await resetUsers();
+});
+
 describe('part review tests', () => {
   let orgId: string;
   let organization: Organization;
@@ -1094,10 +1098,6 @@ describe('Part Review Popups', () => {
       orgId = organization.organizationId;
     });
 
-    afterEach(async () => {
-      await resetUsers();
-    });  
-
     it('Fails if user is not an admin', async () => {
       await expect(
         PartReviewService.setPartReviewSampleImage(file1, await createTestUser(wonderwomanGuest, orgId), organization)
@@ -1141,10 +1141,6 @@ describe('Part Review Popups', () => {
       organization = await createTestOrganization();
       orgId = organization.organizationId;
     });
-
-    afterEach(async () => {
-      await resetUsers();
-    });  
 
     it('Fails if an organization does not exist', async () => {
       await expect(async () => await PartReviewService.getPartReviewSampleImage('1')).rejects.toThrow(

--- a/src/backend/tests/unit/part-review.test.ts
+++ b/src/backend/tests/unit/part-review.test.ts
@@ -36,10 +36,6 @@ vi.mock('../../src/utils/google-integration.utils', () => ({
   uploadFile: vi.fn()
 }));
 
-beforeEach(async () => {
-  await resetUsers();
-});
-
 describe('part review tests', () => {
   let orgId: string;
   let organization: Organization;

--- a/src/backend/tests/unit/part-review.test.ts
+++ b/src/backend/tests/unit/part-review.test.ts
@@ -12,7 +12,14 @@ import {
   resetUsers
 } from '../test-utils';
 import PartReviewService from '../../src/services/part-review.services';
-import { batmanAppAdmin, supermanAdmin, aquamanLeadership, flashAdmin, financeMember } from '../test-data/users.test-data';
+import {
+  batmanAppAdmin,
+  supermanAdmin,
+  aquamanLeadership,
+  flashAdmin,
+  financeMember,
+  wonderwomanGuest
+} from '../test-data/users.test-data';
 import prisma from '../../src/prisma/prisma';
 import {
   AccessDeniedAdminOnlyException,
@@ -22,6 +29,12 @@ import {
 } from '../../src/utils/errors.utils';
 import { validateWBS, WbsNumber } from 'shared';
 import { Review_Status } from 'shared';
+import { uploadFile } from '../../src/utils/google-integration.utils';
+import { Mock, vi } from 'vitest';
+
+vi.mock('../../src/utils/google-integration.utils', () => ({
+  uploadFile: vi.fn()
+}));
 
 describe('part review tests', () => {
   let orgId: string;
@@ -1067,5 +1080,81 @@ describe('Part Review Popups', () => {
     await expect(
       PartReviewService.updatePartReviewPopup(orgId, popup.partReviewPopupId, 10, 10, 'Should Fail', 'Nope', superman)
     ).rejects.toThrow(new NotFoundException('Pop Up', popup.partReviewPopupId));
+  });
+
+  describe('Set Part Review Sample Image', () => {
+    const file1 = { originalname: 'image1.png' } as Express.Multer.File;
+    const file2 = { originalname: 'image2.png' } as Express.Multer.File;
+
+    let orgId: string;
+    let organization: Organization;
+
+    beforeEach(async () => {
+      organization = await createTestOrganization();
+      orgId = organization.organizationId;
+    });
+
+    it('Fails if user is not an admin', async () => {
+      await expect(
+        PartReviewService.setPartReviewSampleImage(file1, await createTestUser(wonderwomanGuest, orgId), organization)
+      ).rejects.toThrow(new AccessDeniedAdminOnlyException('update part review sample image'));
+    });
+
+    it('Succeeds and updates the sample image', async () => {
+      const testBatman = await createTestUser(batmanAppAdmin, orgId);
+      (uploadFile as Mock).mockImplementation((file) => {
+        return Promise.resolve({ name: `${file.originalname}`, id: `uploaded-${file.originalname}` });
+      });
+
+      await PartReviewService.setPartReviewSampleImage(file1, testBatman, organization);
+
+      const oldOrganization = await prisma.organization.findUnique({
+        where: {
+          organizationId: orgId
+        }
+      });
+
+      expect(oldOrganization).not.toBeNull();
+      expect(oldOrganization?.partReviewSampleImageId).toBe('uploaded-image1.png');
+
+      await PartReviewService.setPartReviewSampleImage(file2, testBatman, organization);
+
+      const updatedOrganization = await prisma.organization.findUnique({
+        where: {
+          organizationId: orgId
+        }
+      });
+
+      expect(updatedOrganization?.partReviewSampleImageId).toBe('uploaded-image2.png');
+    });
+  });
+
+  describe('Get Part Review Sample Image', () => {
+    let orgId: string;
+    let organization: Organization;
+
+    beforeEach(async () => {
+      organization = await createTestOrganization();
+      orgId = organization.organizationId;
+    });
+
+    it('Fails if an organization does not exist', async () => {
+      await expect(async () => await PartReviewService.getPartReviewSampleImage('1')).rejects.toThrow(
+        new NotFoundException('Organization', '1')
+      );
+    });
+
+    it('Succeeds and gets the image', async () => {
+      const testBatman = await createTestUser(batmanAppAdmin, orgId);
+      await PartReviewService.setPartReviewSampleImage(
+        { originalname: 'image1.png' } as Express.Multer.File,
+        testBatman,
+        organization
+      );
+      const image = await PartReviewService.getPartReviewSampleImage(orgId);
+
+      expect(image).not.toBeNull();
+      expect(image).toBe('uploaded-image1.png');
+    });
   });
 });

--- a/src/backend/tests/unit/part-review.test.ts
+++ b/src/backend/tests/unit/part-review.test.ts
@@ -1101,7 +1101,7 @@ describe('Part Review Popups', () => {
     });
 
     it('Succeeds and updates the sample image', async () => {
-      const testBatman = await createTestUser(batmanAppAdmin, orgId);
+      const testBatman = batman;
       (uploadFile as Mock).mockImplementation((file) => {
         return Promise.resolve({ name: `${file.originalname}`, id: `uploaded-${file.originalname}` });
       });

--- a/src/backend/tests/unit/part-review.test.ts
+++ b/src/backend/tests/unit/part-review.test.ts
@@ -1090,6 +1090,7 @@ describe('Part Review Popups', () => {
     let organization: Organization;
 
     beforeEach(async () => {
+      await resetUsers();
       organization = await createTestOrganization();
       orgId = organization.organizationId;
     });
@@ -1134,6 +1135,7 @@ describe('Part Review Popups', () => {
     let organization: Organization;
 
     beforeEach(async () => {
+      await resetUsers();
       organization = await createTestOrganization();
       orgId = organization.organizationId;
     });
@@ -1145,7 +1147,7 @@ describe('Part Review Popups', () => {
     });
 
     it('Succeeds and gets the image', async () => {
-      const testBatman = await createTestUser(batmanAppAdmin, orgId);
+      const testBatman = batman;
       await PartReviewService.setPartReviewSampleImage(
         { originalname: 'image1.png' } as Express.Multer.File,
         testBatman,

--- a/src/frontend/src/apis/part-review.api.ts
+++ b/src/frontend/src/apis/part-review.api.ts
@@ -165,3 +165,22 @@ export const setUploadReviewFiles = (reviewId: string, files: File[]) => {
 export const getAllCommonMistakes = () => {
   return axios.get<PartReviewCommonMistake[]>(apiUrls.getAllPartCommonMistakes());
 };
+
+/**
+ * Gets the part review sample image of the organization
+ */
+export const getPartReviewSampleImage = async () => {
+  return axios.get<string>(apiUrls.getPartReviewSampleImage(), {
+    transformResponse: (data) => JSON.parse(data)
+  });
+};
+
+/**
+ * Sets the part review sample image for an organization, User must be admin
+ * @param file the image which will be uploaded
+ */
+export const setPartReviewSampleImage = async (file: File) => {
+  const formData = new FormData();
+  formData.append('partReviewSampleImage', file);
+  return axios.post(apiUrls.setPartReviewSampleImage(), formData);
+};

--- a/src/frontend/src/hooks/part-review.hooks.ts
+++ b/src/frontend/src/hooks/part-review.hooks.ts
@@ -6,7 +6,8 @@ import {
   PartReviewRequest,
   PartSubmission,
   Review_Status,
-  PartReviewCommonMistake
+  PartReviewCommonMistake,
+  Organization
 } from 'shared';
 import {
   createPart,
@@ -22,7 +23,9 @@ import {
   getSinglePart,
   getAllCommonMistakes,
   uploadPreviewImage,
-  setUploadReviewFiles
+  setUploadReviewFiles,
+  setPartReviewSampleImage,
+  getPartReviewSampleImage
 } from '../apis/part-review.api';
 
 export interface PartPayload {
@@ -316,4 +319,18 @@ export const useAllCommonMistakes = () => {
       }
     }
   );
+};
+
+/**
+ * Hook to set the part review sample image for the organization.
+ */
+export const useSetPartReviewSampleImage = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<Organization, Error, File>(['part-review-sample-image'], async (file: File) => {
+    const { data } = await setPartReviewSampleImage(file);
+    queryClient.invalidateQueries(['part-review-sample-image']);
+    queryClient.invalidateQueries(['organizations']);
+    return data;
+  });
 };

--- a/src/frontend/src/hooks/part-review.hooks.ts
+++ b/src/frontend/src/hooks/part-review.hooks.ts
@@ -27,6 +27,7 @@ import {
   setPartReviewSampleImage,
   getPartReviewSampleImage
 } from '../apis/part-review.api';
+import { downloadGoogleImage } from '../apis/organizations.api';
 
 export interface PartPayload {
   wbsNum: string;
@@ -332,5 +333,18 @@ export const useSetPartReviewSampleImage = () => {
     queryClient.invalidateQueries(['part-review-sample-image']);
     queryClient.invalidateQueries(['organizations']);
     return data;
+  });
+};
+
+/**
+ * Hook to get the part review sample image as a Blob
+ */
+export const usePartReviewSampleImage = () => {
+  return useQuery<Blob | undefined, Error>(['part-review-sample-image'], async () => {
+    const { data: fileId } = await getPartReviewSampleImage();
+    if (!fileId) {
+      return;
+    }
+    return await downloadGoogleImage(fileId);
   });
 };

--- a/src/frontend/src/utils/urls.ts
+++ b/src/frontend/src/utils/urls.ts
@@ -57,6 +57,8 @@ const partsCreateReview = () => `${parts()}/review/create`;
 const partsEditReview = (reviewId: string) => `${parts()}/review/${reviewId}/update`;
 const partsReviewUploadFiles = (reviewId: string) => `${parts()}/review/${reviewId}/upload-files`;
 const getAllPartCommonMistakes = () => `${parts()}/common-mistakes`;
+const getPartReviewSampleImage = () => `${parts()}//partReviewSampleImage`;
+const setPartReviewSampleImage = () => `${parts()}//partReviewSampleImage/update`;
 
 /**************** Tasks Endpoints ********************/
 const tasks = () => `${API_URL}/tasks`;
@@ -309,6 +311,8 @@ export const apiUrls = {
   partsEditReview,
   partsReviewUploadFiles,
   getAllPartCommonMistakes,
+  setPartReviewSampleImage,
+  getPartReviewSampleImage,
 
   tasksCreate,
   tasks,


### PR DESCRIPTION
## Changes

Added the endpoints and hooks to get/set the part review sample image. No testing done so far.


## To Do

Test
Hooks for getPartReviewSampleImage

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #3408 
