### PR TITLE
#3501 scroll to current day

### DIFF
--- a/src/frontend/src/pages/GanttPage/GanttChart/GanttChartComponents/GanttChartTimeline.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChart/GanttChartComponents/GanttChartTimeline.tsx
@@ -7,6 +7,7 @@ import { Box, Typography, Card, useTheme } from '@mui/material';
 import { eachDayOfInterval, isMonday, format, getDate } from 'date-fns';
 import { GANTT_CHART_CELL_SIZE, GANTT_CHART_GAP_SIZE } from '../../../../utils/gantt.utils';
 import { dateToString, getMonday } from '../../../../utils/datetime.utils';
+import { useEffect, useRef } from 'react';
 
 interface GanttChartTimelineProps {
   start: Date;
@@ -16,6 +17,17 @@ interface GanttChartTimelineProps {
 export function GanttChartTimeline({ start, end }: GanttChartTimelineProps) {
   const theme = useTheme();
   const days = eachDayOfInterval({ start, end }).filter((day) => isMonday(day));
+  const currentWeekRef = useRef<HTMLDivElement>();
+
+  useEffect(() => {
+    if (currentWeekRef.current) {
+      currentWeekRef.current.scrollIntoView({
+        behavior: 'smooth',
+        block: 'nearest',
+        inline: 'center'
+      });
+    }
+  }, []);
 
   return (
     <Box
@@ -40,6 +52,7 @@ export function GanttChartTimeline({ start, end }: GanttChartTimelineProps) {
         {days.map((day, index) => {
           // displays the month and year for the first monday of a month;
           // displays the month and year for the first date on the calendar if it's the first or second monday
+          const isCurrentWeek = dateToString(day) === dateToString(getMonday(new Date()));
           const monthDisplay = (index === 0 && getDate(day) <= 14) || getDate(day) <= 7 ? format(day, 'MMM y') : '';
           return (
             <Box
@@ -52,6 +65,7 @@ export function GanttChartTimeline({ start, end }: GanttChartTimelineProps) {
                 minWidth: GANTT_CHART_CELL_SIZE,
                 maxWidth: GANTT_CHART_CELL_SIZE
               }}
+              ref={isCurrentWeek ? currentWeekRef : null}
             >
               <Typography fontWeight="bold" variant="h6">
                 {monthDisplay}


### PR DESCRIPTION
## Changes

The gantt chart scrolls to the current day when initially loaded


## Screenshots

where it ends up after scrolling: 
<img width="1419" height="949" alt="Screenshot 2025-08-02 at 10 51 08 AM" src="https://github.com/user-attachments/assets/748c4b2c-3cd5-4357-8cb5-f5da12ad30ae" />



## To Do

_Any remaining things that need to get done_

- [ ] item 1
- [ ] ...

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #3501
