### PR TITLE
#3465 able to make change request for category

### DIFF
--- a/src/backend/src/controllers/change-requests.controllers.ts
+++ b/src/backend/src/controllers/change-requests.controllers.ts
@@ -123,6 +123,22 @@ export default class ChangeRequestsController {
     }
   }
 
+  static async createBudgetChangeRequest(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { otherReasonId, type, proposedBudget } = req.body;
+      const id = await ChangeRequestsService.createBudgetChangeRequest(
+        req.currentUser,
+        otherReasonId,
+        type,
+        proposedBudget,
+        req.organization
+      );
+      res.status(200).json({ message: `Successfully created stage gate request with id #${id}` });
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
   static async createStandardChangeRequest(req: Request, res: Response, next: NextFunction) {
     try {
       const { wbsNum, type, what, why, proposedSolutions, projectProposedChanges, workPackageProposedChanges } = req.body;

--- a/src/backend/src/prisma-query-args/change-requests.query-args.ts
+++ b/src/backend/src/prisma-query-args/change-requests.query-args.ts
@@ -2,6 +2,7 @@ import { Prisma } from '@prisma/client';
 import { getScopeChangeRequestQueryArgs } from './scope-change-requests.query-args';
 import { getUserQueryArgs } from './user.query-args';
 import { getWorkPackageQueryArgs } from './work-packages.query-args';
+import { getReimbursementProductOtherReasonQueryArgs } from './reimbursement-product-other-reason.query-args';
 
 export type ChangeRequestQueryArgs = ReturnType<typeof getChangeRequestQueryArgs>;
 
@@ -16,6 +17,7 @@ export const getChangeRequestQueryArgs = (organizationId: string) =>
     include: {
       submitter: getUserQueryArgs(organizationId),
       wbsElement: true,
+      category: getReimbursementProductOtherReasonQueryArgs(organizationId),
       reviewer: getUserQueryArgs(organizationId),
       changes: {
         where: {
@@ -33,6 +35,7 @@ export const getChangeRequestQueryArgs = (organizationId: string) =>
       activationChangeRequest: {
         include: { lead: getUserQueryArgs(organizationId), manager: getUserQueryArgs(organizationId) }
       },
+      budgetChangeRequest: true,
       deletedBy: getUserQueryArgs(organizationId),
       requestedReviewers: getUserQueryArgs(organizationId)
     }
@@ -43,12 +46,14 @@ export const getManyChangeRequestQueryArgs = (organizationId: string) =>
     include: {
       submitter: getUserQueryArgs(organizationId),
       wbsElement: true,
+      category: getReimbursementProductOtherReasonQueryArgs(organizationId),
       reviewer: getUserQueryArgs(organizationId),
       stageGateChangeRequest: true,
       changes: true,
       activationChangeRequest: {
         include: { lead: getUserQueryArgs(organizationId), manager: getUserQueryArgs(organizationId) }
       },
+      budgetChangeRequest: true,
       deletedBy: getUserQueryArgs(organizationId),
       requestedReviewers: getUserQueryArgs(organizationId)
     }
@@ -70,6 +75,7 @@ export const getChangeRequestWithProjectAndWorkPackageQueryArgs = (organizationI
           links: { where: { dateDeleted: null } }
         }
       },
+      category: getReimbursementProductOtherReasonQueryArgs(organizationId),
       reviewer: getUserQueryArgs(organizationId),
       changes: {
         where: {
@@ -79,7 +85,8 @@ export const getChangeRequestWithProjectAndWorkPackageQueryArgs = (organizationI
         },
         include: {
           implementer: getUserQueryArgs(organizationId),
-          wbsElement: true
+          wbsElement: true,
+          category: getReimbursementProductOtherReasonQueryArgs(organizationId)
         }
       },
       scopeChangeRequest: getScopeChangeRequestQueryArgs(organizationId),
@@ -87,6 +94,7 @@ export const getChangeRequestWithProjectAndWorkPackageQueryArgs = (organizationI
       activationChangeRequest: {
         include: { lead: getUserQueryArgs(organizationId), manager: getUserQueryArgs(organizationId) }
       },
+      budgetChangeRequest: true,
       deletedBy: getUserQueryArgs(organizationId),
       requestedReviewers: getUserQueryArgs(organizationId)
     }

--- a/src/backend/src/prisma/migrations/20250402021534_finance_redesign/migration.sql
+++ b/src/backend/src/prisma/migrations/20250402021534_finance_redesign/migration.sql
@@ -7,6 +7,9 @@
   - Added the required column `indexCodeId` to the `Reimbursement_Request` table without a default value. This is not possible if the table is not empty.
 */
 
+-- AlterEnum
+ALTER TYPE "CR_Type" ADD VALUE 'BUDGET';
+
 -- AlterTable
 ALTER TABLE "Material" ADD COLUMN     "reimbursementRequestId" TEXT;
 
@@ -257,3 +260,45 @@ ALTER TABLE "Reimbursement_Request_Comment" ADD CONSTRAINT "Reimbursement_Reques
 
 -- AlterTable
 ALTER TABLE "Reimbursement_Request_Comment" ADD COLUMN     "dateDeleted" TIMESTAMP(3);
+
+-- DropForeignKey
+ALTER TABLE "Change_Request" DROP CONSTRAINT "Change_Request_wbsElementId_fkey";
+
+-- AlterTable
+ALTER TABLE "Change_Request" ADD COLUMN     "categoryId" TEXT,
+ALTER COLUMN "wbsElementId" DROP NOT NULL;
+
+-- CreateTable
+CREATE TABLE "Budget_CR" (
+    "budgetCrId" TEXT NOT NULL,
+    "changeRequestId" TEXT NOT NULL,
+    "proposedBudget" INTEGER NOT NULL,
+
+    CONSTRAINT "Budget_CR_pkey" PRIMARY KEY ("budgetCrId")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Budget_CR_changeRequestId_key" ON "Budget_CR"("changeRequestId");
+
+-- AddForeignKey
+ALTER TABLE "Change_Request" ADD CONSTRAINT "Change_Request_wbsElementId_fkey" FOREIGN KEY ("wbsElementId") REFERENCES "WBS_Element"("wbsElementId") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Change_Request" ADD CONSTRAINT "Change_Request_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Reimbursement_Product_Other_Reason"("otherReimbursementProductReasonId") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Budget_CR" ADD CONSTRAINT "Budget_CR_changeRequestId_fkey" FOREIGN KEY ("changeRequestId") REFERENCES "Change_Request"("crId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- DropForeignKey
+ALTER TABLE "Change" DROP CONSTRAINT "Change_wbsElementId_fkey";
+
+-- AlterTable
+ALTER TABLE "Change" ADD COLUMN     "categoryId" TEXT,
+ALTER COLUMN "wbsElementId" DROP NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "Change" ADD CONSTRAINT "Change_wbsElementId_fkey" FOREIGN KEY ("wbsElementId") REFERENCES "WBS_Element"("wbsElementId") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Change" ADD CONSTRAINT "Change_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Reimbursement_Product_Other_Reason"("otherReimbursementProductReasonId") ON DELETE SET NULL ON UPDATE CASCADE;
+

--- a/src/backend/src/prisma/schema.prisma
+++ b/src/backend/src/prisma/schema.prisma
@@ -17,6 +17,7 @@ enum CR_Type {
   OTHER
   STAGE_GATE
   ACTIVATION
+  BUDGET
 }
 
 enum Task_Priority {
@@ -292,16 +293,20 @@ model Change_Request {
   dateSubmitted DateTime  @default(now())
   dateDeleted   DateTime?
 
-  organizationId           String
-  organization             Organization   @relation(fields: [organizationId], references: [organizationId])
-  wbsElementId             String
-  wbsElement               WBS_Element    @relation(fields: [wbsElementId], references: [wbsElementId])
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [organizationId])
+
+  // Can be either a WBS_Element or an Other_Reimbursement_Product_Reason, not both and not neither
+  wbsElementId             String?
+  wbsElement               WBS_Element?                        @relation(fields: [wbsElementId], references: [wbsElementId])
+  category                 Reimbursement_Product_Other_Reason? @relation(fields: [categoryId], references: [otherReimbursementProductReasonId])
+  categoryId               String?
   type                     CR_Type
   reviewerId               String?
-  reviewer                 User?          @relation(name: "reviewedChangeRequests", fields: [reviewerId], references: [userId])
-  requestedReviewers       User[]         @relation(name: "requestedChangeRequestReviewers")
+  reviewer                 User?                               @relation(name: "reviewedChangeRequests", fields: [reviewerId], references: [userId])
+  requestedReviewers       User[]                              @relation(name: "requestedChangeRequestReviewers")
   deletedByUserId          String?
-  deletedBy                User?          @relation(name: "deletedChangeRequests", fields: [deletedByUserId], references: [userId])
+  deletedBy                User?                               @relation(name: "deletedChangeRequests", fields: [deletedByUserId], references: [userId])
   dateReviewed             DateTime?
   accepted                 Boolean?
   reviewNotes              String?
@@ -309,6 +314,7 @@ model Change_Request {
   scopeChangeRequest       Scope_CR?
   stageGateChangeRequest   Stage_Gate_CR?
   activationChangeRequest  Activation_CR?
+  budgetChangeRequest      Budget_CR?
   notificationSlackThreads Message_Info[]
 
   @@unique([identifier, organizationId], name: "uniqueChangeRequest")
@@ -383,6 +389,13 @@ model Activation_CR {
   confirmDetails  Boolean
 }
 
+model Budget_CR {
+  budgetCrId      String         @id @default(uuid())
+  changeRequestId String         @unique
+  changeRequest   Change_Request @relation(fields: [changeRequestId], references: [crId])
+  proposedBudget  Int
+}
+
 model Change {
   changeId        String         @id @default(uuid())
   changeRequestId String
@@ -390,9 +403,13 @@ model Change {
   dateImplemented DateTime       @default(now())
   implementerId   String
   implementer     User           @relation(fields: [implementerId], references: [userId])
-  wbsElementId    String
-  wbsElement      WBS_Element    @relation(fields: [wbsElementId], references: [wbsElementId])
-  detail          String
+
+  // Can be either a WBS_Element or an Other_Reimbursement_Product_Reason, not both and not neither
+  wbsElementId String?
+  wbsElement   WBS_Element?                        @relation(fields: [wbsElementId], references: [wbsElementId])
+  categoryId   String?
+  category     Reimbursement_Product_Other_Reason? @relation(fields: [categoryId], references: [otherReimbursementProductReasonId])
+  detail       String
 }
 
 model WBS_Element {
@@ -1187,6 +1204,8 @@ model Reimbursement_Product_Other_Reason {
   indexCode                         Index_Code                     @relation(fields: [indexCodeId], references: [indexCodeId])
   indexCodeId                       String
   accountCodes                      Account_Code[]
+  changeRequests                    Change_Request[]
+  changes                           Change[]
 }
 
 model Reimbursement_Request_Comment {

--- a/src/backend/src/prisma/seed.ts
+++ b/src/backend/src/prisma/seed.ts
@@ -2111,6 +2111,14 @@ const performSeed: () => Promise<void> = async () => {
     ner
   );
 
+  const budgetCR = await ChangeRequestsService.createBudgetChangeRequest(
+    thomasEmrax,
+    otherProductReasonConsumables.otherProductReasonId,
+    'BUDGET',
+    50,
+    ner
+  );
+
   /**
    * Bill of Materials
    */

--- a/src/backend/src/routes/change-requests.routes.ts
+++ b/src/backend/src/routes/change-requests.routes.ts
@@ -59,6 +59,16 @@ changeRequestsRouter.post(
 );
 
 changeRequestsRouter.post(
+  '/new/budget',
+  nonEmptyString(body('submitterId')),
+  nonEmptyString(body('otherReasonId')),
+  body('type').custom((value) => value === ChangeRequestType.Budget),
+  body('proposedBudget').isInt(),
+  validateInputs,
+  ChangeRequestsController.createBudgetChangeRequest
+);
+
+changeRequestsRouter.post(
   '/new/standard',
   nonEmptyString(body('what')),
   intMinZero(body('wbsNum.carNumber')),

--- a/src/backend/src/services/change-requests.services.ts
+++ b/src/backend/src/services/change-requests.services.ts
@@ -800,7 +800,7 @@ export default class ChangeRequestsService {
   }
 
   /**
-   * Validates and creates a budget change request
+   * Validates and creates a budget change request for a category
    * @param submitter The user creating the cr
    * @param otherReasonId the id of the other reason/category to change budget of
    * @param type  the type of cr
@@ -816,7 +816,7 @@ export default class ChangeRequestsService {
     proposedBudget: number,
     organization: Organization
   ): Promise<string> {
-    // verify user is allowed to create stage gate change requests
+    // verify user is allowed to create budget change requests
     if (await userHasPermission(submitter.userId, organization.organizationId, isGuest))
       throw new AccessDeniedGuestException('create budget change requests');
 

--- a/src/backend/src/services/change-requests.services.ts
+++ b/src/backend/src/services/change-requests.services.ts
@@ -33,7 +33,8 @@ import {
   validateNoUnreviewedOpenCRs,
   reviewProposedSolution,
   sendCRSubmitterReviewedNotification,
-  validateWbsElement
+  validateWbsElement,
+  validateNoUnreviewedOpenOtherReasonCRs
 } from '../utils/change-requests.utils';
 import { CR_Type, WBS_Element_Status, User, Scope_CR_Why_Type, Prisma, Organization } from '@prisma/client';
 import { getUserFullName, getUsersWithSettings, userHasPermission } from '../utils/users.utils';
@@ -267,7 +268,7 @@ export default class ChangeRequestsService {
     if (!foundCR) throw new NotFoundException('Change Request', crId);
     if (foundCR.accepted) throw new HttpException(400, `This change request is already approved!`);
     if (foundCR.dateDeleted) throw new DeletedException('Change Request', crId);
-    if (foundCR.wbsElement.dateDeleted) throw new DeletedException('WBS Element', wbsPipe(foundCR.wbsElement));
+    if (foundCR.wbsElement?.dateDeleted) throw new DeletedException('WBS Element', wbsPipe(foundCR.wbsElement));
     if (foundCR.organizationId !== organization.organizationId) throw new InvalidOrganizationException('Change Request');
 
     // verify that the user is not reviewing their own change request
@@ -283,6 +284,8 @@ export default class ChangeRequestsService {
       // Activation Change Requested That Has Been Accepted Being Reviewed
     } else if (foundCR.type === CR_Type.ACTIVATION && foundCR.activationChangeRequest && accepted) {
       await this.reviewActivationChangeRequest(foundCR, reviewer);
+    } else if (foundCR.type === CR_Type.BUDGET && foundCR.budgetChangeRequest && accepted) {
+      await this.reviewBudgetChangeRequest(foundCR, reviewer);
     }
     // finally we can update change request
     const updated = await prisma.change_Request.update({
@@ -332,9 +335,9 @@ export default class ChangeRequestsService {
       // reviews a proposed solution applying certain changes based on the content of the proposed solution
       await reviewProposedSolution(psId, foundCR, reviewer, organization.organizationId);
     } else if (foundCR.scopeChangeRequest?.wbsProposedChanges && !psId) {
-      const associatedProject = foundCR.wbsElement.project
+      const associatedProject = foundCR.wbsElement?.project
         ? {
-            ...foundCR.wbsElement.project,
+            ...foundCR.wbsElement?.project,
             wbsNum: {
               carNumber: foundCR.wbsElement.carNumber,
               projectNumber: foundCR.wbsElement.projectNumber,
@@ -342,7 +345,7 @@ export default class ChangeRequestsService {
             }
           }
         : null;
-      const associatedWorkPackage = foundCR.wbsElement.workPackage;
+      const associatedWorkPackage = foundCR.wbsElement?.workPackage;
       const { wbsProposedChanges } = foundCR.scopeChangeRequest;
       const { workPackageProposedChanges } = wbsProposedChanges;
       const { projectProposedChanges } = wbsProposedChanges;
@@ -359,17 +362,17 @@ export default class ChangeRequestsService {
           },
           wbsOriginalData: {
             create: {
-              name: foundCR.wbsElement.name,
-              status: foundCR.wbsElement.status,
-              leadId: foundCR.wbsElement.leadId,
-              managerId: foundCR.wbsElement.managerId,
+              name: foundCR.wbsElement?.name ?? '',
+              status: foundCR.wbsElement?.status ?? WBS_Element_Status.INACTIVE,
+              leadId: foundCR.wbsElement?.leadId,
+              managerId: foundCR.wbsElement?.managerId,
               links: {
-                connect: foundCR.wbsElement.links.map((link) => ({
+                connect: foundCR.wbsElement?.links.map((link) => ({
                   linkId: link.linkId
                 }))
               },
               proposedDescriptionBulletChanges: {
-                connect: foundCR.wbsElement.descriptionBullets.map((descriptionBullet) => ({
+                connect: foundCR.wbsElement?.descriptionBullets.map((descriptionBullet) => ({
                   descriptionId: descriptionBullet.descriptionId
                 }))
               },
@@ -420,7 +423,7 @@ export default class ChangeRequestsService {
           wbsProposedChanges,
           workPackageProposedChanges,
           associatedProject?.wbsNum ?? null,
-          associatedWorkPackage,
+          associatedWorkPackage ?? null,
           reviewer,
           foundCR.crId,
           organization
@@ -432,7 +435,7 @@ export default class ChangeRequestsService {
           associatedProject,
           reviewer,
           foundCR.crId,
-          foundCR.wbsElement.carNumber,
+          foundCR.wbsElement?.carNumber ?? 0,
           organization
         );
       }
@@ -448,7 +451,7 @@ export default class ChangeRequestsService {
     foundCR: Prisma.Change_RequestGetPayload<ChangeRequestWithProjectAndWorkPackageQueryArgs>,
     reviewer: User
   ): Promise<void> {
-    if (!foundCR.wbsElement.workPackage) {
+    if (!foundCR.wbsElement?.workPackage) {
       throw new HttpException(400, 'Stage gate can only be made on work packages!');
     }
 
@@ -494,31 +497,31 @@ export default class ChangeRequestsService {
     const { activationChangeRequest } = foundCR;
     if (!activationChangeRequest) throw new HttpException(400, 'No activation change request found!');
 
-    const shouldUpdateProjLead = activationChangeRequest.leadId !== foundCR.wbsElement.leadId;
-    const shouldUpdateProjManager = activationChangeRequest.leadId !== foundCR.wbsElement.managerId;
+    const shouldUpdateProjLead = activationChangeRequest.leadId !== foundCR.wbsElement?.leadId;
+    const shouldUpdateProjManager = activationChangeRequest.leadId !== foundCR.wbsElement?.managerId;
     const shouldChangeStartDate =
       activationChangeRequest.startDate.setHours(0, 0, 0, 0) !==
-      foundCR.wbsElement.workPackage?.startDate.setHours(0, 0, 0, 0);
+      foundCR.wbsElement?.workPackage?.startDate.setHours(0, 0, 0, 0);
     const changes = [];
 
     if (shouldUpdateProjLead) {
-      const oldPL = await getUserFullName(foundCR.wbsElement.leadId);
+      const oldPL = await getUserFullName(foundCR.wbsElement?.leadId ?? null);
       const newPL = await getUserFullName(activationChangeRequest.leadId);
       changes.push({
         changeRequestId: foundCR.crId,
         implementerId: reviewer.userId,
-        wbsElementId: foundCR.wbsElementId,
+        wbsElementId: foundCR.wbsElementId ?? '',
         detail: buildChangeDetail('Project Lead', oldPL, newPL)
       });
     }
 
     if (shouldUpdateProjManager) {
-      const oldPM = await getUserFullName(foundCR.wbsElement.managerId);
+      const oldPM = await getUserFullName(foundCR.wbsElement?.managerId ?? null);
       const newPM = await getUserFullName(activationChangeRequest.managerId);
       changes.push({
         changeRequestId: foundCR.crId,
         implementerId: reviewer.userId,
-        wbsElementId: foundCR.wbsElementId,
+        wbsElementId: foundCR.wbsElementId ?? '',
         detail: buildChangeDetail('Project Manager', oldPM, newPM)
       });
     }
@@ -527,10 +530,10 @@ export default class ChangeRequestsService {
       changes.push({
         changeRequestId: foundCR.crId,
         implementerId: reviewer.userId,
-        wbsElementId: foundCR.wbsElementId,
+        wbsElementId: foundCR.wbsElementId ?? '',
         detail: buildChangeDetail(
           'Start Date',
-          foundCR.wbsElement.workPackage?.startDate.toLocaleDateString() || 'null',
+          foundCR.wbsElement?.workPackage?.startDate.toLocaleDateString() || 'null',
           activationChangeRequest.startDate.toLocaleDateString()
         )
       });
@@ -539,19 +542,51 @@ export default class ChangeRequestsService {
     changes.push({
       changeRequestId: foundCR.crId,
       implementerId: reviewer.userId,
-      wbsElementId: foundCR.wbsElementId,
-      detail: buildChangeDetail('status', foundCR.wbsElement.status, WBS_Element_Status.ACTIVE)
+      wbsElementId: foundCR.wbsElementId ?? '',
+      detail: buildChangeDetail('status', foundCR.wbsElement?.status ?? '', WBS_Element_Status.ACTIVE)
     });
 
     await prisma.change.createMany({ data: changes });
 
     await prisma.wBS_Element.update({
-      where: { wbsElementId: foundCR.wbsElementId },
+      where: { wbsElementId: foundCR.wbsElementId ?? '' },
       data: {
         leadId: activationChangeRequest.leadId,
         managerId: activationChangeRequest.managerId,
         workPackage: { update: { startDate: activationChangeRequest.startDate } },
         status: WBS_Element_Status.ACTIVE
+      }
+    });
+  }
+
+  /**
+   * Reviews the budget change request and automates any changes that are made
+   * @param foundCR the change request to be reviewed
+   * @param reviewer the user reviewing the change request
+   */
+  static async reviewBudgetChangeRequest(
+    foundCR: Prisma.Change_RequestGetPayload<ChangeRequestWithProjectAndWorkPackageQueryArgs>,
+    reviewer: User
+  ): Promise<void> {
+    if (!foundCR.category) {
+      throw new HttpException(400, 'Budget changes can only be made on categories!');
+    }
+    const { budgetChangeRequest } = foundCR;
+    if (!budgetChangeRequest) throw new HttpException(400, 'No activation change request found!');
+
+    const changesList = [];
+    changesList.push({
+      changeRequestId: foundCR.crId,
+      implementerId: reviewer.userId,
+      detail: buildChangeDetail('budget', foundCR.category.budget.toString(), budgetChangeRequest.proposedBudget.toString())
+    });
+
+    await prisma.change.createMany({ data: changesList });
+
+    await prisma.reimbursement_Product_Other_Reason.update({
+      where: { otherReimbursementProductReasonId: foundCR.categoryId ?? '' },
+      data: {
+        budget: budgetChangeRequest.proposedBudget
       }
     });
   }
@@ -646,14 +681,14 @@ export default class ChangeRequestsService {
       ...getChangeRequestWithProjectAndWorkPackageQueryArgs(organization.organizationId)
     });
 
-    const teams = createdCR.wbsElement.workPackage?.project.teams;
+    const teams = createdCR.wbsElement?.workPackage?.project.teams;
     if (teams && teams.length > 0) {
       const notifications: { channelId: string; ts: string }[] = await sendAndGetSlackCRNotifications(
         teams,
         createdCR,
         submitter,
         wbsElement,
-        createdCR.wbsElement.workPackage?.project.wbsElement.name || ''
+        createdCR.wbsElement?.workPackage?.project.wbsElement.name || ''
       );
 
       // save the slack references to the change request
@@ -745,14 +780,14 @@ export default class ChangeRequestsService {
       ...getChangeRequestWithProjectAndWorkPackageQueryArgs(organization.organizationId)
     });
 
-    const teams = createdChangeRequest.wbsElement.workPackage?.project.teams;
+    const teams = createdChangeRequest.wbsElement?.workPackage?.project.teams;
     if (teams && teams.length > 0) {
       const notifications: { channelId: string; ts: string }[] = await sendAndGetSlackCRNotifications(
         teams,
         createdChangeRequest,
         submitter,
         wbsElement,
-        createdChangeRequest.wbsElement.workPackage?.project.wbsElement.name || ''
+        createdChangeRequest.wbsElement?.workPackage?.project.wbsElement.name || ''
       );
 
       // save the slack references to the change request
@@ -760,6 +795,93 @@ export default class ChangeRequestsService {
     }
 
     await ChangeRequestsService.reviewStageGateChangeRequest(createdChangeRequest, submitter); // automatically accept stage gate change requests for convenience
+
+    return createdChangeRequest.crId;
+  }
+
+  /**
+   * Validates and creates a budget change request
+   * @param submitter The user creating the cr
+   * @param otherReasonId the id of the other reason/category to change budget of
+   * @param type  the type of cr
+   * @param proposedBudget the proposed budget
+   * @param organization the organization the user is currently in
+   * @returns the id of the created cr
+   * @throws if user is not allowed to create crs, if other reason does not exist, or if the cr type is not budget
+   */
+  static async createBudgetChangeRequest(
+    submitter: User,
+    otherReasonId: string,
+    type: CR_Type,
+    proposedBudget: number,
+    organization: Organization
+  ): Promise<string> {
+    // verify user is allowed to create stage gate change requests
+    if (await userHasPermission(submitter.userId, organization.organizationId, isGuest))
+      throw new AccessDeniedGuestException('create budget change requests');
+
+    // verify category exists
+    const category = await prisma.reimbursement_Product_Other_Reason.findUnique({
+      where: {
+        otherReimbursementProductReasonId: otherReasonId
+      },
+      include: { changeRequests: { include: { changes: true } } }
+    });
+
+    if (!category) throw new NotFoundException('Reimbursement Product Other Reason', otherReasonId);
+    if (category.dateDeleted) throw new DeletedException('Reimbursement Product Other Reason', otherReasonId);
+
+    // we don't want to have merge conflictS on the wbs element thus we check if there are unreviewed or open CRs on the category
+    await validateNoUnreviewedOpenOtherReasonCRs(category.otherReimbursementProductReasonId);
+
+    const { changeRequests } = category;
+    const nonDeletedChangeRequests = changeRequests.filter((changeRequest) => !changeRequest.dateDeleted);
+    if (!allChangeRequestsReviewed(nonDeletedChangeRequests)) {
+      throw new HttpException(
+        400,
+        `Please resolve all change requests related to ${otherReasonId} - ${category.name} before proceeding`
+      );
+    }
+
+    const numChangeRequests = await prisma.change_Request.count({
+      where: { organizationId: organization.organizationId }
+    });
+
+    const createdChangeRequest = await prisma.change_Request.create({
+      data: {
+        submitter: { connect: { userId: submitter.userId } },
+        category: { connect: { otherReimbursementProductReasonId: otherReasonId } },
+        type,
+        budgetChangeRequest: {
+          create: {
+            proposedBudget
+          }
+        },
+        organization: { connect: { organizationId: organization.organizationId } },
+        identifier: numChangeRequests + 1
+      },
+      ...getChangeRequestWithProjectAndWorkPackageQueryArgs(organization.organizationId)
+    });
+
+    const teams = await prisma.team.findMany({
+      where: {
+        financeTeam: true
+      }
+    });
+
+    if (teams && teams.length > 0) {
+      const notifications: { channelId: string; ts: string }[] = await sendAndGetSlackCRNotifications(
+        teams,
+        createdChangeRequest,
+        submitter,
+        undefined,
+        undefined,
+        category
+      );
+
+      // save the slack references to the change request
+      await addSlackThreadsToChangeRequest(createdChangeRequest.crId, notifications);
+    }
 
     return createdChangeRequest.crId;
   }
@@ -1046,7 +1168,7 @@ export default class ChangeRequestsService {
 
     await Promise.all(proposedSolutionPromises);
 
-    const project = createdCR.wbsElement.workPackage?.project || createdCR.wbsElement.project;
+    const project = createdCR.wbsElement?.workPackage?.project || createdCR.wbsElement?.project;
     const teams = project?.teams;
     if (teams && teams.length > 0) {
       const notifications: { channelId: string; ts: string }[] = await sendAndGetSlackCRNotifications(

--- a/src/backend/src/transformers/change-requests.transformer.ts
+++ b/src/backend/src/transformers/change-requests.transformer.ts
@@ -8,7 +8,8 @@ import {
   WbsElementStatus,
   WorkPackageProposedChanges,
   WorkPackageStage,
-  isProject
+  isProject,
+  BudgetChangeRequest
 } from 'shared';
 import { wbsNumOf } from '../utils/utils';
 import { calculateChangeRequestStatus, convertCRScopeWhyType } from '../utils/change-requests.utils';
@@ -27,6 +28,7 @@ import {
   ChangeRequestManyQueryArgs,
   ChangeRequestWithProjectAndWorkPackageQueryArgs
 } from '../prisma-query-args/change-requests.query-args';
+import { otherProductReasonTransformer } from './reimbursement-requests.transformer';
 
 const projectProposedChangesTransformer = (
   wbsProposedChanges: Prisma.Wbs_Proposed_ChangesGetPayload<WbsProposedChangeQueryArgs>
@@ -75,15 +77,16 @@ const workPackageProposedChangesTransformer = (
 
 export const changeRequestManyTransformer = (
   changeRequest: Prisma.Change_RequestGetPayload<ChangeRequestManyQueryArgs>
-): ChangeRequest | StandardChangeRequest | ActivationChangeRequest | StageGateChangeRequest => {
+): ChangeRequest | StandardChangeRequest | ActivationChangeRequest | StageGateChangeRequest | BudgetChangeRequest => {
   const status = calculateChangeRequestStatus(changeRequest);
 
   return {
     // all cr fields
     crId: changeRequest.crId,
     identifier: changeRequest.identifier,
-    wbsNum: wbsNumOf(changeRequest.wbsElement),
-    wbsName: changeRequest.wbsElement.name,
+    wbsNum: changeRequest.wbsElement ? wbsNumOf(changeRequest.wbsElement) : undefined,
+    wbsName: changeRequest.wbsElement?.name ?? undefined,
+    category: changeRequest.category ? otherProductReasonTransformer(changeRequest.category) : undefined,
     submitter: userTransformer(changeRequest.submitter),
     dateSubmitted: changeRequest.dateSubmitted,
     type: changeRequest.type,
@@ -117,25 +120,30 @@ export const changeRequestManyTransformer = (
     // stage gate cr fields
     leftoverBudget: changeRequest.stageGateChangeRequest?.leftoverBudget ?? undefined,
     confirmDone: changeRequest.stageGateChangeRequest?.confirmDone ?? undefined,
-    requestedReviewers: changeRequest.requestedReviewers.map(userTransformer) ?? []
+    requestedReviewers: changeRequest.requestedReviewers.map(userTransformer) ?? [],
+    //budget cr fields
+    proposedBudget: changeRequest.budgetChangeRequest?.proposedBudget ?? undefined
   };
 };
 
 const changeRequestTransformer = (
   changeRequest: Prisma.Change_RequestGetPayload<ChangeRequestWithProjectAndWorkPackageQueryArgs>
-): ChangeRequest | StandardChangeRequest | ActivationChangeRequest | StageGateChangeRequest => {
+): ChangeRequest | StandardChangeRequest | ActivationChangeRequest | StageGateChangeRequest | BudgetChangeRequest => {
   const status = calculateChangeRequestStatus(changeRequest);
 
-  const wbsName = isProject(changeRequest.wbsElement)
-    ? changeRequest.wbsElement.name
-    : `${changeRequest.wbsElement.workPackage?.project.wbsElement.name} - ${changeRequest.wbsElement.name}`;
+  const wbsName = changeRequest.wbsElement
+    ? isProject(changeRequest.wbsElement)
+      ? changeRequest.wbsElement?.name
+      : `${changeRequest.wbsElement?.workPackage?.project.wbsElement.name} - ${changeRequest.wbsElement?.name}`
+    : undefined;
 
   return {
     // all cr fields
     crId: changeRequest.crId,
     identifier: changeRequest.identifier,
-    wbsNum: wbsNumOf(changeRequest.wbsElement),
+    wbsNum: changeRequest.wbsElement ? wbsNumOf(changeRequest.wbsElement) : undefined,
     wbsName,
+    category: changeRequest.category ? otherProductReasonTransformer(changeRequest.category) : undefined,
     submitter: userTransformer(changeRequest.submitter),
     dateSubmitted: changeRequest.dateSubmitted,
     type: changeRequest.type,
@@ -145,7 +153,8 @@ const changeRequestTransformer = (
     reviewNotes: changeRequest.reviewNotes ?? undefined,
     dateImplemented: getDateImplemented(changeRequest),
     implementedChanges: changeRequest.changes.map((change) => ({
-      wbsNum: wbsNumOf(change.wbsElement),
+      wbsNum: change.wbsElement ? wbsNumOf(change.wbsElement) : undefined,
+      category: change.category ? otherProductReasonTransformer(change.category) : undefined,
       changeId: change.changeId,
       changeRequestIdentifier: changeRequest.identifier,
       changeRequestId: change.changeRequestId,
@@ -190,7 +199,9 @@ const changeRequestTransformer = (
     // stage gate cr fields
     leftoverBudget: changeRequest.stageGateChangeRequest?.leftoverBudget ?? undefined,
     confirmDone: changeRequest.stageGateChangeRequest?.confirmDone ?? undefined,
-    requestedReviewers: changeRequest.requestedReviewers.map(userTransformer) ?? []
+    requestedReviewers: changeRequest.requestedReviewers.map(userTransformer) ?? [],
+    //budget cr fields
+    proposedBudget: changeRequest.budgetChangeRequest?.proposedBudget ?? undefined
   };
 };
 

--- a/src/backend/src/utils/change-requests.utils.ts
+++ b/src/backend/src/utils/change-requests.utils.ts
@@ -321,6 +321,20 @@ export const validateNoUnreviewedOpenCRs = async (wbsElemId: string) => {
 };
 
 /**
+ * throws an error if there are any other open unreviewed change requests for this wbs element
+ * @param otherReasonId the other reason Id to find CRs with
+ * @throws if the Category has open unreviewed change requests
+ *
+ */
+export const validateNoUnreviewedOpenOtherReasonCRs = async (otherReasonId: string) => {
+  const openCRs = await prisma.change_Request.findMany({
+    where: { categoryId: otherReasonId, dateReviewed: null, dateDeleted: null }
+  });
+  if (openCRs.length > 1)
+    throw new HttpException(400, 'There are other open unreviewed change requests for this WBS element');
+};
+
+/**
  * Applies the proposed changes by either creating a project if the newProject field is true or editing a project if the newProject field is false and there is an associated project
  * @param wbsProposedChanges the wbs proposed changes of the change request
  * @param projectProposedChanges  the project proposed changes of the change request
@@ -473,7 +487,7 @@ export const reviewProposedSolution = async (
   // automate the changes for the proposed solution
   // if cr is for a project: update the budget based off of the proposed solution
   // else if cr is for a wp: update the budget and duration based off of the proposed solution
-  if (!foundCR.wbsElement.workPackage && foundCR.wbsElement.project) {
+  if (!foundCR.wbsElement?.workPackage && foundCR.wbsElement?.project) {
     const newBudget = foundCR.wbsElement.project.budget + foundPs.budgetImpact;
     const change = createChange(
       'Budget',
@@ -481,7 +495,8 @@ export const reviewProposedSolution = async (
       newBudget,
       foundCR.crId,
       reviewer.userId,
-      foundCR.wbsElementId
+      foundCR.wbsElementId,
+      foundCR.categoryId
     );
     await prisma.project.update({
       where: { projectId: foundCR.wbsElement.project.projectId },
@@ -492,7 +507,7 @@ export const reviewProposedSolution = async (
 
     //Make the associated budget change if there was a change
     if (change) await prisma.change.create({ data: change });
-  } else if (foundCR.wbsElement.workPackage) {
+  } else if (foundCR.wbsElement?.workPackage) {
     // get the project for the work package
     const wpProj = await prisma.project.findUnique({
       where: { projectId: foundCR.wbsElement.workPackage.projectId },
@@ -506,14 +521,23 @@ export const reviewProposedSolution = async (
 
     // create changes that reflect the new budget and duration
     const changes = [
-      createChange('Budget', wpProj.budget, newBudget, foundCR.crId, reviewer.userId, foundCR.wbsElementId),
+      createChange(
+        'Budget',
+        wpProj.budget,
+        newBudget,
+        foundCR.crId,
+        reviewer.userId,
+        foundCR.wbsElementId,
+        foundCR.categoryId
+      ),
       createChange(
         'Duration',
         foundCR.wbsElement.workPackage.duration,
         updatedDuration,
         foundCR.crId,
         reviewer.userId,
-        foundCR.wbsElementId
+        foundCR.wbsElementId,
+        foundCR.categoryId
       )
     ];
 

--- a/src/backend/src/utils/changes.utils.ts
+++ b/src/backend/src/utils/changes.utils.ts
@@ -17,7 +17,8 @@ export enum ChangeType {
 export interface ChangeCreateArgs {
   changeRequestId: string;
   implementerId: string;
-  wbsElementId: string;
+  wbsElementId?: string;
+  categoryId?: string;
   detail: string;
 }
 
@@ -55,28 +56,50 @@ export const createChange = (
   newValue: string | number | null,
   crId: string | null,
   implementerId: string,
-  wbsElementId: string
+  wbsElementId: string | null,
+  categoryId: string | null
 ): ChangeCreateArgs | undefined => {
   if (!crId) return undefined;
-  if (oldValue == null && newValue !== null) {
+  if (oldValue == null && newValue !== null && wbsElementId !== null) {
     return {
       changeRequestId: crId,
       implementerId,
       wbsElementId,
       detail: `Added ${nameOfField} "${newValue}"`
     };
-  } else if (oldValue !== null && newValue == null) {
+  } else if (oldValue == null && newValue !== null && categoryId !== null) {
+    return {
+      changeRequestId: crId,
+      implementerId,
+      categoryId,
+      detail: `Added ${nameOfField} "${newValue}"`
+    };
+  } else if (oldValue !== null && newValue == null && wbsElementId !== null) {
     return {
       changeRequestId: crId,
       implementerId,
       wbsElementId,
       detail: `Deleted ${nameOfField} "${oldValue}"`
     };
-  } else if (oldValue !== newValue) {
+  } else if (oldValue !== null && newValue == null && categoryId !== null) {
+    return {
+      changeRequestId: crId,
+      implementerId,
+      categoryId,
+      detail: `Deleted ${nameOfField} "${oldValue}"`
+    };
+  } else if (oldValue !== newValue && wbsElementId !== null) {
     return {
       changeRequestId: crId,
       implementerId,
       wbsElementId,
+      detail: buildChangeDetail(nameOfField, `${oldValue}`, `${newValue}`)
+    };
+  } else if (oldValue !== newValue && categoryId !== null) {
+    return {
+      changeRequestId: crId,
+      implementerId,
+      categoryId,
       detail: buildChangeDetail(nameOfField, `${oldValue}`, `${newValue}`)
     };
   }
@@ -177,17 +200,18 @@ export const getWorkPackageChanges = async (
   submitterId: string
 ) => {
   let changes: ChangeCreateArgs[] = [];
-  const nameChangeJson = createChange('name', oldName, newName, crId, submitterId, wbsElementId);
-  const stageChangeJson = createChange('stage', oldStage, newStage, crId, submitterId, wbsElementId);
+  const nameChangeJson = createChange('name', oldName, newName, crId, submitterId, wbsElementId, null);
+  const stageChangeJson = createChange('stage', oldStage, newStage, crId, submitterId, wbsElementId, null);
   const startDateChangeJson = createChange(
     'start date',
     oldStartDate?.toDateString() || null,
     new Date(newStartDate).toDateString(),
     crId,
     submitterId,
-    wbsElementId
+    wbsElementId,
+    null
   );
-  const durationChangeJson = createChange('duration', oldDuration, newDuration, crId, submitterId, wbsElementId);
+  const durationChangeJson = createChange('duration', oldDuration, newDuration, crId, submitterId, wbsElementId, null);
   const blockedByChangeJson = createListChanges(
     'blocked by',
     oldBlockedBy.map(transformBlockedByToChangeListValue),
@@ -203,7 +227,8 @@ export const getWorkPackageChanges = async (
     await getUserFullName(newManagerId),
     crId,
     submitterId,
-    wbsElementId
+    wbsElementId,
+    null
   );
 
   const leadChange = createChange(
@@ -212,7 +237,8 @@ export const getWorkPackageChanges = async (
     await getUserFullName(newLeadId),
     crId,
     submitterId,
-    wbsElementId
+    wbsElementId,
+    null
   );
 
   const descriptionBulletChanges = await getDescriptionBulletChanges(

--- a/src/backend/src/utils/projects.utils.ts
+++ b/src/backend/src/utils/projects.utils.ts
@@ -81,16 +81,33 @@ export const updateProjectAndCreateChanges = async (
 
   const { wbsElementId } = originalProject;
 
-  const nameChangeJson = createChange('name', originalProject.wbsElement.name, name, crId, implementerId, wbsElementId);
-  const budgetChangeJson = createChange('budget', originalProject.budget, budget, crId, implementerId, wbsElementId);
-  const summaryChangeJson = createChange('summary', originalProject.summary, summary, crId, implementerId, wbsElementId);
+  const nameChangeJson = createChange(
+    'name',
+    originalProject.wbsElement.name,
+    name,
+    crId,
+    implementerId,
+    wbsElementId,
+    null
+  );
+  const budgetChangeJson = createChange('budget', originalProject.budget, budget, crId, implementerId, wbsElementId, null);
+  const summaryChangeJson = createChange(
+    'summary',
+    originalProject.summary,
+    summary,
+    crId,
+    implementerId,
+    wbsElementId,
+    null
+  );
   const managerChangeJson = createChange(
     'manager',
     await getUserFullName(originalProject.wbsElement.managerId),
     await getUserFullName(managerId),
     crId,
     implementerId,
-    wbsElementId
+    wbsElementId,
+    null
   );
   const leadChangeJson = createChange(
     'lead',
@@ -98,7 +115,8 @@ export const updateProjectAndCreateChanges = async (
     await getUserFullName(leadId),
     crId,
     implementerId,
-    wbsElementId
+    wbsElementId,
+    null
   );
 
   // Dealing with lists

--- a/src/backend/src/utils/slack.utils.ts
+++ b/src/backend/src/utils/slack.utils.ts
@@ -1,5 +1,5 @@
 import { ChangeRequest, daysBetween, Task, UserPreview, wbsPipe, calculateEndDate, meetingStartTimePipe } from 'shared';
-import { User } from '@prisma/client';
+import { Reimbursement_Product_Other_Reason, User } from '@prisma/client';
 import {
   editMessage,
   getChannelName,
@@ -259,17 +259,21 @@ export const sendAndGetSlackCRNotifications = async (
   teams: Team[],
   changeRequest: Change_Request,
   submitter: User,
-  wbsElement: WBS_Element,
-  projectWbsName: string
+  wbsElement?: WBS_Element,
+  projectWbsName?: string,
+  category?: Reimbursement_Product_Other_Reason
 ) => {
   const notifications: { channelId: string; ts: string }[] = [];
   let message = '';
   switch (changeRequest.type) {
     case 'ACTIVATION':
-      message = `${submitter.firstName} ${submitter.lastName} wants to activate ${wbsElement.name} in ${projectWbsName}`;
+      message = `${submitter.firstName} ${submitter.lastName} wants to activate ${wbsElement?.name} in ${projectWbsName}`;
       break;
     case 'STAGE_GATE':
-      message = `${submitter.firstName} ${submitter.lastName} wants to stage gate ${wbsElement.name} in ${projectWbsName}`;
+      message = `${submitter.firstName} ${submitter.lastName} wants to stage gate ${wbsElement?.name} in ${projectWbsName}`;
+      break;
+    case 'BUDGET':
+      message = `${submitter.firstName} ${submitter.lastName} wants to change the budget of ${category?.name}`;
       break;
     default:
       message = `${changeRequest.type} CR submitted by ${submitter.firstName} ${submitter.lastName} for the ${projectWbsName} project`;

--- a/src/backend/tests/test-data/change-requests.test-data.ts
+++ b/src/backend/tests/test-data/change-requests.test-data.ts
@@ -13,6 +13,7 @@ export const prismaChangeRequest1: PrismaChangeRequest = {
   organizationId: '1',
   submitterId: '1',
   wbsElementId: '65',
+  categoryId: null,
   type: PrismaCRType.DEFINITION_CHANGE,
   dateSubmitted: new Date('11/24/2020'),
   dateReviewed: new Date('11/25/2020'),

--- a/src/backend/tests/test-utils.ts
+++ b/src/backend/tests/test-utils.ts
@@ -117,6 +117,7 @@ export const resetUsers = async () => {
   await prisma.proposed_Solution.deleteMany();
   await prisma.scope_CR_Why.deleteMany();
   await prisma.scope_CR.deleteMany();
+  await prisma.budget_CR.deleteMany();
   await prisma.change_Request.deleteMany();
   await prisma.link.deleteMany();
   await prisma.link_Type.deleteMany();

--- a/src/frontend/src/apis/change-requests.api.ts
+++ b/src/frontend/src/apis/change-requests.api.ts
@@ -133,6 +133,21 @@ export const createStageGateChangeRequest = (submitterId: string, wbsNum: WbsNum
 };
 
 /**
+ * Create a budget change request.
+ * @param submitterId The ID of the user creating the change request.
+ * @param otherReasonId the other reason id the change request is for.
+ * @param proposedBudget the new budget
+ */
+export const createBudgetChangeRequest = (submitterId: string, otherReasonId: string, proposedBudget: number) => {
+  return axios.post<{ message: string }>(apiUrls.changeRequestsCreateBudget(), {
+    submitterId,
+    otherReasonId,
+    type: ChangeRequestType.Budget,
+    proposedBudget
+  });
+};
+
+/**
  * Create a propose solution
  * @param submitterId The ID of the user creating the change request.
  * @param crId The ID of the associated change request.

--- a/src/frontend/src/components/ChangeRequestDetailCard.tsx
+++ b/src/frontend/src/components/ChangeRequestDetailCard.tsx
@@ -9,7 +9,7 @@ import { Link } from '@mui/material';
 import { ActivationChangeRequest, ChangeRequest, ChangeRequestStatus, ChangeRequestType, wbsPipe } from 'shared';
 import { routes } from '../utils/routes';
 import { Link as RouterLink } from 'react-router-dom';
-import { fullNamePipe } from '../utils/pipes';
+import { displayEnum, fullNamePipe } from '../utils/pipes';
 import ChangeRequestTypePill from './ChangeRequestTypePill';
 import ChangeRequestStatusPill from './ChangeRequestStatusPill';
 
@@ -17,6 +17,7 @@ const CRCardDescription = ({ cr }: { cr: ChangeRequest }) => {
   const theme = useTheme();
   const isAccepted = cr.status === ChangeRequestStatus.Implemented || cr.status === ChangeRequestStatus.Accepted;
   const isStageGate = cr.type === ChangeRequestType.StageGate;
+  const isBudget = cr.type === ChangeRequestType.Budget;
   const isActivation = cr.type === ChangeRequestType.Activation;
   return (
     <Box
@@ -46,8 +47,10 @@ const CRCardDescription = ({ cr }: { cr: ChangeRequest }) => {
               Manager: {fullNamePipe((cr as ActivationChangeRequest).manager)}
             </Typography>
           </div>
-        ) : isStageGate ? (
+        ) : isStageGate && cr.wbsNum ? (
           'Stage Gate ' + wbsPipe(cr.wbsNum) + ' - ' + cr.wbsName
+        ) : isBudget && cr.category ? (
+          'Change budget'
         ) : (
           'Standard Change Request (Click To view more details)'
         )}
@@ -92,9 +95,12 @@ const ChangeRequestDetailCard: React.FC<ChangeRequestDetailCardProps> = ({ chang
                 From: {fullNamePipe(changeRequest.submitter)}
               </Typography>
               <Typography fontWeight={'bold'} fontSize={12} noWrap>
-                <Link component={RouterLink} to={`${routes.PROJECTS}/${wbsPipe(changeRequest.wbsNum)}`}>
-                  {wbsPipe(changeRequest.wbsNum)} {changeRequest.wbsName}
-                </Link>
+                {changeRequest.wbsNum && (
+                  <Link component={RouterLink} to={`${routes.PROJECTS}/${wbsPipe(changeRequest.wbsNum)}`}>
+                    {wbsPipe(changeRequest.wbsNum)} {changeRequest.wbsName}
+                  </Link>
+                )}
+                {changeRequest.category && displayEnum(changeRequest.category.name)}
               </Typography>
             </Stack>
           </Grid>

--- a/src/frontend/src/components/ChangeRequestDropdown.tsx
+++ b/src/frontend/src/components/ChangeRequestDropdown.tsx
@@ -45,7 +45,7 @@ const ChangeRequestDropdown = ({ control, name }: ChangeRequestDropdownProps) =>
   const filteredRequests = getFilteredChangeRequests(changeRequests, user);
 
   const approvedChangeRequestOptions = filteredRequests.map((cr) => ({
-    label: `${cr.identifier} - ${wbsPipe(cr.wbsNum)} - ${cr.submitter.firstName} ${cr.submitter.lastName} - ${cr.type}`,
+    label: `${cr.identifier} - ${cr.wbsNum ? wbsPipe(cr.wbsNum) : cr.category ? cr.category.name : ''} - ${cr.submitter.firstName} ${cr.submitter.lastName} - ${cr.type}`,
     id: cr.crId
   }));
 

--- a/src/frontend/src/hooks/change-requests.hooks.ts
+++ b/src/frontend/src/hooks/change-requests.hooks.ts
@@ -25,7 +25,8 @@ import {
   requestCRReview,
   getToReviewChangeRequests,
   getUnreviewedChangeRequests,
-  getApprovedChangeRequests
+  getApprovedChangeRequests,
+  createBudgetChangeRequest
 } from '../apis/change-requests.api';
 
 /**
@@ -169,6 +170,13 @@ export interface CreateStageGateChangeRequestPayload {
   type: string;
 }
 
+export interface CreateBudgetChangeRequestPayload {
+  submitterId: string;
+  otherReasonId: string;
+  proposedBudget: number;
+  type: string;
+}
+
 export interface CreateProposedSolutionPayload {
   submitterId: string;
   crId: string;
@@ -206,6 +214,19 @@ export const useCreateStageGateChangeRequest = () => {
     ['change requests', 'create', 'stage gate'],
     async (payload: CreateStageGateChangeRequestPayload) => {
       const { data } = await createStageGateChangeRequest(payload.submitterId, payload.wbsNum, payload.confirmDone);
+      return data;
+    }
+  );
+};
+
+/**
+ * Custom React Hook to create a budget change request.
+ */
+export const useCreateBudgetChangeRequest = () => {
+  return useMutation<{ message: string }, Error, CreateBudgetChangeRequestPayload>(
+    ['change requests', 'create', 'budget'],
+    async (payload: CreateBudgetChangeRequestPayload) => {
+      const { data } = await createBudgetChangeRequest(payload.submitterId, payload.otherReasonId, payload.proposedBudget);
       return data;
     }
   );

--- a/src/frontend/src/pages/ChangeRequestDetailPage/BudgetDetails.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/BudgetDetails.tsx
@@ -8,7 +8,6 @@ interface BudgetDetailsProps {
 }
 
 const BudgetDetails: React.FC<BudgetDetailsProps> = ({ cr }) => {
-  console.log(cr);
   return (
     <Grid container rowSpacing="10px" mb="40px">
       <Grid item xs={12} md={7}>

--- a/src/frontend/src/pages/ChangeRequestDetailPage/BudgetDetails.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/BudgetDetails.tsx
@@ -1,0 +1,26 @@
+import { Box, Typography } from '@mui/material';
+import Grid from '@mui/material/Grid';
+import { BudgetChangeRequest } from 'shared';
+import { dollarsPipe } from '../../utils/pipes';
+
+interface BudgetDetailsProps {
+  cr: BudgetChangeRequest;
+}
+
+const BudgetDetails: React.FC<BudgetDetailsProps> = ({ cr }) => {
+  console.log(cr);
+  return (
+    <Grid container rowSpacing="10px" mb="40px">
+      <Grid item xs={12} md={7}>
+        {cr.category && (
+          <Box display="flex" flexDirection="column" gap={1}>
+            <Typography fontSize={18}>Current Budget: {dollarsPipe(cr.category.budget)}</Typography>
+            <Typography fontSize={18}>Proposed Budget: {dollarsPipe(cr.proposedBudget)}</Typography>
+          </Box>
+        )}
+      </Grid>
+    </Grid>
+  );
+};
+
+export default BudgetDetails;

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ChangeRequestActionMenu.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ChangeRequestActionMenu.tsx
@@ -135,36 +135,40 @@ const ChangeRequestActionMenu: React.FC<ChangeRequestActionMenuProps> = ({
   const renderUnreviewedActionsDropdown = () =>
     isRequestAllowed ? requestReviewerDropdown() : <UnreviewedActionsDropdown />;
 
-  const ImplementCrDropdown = () => (
-    <ActionsMenu
-      buttons={[
-        {
-          title: 'Create New Project',
-          onClick: () =>
-            history.push(`${routes.PROJECTS_NEW}?crId=${changeRequest.crId}&wbs=${projectWbsPipe(changeRequest.wbsNum)}`),
-          disabled: !isUserAllowedToImplement,
-          icon: <CreateNewFolderIcon fontSize="small" />
-        },
-        {
-          title: 'Create New Work Package',
-          onClick: () =>
-            history.push(
-              `${routes.WORK_PACKAGE_NEW}?crId=${changeRequest.crId}&wbs=${projectWbsPipe(changeRequest.wbsNum)}`
-            ),
-          disabled: !isUserAllowedToImplement,
-          icon: <PostAddIcon fontSize="small" />
-        },
-        {
-          title: `Edit ${changeRequest.wbsNum.workPackageNumber === 0 ? 'Project' : 'Work Package'}`,
-          onClick: () =>
-            history.push(`${routes.PROJECTS}/${wbsPipe(changeRequest.wbsNum)}?crId=${changeRequest.crId}&edit=${true}`),
-          disabled: !isUserAllowedToImplement,
-          icon: <EditIcon fontSize="small" />
-        }
-      ]}
-      title="Implement Change Request"
-    />
-  );
+  const ImplementCrDropdown = () => {
+    if (!changeRequest.wbsNum) return null;
+
+    return (
+      <ActionsMenu
+        buttons={[
+          {
+            title: 'Create New Project',
+            onClick: () =>
+              history.push(`${routes.PROJECTS_NEW}?crId=${changeRequest.crId}&wbs=${projectWbsPipe(changeRequest.wbsNum!)}`),
+            disabled: !isUserAllowedToImplement,
+            icon: <CreateNewFolderIcon fontSize="small" />
+          },
+          {
+            title: 'Create New Work Package',
+            onClick: () =>
+              history.push(
+                `${routes.WORK_PACKAGE_NEW}?crId=${changeRequest.crId}&wbs=${projectWbsPipe(changeRequest.wbsNum!)}`
+              ),
+            disabled: !isUserAllowedToImplement,
+            icon: <PostAddIcon fontSize="small" />
+          },
+          {
+            title: `Edit ${changeRequest.wbsNum.workPackageNumber === 0 ? 'Project' : 'Work Package'}`,
+            onClick: () =>
+              history.push(`${routes.PROJECTS}/${wbsPipe(changeRequest.wbsNum!)}?crId=${changeRequest.crId}&edit=true`),
+            disabled: !isUserAllowedToImplement,
+            icon: <EditIcon fontSize="small" />
+          }
+        ]}
+        title="Implement Change Request"
+      />
+    );
+  };
 
   return changeRequest.accepted ? <ImplementCrDropdown /> : <>{renderUnreviewedActionsDropdown()}</>;
 };

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ChangeRequestDetailsView.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ChangeRequestDetailsView.tsx
@@ -5,9 +5,15 @@
 
 import { ReactElement, useState } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
-import { ActivationChangeRequest, ChangeRequest, ChangeRequestType, StandardChangeRequest } from 'shared';
+import {
+  ActivationChangeRequest,
+  BudgetChangeRequest,
+  ChangeRequest,
+  ChangeRequestType,
+  StandardChangeRequest
+} from 'shared';
 import { routes } from '../../utils/routes';
-import { datePipe, fullNamePipe, wbsPipe } from '../../utils/pipes';
+import { datePipe, displayEnum, fullNamePipe, wbsPipe } from '../../utils/pipes';
 import ActivationDetails from './ActivationDetails';
 import ImplementedChangesList from './ImplementedChangesList';
 import StandardDetails from './StandardDetails';
@@ -23,6 +29,7 @@ import ChangeRequestTypePill from '../../components/ChangeRequestTypePill';
 import ChangeRequestStatusPill from '../../components/ChangeRequestStatusPill';
 import DiffSection from './DiffSection/DiffSection';
 import { hasProposedChanges } from '../../utils/change-request.utils';
+import BudgetDetails from './BudgetDetails';
 
 const buildDetails = (cr: ChangeRequest): ReactElement => {
   switch (cr.type) {
@@ -30,6 +37,8 @@ const buildDetails = (cr: ChangeRequest): ReactElement => {
       return <ActivationDetails cr={cr as ActivationChangeRequest} />;
     case ChangeRequestType.StageGate:
       return <></>;
+    case ChangeRequestType.Budget:
+      return <BudgetDetails cr={cr as BudgetChangeRequest} />;
     default:
       return <StandardDetails cr={cr as StandardChangeRequest} />;
   }
@@ -55,7 +64,9 @@ const ChangeRequestDetailsView: React.FC<ChangeRequestDetailsProps> = ({
   const handleDeleteOpen = () => setDeleteModalShow(true);
 
   const isStandard =
-    changeRequest.type !== ChangeRequestType.Activation && changeRequest.type !== ChangeRequestType.StageGate;
+    changeRequest.type !== ChangeRequestType.Activation &&
+    changeRequest.type !== ChangeRequestType.StageGate &&
+    changeRequest.type !== ChangeRequestType.Budget;
 
   const isActivation = changeRequest.type === ChangeRequestType.Activation;
 
@@ -83,12 +94,20 @@ const ChangeRequestDetailsView: React.FC<ChangeRequestDetailsProps> = ({
       <Grid container rowGap={3}>
         <Grid container columnSpacing={3}>
           <Grid item xs={'auto'}>
-            <Typography sx={{ fontWeight: 'normal', fontSize: '21px' }}>
-              <b>WBS: </b>
-              <Link component={RouterLink} to={`${routes.PROJECTS}/${wbsPipe(changeRequest.wbsNum)}`}>
-                {changeRequest.wbsName}
-              </Link>
-            </Typography>
+            {changeRequest.wbsNum && (
+              <Typography sx={{ fontWeight: 'normal', fontSize: '21px' }}>
+                <b>WBS: </b>
+                <Link component={RouterLink} to={`${routes.PROJECTS}/${wbsPipe(changeRequest.wbsNum)}`}>
+                  {changeRequest.wbsName}
+                </Link>
+              </Typography>
+            )}
+            {changeRequest.category && (
+              <Typography sx={{ fontWeight: 'normal', fontSize: '21px' }}>
+                <b>Category: </b>
+                {displayEnum(changeRequest.category.name)}
+              </Typography>
+            )}
           </Grid>
           <Grid item xs={'auto'}>
             <Typography sx={{ fontWeight: 'normal', fontSize: '21px' }}>

--- a/src/frontend/src/pages/ChangeRequestDetailPage/DiffSection/DiffSection.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/DiffSection/DiffSection.tsx
@@ -5,6 +5,7 @@ import { displayEnum } from '../../../utils/pipes';
 import DiffSectionCreate from './DiffSectionCreate';
 import DiffSectionEdit from './DiffSectionEdit';
 import { projectProposedChangesToPreview, workPackageProposedChangesToPreview } from '../../../utils/diff-page.utils';
+import LoadingIndicator from '../../../components/LoadingIndicator';
 
 interface DiffSectionProps {
   changeRequest: StandardChangeRequest;
@@ -52,7 +53,9 @@ const DiffSection: React.FC<DiffSectionProps> = ({ changeRequest }) => {
           originalWorkPackageData={originalWorkPackageData}
           wbsNum={wbsNum}
         />
-      ) : null}
+      ) : (
+        <LoadingIndicator />
+      )}
     </Box>
   );
 };

--- a/src/frontend/src/pages/ChangeRequestDetailPage/DiffSection/DiffSection.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/DiffSection/DiffSection.tsx
@@ -19,7 +19,7 @@ enum ChangeRequestAction {
 
 const DiffSection: React.FC<DiffSectionProps> = ({ changeRequest }) => {
   const { wbsNum, projectProposedChanges, workPackageProposedChanges } = changeRequest;
-  const isOnProject = isProject(wbsNum);
+  const isOnProject = wbsNum ? isProject(wbsNum) : false;
 
   const changeRequestAction: ChangeRequestAction =
     projectProposedChanges && projectProposedChanges.carNumber !== undefined
@@ -44,7 +44,7 @@ const DiffSection: React.FC<DiffSectionProps> = ({ changeRequest }) => {
           projectProposedChanges={projectProposedChangesPreview}
           workPackageProposedChanges={workPackageProposedChangesPreview}
         />
-      ) : (
+      ) : wbsNum ? (
         <DiffSectionEdit
           projectProposedChanges={projectProposedChangesPreview}
           workPackageProposedChanges={workPackageProposedChangesPreview}
@@ -52,7 +52,7 @@ const DiffSection: React.FC<DiffSectionProps> = ({ changeRequest }) => {
           originalWorkPackageData={originalWorkPackageData}
           wbsNum={wbsNum}
         />
-      )}
+      ) : null}
     </Box>
   );
 };

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ImplementedChangesList.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ImplementedChangesList.tsx
@@ -29,12 +29,12 @@ const ImplementedChangesList: React.FC<ImplementedChangesListProps> = ({ changes
                 {
                   <Typography>
                     [
-                    {
+                    {ic.wbsNum && (
                       <Link component={RouterLink} to={`${routes.PROJECTS}/${wbsPipe(ic.wbsNum)}`}>
                         {wbsPipe(ic.wbsNum)}
                       </Link>
-                    }
-                    ] {ic.detail}
+                    )}
+                    {ic.category && <Typography> {ic.category.name} </Typography>}] {ic.detail}
                   </Typography>
                 }
               </DynamicTooltip>

--- a/src/frontend/src/pages/ChangeRequestDetailPage/OtherChangeRequestsPopupTabs.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/OtherChangeRequestsPopupTabs.tsx
@@ -10,7 +10,7 @@ import ChangeRequestDetailCard from '../../components/ChangeRequestDetailCard';
 import { useAllChangeRequests } from '../../hooks/change-requests.hooks';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import ErrorPage from '../ErrorPage';
-import { fullNamePipe } from '../../utils/pipes';
+import { displayEnum, fullNamePipe } from '../../utils/pipes';
 
 interface OtherChangeRequestsPopupTabsProps {
   changeRequest: ChangeRequest;
@@ -39,6 +39,12 @@ const OtherChangeRequestsPopupTabs: React.FC<OtherChangeRequestsPopupTabsProps> 
 
   const crsFromWbs = changeRequests
     ?.filter((cr) => cr.wbsName === changeRequest.wbsName)
+    .sort((a: ChangeRequest, b: ChangeRequest) => {
+      return b.dateSubmitted.getTime() - a.dateSubmitted.getTime();
+    });
+
+  const crsFromCategory = changeRequests
+    ?.filter((cr) => cr.category?.name === changeRequest.category?.name)
     .sort((a: ChangeRequest, b: ChangeRequest) => {
       return b.dateSubmitted.getTime() - a.dateSubmitted.getTime();
     });
@@ -107,11 +113,14 @@ const OtherChangeRequestsPopupTabs: React.FC<OtherChangeRequestsPopupTabsProps> 
           mb: '-1px'
         }}
       >
-        {displayTab(1, `Other CR's on ${wbsPipe(changeRequest.wbsNum)}`)}
+        {changeRequest.wbsNum && displayTab(1, `Other CR's on ${wbsPipe(changeRequest.wbsNum)}`)}
+        {changeRequest.category && displayTab(1, `Other CR's on ${displayEnum(changeRequest.category.name)}`)}
         {displayTab(2, `Other CR's from ${fullNamePipe(changeRequest.submitter)}`)}
       </Tabs>
       <Collapse in={tab !== 0}>
-        {tab === 1 ? displayCRCards(crsFromWbs || []) : tab === 2 && displayCRCards(crsFromSubmitter || [])}
+        {tab === 1
+          ? displayCRCards(crsFromWbs || crsFromCategory || [])
+          : tab === 2 && displayCRCards(crsFromSubmitter || [])}
       </Collapse>
     </Box>
   );

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequest.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequest.tsx
@@ -8,9 +8,10 @@ import { useAuth } from '../../hooks/auth.hooks';
 import { useReviewChangeRequest } from '../../hooks/change-requests.hooks';
 import ErrorPage from '../ErrorPage';
 import LoadingIndicator from '../../components/LoadingIndicator';
-import ReviewChangeRequestsView from './ReviewChangeRequestView';
 import { ChangeRequest } from 'shared';
 import { useToast } from '../../hooks/toasts.hooks';
+import ReviewChangeRequestsViewWBSWrapper from './ReviewChangeRequestsViewWBSWrapper';
+import ReviewChangeRequestsViewCategoryWrapper from './ReviewChangeRequestsViewCategoryWrapper';
 
 interface ReviewChangeRequestProps {
   modalShow: boolean;
@@ -59,7 +60,15 @@ const ReviewChangeRequest: React.FC<ReviewChangeRequestProps> = ({
 
   if (isError) return <ErrorPage message={error?.message} />;
 
-  return <ReviewChangeRequestsView cr={cr} modalShow={modalShow} onHide={handleClose} onSubmit={handleConfirm} />;
+  if (cr.wbsNum) {
+    return (
+      <ReviewChangeRequestsViewWBSWrapper cr={cr} modalShow={modalShow} onHide={handleClose} onSubmit={handleConfirm} />
+    );
+  }
+
+  return (
+    <ReviewChangeRequestsViewCategoryWrapper cr={cr} modalShow={modalShow} onHide={handleClose} onSubmit={handleConfirm} />
+  );
 };
 
 export default ReviewChangeRequest;

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequestView.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequestView.tsx
@@ -7,7 +7,7 @@ import { Controller, useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import * as yup from 'yup';
 import { FormInput } from './ReviewChangeRequest';
-import { ChangeRequest, ProposedSolution, StandardChangeRequest } from 'shared';
+import { ChangeRequest, ProposedSolution, StandardChangeRequest, WorkPackage } from 'shared';
 import { useState } from 'react';
 import ProposedSolutionSelectItem from './ProposedSolutionSelectItem';
 import {
@@ -25,10 +25,7 @@ import { useToast } from '../../hooks/toasts.hooks';
 import NERSuccessButton from '../../components/NERSuccessButton';
 import NERFailButton from '../../components/NERFailButton';
 import CloseIcon from '@mui/icons-material/Close';
-import { useGetBlockingWorkPackages } from '../../hooks/work-packages.hooks';
 import ChangeRequestBlockerWarning from '../../components/ChangeRequestBlockerWarning';
-import LoadingIndicator from '../../components/LoadingIndicator';
-import ErrorPage from '../ErrorPage';
 import { hasProposedChanges } from '../../utils/change-request.utils';
 
 interface ReviewChangeRequestViewProps {
@@ -36,6 +33,7 @@ interface ReviewChangeRequestViewProps {
   modalShow: boolean;
   onHide: () => void;
   onSubmit: (data: FormInput) => Promise<void>;
+  blockingWorkPackages: WorkPackage[];
 }
 
 const schema = yup.object().shape({
@@ -48,19 +46,16 @@ const ReviewChangeRequestsView: React.FC<ReviewChangeRequestViewProps> = ({
   cr,
   modalShow,
   onHide,
-  onSubmit
+  onSubmit,
+  blockingWorkPackages
 }: ReviewChangeRequestViewProps) => {
   const [selected, setSelected] = useState(-1);
   const [selectedTimelineImpact, setSelectedTimelineImpact] = useState(-1);
   const toast = useToast();
-  const { isLoading, isError, error, data: blockingWorkPackages } = useGetBlockingWorkPackages(cr.wbsNum);
   const [showWarning, setShowWarning] = useState(false);
   const { register, setValue, getFieldState, reset, handleSubmit, control, getValues } = useForm<FormInput>({
     resolver: yupResolver(schema)
   });
-
-  if (isLoading) return <LoadingIndicator />;
-  if (isError) return <ErrorPage error={error} />;
 
   /**
    * Register (or set registered field) to the appropriate boolean based on which action button was clicked
@@ -300,7 +295,7 @@ const ReviewChangeRequestsView: React.FC<ReviewChangeRequestViewProps> = ({
           onHide={() => setShowWarning(false)}
           open={showWarning}
           onSubmit={() => onSubmitWrapper(getValues())}
-          blockingWorkPackages={blockingWorkPackages ?? []}
+          blockingWorkPackages={blockingWorkPackages}
         />
       }
     </>

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequestsViewCategoryWrapper.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequestsViewCategoryWrapper.tsx
@@ -1,0 +1,23 @@
+import { ChangeRequest } from 'shared';
+import ReviewChangeRequestsView from './ReviewChangeRequestView';
+import { FormInput } from './ReviewChangeRequest';
+
+interface ReviewChangeRequestViewCategoryWrapperProps {
+  cr: ChangeRequest;
+  modalShow: boolean;
+  onHide: () => void;
+  onSubmit: (data: FormInput) => Promise<void>;
+}
+
+const ReviewChangeRequestsViewCategoryWrapper: React.FC<ReviewChangeRequestViewCategoryWrapperProps> = ({
+  cr,
+  modalShow,
+  onHide,
+  onSubmit
+}: ReviewChangeRequestViewCategoryWrapperProps) => {
+  return (
+    <ReviewChangeRequestsView cr={cr} modalShow={modalShow} onHide={onHide} onSubmit={onSubmit} blockingWorkPackages={[]} />
+  );
+};
+
+export default ReviewChangeRequestsViewCategoryWrapper;

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequestsViewWBSWrapper.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ReviewChangeRequestsViewWBSWrapper.tsx
@@ -1,0 +1,37 @@
+import { ChangeRequest } from 'shared';
+import LoadingIndicator from '../../components/LoadingIndicator';
+import { useGetBlockingWorkPackages } from '../../hooks/work-packages.hooks';
+import ErrorPage from '../ErrorPage';
+import ReviewChangeRequestsView from './ReviewChangeRequestView';
+import { FormInput } from './ReviewChangeRequest';
+
+interface ReviewChangeRequestViewWBSWrapperProps {
+  cr: ChangeRequest;
+  modalShow: boolean;
+  onHide: () => void;
+  onSubmit: (data: FormInput) => Promise<void>;
+}
+
+const ReviewChangeRequestsViewWBSWrapper: React.FC<ReviewChangeRequestViewWBSWrapperProps> = ({
+  cr,
+  modalShow,
+  onHide,
+  onSubmit
+}: ReviewChangeRequestViewWBSWrapperProps) => {
+  const { isLoading, isError, error, data: blockingWorkPackages } = useGetBlockingWorkPackages(cr.wbsNum!);
+
+  if (isLoading) return <LoadingIndicator />;
+  if (isError) return <ErrorPage error={error} />;
+
+  return (
+    <ReviewChangeRequestsView
+      cr={cr}
+      modalShow={modalShow}
+      onHide={onHide}
+      onSubmit={onSubmit}
+      blockingWorkPackages={blockingWorkPackages ?? []}
+    />
+  );
+};
+
+export default ReviewChangeRequestsViewWBSWrapper;

--- a/src/frontend/src/pages/ChangeRequestsPage/ChangeRequestsTable.tsx
+++ b/src/frontend/src/pages/ChangeRequestsPage/ChangeRequestsTable.tsx
@@ -8,14 +8,18 @@ import { Box, useTheme } from '@mui/system';
 import { DataGrid, GridColDef, GridFilterModel, GridRow, GridRowProps } from '@mui/x-data-grid';
 import { useEffect, useState } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
-import { ChangeRequest, ChangeRequestType, WbsNumber, validateWBS } from 'shared';
+import { ChangeRequest, ChangeRequestType, WbsElement } from 'shared';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import { useAllChangeRequests } from '../../hooks/change-requests.hooks';
-import { datePipe, fullNamePipe, wbsPipe } from '../../utils/pipes';
+import { datePipe, displayEnum, fullNamePipe, wbsPipe } from '../../utils/pipes';
 import { routes } from '../../utils/routes';
 import { GridColDefStyle } from '../../utils/tables';
 import ErrorPage from '../ErrorPage';
 import TableCustomToolbar from '../../components/TableCustomToolbar';
+
+function isWBSElement(value: any): value is WbsElement {
+  return value && 'wbsNum' in value;
+}
 
 const ChangeRequestsTable: React.FC = () => {
   const [windowSize, setWindowSize] = useState(window.innerWidth);
@@ -69,26 +73,39 @@ const ChangeRequestsTable: React.FC = () => {
     maxWidth: 200
   };
 
-  const wbsColumn: GridColDef = {
+  const dynamicColumn: GridColDef = {
     ...baseColDef,
-    field: 'wbs',
-    headerName: 'WBS',
+    field: 'wbsOrCategory',
+    headerName: 'WBS / Category',
     filterable: true,
     sortable: true,
     maxWidth: 300,
-    valueGetter: (params) => `${wbsPipe(params.value.wbsNum)} - ${params.value.name}`,
+    valueGetter: (params) => {
+      const { value } = params;
+      if (isWBSElement(value)) {
+        return `${wbsPipe(value.wbsNum)} - ${value.name}`;
+      }
+      return `${value?.name ? displayEnum(value?.name) : ''}`;
+    },
     sortComparator: (_v1, _v2, param1, param2) => {
-      const wbs1: WbsNumber = validateWBS((param1.value as string).split(' ')[0]);
-      const wbs2: WbsNumber = validateWBS((param2.value as string).split(' ')[0]);
+      const val1 = param1.value;
+      const val2 = param2.value;
 
-      if (wbs1.carNumber !== wbs2.carNumber) {
-        return wbs1.carNumber - wbs2.carNumber;
-      } else if (wbs1.projectNumber !== wbs2.projectNumber) {
-        return wbs1.projectNumber - wbs2.projectNumber;
-      } else if (wbs1.workPackageNumber !== wbs2.workPackageNumber) {
+      if (isWBSElement(val1) && isWBSElement(val2)) {
+        const wbs1 = val1.wbsNum;
+        const wbs2 = val2.wbsNum;
+
+        if (wbs1.carNumber !== wbs2.carNumber) return wbs1.carNumber - wbs2.carNumber;
+        if (wbs1.projectNumber !== wbs2.projectNumber) return wbs1.projectNumber - wbs2.projectNumber;
         return wbs1.workPackageNumber - wbs2.workPackageNumber;
       }
-      return 0;
+
+      if (!isWBSElement(val1) && !isWBSElement(val2)) {
+        return val1.budget - val2.budget;
+      }
+
+      // Prefer WBS entries first, or reverse depending on your preference
+      return isWBSElement(val1) ? -1 : 1;
     }
   };
 
@@ -99,7 +116,7 @@ const ChangeRequestsTable: React.FC = () => {
     maxWidth: 200
   };
 
-  const smallColumns: GridColDef[] = [idColumn, dateReviewedColumn, wbsColumn, submitterColumn];
+  const smallColumns: GridColDef[] = [idColumn, dateReviewedColumn, dynamicColumn, submitterColumn];
 
   const columns: GridColDef[] = [
     idColumn,
@@ -112,7 +129,7 @@ const ChangeRequestsTable: React.FC = () => {
       maxWidth: 150
     },
     { ...baseColDef, field: 'carNumber', headerName: 'Car #', type: 'number', maxWidth: 50 },
-    wbsColumn,
+    dynamicColumn,
     {
       ...baseColDef,
       field: 'dateSubmitted',
@@ -189,11 +206,14 @@ const ChangeRequestsTable: React.FC = () => {
         loading={isLoading}
         error={error}
         rows={
-          // flatten some complex data to allow MUI to sort/filter yet preserve the original data being available to the front-end
           data.map((v) => ({
             ...v,
-            carNumber: v.wbsNum.carNumber,
-            wbs: { wbsNum: v.wbsNum, name: v.wbsName },
+            carNumber: v.wbsNum ? v.wbsNum.carNumber : undefined,
+            wbsOrCategory: v.wbsNum
+              ? { wbsNum: v.wbsNum, name: v.wbsName }
+              : v.category
+                ? { category: v.category, name: v.category.name }
+                : undefined,
             submitter: fullNamePipe(v.submitter),
             reviewer: fullNamePipe(v.reviewer)
           })) || []

--- a/src/frontend/src/pages/FinancePage/FinanceComponents/EditBudgetModalForReason.tsx
+++ b/src/frontend/src/pages/FinancePage/FinanceComponents/EditBudgetModalForReason.tsx
@@ -8,7 +8,10 @@ import AttachMoneyIcon from '@mui/icons-material/AttachMoney';
 import { useGetAllIndexCodes, useGetAllOtherProductReason } from '../../../hooks/finance.hooks';
 import LoadingIndicator from '../../../components/LoadingIndicator';
 import ErrorPage from '../../ErrorPage';
-import { useEditOtherReimbursementProductReason } from '../../../hooks/finance.hooks';
+import { CreateBudgetChangeRequestPayload } from '../../../hooks/change-requests.hooks';
+import { createBudgetChangeRequest } from '../../../apis/change-requests.api';
+import { useAuth } from '../../../hooks/auth.hooks';
+import { ChangeRequestType } from 'shared';
 
 const schema = yup.object().shape({
   category: yup.string().required('Reason is required'),
@@ -48,15 +51,14 @@ export const EditBudgetModalForReason: React.FC<EditBudgetModalForReasonProps> =
 
   const currentCategoryId = watch('category');
 
+  const auth = useAuth();
+
   const {
     data: indexCodes,
     isLoading: indexCodesIsLoading,
     isError: indexCodeIsError,
     error: indexCodeError
   } = useGetAllIndexCodes();
-
-  const { isLoading: editReasonIsLoading, mutateAsync: editReason } =
-    useEditOtherReimbursementProductReason(currentCategoryId);
 
   const {
     data: otherReasons,
@@ -65,7 +67,7 @@ export const EditBudgetModalForReason: React.FC<EditBudgetModalForReasonProps> =
     error: otherReasonError
   } = useGetAllOtherProductReason();
 
-  if (!indexCodes || indexCodesIsLoading || editReasonIsLoading) {
+  if (!indexCodes || indexCodesIsLoading) {
     return <LoadingIndicator />;
   }
   if (indexCodeIsError) {
@@ -81,12 +83,19 @@ export const EditBudgetModalForReason: React.FC<EditBudgetModalForReasonProps> =
 
   const onSubmit = async (data: EditBudgetInputs) => {
     if (!currentCategoryId) return;
+    if (auth.user?.userId === undefined) throw new Error('Cannot create budget change request without being logged in');
 
-    const payload = {
-      updatedIndexCodeId: data.updatedIndexCode,
-      updatedBudget: data.updatedBudget
+    const currentCategory = otherReasons.find((reason) => reason.otherProductReasonId === currentCategoryId);
+    if (!currentCategory) return;
+
+    const payload: CreateBudgetChangeRequestPayload = {
+      submitterId: auth.user?.userId,
+      otherReasonId: currentCategoryId,
+      proposedBudget: data.updatedBudget,
+      type: ChangeRequestType.Budget
     };
-    await editReason(payload);
+
+    await createBudgetChangeRequest(payload.submitterId, payload.otherReasonId, payload.proposedBudget);
 
     handleClose();
   };
@@ -101,7 +110,7 @@ export const EditBudgetModalForReason: React.FC<EditBudgetModalForReasonProps> =
       handleUseFormSubmit={handleSubmit}
       onFormSubmit={onSubmit}
       cancelText="Cancel"
-      submitText="Save"
+      submitText="Create Change Request"
       showCloseButton
     >
       <Box display="flex" flexDirection={'column'} minWidth={400}>

--- a/src/frontend/src/pages/FinancePage/FinanceComponents/VendorFormModal.tsx
+++ b/src/frontend/src/pages/FinancePage/FinanceComponents/VendorFormModal.tsx
@@ -2,14 +2,14 @@ import { Controller, useForm } from 'react-hook-form';
 import NERFormModal from '../../../components/NERFormModal';
 import {
   FormControl,
-  FormLabel,
   FormHelperText,
   Box,
   MenuItem,
   Checkbox,
   ListItemText,
   Autocomplete,
-  TextField
+  TextField,
+  Typography
 } from '@mui/material';
 import ReactHookTextField from '../../../components/ReactHookTextField';
 import { useToast } from '../../../hooks/toasts.hooks';
@@ -92,17 +92,23 @@ const VendorFormModal = ({ showModal, handleClose, defaultValues, onSubmit }: Ve
     >
       <Box display="flex" flexDirection={'column'} minWidth={400} maxWidth={400}>
         <FormControl sx={{ paddingBottom: 2 }}>
-          <FormLabel sx={{ fontWeight: 'bold', fontSize: 18, color: '#EF4345' }}>Vendor Name:*</FormLabel>
+          <Typography sx={{ fontWeight: 'bold', fontSize: 22, color: '#EF4345' }} variant="h5">
+            Vendor Name:*
+          </Typography>
           <ReactHookTextField name="name" placeholder="Vendor Name Here" control={control} sx={{ width: 1 }} />
           <FormHelperText error>{errors.name?.message}</FormHelperText>
         </FormControl>
         <FormControl sx={{ paddingBottom: 2 }}>
-          <FormLabel sx={{ fontWeight: 'bold', fontSize: 18, color: '#EF4345' }}>Username:*</FormLabel>
+          <Typography sx={{ fontWeight: 'bold', fontSize: 22, color: '#EF4345' }} variant="h5">
+            Username:*
+          </Typography>
           <ReactHookTextField name="username" placeholder="Add Username Here" control={control} sx={{ width: 1 }} />
           <FormHelperText error>{errors.username?.message}</FormHelperText>
         </FormControl>
         <FormControl sx={{ paddingBottom: 2 }}>
-          <FormLabel sx={{ fontWeight: 'bold', fontSize: 18, color: '#EF4345' }}>Password:*</FormLabel>
+          <Typography sx={{ fontWeight: 'bold', fontSize: 22, color: '#EF4345' }} variant="h5">
+            Password:*
+          </Typography>
           <ReactHookTextField name="password" placeholder="Add Password Here" control={control} sx={{ width: 1 }} />
           <FormHelperText error>{errors.password?.message}</FormHelperText>
         </FormControl>
@@ -117,19 +123,20 @@ const VendorFormModal = ({ showModal, handleClose, defaultValues, onSubmit }: Ve
               paddingTop: 1
             }}
           >
-            <FormLabel
+            <Typography
               sx={{
                 fontWeight: 'bold',
-                fontSize: 18,
+                fontSize: 22,
                 color: '#EF4345',
                 textAlign: 'center',
                 '&.Mui-focused': { color: '#EF4345' },
                 '&.Mui-error': { color: '#EF4345' },
                 marginBottom: 1
               }}
+              variant="h5"
             >
               Tax Exempt:*
-            </FormLabel>
+            </Typography>
             <Controller
               control={control}
               name="taxExempt"
@@ -144,7 +151,9 @@ const VendorFormModal = ({ showModal, handleClose, defaultValues, onSubmit }: Ve
             />
           </FormControl>
           <FormControl sx={{ paddingBottom: 2, flex: 3 }}>
-            <FormLabel sx={{ fontWeight: 'bold', fontSize: 18, color: '#EF4345' }}>Discount Code:*</FormLabel>
+            <Typography sx={{ fontWeight: 'bold', fontSize: 22, color: '#EF4345' }} variant="h5">
+              Discount Code:*
+            </Typography>
             <ReactHookTextField
               name="discountCode"
               placeholder="Add Discount Code Here"
@@ -155,16 +164,17 @@ const VendorFormModal = ({ showModal, handleClose, defaultValues, onSubmit }: Ve
           </FormControl>
         </Box>
         <FormControl fullWidth sx={{ paddingBottom: 2 }}>
-          <FormLabel
+          <Typography
             sx={{
               alignSelf: 'start',
               fontWeight: 'bold',
-              fontSize: 18,
+              fontSize: 22,
               color: '#EF4345'
             }}
+            variant="h5"
           >
             2FA Contacts:
-          </FormLabel>
+          </Typography>
           <Controller
             control={control}
             defaultValue={[]}
@@ -206,7 +216,9 @@ const VendorFormModal = ({ showModal, handleClose, defaultValues, onSubmit }: Ve
           />
         </FormControl>
         <FormControl>
-          <FormLabel sx={{ fontWeight: 'bold', fontSize: 18, color: '#EF4345' }}>Notes on Vendor:</FormLabel>
+          <Typography sx={{ fontWeight: 'bold', fontSize: 22, color: '#EF4345' }} variant="h5">
+            Notes on Vendor:
+          </Typography>
           <ReactHookTextField name="notes" placeholder="e.g. Vendor is tax-exempt" control={control} sx={{ width: 1 }} />
           <FormHelperText error>{errors.note?.message}</FormHelperText>
         </FormControl>

--- a/src/frontend/src/tests/pages/ChangeRequestDetailPage/ReviewChangeRequestView.test.tsx
+++ b/src/frontend/src/tests/pages/ChangeRequestDetailPage/ReviewChangeRequestView.test.tsx
@@ -30,6 +30,7 @@ const renderComponent = (modalShow: boolean) => {
         modalShow={modalShow}
         onHide={mockHandleHide}
         onSubmit={mockHandleSubmit}
+        blockingWorkPackages={[]}
       />
     </RouterWrapper>
   );

--- a/src/frontend/src/utils/enum-pipes.ts
+++ b/src/frontend/src/utils/enum-pipes.ts
@@ -53,6 +53,8 @@ export const ChangeRequestTypeTextPipe: (type: ChangeRequestType) => string = (t
       return 'Issue';
     case ChangeRequestType.Other:
       return 'Other';
+    case ChangeRequestType.Budget:
+      return 'Budget';
   }
 };
 

--- a/src/frontend/src/utils/urls.ts
+++ b/src/frontend/src/utils/urls.ts
@@ -82,6 +82,7 @@ const changeRequestDelete = (id: string) => changeRequestsById(id) + '/delete';
 const changeRequestsCreate = () => `${changeRequests()}/new`;
 const changeRequestsCreateActivation = () => `${changeRequestsCreate()}/activation`;
 const changeRequestsCreateStageGate = () => `${changeRequestsCreate()}/stage-gate`;
+const changeRequestsCreateBudget = () => `${changeRequestsCreate()}/budget`;
 const changeRequestsCreateStandard = () => `${changeRequestsCreate()}/standard`;
 const changeRequestCreateProposeSolution = () => `${changeRequestsCreate()}/proposed-solution`;
 const changeRequestRequestReviewer = (id: string) => changeRequestsById(id) + '/request-review';
@@ -395,6 +396,7 @@ export const apiUrls = {
   changeRequestsCreate,
   changeRequestsCreateActivation,
   changeRequestsCreateStageGate,
+  changeRequestsCreateBudget,
   changeRequestsCreateStandard,
   changeRequestCreateProposeSolution,
   changeRequestRequestReviewer,

--- a/src/shared/src/types/change-request-types.ts
+++ b/src/shared/src/types/change-request-types.ts
@@ -6,12 +6,14 @@
 import { User } from './user-types';
 import { LinkCreateArgs, ProjectProposedChanges, WbsNumber, WorkPackageProposedChanges } from './project-types';
 import { WorkPackageStage } from './work-package-types';
+import { OtherProductReason } from './reimbursement-requests-types';
 
 export interface ChangeRequest {
   crId: string;
   identifier: number;
-  wbsNum: WbsNumber;
-  wbsName: string;
+  wbsNum?: WbsNumber;
+  wbsName?: string;
+  category?: OtherProductReason;
   submitter: User;
   dateSubmitted: Date;
   type: ChangeRequestType;
@@ -30,7 +32,8 @@ export const ChangeRequestType = {
   Redefinition: 'DEFINITION_CHANGE',
   Other: 'OTHER',
   StageGate: 'STAGE_GATE',
-  Activation: 'ACTIVATION'
+  Activation: 'ACTIVATION',
+  Budget: 'BUDGET'
 } as const;
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type ChangeRequestType = (typeof ChangeRequestType)[keyof typeof ChangeRequestType];
@@ -71,6 +74,10 @@ export interface StageGateChangeRequest extends ChangeRequest {
   confirmDone: boolean;
 }
 
+export interface BudgetChangeRequest extends ChangeRequest {
+  proposedBudget: number;
+}
+
 export interface ChangeRequestExplanation {
   type: ChangeRequestReason;
   explain: string;
@@ -100,7 +107,8 @@ export interface ImplementedChange {
   changeId: string;
   changeRequestId: string;
   changeRequestIdentifier: number;
-  wbsNum: WbsNumber;
+  wbsNum?: WbsNumber;
+  category?: OtherProductReason;
   implementer: User;
   detail: string;
   dateImplemented: Date;


### PR DESCRIPTION
## Changes

Changed the schema so Change and Change Request can either be wbsElement or Other Reimbursement Product Reason. I didn't change the existing endpoints since right now finance only wants a change request for editing an Other Reimbursement Product Reason budget. I created a new type of change request to edit the budget. This is the only one that takes an other reason id since that is all that is necessary right now. Fixed the frontend to allow for both. I think I got everything-> did some major clicking around.

Also made a change to the add vendor table, just made the labels bigger and bolder. This was just the easiest ticket to do it in because it is up to date.

## Screenshots
<img width="1470" alt="Screenshot 2025-05-14 at 8 11 21 PM" src="https://github.com/user-attachments/assets/9760f5ca-0cf1-41de-90a7-904cb7a0aabc" />
<img width="1470" alt="Screenshot 2025-05-14 at 8 11 14 PM" src="https://github.com/user-attachments/assets/34f16593-9e90-49f0-a42a-61491e5f4db4" />


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3465
