### PR TITLE
#3444 total amount spent modal now accounts for all index codes

### DIFF
--- a/src/frontend/src/pages/FinancePage/FinanceComponents/TotalAmountSpentModal.tsx
+++ b/src/frontend/src/pages/FinancePage/FinanceComponents/TotalAmountSpentModal.tsx
@@ -1,38 +1,61 @@
-import { ReimbursementRequest } from 'shared';
-import NERModal from '../../../components/NERModal';
+import React from 'react';
 import { Box } from '@mui/material';
-import DetailDisplay from '../../../components/DetailDisplay';
-import { centsToDollar } from '../../../utils/pipes';
+import { ReimbursementRequest } from 'shared';
+import { useGetAllIndexCodes } from '../../../hooks/finance.hooks';
+import ErrorPage from '../../ErrorPage';
+import LoadingIndicator from '../../../components/LoadingIndicator';
 import { isReimbursementRequestDenied } from '../../../utils/reimbursement-request.utils';
+import { centsToDollar } from '../../../utils/pipes';
+import NERModal from '../../../components/NERModal';
+import DetailDisplay from '../../../components/DetailDisplay';
 
 interface TotalAmountSpentModalProps {
   open: boolean;
-  allReimbursementRequests: ReimbursementRequest[];
   onHide: () => void;
+  allReimbursementRequests: ReimbursementRequest[];
 }
-const TotalAmountSpentModal: React.FC<TotalAmountSpentModalProps> = ({ open, allReimbursementRequests, onHide }) => {
-  const unDeniedReimbursementRequests = allReimbursementRequests.filter((request) => !isReimbursementRequestDenied(request));
-  const cashAccountSpent = centsToDollar(
-    unDeniedReimbursementRequests
-      .filter((request) => request.indexCode.name === 'CASH')
-      .reduce((acc, curr) => {
-        return acc + curr.totalCost;
-      }, 0)
-  );
 
-  const budgetAccountSpent = centsToDollar(
-    unDeniedReimbursementRequests
-      .filter((request) => request.indexCode.name === 'BUDGET')
-      .reduce((acc, curr) => {
-        return acc + curr.totalCost;
-      }, 0)
+const TotalAmountSpentModal: React.FC<TotalAmountSpentModalProps> = ({ open, onHide, allReimbursementRequests }) => {
+  const {
+    data: indexCodes,
+    isLoading: indexCodesIsLoading,
+    isError: indexCodesIsError,
+    error: indexCodesError
+  } = useGetAllIndexCodes();
+
+  if (indexCodesIsError) {
+    return <ErrorPage error={indexCodesError} />;
+  }
+
+  if (!indexCodes || indexCodesIsLoading) {
+    return <LoadingIndicator />;
+  }
+
+  const unDeniedReimbursementRequests = allReimbursementRequests.filter((request) => !isReimbursementRequestDenied(request));
+
+  const indexCodeSpendingMap = indexCodes.reduce(
+    (acc, indexCode) => {
+      const totalCents = unDeniedReimbursementRequests
+        .filter((request) => request.indexCode.indexCodeId === indexCode.indexCodeId)
+        .reduce((sum, request) => sum + request.totalCost, 0);
+
+      acc.push({
+        name: indexCode.name,
+        code: indexCode.code,
+        amount: centsToDollar(totalCents)
+      });
+
+      return acc;
+    },
+    [] as { name: string; code: string; amount: string }[]
   );
 
   return (
-    <NERModal open={open} title={'Total Amount Spent'} onHide={onHide} hideFormButtons showCloseButton>
-      <Box display={'flex'} gap={2}>
-        <DetailDisplay label={'Cash (830667)'} content={'$' + cashAccountSpent} />
-        <DetailDisplay label={'Budget (800462)'} content={'$' + budgetAccountSpent} />
+    <NERModal open={open} title="Total Amount Spent" onHide={onHide} hideFormButtons showCloseButton>
+      <Box display="flex" flexDirection="column" gap={2}>
+        {indexCodeSpendingMap.map((entry) => (
+          <DetailDisplay key={entry.name} label={`${entry.name} (${entry.code})`} content={`$${entry.amount}`} />
+        ))}
       </Box>
     </NERModal>
   );


### PR DESCRIPTION
## Changes

Changed the total amount spent modal to now account for all index codes in the db.

## Screenshots

<img width="496" alt="Screenshot 2025-05-02 at 7 44 16 PM" src="https://github.com/user-attachments/assets/7e68d4a1-c9e3-489a-9499-b876cb487088" />
<img width="1470" alt="Screenshot 2025-05-02 at 7 43 56 PM" src="https://github.com/user-attachments/assets/b64933b5-bfb0-4655-9bd0-1fb8c714fc07" />


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3444
