### PR TITLE
#3204 submission guide faq

### DIFF
--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/PartReview/PartReviewFAQs.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/PartReview/PartReviewFAQs.tsx
@@ -1,0 +1,67 @@
+import { Accordion, AccordionSummary, AccordionDetails, Typography, Box } from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { useAllPartReviewFaqs } from '../../../../hooks/part-review.hooks';
+import LoadingIndicator from '../../../../components/LoadingIndicator';
+import ErrorPage from '../../../ErrorPage';
+
+const PartReviewFAQs: React.FC = () => {
+  const { data: faqs, isLoading, error } = useAllPartReviewFaqs();
+
+  if (isLoading || !faqs) {
+    return <LoadingIndicator />;
+  }
+
+  if (error) {
+    return <ErrorPage message="Error loading part review FAQs." error={error} />;
+  }
+
+  return (
+    <Box sx={{ mt: 4 }}>
+      <Typography variant="h6" component="h2" gutterBottom sx={{ fontWeight: 'bold' }}>
+        FAQs
+      </Typography>
+      <Box sx={{ padding: 0 }}>
+        {faqs.map((faq) => (
+          <Accordion
+            key={faq.faqId}
+            sx={{
+              borderRadius: 2,
+              marginBottom: 1,
+              boxShadow: 1,
+              overflow: 'hidden',
+              '&:before': {
+                display: 'none'
+              },
+              backgroundColor: '#333333'
+            }}
+            disableGutters
+          >
+            <AccordionSummary
+              expandIcon={<ExpandMoreIcon />}
+              sx={{
+                flexDirection: 'row-reverse',
+                '& .MuiAccordionSummary-content': {
+                  marginLeft: 1
+                }
+              }}
+            >
+              <Typography variant="body1">{faq.question}</Typography>
+            </AccordionSummary>
+
+            <AccordionDetails
+              sx={{
+                paddingLeft: 8,
+                paddingBottom: 1.5,
+                marginTop: -2
+              }}
+            >
+              <Typography variant="body1">{faq.answer}</Typography>
+            </AccordionDetails>
+          </Accordion>
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+export default PartReviewFAQs;

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/PartReview/PartsReviewPage.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/PartReview/PartsReviewPage.tsx
@@ -9,6 +9,7 @@ import CommonMistakes from './CommonMistakes';
 import { usePartsFromProject } from '../../../../hooks/part-review.hooks';
 import ErrorPage from '../../../ErrorPage';
 import { Link as RouterLink } from 'react-router-dom';
+import PartReviewFAQs from './PartReviewFAQs';
 
 const PartsReviewPage = ({ project }: { project: Project }) => {
   const currentUser = useCurrentUser();
@@ -41,13 +42,24 @@ const PartsReviewPage = ({ project }: { project: Project }) => {
         <Grid item xs={12}>
           {/* The guide should be toggled off by default for admins, heads, and leads and toggled on for all other roles */}
           {showSubmissionGuide ? (
-            <Grid container spacing={3}>
-              <Grid item xs={12}>
-                <Typography variant="h4">Submission Guide</Typography>
-                <CommonMistakes />
-                {/* Submission Guide components will go here */}
-                <LoadingIndicator />
-                {/* Loading indicator will be replaced by a grid of all the part cards */}
+            <Grid item container direction="column" spacing={3} sx={{ paddingTop: '10px' }}>
+              <Typography variant="h4" sx={{ pl: 2 }}>
+                Submission Guide
+              </Typography>
+
+              <Grid container spacing={3} sx={{ paddingTop: '10px' }}>
+                <Grid item xs={12} md={6}>
+                  <Typography variant="h6" sx={{ pl: 2 }}>
+                    Sample Drawing
+                  </Typography>
+                </Grid>
+
+                <Grid item xs={12} md={6}>
+                  <Stack spacing={2}>
+                    <PartReviewFAQs />
+                    <CommonMistakes />
+                  </Stack>
+                </Grid>
               </Grid>
             </Grid>
           ) : (


### PR DESCRIPTION
## Changes

- Created accordion component to display FAQs on the parts review submission guide
- Added component to Submission Guide on Parts Review Page
- Also reformatted Submission Guide to more closely reflect the style defined in the epic


## Screenshots

<img width="613" alt="Screenshot 2025-04-30 at 2 20 31 PM" src="https://github.com/user-attachments/assets/7c26adf7-815b-4dac-93d0-15bf2b74ac48" />

<img width="619" alt="Screenshot 2025-04-30 at 2 20 51 PM" src="https://github.com/user-attachments/assets/4520d125-3b31-46eb-9bd8-c78dc992c143" />

<img width="1431" alt="Screenshot 2025-04-30 at 2 21 15 PM" src="https://github.com/user-attachments/assets/88afb6b1-308e-4ae6-b8a6-d4fcaf2339f9" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3204
