### PR TITLE
#2406 dr links prefill with existing info

### DIFF
--- a/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/FinalizeDesignReviewDetailsModal.tsx
+++ b/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/FinalizeDesignReviewDetailsModal.tsx
@@ -55,6 +55,12 @@ const FinalizeDesignReviewDetailsModal = ({
     setOpen(false);
   };
 
+  const defaultValues = {
+    docTemplateLink: designReview.docTemplateLink ?? '',
+    zoomLink: designReview.zoomLink ?? undefined,
+    location: designReview.location ?? undefined
+  };
+
   const {
     handleSubmit,
     control,
@@ -62,11 +68,7 @@ const FinalizeDesignReviewDetailsModal = ({
     formState: { errors }
   } = useForm({
     resolver: yupResolver(schema),
-    defaultValues: {
-      docTemplateLink: '',
-      zoomLink: undefined,
-      location: undefined
-    }
+    defaultValues
   });
 
   return (
@@ -74,7 +76,7 @@ const FinalizeDesignReviewDetailsModal = ({
       open={open}
       onHide={() => setOpen(false)}
       title={title}
-      reset={() => reset({ docTemplateLink: '', zoomLink: undefined, location: undefined })}
+      reset={() => reset(defaultValues)}
       handleUseFormSubmit={handleSubmit}
       onFormSubmit={onSubmit}
       submitText="Schedule"


### PR DESCRIPTION
## Changes

The Question Doc, Zoom Link, and Location fields in the finalize modal for a design review now prefill with existing information

## Screenshots

<img width="473" height="520" alt="Screenshot 2025-08-08 at 2 40 21 PM" src="https://github.com/user-attachments/assets/0f372273-a3dc-4f01-9301-6c9a8fd6959d" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #2406
