### PR TITLE
#2314 add zoom info buttons

### DIFF
--- a/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/FinalizeDesignReviewDetailsModal.tsx
+++ b/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/FinalizeDesignReviewDetailsModal.tsx
@@ -115,10 +115,7 @@ const FinalizeDesignReviewDetailsModal = ({
       {meetingType.includes('virtual') && (
         <Box style={{ display: 'flex', marginBottom: 20, alignItems: 'center' }}>
           <Typography style={{ fontSize: '1.2em', marginRight: 5 }}>Zoom Link:</Typography>
-          <Tooltip
-            title="Double check that your Zoom link is publicly accessible and does not require a password."
-            placement="right"
-          >
+          <Tooltip title="Ensure your Zoom Link is Publicly Accessible and Does Not Require a Password." placement="right">
             <HelpIcon style={{ fontSize: 'medium', marginRight: 96 }} />
           </Tooltip>
           <ReactHookTextField name="zoomLink" control={control} sx={{ width: 0.48 }} errorMessage={errors.zoomLink} />

--- a/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/FinalizeDesignReviewDetailsModal.tsx
+++ b/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/FinalizeDesignReviewDetailsModal.tsx
@@ -1,4 +1,5 @@
-import { Box, Grid, Link, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material';
+import { Box, Grid, Link, ToggleButton, ToggleButtonGroup, Typography, Tooltip } from '@mui/material';
+import HelpIcon from '@mui/icons-material/Help';
 import { useState } from 'react';
 import { DesignReview, wbsPipe } from 'shared';
 import { meetingStartTimePipe } from '../../../utils/pipes';
@@ -113,7 +114,13 @@ const FinalizeDesignReviewDetailsModal = ({
       </Box>
       {meetingType.includes('virtual') && (
         <Box style={{ display: 'flex', marginBottom: 20, alignItems: 'center' }}>
-          <Typography style={{ fontSize: '1.2em', marginRight: 118 }}>Zoom Link:</Typography>
+          <Typography style={{ fontSize: '1.2em', marginRight: 5 }}>Zoom Link:</Typography>
+          <Tooltip
+            title="Double check that your Zoom link is publicly accessible and does not require a password."
+            placement="right"
+          >
+            <HelpIcon style={{ fontSize: 'medium', marginRight: 96 }} />
+          </Tooltip>
           <ReactHookTextField name="zoomLink" control={control} sx={{ width: 0.48 }} errorMessage={errors.zoomLink} />
         </Box>
       )}

--- a/src/frontend/src/pages/SettingsPage/UserScheduleSettings/UserScheduleSettingsEdit.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserScheduleSettings/UserScheduleSettingsEdit.tsx
@@ -4,7 +4,8 @@
  */
 
 import * as yup from 'yup';
-import { FormControl, FormLabel, Grid, TextField, Typography } from '@mui/material';
+import { FormControl, FormLabel, Grid, TextField, Typography, Tooltip } from '@mui/material';
+import HelpIcon from '@mui/icons-material/Help';
 import { Controller, useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { NERButton } from '../../../components/NERButton';
@@ -120,6 +121,12 @@ const UserScheduleSettingsEdit: React.FC<UserScheduleSettingsEditProps> = ({
           <FormControl fullWidth>
             <FormLabel sx={{ display: 'flex' }}>
               <Typography sx={{ whiteSpace: 'nowrap' }}>Personal Zoom Link</Typography>
+              <Tooltip
+                title="Ensure your Zoom Link is Publicly Accessible and Does Not Require a Password."
+                placement="right"
+              >
+                <HelpIcon style={{ fontSize: 'medium', marginLeft: '5px', marginTop: '3px' }} />
+              </Tooltip>
               <ExternalLink
                 link="https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0066271"
                 description="(Find your Personal Zoom Link)"


### PR DESCRIPTION
## Changes

Added hoverable info icons for zoom link inputs on both the schedule settings edit page and the finalize design review modal. warns users to ensure zoom link doesn't have a password and that it's publicly available

## Screenshots
<img width="566" alt="Screenshot 2025-05-12 at 9 51 45 PM" src="https://github.com/user-attachments/assets/d0047520-b338-4016-acf6-22fd5da08ae5" />
<img width="1229" alt="Screenshot 2025-05-12 at 9 43 01 PM" src="https://github.com/user-attachments/assets/940a320a-4355-47a9-ae3b-aff3df34d4b2" />
<img width="394" alt="Screenshot 2025-05-12 at 9 43 10 PM" src="https://github.com/user-attachments/assets/2fe603ec-2256-4317-966c-d3ec6d1d7d1c" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #2314
