### PR TITLE
#2414 Indicate Current Day

### DIFF
--- a/src/frontend/src/pages/GanttPage/GanttChart/GanttChart.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChart/GanttChart.tsx
@@ -1,4 +1,4 @@
-import { Box } from '@mui/material';
+import { Box, useTheme } from '@mui/material';
 import {
   GanttChange,
   GanttCollection,
@@ -8,7 +8,9 @@ import {
 } from '../../../utils/gantt.utils';
 import GanttChartCollectionSection from './GanttChartCollectionSection';
 import { GanttChartTimeline } from './GanttChartComponents/GanttChartTimeline';
-
+import { eachDayOfInterval, isMonday } from 'date-fns';
+import { dateToString, getMonday } from '../../../utils/datetime.utils';
+import { GANTT_CHART_CELL_SIZE, GANTT_CHART_GAP_SIZE } from '../../../utils/gantt.utils';
 export interface GanttEditability<E, T> {
   highlightTaskComparator: HighlightTaskComparator<T>;
   highlightSubtaskComparator: HighlightTaskComparator<T>;
@@ -40,12 +42,17 @@ const GanttChart = <E, T>({
   onShowChildrenToggle,
   editability
 }: GanttChartProps<E, T>) => {
+  const theme = useTheme();
+  const days = eachDayOfInterval({ start: startDate, end: endDate }).filter((day) => isMonday(day));
+  const currentDayCol = days.findIndex((day) => dateToString(day) === dateToString(getMonday(new Date()))) + 1;
+
   return (
     <Box
       sx={{
         width: '100%',
         height: { xs: 'calc(100vh - 9.5rem )', md: 'calc(100vh - 6.25rem)' },
         overflow: 'scroll',
+        position: 'relative',
         '&::-webkit-scrollbar': {
           display: 'none'
         },
@@ -70,6 +77,21 @@ const GanttChart = <E, T>({
           );
         })}
       </Box>
+
+      {currentDayCol > 0 && (
+        <Box
+          sx={{
+            position: 'absolute',
+            left: `calc(${currentDayCol - 1} * (${GANTT_CHART_CELL_SIZE} + ${GANTT_CHART_GAP_SIZE}) + 2rem)`,
+            top: '5rem',
+            width: '1px',
+            backgroundColor: theme.palette.info.main,
+            zIndex: 3,
+            pointerEvents: 'none',
+            height: '150%'
+          }}
+        />
+      )}
     </Box>
   );
 };

--- a/src/frontend/src/pages/GanttPage/GanttChart/GanttChart.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChart/GanttChart.tsx
@@ -8,7 +8,7 @@ import {
 } from '../../../utils/gantt.utils';
 import GanttChartCollectionSection from './GanttChartCollectionSection';
 import { GanttChartTimeline } from './GanttChartComponents/GanttChartTimeline';
-import { eachDayOfInterval, isMonday } from 'date-fns';
+import { eachDayOfInterval, isMonday, differenceInDays } from 'date-fns';
 import { dateToString, getMonday } from '../../../utils/datetime.utils';
 import { GANTT_CHART_CELL_SIZE, GANTT_CHART_GAP_SIZE } from '../../../utils/gantt.utils';
 export interface GanttEditability<E, T> {
@@ -44,7 +44,12 @@ const GanttChart = <E, T>({
 }: GanttChartProps<E, T>) => {
   const theme = useTheme();
   const days = eachDayOfInterval({ start: startDate, end: endDate }).filter((day) => isMonday(day));
-  const currentDayCol = days.findIndex((day) => dateToString(day) === dateToString(getMonday(new Date()))) + 1;
+
+  const today = new Date(new Date().setHours(0, 0, 0, 0));
+  const currentWeekCol = days.findIndex((day) => dateToString(day) === dateToString(getMonday(today))) + 1;
+
+  const daysIntoWeek = differenceInDays(today, getMonday(today));
+  const dailyOffset = daysIntoWeek * (parseFloat(GANTT_CHART_CELL_SIZE) / 7);
 
   return (
     <Box
@@ -78,11 +83,11 @@ const GanttChart = <E, T>({
         })}
       </Box>
 
-      {currentDayCol > 0 && (
+      {currentWeekCol > 0 && (
         <Box
           sx={{
             position: 'absolute',
-            left: `calc(${currentDayCol - 1} * (${GANTT_CHART_CELL_SIZE} + ${GANTT_CHART_GAP_SIZE}) + 2rem)`,
+            left: `calc(${currentWeekCol - 1} * (${GANTT_CHART_CELL_SIZE} + ${GANTT_CHART_GAP_SIZE}) + 1.1rem + ${dailyOffset}rem)`,
             top: '5rem',
             width: '1px',
             backgroundColor: theme.palette.info.main,

--- a/src/frontend/src/pages/GanttPage/GanttChart/GanttChartComponents/GanttChartTimeline.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChart/GanttChartComponents/GanttChartTimeline.tsx
@@ -6,6 +6,7 @@
 import { Box, Typography, Card, useTheme } from '@mui/material';
 import { eachDayOfInterval, isMonday, format, getDate } from 'date-fns';
 import { GANTT_CHART_CELL_SIZE, GANTT_CHART_GAP_SIZE } from '../../../../utils/gantt.utils';
+import { dateToString, getMonday } from '../../../../utils/datetime.utils';
 
 interface GanttChartTimelineProps {
   start: Date;
@@ -74,6 +75,8 @@ export function GanttChartTimeline({ start, end }: GanttChartTimelineProps) {
               key={day.toISOString()}
               sx={{
                 display: 'flex',
+                backgroundColor:
+                  dateToString(day) === dateToString(getMonday(new Date())) ? theme.palette.info.main : 'transparent',
                 justifyContent: 'center',
                 alignItems: 'center',
                 borderRadius: '0.25rem',


### PR DESCRIPTION
## Changes

Added a vertical line indicator that represents the Monday of the current week, as well as color the current Monday blue for the Gantt timeline bar (as requested from the issue). The Monday line offsets based on the current day compared to its Monday of the week.

## Screenshots
At the time screenshot, date is 07-21-2025
<img width="1907" height="1918" alt="Screenshot 2025-07-22 at 4 42 46 PM" src="https://github.com/user-attachments/assets/692f2fcc-9318-4102-9e14-cb0616e9b519" />

Here's a 07-28-2025 
<img width="1905" height="1924" alt="Screenshot 2025-07-22 at 4 45 20 PM" src="https://github.com/user-attachments/assets/dfd1ee9e-15c9-4e3f-8dc3-0a1739300920" />

Here's a 07-25-2025
<img width="1906" height="1915" alt="Screenshot 2025-07-22 at 4 46 02 PM" src="https://github.com/user-attachments/assets/a75dafde-3503-4157-bfe7-93cd829d81d9" />


## Checklist
- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #2414