### PR TITLE
#2591 Make Days Clickable And Remove + Button

### DIFF
--- a/src/frontend/src/pages/CalendarPage/CalendarComponents/CalendarDayCard.tsx
+++ b/src/frontend/src/pages/CalendarPage/CalendarComponents/CalendarDayCard.tsx
@@ -1,5 +1,4 @@
-import { Box, Card, CardContent, Grid, IconButton, Link, Stack, Tooltip, Typography } from '@mui/material';
-import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
+import { Box, Card, CardContent, Grid, Link, Stack, Tooltip, Typography } from '@mui/material';
 import { DesignReview, DesignReviewStatus, TeamType } from 'shared';
 import { meetingStartTimePipe } from '../../../utils/pipes';
 import ConstructionIcon from '@mui/icons-material/Construction';

--- a/src/frontend/src/pages/CalendarPage/CalendarComponents/CalendarDayCard.tsx
+++ b/src/frontend/src/pages/CalendarPage/CalendarComponents/CalendarDayCard.tsx
@@ -1,4 +1,4 @@
-import { Box, Card, CardContent, Grid, Link, Stack, Tooltip, Typography } from '@mui/material';
+import { Box, Card, CardContent, Grid, Link, Stack, Tooltip, Typography, useTheme } from '@mui/material';
 import { DesignReview, DesignReviewStatus, TeamType } from 'shared';
 import { meetingStartTimePipe } from '../../../utils/pipes';
 import ConstructionIcon from '@mui/icons-material/Construction';
@@ -29,11 +29,18 @@ interface CalendarDayCardProps {
 
 const CalendarDayCard: React.FC<CalendarDayCardProps> = ({ cardDate, events, teamTypes }) => {
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
-
+  const theme = useTheme();
   const DayCardTitle = () => (
     <Grid container alignItems="center" margin={0} padding={0}>
       <Grid item xs display="flex" justifyContent="flex-end">
-        <Typography variant="h6" marginRight={1} noWrap>
+        <Typography
+          variant="h6"
+          marginRight={1}
+          noWrap
+          sx={{
+            color: !(isFutureDay || isCurrentDay) ? theme.palette.grey[600] : 'inherit'
+          }}
+        >
           {cardDate.getDate()}
         </Typography>
       </Grid>
@@ -64,7 +71,8 @@ const CalendarDayCard: React.FC<CalendarDayCardProps> = ({ cardDate, events, tea
           }}
           sx={{
             position: 'relative',
-            zIndex: 2
+            zIndex: 2,
+            cursor: 'pointer'
           }}
         >
           <Card
@@ -192,7 +200,7 @@ const CalendarDayCard: React.FC<CalendarDayCardProps> = ({ cardDate, events, tea
 
   const today = new Date().toDateString();
   const isCurrentDay = cardDate.toDateString() === today;
-  const isFutureDay = cardDate > new Date();
+  const isFutureDay = cardDate >= new Date();
 
   return (
     <>
@@ -207,19 +215,20 @@ const CalendarDayCard: React.FC<CalendarDayCardProps> = ({ cardDate, events, tea
       <Card
         sx={{
           position: 'relative',
+          backgroundColor: !(isFutureDay || isCurrentDay) ? theme.palette.grey[900] : 'inherit',
           borderRadius: 2,
           width: { xs: '95%', md: '80%' },
           height: { xs: '10vh', sm: '15vh' },
           border: isCurrentDay ? '2px solid gray' : 'none',
           boxShadow: isCurrentDay ? '0 0 10px rgba(255, 255, 255, 0.5)' : 'none',
-          cursor: isFutureDay ? 'pointer' : 'default',
+          cursor: isFutureDay || isCurrentDay ? 'pointer' : 'default',
           transition: 'background 0.2s',
-          '&:hover': isFutureDay ? { background: '#232323' } : {}
+          '&:hover': isFutureDay || isCurrentDay ? { background: '#232323' } : {}
         }}
       >
         <Box
           onClick={() => {
-            if (cardDate.getTime() >= new Date().getTime()) {
+            if (isFutureDay || isCurrentDay) {
               setIsCreateModalOpen(true);
             }
           }}

--- a/src/frontend/src/pages/CalendarPage/CalendarComponents/CalendarDayCard.tsx
+++ b/src/frontend/src/pages/CalendarPage/CalendarComponents/CalendarDayCard.tsx
@@ -33,11 +33,6 @@ const CalendarDayCard: React.FC<CalendarDayCardProps> = ({ cardDate, events, tea
 
   const DayCardTitle = () => (
     <Grid container alignItems="center" margin={0} padding={0}>
-      <Grid item>
-        <IconButton onClick={() => setIsCreateModalOpen(true)} disabled={cardDate.getTime() < new Date().getTime()}>
-          <AddCircleOutlineIcon fontSize="small" />
-        </IconButton>
-      </Grid>
       <Grid item xs display="flex" justifyContent="flex-end">
         <Typography variant="h6" marginRight={1} noWrap>
           {cardDate.getDate()}
@@ -61,7 +56,15 @@ const CalendarDayCard: React.FC<CalendarDayCardProps> = ({ cardDate, events, tea
           markedStatus={markedStatus}
           setMarkedStatus={setMarkedStatus}
         />
-        <Box marginLeft={0.5} marginBottom={0.5} onClick={() => setIsSummaryModalOpen(true)} sx={{ cursor: 'pointer' }}>
+        <Box
+          marginLeft={0.5}
+          marginBottom={0.5}
+          onClick={(e) => {
+            e.stopPropagation();
+            setIsSummaryModalOpen(true);
+          }}
+          sx={{ cursor: 'pointer' }}
+        >
           <Card
             sx={{
               backgroundColor: designReviewStatusColor(markedStatus),
@@ -180,6 +183,7 @@ const CalendarDayCard: React.FC<CalendarDayCardProps> = ({ cardDate, events, tea
 
   const today = new Date().toDateString();
   const isCurrentDay = cardDate.toDateString() === today;
+  const isFutureDay = cardDate > new Date();
 
   return (
     <>
@@ -197,7 +201,15 @@ const CalendarDayCard: React.FC<CalendarDayCardProps> = ({ cardDate, events, tea
           width: { xs: '95%', md: '80%' },
           height: { xs: '10vh', sm: '15vh' },
           border: isCurrentDay ? '2px solid gray' : 'none',
-          boxShadow: isCurrentDay ? '0 0 10px rgba(255, 255, 255, 0.5)' : 'none'
+          boxShadow: isCurrentDay ? '0 0 10px rgba(255, 255, 255, 0.5)' : 'none',
+          cursor: isFutureDay ? 'pointer' : 'default',
+          transition: 'background 0.2s',
+          '&:hover': isFutureDay ? { background: '#232323' } : {}
+        }}
+        onClick={() => {
+          if (cardDate.getTime() >= new Date().getTime()) {
+            setIsCreateModalOpen(true);
+          }
         }}
       >
         <CardContent sx={{ padding: 0 }}>

--- a/src/frontend/src/pages/CalendarPage/CalendarComponents/CalendarDayCard.tsx
+++ b/src/frontend/src/pages/CalendarPage/CalendarComponents/CalendarDayCard.tsx
@@ -62,7 +62,10 @@ const CalendarDayCard: React.FC<CalendarDayCardProps> = ({ cardDate, events, tea
             e.stopPropagation();
             setIsSummaryModalOpen(true);
           }}
-          sx={{ cursor: 'pointer' }}
+          sx={{
+            position: 'relative',
+            zIndex: 2
+          }}
         >
           <Card
             sx={{
@@ -124,7 +127,14 @@ const CalendarDayCard: React.FC<CalendarDayCardProps> = ({ cardDate, events, tea
   const ExtraEventsCard = ({ extraEvents }: { extraEvents: DesignReview[] }) => {
     const [showTooltip, setShowTooltip] = useState(false);
     return (
-      <Box marginLeft={0.5} marginBottom={0.2}>
+      <Box
+        marginLeft={0.5}
+        marginBottom={0.2}
+        sx={{
+          position: 'relative',
+          zIndex: 2
+        }}
+      >
         <Card
           sx={{
             backgroundColor: 'grey',
@@ -196,6 +206,7 @@ const CalendarDayCard: React.FC<CalendarDayCardProps> = ({ cardDate, events, tea
       />
       <Card
         sx={{
+          position: 'relative',
           borderRadius: 2,
           width: { xs: '95%', md: '80%' },
           height: { xs: '10vh', sm: '15vh' },
@@ -205,12 +216,21 @@ const CalendarDayCard: React.FC<CalendarDayCardProps> = ({ cardDate, events, tea
           transition: 'background 0.2s',
           '&:hover': isFutureDay ? { background: '#232323' } : {}
         }}
-        onClick={() => {
-          if (cardDate.getTime() >= new Date().getTime()) {
-            setIsCreateModalOpen(true);
-          }
-        }}
       >
+        <Box
+          onClick={() => {
+            if (cardDate.getTime() >= new Date().getTime()) {
+              setIsCreateModalOpen(true);
+            }
+          }}
+          sx={{
+            position: 'absolute',
+            width: '100%',
+            height: '100%',
+            zIndex: 1,
+            pointerEvents: 'auto'
+          }}
+        />
         <CardContent sx={{ padding: 0 }}>
           <DayCardTitle />
           {events.length < 3 ? (

--- a/src/frontend/src/pages/CalendarPage/CalendarComponents/FillerCalendarDayCard.tsx
+++ b/src/frontend/src/pages/CalendarPage/CalendarComponents/FillerCalendarDayCard.tsx
@@ -14,7 +14,9 @@ const FillerCalendarDayCard: React.FC<FillerCalendarDayCardProps> = ({ day }) =>
         borderRadius: 2,
         width: { xs: '95%', md: '80%' },
         height: { xs: '10vh', sm: '15vh' },
-        backgroundColor: theme.palette.grey[900]
+        backgroundColor: theme.palette.grey[900],
+        color: theme.palette.grey[500],
+        opacity: 0.5
       }}
     >
       <CardContent sx={{ padding: 0 }}>

--- a/src/frontend/src/pages/CalendarPage/CalendarPage.tsx
+++ b/src/frontend/src/pages/CalendarPage/CalendarPage.tsx
@@ -134,13 +134,11 @@ const CalendarPage = () => {
       )}
       <PageLayout hidePageTitle>
         <Stack direction="row" spacing={1} alignItems="center" justifyContent="space-between" sx={{ mt: 2, mb: 2 }}>
+          <Typography variant="h4">Design Review Calendar</Typography>
           <Stack direction="row" spacing={1} alignItems="center">
-            <Typography variant="h4">Design Review Calendar</Typography>
             <Tooltip title="Click on a day to schedule an event">
-              <HelpOutlineIcon fontSize="large" sx={{ position: 'relative', top: '3px' }} />
+              <HelpOutlineIcon fontSize="medium" sx={{ position: 'relative' }} />
             </Tooltip>
-          </Stack>
-          <Stack direction="row" spacing={1} alignItems="center">
             <MonthSelector displayMonth={displayMonthYear} setDisplayMonth={setDisplayMonthYear} />
             <Box marginLeft={1}>{unconfirmedDRSDropdown}</Box>
           </Stack>

--- a/src/frontend/src/pages/CalendarPage/CalendarPage.tsx
+++ b/src/frontend/src/pages/CalendarPage/CalendarPage.tsx
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 import { useState } from 'react';
-import { Box, Grid, Stack, Typography, useMediaQuery, useTheme } from '@mui/material';
+import { Box, Grid, Stack, Tooltip, Typography, useMediaQuery, useTheme } from '@mui/material';
 import PageLayout from '../../components/PageLayout';
 import { DesignReview, DesignReviewStatus } from 'shared';
 import MonthSelector from './CalendarComponents/MonthSelector';
@@ -18,6 +18,7 @@ import { datePipe } from '../../utils/pipes';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import DRCSummaryModal from './DesignReviewSummaryModal';
 import { useAllTeamTypes } from '../../hooks/team-types.hooks';
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 
 const CalendarPage = () => {
   const theme = useTheme();
@@ -131,15 +132,19 @@ const CalendarPage = () => {
           teamTypes={allTeamTypes}
         />
       )}
-      <PageLayout
-        title="Design Review Calendar"
-        headerRight={
-          <Stack direction="row" justifyContent="flex-end">
+      <PageLayout hidePageTitle>
+        <Stack direction="row" spacing={1} alignItems="center" justifyContent="space-between" sx={{ mt: 2, mb: 2 }}>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Typography variant="h4">Design Review Calendar</Typography>
+            <Tooltip title="Click on a day to schedule an event">
+              <HelpOutlineIcon fontSize="large" sx={{ position: 'relative', top: '3px' }} />
+            </Tooltip>
+          </Stack>
+          <Stack direction="row" spacing={1} alignItems="center">
             <MonthSelector displayMonth={displayMonthYear} setDisplayMonth={setDisplayMonthYear} />
             <Box marginLeft={1}>{unconfirmedDRSDropdown}</Box>
           </Stack>
-        }
-      >
+        </Stack>
         <Grid container>
           {EnumToArray(DAY_NAMES).map((day) => (
             <Grid item xs={12 / 7}>


### PR DESCRIPTION
## Changes

Removed the + buttons and made the card clickable with hover effect (to show it is clickable) to open design review modal. Also allowed users to click the design reviews within the card as well. 

## Notes
When adjusting, I made sure to use existing components as Sean mentioned https://github.com/Northeastern-Electric-Racing/FinishLine/pull/2666#pullrequestreview-2159657366, but found a minor behavior issue when integrating these changes.

When a user clicks on an EventCard (existing design reviews) which is within a date card, if a user hides the EventCard the DesignReviewCreateModal (create new design review) always opens up right after. User can adjust to this easily by hiding the design review modal right after if they don't need to add a new design review. If this behavior is wanted (to ensure user wants to add another design review), then ignore all of this. If not, I did try finding ways to prevent this behavior but struggled to find a solution such as using z-index with pointer-events.

## Screenshots
![Screenshot 2025-05-12 at 4 49 28 PM](https://github.com/user-attachments/assets/ef2d2a0e-057d-48bd-9d99-ac9aac25eac5)
![Screenshot 2025-05-12 at 4 49 35 PM](https://github.com/user-attachments/assets/2d7e7a3d-5c62-4d67-ad3f-8905d9b8ec80)


New change update:
![Screenshot 2025-05-17 at 3 56 47 PM](https://github.com/user-attachments/assets/3e903f52-ec25-497d-98a2-9490a536c495)


## Checklist
- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #2591
