### PR TITLE
#3426 breadcrumbs and url resolution

### DIFF
--- a/src/backend/src/transformers/projects.transformer.ts
+++ b/src/backend/src/transformers/projects.transformer.ts
@@ -56,6 +56,7 @@ const projectTransformer = (project: Prisma.ProjectGetPayload<ProjectQueryArgs>)
     tasks: wbsElement.tasks.map(taskTransformer),
     materials: wbsElement.materials.map(materialTransformer),
     assemblies: wbsElement.assemblies.map(assemblyTransformer),
+    abbreviation: project.abbreviation ?? undefined,
     workPackages: project.workPackages.map((workPackage) => {
       const endDate = calculateEndDate(workPackage.startDate, workPackage.duration);
 

--- a/src/frontend/src/pages/PartPage/PartPage.tsx
+++ b/src/frontend/src/pages/PartPage/PartPage.tsx
@@ -1,94 +1,55 @@
 import { Box, Typography, Grid, Breadcrumbs } from '@mui/material';
-import { RoleEnum } from 'shared';
+import { RoleEnum, validateWBS, wbsPipe } from 'shared';
 import PartSubmissionDetails, { partReviewExample1, partReviewExample2 } from './Components/PartSubmissionDetails';
+import PageLayout from '../../components/PageLayout';
+import { routes } from '../../utils/routes';
+import { useParams } from 'react-router-dom';
+import { usePartsFromProject, useSinglePart } from '../../hooks/part-review.hooks';
+import { useSingleProject } from '../../hooks/projects.hooks';
+import LoadingIndicator from '../../components/LoadingIndicator';
+import ErrorPage from '../ErrorPage';
 
 const PartPage: React.FC = () => {
+  interface ParamTypes {
+    wbsNum: string;
+    indexNum: string;
+  }
+  const { wbsNum, indexNum } = useParams<ParamTypes>();
+
+  const {
+    data: project,
+    isLoading: projectLoading,
+    isError: projectIsError,
+    error: projectError
+  } = useSingleProject(validateWBS(wbsNum));
+
+  const {
+    data: part,
+    isLoading: partLoading,
+    isError: partIsError,
+    error: partError
+  } = useSinglePart(wbsNum, parseInt(indexNum));
+
+  if (projectLoading || !project || partLoading || !part) return <LoadingIndicator />;
+  if (projectIsError) return <ErrorPage message={projectError?.message} />;
+  if (partIsError) return <ErrorPage message={partError?.message} />;
+
+  const pageTitle = `${project.abbreviation ?? project.name}_${part.commonName}_${part.index.toString().padStart(5, '0')}`;
+
   return (
-    <Box padding={4}>
-      {/* This is where the breadcrumbs (series of links) will go */}
-      <Breadcrumbs sx={{ mb: 2 }}></Breadcrumbs>
-
-      {/* Need to query for the part title */}
-      <Typography variant="h4" fontWeight="bold" mb={3}>
-        [PROJ_PartName_PartNum]
-      </Typography>
-
-      <Grid container spacing={3}>
-        {/* The code below will be replaced by the part preview */}
-        <Grid item xs={12} md={6}>
-          <Box
-            sx={{
-              backgroundColor: 'black',
-              height: '75vh',
-              width: '50%',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              border: '2px solid white'
-            }}
-          >
-            <Typography color="white">No submission yet.</Typography>
-          </Box>
-        </Grid>
-
-        {/* The code below will be replaced by the Overview, Details, and History components */}
-        <Grid item xs={12} md={6}>
-          <Grid container spacing={2} direction="column">
-            <Grid item>
-              <Box
-                sx={{
-                  backgroundColor: 'gray',
-                  height: '24vh',
-                  width: '50%',
-                  borderRadius: 2,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  mb: 2
-                }}
-              >
-                <Typography>Overview</Typography>
-              </Box>
-              <Box
-                sx={{
-                  backgroundColor: 'gray',
-                  height: '24vh',
-                  width: '50%',
-                  borderRadius: 2,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  mb: 2
-                }}
-              ></Box>
-              <Box>
-                <PartSubmissionDetails
-                  submission={{
-                    partSubmissionId: '1',
-                    userCreated: {
-                      userId: '123',
-                      email: 'john.doe@example.com',
-                      emailId: 'john.doe@example.com',
-                      role: RoleEnum.MEMBER,
-                      permissions: [],
-                      firstName: 'John',
-                      lastName: 'Doe'
-                    },
-                    notes: 'This is a test note.',
-                    reviews: [partReviewExample1, partReviewExample2],
-                    fileIds: [],
-                    name: 'Test Part Submission',
-                    partId: '456',
-                    createdAt: new Date()
-                  }}
-                />
-              </Box>
-              <Typography>History</Typography>
-            </Grid>
-          </Grid>
-        </Grid>
-      </Grid>
-    </Box>
+    <PageLayout
+      title={pageTitle}
+      previousPages={[
+        { name: 'Projects', route: routes.PROJECTS },
+        { name: `${wbsPipe(project.wbsNum)} - ${project.name}`, route: `${routes.PROJECTS}/${wbsNum}` },
+        { name: 'Files', route: `${routes.PROJECTS}/${wbsNum}/parts-review` }
+      ]}
+    >
+      <Box>
+        <Typography>Part: {part.commonName}</Typography>
+        <Breadcrumbs sx={{ mb: 2 }}></Breadcrumbs>
+      </Box>
+    </PageLayout>
   );
 };
 

--- a/src/frontend/src/pages/PartPage/PartPage.tsx
+++ b/src/frontend/src/pages/PartPage/PartPage.tsx
@@ -1,10 +1,9 @@
-import { Box, Typography, Grid, Breadcrumbs } from '@mui/material';
-import { RoleEnum, validateWBS, wbsPipe } from 'shared';
-import PartSubmissionDetails, { partReviewExample1, partReviewExample2 } from './Components/PartSubmissionDetails';
+import { Box, Typography, Breadcrumbs } from '@mui/material';
+import { validateWBS, wbsPipe } from 'shared';
 import PageLayout from '../../components/PageLayout';
 import { routes } from '../../utils/routes';
 import { useParams } from 'react-router-dom';
-import { usePartsFromProject, useSinglePart } from '../../hooks/part-review.hooks';
+import { useSinglePart } from '../../hooks/part-review.hooks';
 import { useSingleProject } from '../../hooks/projects.hooks';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import ErrorPage from '../ErrorPage';

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/PartReview/PartsReviewPage.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/PartReview/PartsReviewPage.tsx
@@ -1,18 +1,25 @@
 import LoadingIndicator from '../../../../components/LoadingIndicator';
-import { Box } from '@mui/system';
-import { Grid, FormGroup, FormControlLabel, Typography } from '@mui/material';
+import { Box, Stack } from '@mui/system';
+import { Grid, FormGroup, FormControlLabel, Typography, Link } from '@mui/material';
 import { useState } from 'react';
 import { useCurrentUser } from '../../../../hooks/users.hooks';
-import { rankUserRole } from 'shared';
+import { Project, rankUserRole, wbsPipe } from 'shared';
 import NERSwitch from '../../../../components/NERSwitch';
 import CommonMistakes from './CommonMistakes';
+import { usePartsFromProject } from '../../../../hooks/part-review.hooks';
+import ErrorPage from '../../../ErrorPage';
+import { Link as RouterLink } from 'react-router-dom';
 
-const PartsReviewPage = () => {
+const PartsReviewPage = ({ project }: { project: Project }) => {
   const currentUser = useCurrentUser();
   const [showSubmissionGuide, setShowSubmissionGuide] = useState(() => {
     const userRole = currentUser.role;
     return rankUserRole(userRole) < rankUserRole('LEADERSHIP');
   });
+  const { data: parts, isLoading, isError, error } = usePartsFromProject(wbsPipe(project.wbsNum));
+
+  if (isLoading || !parts) return <LoadingIndicator />;
+  if (isError) return <ErrorPage message={error?.message} />;
 
   return (
     <Box>
@@ -33,7 +40,6 @@ const PartsReviewPage = () => {
         </Grid>
         <Grid item xs={12}>
           {/* The guide should be toggled off by default for admins, heads, and leads and toggled on for all other roles */}
-
           {showSubmissionGuide ? (
             <Grid container spacing={3}>
               <Grid item xs={12}>
@@ -47,6 +53,17 @@ const PartsReviewPage = () => {
           ) : (
             <LoadingIndicator /> /* Loading indicator will be replaced by a grid of all the part cards */
           )}
+          {/* temporary test component to show that parts are being displayed */}
+          <Stack>
+            Parts for this project:
+            {parts.map((part, _index) => (
+              <Box>
+                <Link component={RouterLink} to={`/projects/${wbsPipe(project.wbsNum)}/part/${part.index}`}>
+                  index:{part.index}, commonName: {part.commonName}, status: {part.status}
+                </Link>
+              </Box>
+            ))}
+          </Stack>
         </Grid>
       </Grid>
     </Box>

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
@@ -252,7 +252,7 @@ const ProjectViewContainer: React.FC<ProjectViewContainerProps> = ({ project, en
       ) : tab === 6 ? (
         <ChangeRequestTab project={project} />
       ) : (
-        <PartsReviewPage />
+        <PartsReviewPage project={project} />
       )}
       {deleteModalShow && (
         <DeleteProject modalShow={deleteModalShow} handleClose={handleDeleteClose} wbsNum={project.wbsNum} />

--- a/src/frontend/src/utils/routes.ts
+++ b/src/frontend/src/utils/routes.ts
@@ -33,7 +33,7 @@ const PROJECTS_ALL = PROJECTS + '/all';
 const PROJECTS_BY_WBS = PROJECTS + `/:wbsNum`;
 const PROJECTS_NEW = PROJECTS + `/new`;
 const WORK_PACKAGE_NEW = PROJECTS + `/work-package/new`;
-const PROJECT_PART = PROJECTS_BY_WBS + '/part';
+const PROJECT_PART = PROJECTS_BY_WBS + '/part/:indexNum';
 
 /**************** Teams Section ****************/
 const TEAMS = `/teams`;

--- a/src/shared/src/types/project-types.ts
+++ b/src/shared/src/types/project-types.ts
@@ -48,6 +48,7 @@ export interface Project extends WbsElement {
   teams: TeamPreview[];
   tasks: Task[];
   favoritedBy: UserPreview[];
+  abbreviation?: string;
 }
 
 export type ProjectPreview = Pick<


### PR DESCRIPTION
## Changes

- Made it so part pages would show up under the project URL + '/part/partid'
- added breadcrumbs
- Added hooks for getAllProjects on project parts tab and single part on a parts page

## Screenshots
<img width="1463" alt="Screenshot 2025-04-25 at 8 26 12 PM" src="https://github.com/user-attachments/assets/291817c5-a02f-4388-9063-970994be39c7" />
<img width="595" alt="Screenshot 2025-04-25 at 8 26 24 PM" src="https://github.com/user-attachments/assets/3422f90b-c703-4d81-877d-b35c08fa417a" />


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #3426 
