### PR TITLE
#3440 put pie chart on each project's page

### DIFF
--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectDetails.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectDetails.tsx
@@ -5,7 +5,7 @@
 
 import { Construction, Work } from '@mui/icons-material';
 import ScheduleIcon from '@mui/icons-material/Schedule';
-import { Project, WorkPackage, wbsPipe } from 'shared';
+import { Project, wbsPipe } from 'shared';
 import { datePipe, dollarsPipe, fullNamePipe, weeksPipe } from '../../../utils/pipes';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
@@ -45,207 +45,103 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ project }) => {
     return <LoadingIndicator />;
   }
 
-  const isEmpty =
+  const emptyRRData =
     rrData.pendingLeadership === 0 &&
     rrData.pendingFinance === 0 &&
     rrData.submittedToSabo === 0 &&
     rrData.reimbursed === 0 &&
     rrData.available === 0;
 
-  if (isEmpty) {
-    return (
-      <Grid container display="flex" flexDirection="row" sx={{ mt: '10px' }}>
-        <Grid item sm={12} md={6} sx={{ mb: 2 }}>
-          <Typography
-            variant="h5"
-            sx={{
-              cursor: 'pointer',
-              mb: 1
-            }}
-          >
-            Details
-          </Typography>
+  const detailGridSize = emptyRRData ? { sm: 12, md: 6 } : { xs: 12, md: 3 };
+  const summaryGridSize = emptyRRData ? { sm: 12, md: 6 } : { xs: 12, md: 3 };
 
-          <Grid container spacing={2}>
-            <Grid item display="flex" alignItems="center" xs={12} sm={6}>
-              <GroupIcon sx={{ mr: 2 }} />
-              <DetailDisplay
-                label={project.teams.length > 1 ? 'Teams' : 'Team'}
-                content={getProjectTeamsName(project)}
-                paddingRight={1}
-              />
-            </Grid>
-            <Grid item display="flex" alignItems="center" xs={12} sm={6}>
-              <Construction sx={{ mr: 2 }} />
-              <DetailDisplay label="Project Lead" content={fullNamePipe(project.lead)} paddingRight={1} />
-            </Grid>
-            <Grid item display="flex" alignItems="center" xs={12} sm={6}>
-              <ScheduleIcon sx={{ mr: 2 }} />
-              <DetailDisplay label="Start Date" content={datePipe(project.startDate) || 'n/a'} paddingRight={1} />
-            </Grid>
-            <Grid item display="flex" alignItems="center" xs={12} sm={6}>
-              <Work sx={{ mr: 2 }} />
-              <DetailDisplay label="Project Manager" content={fullNamePipe(project.manager)} paddingRight={1} />
-            </Grid>
-            <Grid item display="flex" alignItems="center" xs={12} sm={6}>
-              <ScheduleIcon sx={{ mr: 2 }} />
-              <DetailDisplay label="End Date" content={datePipe(project.endDate) || 'n/a'} paddingRight={1} />
-            </Grid>
-            <Grid item display="flex" alignItems="center" xs={12} sm={6}>
-              <AttachMoneyIcon sx={{ mr: 2 }} />
-              <DetailDisplay label="Budget" content={dollarsPipe(project.budget)} paddingRight={1} />
-            </Grid>
-            <Grid item display="flex" alignItems="center" xs={12} sm={6}>
-              <ScheduleIcon sx={{ mr: 2 }} />
-              <DetailDisplay label="Duration" content={weeksPipe(project.duration)} paddingRight={1} />
-            </Grid>
-          </Grid>
-        </Grid>
+  const detailItems = [
+    {
+      icon: <GroupIcon sx={{ mr: emptyRRData ? 2 : 1 }} />,
+      label: project.teams.length > 1 ? 'Teams' : 'Team',
+      content: getProjectTeamsName(project)
+    },
+    {
+      icon: <Construction sx={{ mr: emptyRRData ? 2 : 1 }} />,
+      label: 'Project Lead',
+      content: fullNamePipe(project.lead)
+    },
+    {
+      icon: <Work sx={{ mr: emptyRRData ? 2 : 1 }} />,
+      label: 'Project Manager',
+      content: fullNamePipe(project.manager)
+    },
+    {
+      icon: <ScheduleIcon sx={{ mr: emptyRRData ? 2 : 1 }} />,
+      label: 'Start Date',
+      content: datePipe(project.startDate) || 'n/a'
+    },
+    {
+      icon: <ScheduleIcon sx={{ mr: emptyRRData ? 2 : 1 }} />,
+      label: 'Duration',
+      content: weeksPipe(project.duration)
+    },
+    {
+      icon: <ScheduleIcon sx={{ mr: emptyRRData ? 2 : 1 }} />,
+      label: 'End Date',
+      content: datePipe(project.endDate) || 'n/a'
+    },
+    ...(emptyRRData
+      ? [
+          {
+            icon: <AttachMoneyIcon sx={{ mr: 2 }} />,
+            label: 'Budget',
+            content: dollarsPipe(project.budget)
+          }
+        ]
+      : [])
+  ];
 
-        <Grid container display="flex" flexDirection="row" item sm={12} md={6} sx={{ mb: 2 }}>
-          <Grid item xs sx={{ mb: 2 }}>
-            <Typography
-              variant="h5"
-              sx={{
-                mb: 1,
-                cursor: 'pointer'
-              }}
-            >
-              Summary
-            </Typography>
-            <Typography>{project.summary}</Typography>
-          </Grid>
-
-          <Grid container item xs={12}>
-            <Grid item xs={12}>
-              <Typography
-                variant="h5"
-                sx={{
-                  mb: 1,
-                  cursor: 'pointer'
-                }}
-              >
-                Links
-              </Typography>
-            </Grid>
-            {project.links.map((link) => (
-              <Grid item xs={4} key={link.linkId}>
-                <LinkView link={link} />
-              </Grid>
-            ))}
-          </Grid>
-        </Grid>
-        <Grid container item display="flex">
-          <Grid item xs={12}>
-            <Typography
-              variant="h5"
-              sx={{
-                mb: 1,
-                cursor: 'pointer'
-              }}
-            >
-              Work Packages
-            </Typography>
-          </Grid>
-          {project.workPackages.map((ele: WorkPackage) => (
-            <Grid item xs={12} key={wbsPipe(ele.wbsNum)} sx={{ mb: 0.5 }}>
-              <WorkPackageSummary workPackage={ele} />
+  return (
+    <Grid container spacing={2} sx={{ mt: '10px' }}>
+      <Grid item {...detailGridSize} sx={{ mb: 2 }}>
+        <Typography variant="h5" sx={{ cursor: 'pointer', mb: 1 }}>
+          Details
+        </Typography>
+        <Grid container spacing={2}>
+          {detailItems.map((item, index) => (
+            <Grid item display="flex" alignItems="center" xs={12} sm={emptyRRData ? 6 : 12} key={index}>
+              {item.icon}
+              <DetailDisplay label={item.label} content={item.content} paddingRight={1} />
             </Grid>
           ))}
         </Grid>
       </Grid>
-    );
-  }
-
-  return (
-    <Grid container spacing={2} sx={{ mt: '10px' }}>
-      <Grid item xs={12} md={3} sx={{ mb: 2 }}>
-        <Typography
-          variant="h5"
-          sx={{
-            cursor: 'pointer',
-            mb: 1
-          }}
-        >
-          Details
-        </Typography>
-        <Grid container spacing={2}>
-          <Grid item display="flex" alignItems="center" xs={12}>
-            <GroupIcon sx={{ mr: 1 }} />
-            <DetailDisplay
-              label={project.teams.length > 1 ? 'Teams' : 'Team'}
-              content={getProjectTeamsName(project)}
-              paddingRight={1}
-            />
-          </Grid>
-          <Grid item display="flex" alignItems="center" xs={12}>
-            <Construction sx={{ mr: 1 }} />
-            <DetailDisplay label="Project Lead" content={fullNamePipe(project.lead)} paddingRight={1} />
-          </Grid>
-          <Grid item display="flex" alignItems="center" xs={12}>
-            <Work sx={{ mr: 1 }} />
-            <DetailDisplay label="Project Manager" content={fullNamePipe(project.manager)} paddingRight={1} />
-          </Grid>
-          <Grid item display="flex" alignItems="center" xs={12}>
-            <ScheduleIcon sx={{ mr: 1 }} />
-            <DetailDisplay label="Start Date" content={datePipe(project.startDate) || 'n/a'} paddingRight={1} />
-          </Grid>
-          <Grid item display="flex" alignItems="center" xs={12}>
-            <ScheduleIcon sx={{ mr: 1 }} />
-            <DetailDisplay label="End Date" content={datePipe(project.endDate) || 'n/a'} paddingRight={1} />
-          </Grid>
-          <Grid item display="flex" alignItems="center" xs={12}>
-            <ScheduleIcon sx={{ mr: 1 }} />
-            <DetailDisplay label="Duration" content={weeksPipe(project.duration)} paddingRight={1} />
-          </Grid>
+      {!emptyRRData && (
+        <Grid item xs={12} md={3} sx={{ mb: 7, mr: 29 }}>
+          <Typography variant="h5" sx={{ cursor: 'pointer', mb: -4 }}>
+            Budget
+          </Typography>
+          <PieChart
+            totalBalance={rrData.totalBudget}
+            pendingLeadership={rrData.pendingLeadership}
+            pendingFinance={rrData.pendingFinance}
+            submittedToSABO={rrData.submittedToSabo}
+            reimbursed={rrData.reimbursed}
+            available={rrData.available}
+          />
         </Grid>
-      </Grid>
-      <Grid item xs={12} md={3} sx={{ mb: 7, mr: 29 }}>
-        <Typography
-          variant="h5"
-          sx={{
-            cursor: 'pointer',
-            mb: -4
-          }}
-        >
-          Budget
-        </Typography>
-        <PieChart
-          totalBalance={rrData.totalBudget}
-          pendingLeadership={rrData.pendingLeadership}
-          pendingFinance={rrData.pendingFinance}
-          submittedToSABO={rrData.submittedToSabo}
-          reimbursed={rrData.reimbursed}
-          available={rrData.available}
-        />
-      </Grid>
-      <Grid item xs={12} md={3} sx={{ mb: 2 }}>
+      )}
+      <Grid item {...summaryGridSize} sx={{ mb: emptyRRData ? 2 : 7 }}>
         <Grid container spacing={2}>
           <Grid item xs={12}>
-            <Typography
-              variant="h5"
-              sx={{
-                cursor: 'pointer',
-                mb: 1
-              }}
-            >
+            <Typography variant="h5" sx={{ cursor: 'pointer', mb: 1 }}>
               Summary
             </Typography>
             <Typography>{project.summary}</Typography>
           </Grid>
           <Grid item xs={12}>
-            <Typography
-              variant="h5"
-              sx={{
-                cursor: 'pointer',
-                mb: 1
-              }}
-            >
+            <Typography variant="h5" sx={{ cursor: 'pointer', mb: 1 }}>
               Links
             </Typography>
             <Grid container spacing={1}>
               {project.links.map((link) => (
-                <Grid item xs={12} key={link.linkId}>
+                <Grid item xs={emptyRRData ? 4 : 12} key={link.linkId}>
                   <LinkView link={link} />
                 </Grid>
               ))}
@@ -254,16 +150,10 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ project }) => {
         </Grid>
       </Grid>
       <Grid item xs={12}>
-        <Typography
-          variant="h5"
-          sx={{
-            mb: 2,
-            cursor: 'pointer'
-          }}
-        >
+        <Typography variant="h5" sx={{ mb: 2, cursor: 'pointer' }}>
           Work Packages
         </Typography>
-        {project.workPackages.map((ele: WorkPackage) => (
+        {project.workPackages.map((ele) => (
           <Grid item xs={12} key={wbsPipe(ele.wbsNum)} sx={{ mb: 0.5 }}>
             <WorkPackageSummary workPackage={ele} />
           </Grid>

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectDetails.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectDetails.tsx
@@ -45,16 +45,12 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ project }) => {
     return <LoadingIndicator />;
   }
 
-  let isEmpty = false;
-  if (
+  const isEmpty =
     rrData.pendingLeadership === 0 &&
     rrData.pendingFinance === 0 &&
     rrData.submittedToSabo === 0 &&
     rrData.reimbursed === 0 &&
-    rrData.available === 0
-  ) {
-    isEmpty = true;
-  }
+    rrData.available === 0;
 
   if (isEmpty) {
     return (

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectDetails.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectDetails.tsx
@@ -5,7 +5,6 @@
 
 import { Construction, Work } from '@mui/icons-material';
 import ScheduleIcon from '@mui/icons-material/Schedule';
-import AttachMoneyIcon from '@mui/icons-material/AttachMoney';
 import { Project, WorkPackage, wbsPipe } from 'shared';
 import { datePipe, dollarsPipe, fullNamePipe, weeksPipe } from '../../../utils/pipes';
 import Grid from '@mui/material/Grid';
@@ -14,6 +13,11 @@ import WorkPackageSummary from './WorkPackageSummary';
 import DetailDisplay from '../../../components/DetailDisplay';
 import LinkView from '../../../components/Link/LinkView';
 import GroupIcon from '@mui/icons-material/Group';
+import { useGetReimbursementRequestProjectData } from '../../../hooks/finance.hooks';
+import ErrorPage from '../../ErrorPage';
+import LoadingIndicator from '../../../components/LoadingIndicator';
+import PieChart from '../../FinancePage/FinanceComponents/PieChart';
+import AttachMoneyIcon from '@mui/icons-material/AttachMoney';
 
 export const getProjectTeamsName = (project: Project): string => {
   return project.teams.map((team) => team.teamName).join(', ');
@@ -24,9 +28,142 @@ interface ProjectDetailsProps {
 }
 
 const ProjectDetails: React.FC<ProjectDetailsProps> = ({ project }) => {
+  const { id: projectId, startDate, endDate } = project;
+
+  const {
+    data: rrData,
+    isLoading: rrDataIsLoading,
+    isError: rrDataIsError,
+    error: rrDataError
+  } = useGetReimbursementRequestProjectData({ projectId, startDate, endDate });
+
+  if (rrDataIsError) {
+    return <ErrorPage error={rrDataError} />;
+  }
+
+  if (!rrData || rrDataIsLoading) {
+    return <LoadingIndicator />;
+  }
+
+  let isEmpty = false;
+  if (
+    rrData.pendingLeadership === 0 &&
+    rrData.pendingFinance === 0 &&
+    rrData.submittedToSabo === 0 &&
+    rrData.reimbursed === 0 &&
+    rrData.available === 0
+  ) {
+    isEmpty = true;
+  }
+
+  if (isEmpty) {
+    return (
+      <Grid container display="flex" flexDirection="row" sx={{ mt: '10px' }}>
+        <Grid item sm={12} md={6} sx={{ mb: 2 }}>
+          <Typography
+            variant="h5"
+            sx={{
+              cursor: 'pointer',
+              mb: 1
+            }}
+          >
+            Details
+          </Typography>
+
+          <Grid container spacing={2}>
+            <Grid item display="flex" alignItems="center" xs={12} sm={6}>
+              <GroupIcon sx={{ mr: 2 }} />
+              <DetailDisplay
+                label={project.teams.length > 1 ? 'Teams' : 'Team'}
+                content={getProjectTeamsName(project)}
+                paddingRight={1}
+              />
+            </Grid>
+            <Grid item display="flex" alignItems="center" xs={12} sm={6}>
+              <Construction sx={{ mr: 2 }} />
+              <DetailDisplay label="Project Lead" content={fullNamePipe(project.lead)} paddingRight={1} />
+            </Grid>
+            <Grid item display="flex" alignItems="center" xs={12} sm={6}>
+              <ScheduleIcon sx={{ mr: 2 }} />
+              <DetailDisplay label="Start Date" content={datePipe(project.startDate) || 'n/a'} paddingRight={1} />
+            </Grid>
+            <Grid item display="flex" alignItems="center" xs={12} sm={6}>
+              <Work sx={{ mr: 2 }} />
+              <DetailDisplay label="Project Manager" content={fullNamePipe(project.manager)} paddingRight={1} />
+            </Grid>
+            <Grid item display="flex" alignItems="center" xs={12} sm={6}>
+              <ScheduleIcon sx={{ mr: 2 }} />
+              <DetailDisplay label="End Date" content={datePipe(project.endDate) || 'n/a'} paddingRight={1} />
+            </Grid>
+            <Grid item display="flex" alignItems="center" xs={12} sm={6}>
+              <AttachMoneyIcon sx={{ mr: 2 }} />
+              <DetailDisplay label="Budget" content={dollarsPipe(project.budget)} paddingRight={1} />
+            </Grid>
+            <Grid item display="flex" alignItems="center" xs={12} sm={6}>
+              <ScheduleIcon sx={{ mr: 2 }} />
+              <DetailDisplay label="Duration" content={weeksPipe(project.duration)} paddingRight={1} />
+            </Grid>
+          </Grid>
+        </Grid>
+
+        <Grid container display="flex" flexDirection="row" item sm={12} md={6} sx={{ mb: 2 }}>
+          <Grid item xs sx={{ mb: 2 }}>
+            <Typography
+              variant="h5"
+              sx={{
+                mb: 1,
+                cursor: 'pointer'
+              }}
+            >
+              Summary
+            </Typography>
+            <Typography>{project.summary}</Typography>
+          </Grid>
+
+          <Grid container item xs={12}>
+            <Grid item xs={12}>
+              <Typography
+                variant="h5"
+                sx={{
+                  mb: 1,
+                  cursor: 'pointer'
+                }}
+              >
+                Links
+              </Typography>
+            </Grid>
+            {project.links.map((link) => (
+              <Grid item xs={4} key={link.linkId}>
+                <LinkView link={link} />
+              </Grid>
+            ))}
+          </Grid>
+        </Grid>
+        <Grid container item display="flex">
+          <Grid item xs={12}>
+            <Typography
+              variant="h5"
+              sx={{
+                mb: 1,
+                cursor: 'pointer'
+              }}
+            >
+              Work Packages
+            </Typography>
+          </Grid>
+          {project.workPackages.map((ele: WorkPackage) => (
+            <Grid item xs={12} key={wbsPipe(ele.wbsNum)} sx={{ mb: 0.5 }}>
+              <WorkPackageSummary workPackage={ele} />
+            </Grid>
+          ))}
+        </Grid>
+      </Grid>
+    );
+  }
+
   return (
-    <Grid container display="flex" flexDirection="row" sx={{ mt: '10px' }}>
-      <Grid item sm={12} md={6} sx={{ mb: 2 }}>
+    <Grid container spacing={2} sx={{ mt: '10px' }}>
+      <Grid item xs={12} md={3} sx={{ mb: 2 }}>
         <Typography
           variant="h5"
           sx={{
@@ -36,88 +173,100 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ project }) => {
         >
           Details
         </Typography>
-
         <Grid container spacing={2}>
-          <Grid item display="flex" alignItems="center" xs={12} sm={6}>
-            <GroupIcon sx={{ mr: 2 }} />
+          <Grid item display="flex" alignItems="center" xs={12}>
+            <GroupIcon sx={{ mr: 1 }} />
             <DetailDisplay
               label={project.teams.length > 1 ? 'Teams' : 'Team'}
               content={getProjectTeamsName(project)}
               paddingRight={1}
             />
           </Grid>
-          <Grid item display="flex" alignItems="center" xs={12} sm={6}>
-            <Construction sx={{ mr: 2 }} />
+          <Grid item display="flex" alignItems="center" xs={12}>
+            <Construction sx={{ mr: 1 }} />
             <DetailDisplay label="Project Lead" content={fullNamePipe(project.lead)} paddingRight={1} />
           </Grid>
-          <Grid item display="flex" alignItems="center" xs={12} sm={6}>
-            <ScheduleIcon sx={{ mr: 2 }} />
-            <DetailDisplay label="Start Date" content={datePipe(project.startDate) || 'n/a'} paddingRight={1} />
-          </Grid>
-          <Grid item display="flex" alignItems="center" xs={12} sm={6}>
-            <Work sx={{ mr: 2 }} />
+          <Grid item display="flex" alignItems="center" xs={12}>
+            <Work sx={{ mr: 1 }} />
             <DetailDisplay label="Project Manager" content={fullNamePipe(project.manager)} paddingRight={1} />
           </Grid>
-          <Grid item display="flex" alignItems="center" xs={12} sm={6}>
-            <ScheduleIcon sx={{ mr: 2 }} />
+          <Grid item display="flex" alignItems="center" xs={12}>
+            <ScheduleIcon sx={{ mr: 1 }} />
+            <DetailDisplay label="Start Date" content={datePipe(project.startDate) || 'n/a'} paddingRight={1} />
+          </Grid>
+          <Grid item display="flex" alignItems="center" xs={12}>
+            <ScheduleIcon sx={{ mr: 1 }} />
             <DetailDisplay label="End Date" content={datePipe(project.endDate) || 'n/a'} paddingRight={1} />
           </Grid>
-          <Grid item display="flex" alignItems="center" xs={12} sm={6}>
-            <AttachMoneyIcon sx={{ mr: 2 }} />
-            <DetailDisplay label="Budget" content={dollarsPipe(project.budget)} paddingRight={1} />
-          </Grid>
-          <Grid item display="flex" alignItems="center" xs={12} sm={6}>
-            <ScheduleIcon sx={{ mr: 2 }} />
+          <Grid item display="flex" alignItems="center" xs={12}>
+            <ScheduleIcon sx={{ mr: 1 }} />
             <DetailDisplay label="Duration" content={weeksPipe(project.duration)} paddingRight={1} />
           </Grid>
         </Grid>
       </Grid>
-
-      <Grid container display="flex" flexDirection="row" item sm={12} md={6} sx={{ mb: 2 }}>
-        <Grid item xs sx={{ mb: 2 }}>
-          <Typography
-            variant="h5"
-            sx={{
-              mb: 1,
-              cursor: 'pointer'
-            }}
-          >
-            Summary
-          </Typography>
-          <Typography>{project.summary}</Typography>
-        </Grid>
-
-        <Grid container item xs={12}>
+      <Grid item xs={12} md={3} sx={{ mb: 7, mr: 29 }}>
+        <Typography
+          variant="h5"
+          sx={{
+            cursor: 'pointer',
+            mb: -4
+          }}
+        >
+          Budget
+        </Typography>
+        <PieChart
+          totalBalance={rrData.totalBudget}
+          pendingLeadership={rrData.pendingLeadership}
+          pendingFinance={rrData.pendingFinance}
+          submittedToSABO={rrData.submittedToSabo}
+          reimbursed={rrData.reimbursed}
+          available={rrData.available}
+        />
+      </Grid>
+      <Grid item xs={12} md={3} sx={{ mb: 2 }}>
+        <Grid container spacing={2}>
           <Grid item xs={12}>
             <Typography
               variant="h5"
               sx={{
-                mb: 1,
-                cursor: 'pointer'
+                cursor: 'pointer',
+                mb: 1
+              }}
+            >
+              Summary
+            </Typography>
+            <Typography>{project.summary}</Typography>
+          </Grid>
+          <Grid item xs={12}>
+            <Typography
+              variant="h5"
+              sx={{
+                cursor: 'pointer',
+                mb: 1
               }}
             >
               Links
             </Typography>
-          </Grid>
-          {project.links.map((link) => (
-            <Grid item xs={4} key={link.linkId}>
-              <LinkView link={link} />
+            <Grid container spacing={1}>
+              {project.links.map((link) => (
+                <Grid item xs={12} key={link.linkId}>
+                  <LinkView link={link} />
+                </Grid>
+              ))}
             </Grid>
-          ))}
+          </Grid>
         </Grid>
       </Grid>
-      <Grid container item display="flex">
-        <Grid item xs={12}>
-          <Typography
-            variant="h5"
-            sx={{
-              mb: 1,
-              cursor: 'pointer'
-            }}
-          >
-            Work Packages
-          </Typography>
-        </Grid>
+      <Grid item xs={12}>
+        <Typography
+          variant="h5"
+          sx={{
+            mb: 2,
+            cursor: 'pointer'
+          }}
+        >
+          Work Packages
+        </Typography>
         {project.workPackages.map((ele: WorkPackage) => (
           <Grid item xs={12} key={wbsPipe(ele.wbsNum)} sx={{ mb: 0.5 }}>
             <WorkPackageSummary workPackage={ele} />

--- a/src/frontend/src/tests/pages/ProjectDetailPage/ProjectViewContainer.test.tsx
+++ b/src/frontend/src/tests/pages/ProjectDetailPage/ProjectViewContainer.test.tsx
@@ -10,11 +10,18 @@ import { exampleAdminUser, exampleGuestUser } from '../../test-support/test-data
 import ProjectViewContainer from '../../../pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer';
 import { WorkPackageStage } from 'shared/src/types/work-package-types';
 import * as userHooks from '../../../hooks/users.hooks';
+import * as financeHooks from '../../../hooks/finance.hooks';
 import * as authHooks from '../../../hooks/auth.hooks';
 import * as wpHooks from '../../../hooks/work-packages.hooks';
 import * as bomHooks from '../../../hooks/bom.hooks';
-import { mockManyMaterials, mockManyWorkPackages, mockUseUsersFavoriteProjects } from '../../test-support/mock-hooks';
+import {
+  mockManyMaterials,
+  mockManyWorkPackages,
+  mockUseGetReimbursementRequestProjectData,
+  mockUseUsersFavoriteProjects
+} from '../../test-support/mock-hooks';
 import { exampleAllWorkPackages } from '../../test-support/test-data/work-packages.stub';
+import { exampleRRData } from '../../test-support/test-data/finance.stubs';
 
 vi.mock('../../../utils/axios');
 vi.mock('../../../hooks/toasts.hooks');
@@ -31,15 +38,24 @@ const renderComponent = () => {
 
 describe('Rendering Project View Container', () => {
   beforeEach(() => {
+    global.ResizeObserver = vi.fn().mockImplementation(() => ({
+      observe: vi.fn(),
+      unobserve: vi.fn(),
+      disconnect: vi.fn()
+    }));
     vi.spyOn(authHooks, 'useAuth').mockReturnValue(mockAuth(false, exampleAdminUser));
     vi.spyOn(userHooks, 'useCurrentUser').mockReturnValue(exampleAdminUser);
     vi.spyOn(userHooks, 'useUsersFavoriteProjects').mockReturnValue(mockUseUsersFavoriteProjects());
     vi.spyOn(wpHooks, 'useGetManyWorkPackages').mockReturnValue(mockManyWorkPackages(exampleAllWorkPackages));
     vi.spyOn(bomHooks, 'useGetMaterialsForWbsElement').mockReturnValue(mockManyMaterials([]));
+    vi.spyOn(financeHooks, 'useGetReimbursementRequestProjectData').mockReturnValue(
+      mockUseGetReimbursementRequestProjectData(exampleRRData)
+    );
   });
 
-  it('renders the provided project', () => {
+  it('renders the provided project', async () => {
     renderComponent();
+    await screen.findAllByText('1.1.0 - Impact Attenuator');
     expect(screen.getAllByText('1.1.0 - Impact Attenuator').length).toEqual(2);
     expect(screen.getByText('Details')).toBeInTheDocument();
     expect(screen.getByText('Work Packages')).toBeInTheDocument();

--- a/src/frontend/src/tests/test-support/mock-hooks.ts
+++ b/src/frontend/src/tests/test-support/mock-hooks.ts
@@ -4,6 +4,7 @@ import {
   DescriptionBullet,
   Material,
   Project,
+  ReimbursementRequestData,
   Task,
   TaskPriority,
   TaskStatus,
@@ -140,3 +141,6 @@ export const mockManyWorkPackages = (workPackages: WorkPackage[]) =>
 
 export const mockManyMaterials = (materials: Material[]) =>
   mockUseQueryResult<Material[]>(false, false, materials, new Error());
+
+export const mockUseGetReimbursementRequestProjectData = (rrData: ReimbursementRequestData) =>
+  mockUseQueryResult<ReimbursementRequestData>(false, false, rrData, new Error());

--- a/src/frontend/src/tests/test-support/test-data/finance.stubs.ts
+++ b/src/frontend/src/tests/test-support/test-data/finance.stubs.ts
@@ -1,0 +1,10 @@
+import { ReimbursementRequestData } from 'shared';
+
+export const exampleRRData: ReimbursementRequestData = {
+  totalBudget: 1000,
+  pendingLeadership: 200,
+  pendingFinance: 100,
+  submittedToSabo: 300,
+  reimbursed: 200,
+  available: 200
+};


### PR DESCRIPTION
## Changes

I added the pie chart to each project's page only if there was data available. If not, I left the page the same. 

## Screenshots

with data:
<img width="1470" alt="Screenshot 2025-05-06 at 5 05 26 PM" src="https://github.com/user-attachments/assets/a5aaea10-2fee-4d85-9fb5-6d9aed7c268c" />
<img width="1470" alt="Screenshot 2025-05-06 at 5 05 33 PM" src="https://github.com/user-attachments/assets/2b70a260-3699-471c-9692-317ff511815a" />

without data:
<img width="1470" alt="Screenshot 2025-05-06 at 4 59 46 PM" src="https://github.com/user-attachments/assets/d28edb55-8b0a-458b-b6ca-3a4dddaa4614" />


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3440
