### PR TITLE
#3529 onboarding markdown

### DIFF
--- a/src/frontend/src/components/NERFormModal.tsx
+++ b/src/frontend/src/components/NERFormModal.tsx
@@ -8,6 +8,7 @@ interface NERFormModalProps<T extends FieldValues> extends NERModalProps {
   onFormSubmit: (data: T) => void;
   formId: string;
   children?: ReactNode;
+  paperProps?: any;
 }
 
 const NERFormModal = ({
@@ -23,7 +24,8 @@ const NERFormModal = ({
   disabled,
   children,
   showCloseButton,
-  hideBackDrop = false
+  hideBackDrop = false,
+  paperProps
 }: NERFormModalProps<any>) => {
   /**
    * Wrapper function for onSubmit so that form data is reset after submit
@@ -53,6 +55,7 @@ const NERFormModal = ({
       disabled={disabled}
       showCloseButton={showCloseButton}
       hideBackDrop={hideBackDrop}
+      paperProps={paperProps}
     >
       <form id={formId} onSubmit={handleFormSubmit} noValidate>
         {children}

--- a/src/frontend/src/components/NERMarkdown.tsx
+++ b/src/frontend/src/components/NERMarkdown.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import { Box } from '@mui/material';
+
+interface NERMarkdownProps {
+  markdown: string;
+}
+
+const NERMarkdown = ({ markdown }: NERMarkdownProps) => {
+  return (
+    <Box
+      sx={{
+        fontSize: '16px',
+        lineHeight: 1.3,
+        '& h1': {
+          fontSize: '1.4em',
+          margin: '0.8em 0 0.4em 0',
+          fontWeight: 600
+        },
+        '& h2': {
+          fontSize: '1.2em',
+          margin: '0.7em 0 0.3em 0',
+          fontWeight: 600
+        },
+        '& h3': {
+          fontSize: '1.1em',
+          margin: '0.6em 0 0.2em 0',
+          fontWeight: 600
+        },
+        '& h4, & h5, & h6': {
+          fontSize: '1em',
+          margin: '0.5em 0 0.2em 0',
+          fontWeight: 600
+        },
+        '& p': {
+          margin: '0.3em 0'
+        },
+        '& ul, & ol': {
+          margin: '0.4em 0',
+          paddingLeft: '1.5em'
+        },
+        '& li': {
+          margin: '0.1em 0'
+        },
+        '& li > ul, & li > ol': {
+          margin: '0.2em 0'
+        },
+        '& a': {
+          color: '#dc2626',
+          textDecoration: 'underline',
+          '&:hover': {
+            color: '#b91c1c',
+            textDecoration: 'none'
+          }
+        },
+        '& code': {
+          backgroundColor: '#f3f4f6',
+          color: '#374151',
+          padding: '0.1em 0.3em',
+          borderRadius: '3px',
+          fontSize: '0.9em'
+        },
+        '& pre': {
+          backgroundColor: '#f3f4f6',
+          color: '#374151',
+          padding: '0.5em',
+          borderRadius: '4px',
+          overflowX: 'auto',
+          margin: '0.4em 0'
+        },
+        '& pre code': {
+          background: 'none',
+          color: 'inherit',
+          padding: 0
+        },
+        '& blockquote': {
+          borderLeft: '3px solid #d1d5db',
+          paddingLeft: '0.8em',
+          margin: '0.4em 0',
+          fontStyle: 'italic',
+          color: '#6b7280'
+        },
+        '& table': {
+          borderCollapse: 'collapse',
+          margin: '0.4em 0',
+          fontSize: '0.9em'
+        },
+        '& th, & td': {
+          border: '1px solid #d1d5db',
+          padding: '0.3em 0.5em',
+          textAlign: 'left'
+        },
+        '& th': {
+          backgroundColor: '#f9fafb',
+          fontWeight: 600
+        },
+        '& hr': {
+          border: 'none',
+          borderTop: '1px solid #e5e7eb',
+          margin: '0.6em 0'
+        },
+        '& img': {
+          maxWidth: '100%',
+          height: 'auto',
+          margin: '0.3em 0'
+        }
+      }}
+    >
+      <ReactMarkdown>{markdown}</ReactMarkdown>
+    </Box>
+  );
+};
+
+export default NERMarkdown;

--- a/src/frontend/src/components/NERModal.tsx
+++ b/src/frontend/src/components/NERModal.tsx
@@ -49,7 +49,7 @@ const NERModal = ({
       onClose={onHide}
       PaperProps={{
         style: paperProps
-          ? { ...paperProps, borderRadius: '10px', maxWidth: '700px' }
+          ? { borderRadius: '10px', maxWidth: '700px', ...paperProps }
           : { borderRadius: '10px', maxWidth: '700px' }
       }}
     >

--- a/src/frontend/src/pages/AdminToolsPage/OnboardingConfig/Checklists/AdminSubtaskSection.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/OnboardingConfig/Checklists/AdminSubtaskSection.tsx
@@ -11,7 +11,7 @@ import NERDeleteModal from '../../../../components/NERDeleteModal';
 import { useToast } from '../../../../hooks/toasts.hooks';
 import { useDeleteChecklist } from '../../../../hooks/onboarding.hook';
 import EditSubtaskModal from './EditSubtaskModal';
-import Markdown from 'react-markdown';
+import NERMarkdown from '../../../../components/NERMarkdown';
 
 interface AdminSubtaskSectionProps {
   parentTask: Checklist;
@@ -89,7 +89,7 @@ const AdminSubtaskSection: React.FC<AdminSubtaskSectionProps> = ({ parentTask })
             marginBottom: 1
           }}
         >
-          <Markdown>{description}</Markdown>
+          <NERMarkdown markdown={description} />
         </Box>
       ))}
       <Box sx={{ display: 'flex', justifyContent: 'flex-start', mb: -1 }}>

--- a/src/frontend/src/pages/AdminToolsPage/OnboardingConfig/Checklists/AdminSubtaskSection.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/OnboardingConfig/Checklists/AdminSubtaskSection.tsx
@@ -11,6 +11,7 @@ import NERDeleteModal from '../../../../components/NERDeleteModal';
 import { useToast } from '../../../../hooks/toasts.hooks';
 import { useDeleteChecklist } from '../../../../hooks/onboarding.hook';
 import EditSubtaskModal from './EditSubtaskModal';
+import Markdown from 'react-markdown';
 
 interface AdminSubtaskSectionProps {
   parentTask: Checklist;
@@ -88,7 +89,7 @@ const AdminSubtaskSection: React.FC<AdminSubtaskSectionProps> = ({ parentTask })
             marginBottom: 1
           }}
         >
-          <Typography color={theme.palette.text.primary}>{description}</Typography>
+          <Markdown>{description}</Markdown>
         </Box>
       ))}
       <Box sx={{ display: 'flex', justifyContent: 'flex-start', mb: -1 }}>

--- a/src/frontend/src/pages/AdminToolsPage/OnboardingConfig/Checklists/CreateChecklistModal.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/OnboardingConfig/Checklists/CreateChecklistModal.tsx
@@ -21,7 +21,7 @@ import NERFormModal from '../../../../components/NERFormModal';
 import * as yup from 'yup';
 import RemoveCircleOutlineIcon from '@mui/icons-material/RemoveCircleOutline';
 import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
-import Markdown from 'react-markdown';
+import NERMarkdown from '../../../../components/NERMarkdown';
 
 interface CreateChecklistModalProps {
   open: boolean;
@@ -147,6 +147,7 @@ const CreateChecklistModal = ({ open, handleClose, teamId, teamTypeId }: CreateC
       onFormSubmit={onFormSubmit}
       formId={'create-task-form'}
       showCloseButton
+      paperProps={{ maxWidth: '80vw' }}
     >
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
         <FormControl fullWidth>
@@ -277,7 +278,7 @@ const CreateChecklistModal = ({ open, handleClose, teamId, teamTypeId }: CreateC
                 <Box
                   sx={{
                     display: 'flex',
-                    minWidth: '600px',
+                    width: '30vw',
                     alignItems: 'stretch'
                   }}
                 >
@@ -288,7 +289,7 @@ const CreateChecklistModal = ({ open, handleClose, teamId, teamTypeId }: CreateC
                     render={({ field }) => (
                       <TextField
                         {...field}
-                        placeholder="Enter description..."
+                        placeholder="Enter description markdown..."
                         fullWidth
                         multiline
                         variant="outlined"
@@ -328,7 +329,7 @@ const CreateChecklistModal = ({ open, handleClose, teamId, teamTypeId }: CreateC
                   sx={{
                     backgroundColor: theme.palette.background.paper,
                     borderRadius: 3,
-                    minWidth: '600px',
+                    width: '30vw',
                     padding: 2,
                     display: 'flex',
                     flexDirection: 'column',
@@ -354,42 +355,11 @@ const CreateChecklistModal = ({ open, handleClose, teamId, teamTypeId }: CreateC
                   <Box
                     sx={{
                       flex: 1,
-                      overflow: 'auto',
-                      wordBreak: 'break-word',
-                      whiteSpace: 'pre-wrap',
-                      fontSize: '1.1rem',
-                      lineHeight: 1.6,
-                      '& h1, & h2, & h3, & h4, & h5, & h6': {
-                        margin: '0.5em 0 0.25em 0',
-                        color: theme.palette.text.primary
-                      },
-                      '& p': {
-                        margin: '0.25em 0',
-                        color: theme.palette.text.primary
-                      },
-                      '& ul, & ol': {
-                        margin: '0.25em 0',
-                        paddingLeft: '1.5em'
-                      },
-                      '& li': {
-                        margin: '0.1em 0'
-                      },
-                      '& code': {
-                        backgroundColor: theme.palette.action.hover,
-                        padding: '2px 4px',
-                        borderRadius: 1,
-                        fontSize: '0.95em'
-                      },
-                      '& pre': {
-                        backgroundColor: theme.palette.action.hover,
-                        padding: 1,
-                        borderRadius: 1,
-                        overflow: 'auto'
-                      }
+                      overflow: 'auto'
                     }}
                   >
                     {watch(`descriptions.${index}.name`) ? (
-                      <Markdown>{watch(`descriptions.${index}.name`)}</Markdown>
+                      <NERMarkdown markdown={watch(`descriptions.${index}.name`)} />
                     ) : (
                       <Typography
                         variant="body2"
@@ -398,7 +368,7 @@ const CreateChecklistModal = ({ open, handleClose, teamId, teamTypeId }: CreateC
                           fontStyle: 'italic'
                         }}
                       >
-                        Start typing to see preview...
+                        Start typing to see formatted markdown...
                       </Typography>
                     )}
                   </Box>

--- a/src/frontend/src/pages/AdminToolsPage/OnboardingConfig/Checklists/CreateChecklistModal.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/OnboardingConfig/Checklists/CreateChecklistModal.tsx
@@ -3,8 +3,17 @@ import LoadingIndicator from '../../../../components/LoadingIndicator';
 import { ChecklistCreateArgs, useCreateChecklist } from '../../../../hooks/onboarding.hook';
 import { useToast } from '../../../../hooks/toasts.hooks';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { FormControl, FormLabel, TextField, InputAdornment, Checkbox, IconButton, useTheme } from '@mui/material';
-import { Box } from '@mui/system';
+import {
+  FormControl,
+  FormLabel,
+  TextField,
+  InputAdornment,
+  Checkbox,
+  IconButton,
+  useTheme,
+  Typography
+} from '@mui/material';
+import { Box, Stack } from '@mui/system';
 import React, { useState } from 'react';
 import { useForm, useFieldArray, Controller } from 'react-hook-form';
 import { CreateChecklistPreview } from 'shared';
@@ -12,6 +21,7 @@ import NERFormModal from '../../../../components/NERFormModal';
 import * as yup from 'yup';
 import RemoveCircleOutlineIcon from '@mui/icons-material/RemoveCircleOutline';
 import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
+import Markdown from 'react-markdown';
 
 interface CreateChecklistModalProps {
   open: boolean;
@@ -64,6 +74,7 @@ const CreateChecklistModal = ({ open, handleClose, teamId, teamTypeId }: CreateC
   const {
     handleSubmit,
     control,
+    watch,
     reset,
     formState: { errors }
   } = useForm<ChecklistFormValues>({
@@ -255,53 +266,144 @@ const CreateChecklistModal = ({ open, handleClose, teamId, teamTypeId }: CreateC
                 color: theme.palette.error.main,
                 fontWeight: 'bold',
                 fontSize: '1.5rem',
-                textDecoration: 'underline'
+                textDecoration: 'underline',
+                mb: 2
               }}
             >
               Descriptions*
             </FormLabel>
             {fields.map((item, index) => (
-              <Box key={item.id} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                <Controller
-                  name={`descriptions.${index}.name`}
-                  control={control}
-                  defaultValue={item.name || ''}
-                  render={({ field }) => (
-                    <TextField
-                      {...field}
-                      placeholder="Enter description..."
-                      fullWidth
-                      multiline
-                      variant="outlined"
-                      InputProps={{
-                        endAdornment: (
-                          <InputAdornment position="end">
-                            {index !== 0 && (
+              <Stack key={item.id} direction={'row'} spacing={3} sx={{ mb: 3 }}>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    minWidth: '600px',
+                    alignItems: 'stretch'
+                  }}
+                >
+                  <Controller
+                    name={`descriptions.${index}.name`}
+                    control={control}
+                    defaultValue={item.name || ''}
+                    render={({ field }) => (
+                      <TextField
+                        {...field}
+                        placeholder="Enter description..."
+                        fullWidth
+                        multiline
+                        variant="outlined"
+                        minRows={12}
+                        maxRows={20}
+                        InputProps={{
+                          endAdornment: index !== 0 && (
+                            <InputAdornment position="end" sx={{ alignSelf: 'flex-start', mt: 1 }}>
                               <IconButton onClick={() => remove(index)}>
                                 <RemoveCircleOutlineIcon sx={{ color: 'white' }} />
                               </IconButton>
-                            )}
-                          </InputAdornment>
-                        ),
-                        disableUnderline: true,
-                        sx: { '& fieldset': { border: 'none' } }
-                      }}
-                      sx={{
-                        backgroundColor: theme.palette.background.paper,
-                        borderRadius: 5,
-                        mt: 1,
-                        width: '100%',
-                        ...(index === 0 && {
-                          minHeight: '150px',
-                          fontSize: '1.25rem'
-                        })
-                      }}
-                      error={!!errors.descriptions?.[index]?.name}
-                      helperText={errors.descriptions?.[index]?.name?.message}
-                    />
-                  )}
-                />
-              </Box>
+                            </InputAdornment>
+                          ),
+                          disableUnderline: true,
+                          sx: {
+                            '& fieldset': { border: 'none' },
+                            fontSize: '1.1rem',
+                            lineHeight: 1.6,
+                            padding: 2
+                          }
+                        }}
+                        sx={{
+                          backgroundColor: theme.palette.background.paper,
+                          borderRadius: 3,
+                          width: '100%',
+                          '& .MuiInputBase-root': {
+                            alignItems: 'flex-start'
+                          }
+                        }}
+                        error={!!errors.descriptions?.[index]?.name}
+                        helperText={errors.descriptions?.[index]?.name?.message}
+                      />
+                    )}
+                  />
+                </Box>
+                <Box
+                  sx={{
+                    backgroundColor: theme.palette.background.paper,
+                    borderRadius: 3,
+                    minWidth: '600px',
+                    padding: 2,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    overflow: 'hidden',
+                    wordWrap: 'break-word',
+                    border: `1px solid ${theme.palette.divider}`,
+                    '& *': {
+                      wordWrap: 'break-word',
+                      overflowWrap: 'break-word'
+                    }
+                  }}
+                >
+                  <Typography
+                    variant="caption"
+                    sx={{
+                      color: theme.palette.text.secondary,
+                      mb: 1,
+                      fontStyle: 'italic'
+                    }}
+                  >
+                    Preview:
+                  </Typography>
+                  <Box
+                    sx={{
+                      flex: 1,
+                      overflow: 'auto',
+                      wordBreak: 'break-word',
+                      whiteSpace: 'pre-wrap',
+                      fontSize: '1.1rem',
+                      lineHeight: 1.6,
+                      '& h1, & h2, & h3, & h4, & h5, & h6': {
+                        margin: '0.5em 0 0.25em 0',
+                        color: theme.palette.text.primary
+                      },
+                      '& p': {
+                        margin: '0.25em 0',
+                        color: theme.palette.text.primary
+                      },
+                      '& ul, & ol': {
+                        margin: '0.25em 0',
+                        paddingLeft: '1.5em'
+                      },
+                      '& li': {
+                        margin: '0.1em 0'
+                      },
+                      '& code': {
+                        backgroundColor: theme.palette.action.hover,
+                        padding: '2px 4px',
+                        borderRadius: 1,
+                        fontSize: '0.95em'
+                      },
+                      '& pre': {
+                        backgroundColor: theme.palette.action.hover,
+                        padding: 1,
+                        borderRadius: 1,
+                        overflow: 'auto'
+                      }
+                    }}
+                  >
+                    {watch(`descriptions.${index}.name`) ? (
+                      <Markdown>{watch(`descriptions.${index}.name`)}</Markdown>
+                    ) : (
+                      <Typography
+                        variant="body2"
+                        sx={{
+                          color: theme.palette.text.disabled,
+                          fontStyle: 'italic'
+                        }}
+                      >
+                        Start typing to see preview...
+                      </Typography>
+                    )}
+                  </Box>
+                </Box>
+              </Stack>
             ))}
 
             <IconButton

--- a/src/frontend/src/pages/AdminToolsPage/OnboardingConfig/Checklists/EditChecklistModal.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/OnboardingConfig/Checklists/EditChecklistModal.tsx
@@ -4,13 +4,14 @@ import { ChecklistCreateArgs, useEditChecklist } from '../../../../hooks/onboard
 import { useToast } from '../../../../hooks/toasts.hooks';
 import { Checklist } from 'shared';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { FormControl, FormLabel, TextField, InputAdornment, IconButton, useTheme } from '@mui/material';
+import { FormControl, FormLabel, TextField, InputAdornment, IconButton, useTheme, Stack, Typography } from '@mui/material';
 import { Box } from '@mui/system';
 import { useForm, useFieldArray, Controller } from 'react-hook-form';
 import NERFormModal from '../../../../components/NERFormModal';
 import * as yup from 'yup';
 import RemoveCircleOutlineIcon from '@mui/icons-material/RemoveCircleOutline';
 import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
+import NERMarkdown from '../../../../components/NERMarkdown';
 
 interface EditChecklistModalProps {
   open: boolean;
@@ -46,6 +47,7 @@ const EditChecklistModal = ({ open, handleClose, defaultValues, teamId, teamType
   const {
     handleSubmit,
     control,
+    watch,
     reset,
     formState: { errors }
   } = useForm<ChecklistFormValues>({
@@ -94,6 +96,7 @@ const EditChecklistModal = ({ open, handleClose, defaultValues, teamId, teamType
       onFormSubmit={onFormSubmit}
       formId={!!defaultValues ? 'edit-UsefulLink-form' : 'create-UsefulLink-form'}
       showCloseButton
+      paperProps={{ maxWidth: '80vw' }}
     >
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
         <FormControl fullWidth>
@@ -147,47 +150,108 @@ const EditChecklistModal = ({ open, handleClose, defaultValues, teamId, teamType
               Descriptions*
             </FormLabel>
             {fields.map((item, index) => (
-              <Box key={item.id} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                <Controller
-                  name={`descriptions.${index}.name`}
-                  control={control}
-                  defaultValue={item.name || ''}
-                  render={({ field }) => (
-                    <TextField
-                      {...field}
-                      placeholder="Enter description..."
-                      fullWidth
-                      multiline
-                      variant="outlined"
-                      InputProps={{
-                        endAdornment: (
-                          <InputAdornment position="end">
-                            {index !== 0 && (
-                              <IconButton onClick={() => remove(index)}>
-                                <RemoveCircleOutlineIcon sx={{ color: 'white' }} />
-                              </IconButton>
-                            )}
-                          </InputAdornment>
-                        ),
-                        disableUnderline: true,
-                        sx: { '& fieldset': { border: 'none' } }
-                      }}
-                      sx={{
-                        backgroundColor: theme.palette.background.paper,
-                        borderRadius: 5,
-                        mt: 1,
-                        width: '100%',
-                        ...(index === 0 && {
-                          minHeight: '150px',
-                          fontSize: '1.25rem'
-                        })
-                      }}
-                      error={!!errors.descriptions?.[index]?.name}
-                      helperText={errors.descriptions?.[index]?.name?.message}
-                    />
-                  )}
-                />
-              </Box>
+              <Stack key={item.id} direction={'row'} spacing={3} sx={{ mb: 3 }}>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    width: '30vw',
+                    alignItems: 'stretch'
+                  }}
+                >
+                  <Controller
+                    name={`descriptions.${index}.name`}
+                    control={control}
+                    defaultValue={item.name || ''}
+                    render={({ field }) => (
+                      <TextField
+                        {...field}
+                        placeholder="Enter description markdown..."
+                        fullWidth
+                        multiline
+                        variant="outlined"
+                        minRows={12}
+                        maxRows={20}
+                        InputProps={{
+                          endAdornment: (
+                            <InputAdornment position="end">
+                              {index !== 0 && (
+                                <IconButton onClick={() => remove(index)}>
+                                  <RemoveCircleOutlineIcon sx={{ color: 'white' }} />
+                                </IconButton>
+                              )}
+                            </InputAdornment>
+                          ),
+                          disableUnderline: true,
+                          sx: {
+                            '& fieldset': { border: 'none' },
+                            fontSize: '1.1rem',
+                            lineHeight: 1.6,
+                            padding: 2
+                          }
+                        }}
+                        sx={{
+                          backgroundColor: theme.palette.background.paper,
+                          borderRadius: 3,
+                          width: '100%',
+                          '& .MuiInputBase-root': {
+                            alignItems: 'flex-start'
+                          }
+                        }}
+                        error={!!errors.descriptions?.[index]?.name}
+                        helperText={errors.descriptions?.[index]?.name?.message}
+                      />
+                    )}
+                  />
+                </Box>
+                <Box
+                  sx={{
+                    backgroundColor: theme.palette.background.paper,
+                    borderRadius: 3,
+                    width: '30vw',
+                    padding: 2,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    overflow: 'hidden',
+                    wordWrap: 'break-word',
+                    border: `1px solid ${theme.palette.divider}`,
+                    '& *': {
+                      wordWrap: 'break-word',
+                      overflowWrap: 'break-word'
+                    }
+                  }}
+                >
+                  <Typography
+                    variant="caption"
+                    sx={{
+                      color: theme.palette.text.secondary,
+                      mb: 1,
+                      fontStyle: 'italic'
+                    }}
+                  >
+                    Preview:
+                  </Typography>
+                  <Box
+                    sx={{
+                      flex: 1,
+                      overflow: 'auto'
+                    }}
+                  >
+                    {watch(`descriptions.${index}.name`) ? (
+                      <NERMarkdown markdown={watch(`descriptions.${index}.name`)} />
+                    ) : (
+                      <Typography
+                        variant="body2"
+                        sx={{
+                          color: theme.palette.text.disabled,
+                          fontStyle: 'italic'
+                        }}
+                      >
+                        Start typing to see formatted markdown...
+                      </Typography>
+                    )}
+                  </Box>
+                </Box>
+              </Stack>
             ))}
             <IconButton
               onClick={() => append({ name: '' })}

--- a/src/frontend/src/pages/HomePage/OnboardingHomePage.tsx
+++ b/src/frontend/src/pages/HomePage/OnboardingHomePage.tsx
@@ -118,7 +118,7 @@ const OnboardingHomePage = () => {
           <Grid
             item
             xs={12}
-            md={7}
+            md={8}
             sx={{
               maxHeight: '82vh',
               overflow: 'auto',
@@ -129,7 +129,7 @@ const OnboardingHomePage = () => {
           >
             <ChecklistSection usersChecklists={usersChecklists} checkedChecklists={checkedChecklists} />
           </Grid>
-          <Grid container item xs={12} md={5} sx={{ display: 'flex', flexDirection: 'column', gap: 2.5, mt: 4 }}>
+          <Grid container item xs={12} md={4} sx={{ display: 'flex', flexDirection: 'column', gap: 2.5, mt: 4 }}>
             <Grid item>
               <OnboardingInfoSection />
             </Grid>

--- a/src/frontend/src/pages/HomePage/components/Checklist.tsx
+++ b/src/frontend/src/pages/HomePage/components/Checklist.tsx
@@ -35,7 +35,6 @@ const Checklist: React.FC<{
           <Grid item xs={12}>
             <Box
               sx={{
-                marginTop: 3,
                 display: 'flex',
                 flexDirection: 'column',
                 alignItems: 'center',

--- a/src/frontend/src/pages/HomePage/components/ParentTask.tsx
+++ b/src/frontend/src/pages/HomePage/components/ParentTask.tsx
@@ -30,12 +30,11 @@ const ParentTask: React.FC<ParentTaskProps> = ({ parentTask, checkedChecklists }
   };
 
   return (
-    <Box sx={{ width: '85%' }}>
+    <Box sx={{ width: '100%' }}>
       <Box
         sx={{
           backgroundColor: showSubtasks ? 'white' : '#CECECE',
           borderRadius: 2,
-          padding: 1.5,
           alignContent: 'center',
           position: 'relative',
           boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.25)',

--- a/src/frontend/src/pages/HomePage/components/SubtaskSection.tsx
+++ b/src/frontend/src/pages/HomePage/components/SubtaskSection.tsx
@@ -7,6 +7,7 @@ import { GridDragIcon } from '@mui/x-data-grid';
 import { useToggleChecklist } from '../../../hooks/onboarding.hook';
 import { useToast } from '../../../hooks/toasts.hooks';
 import { isChecklistChecked } from '../../../utils/onboarding.utils';
+import Markdown from 'react-markdown';
 
 interface SubtaskSectionProps {
   parentTask: Checklist;
@@ -89,7 +90,7 @@ const SubtaskSection: React.FC<SubtaskSectionProps> = ({ parentTask, checkedChec
               borderRadius: 2
             }}
           >
-            <Typography color={theme.palette.common.white}>{parentTask.descriptions[0]}</Typography>
+            <Markdown>{parentTask.descriptions[0]}</Markdown>
           </Grid>
         </Grid>
       ) : (
@@ -113,7 +114,7 @@ const SubtaskSection: React.FC<SubtaskSectionProps> = ({ parentTask, checkedChec
                   margin: 'auto'
                 }}
               >
-                <Typography color={theme.palette.common.white}>{description}</Typography>
+                <Markdown>{description}</Markdown>
               </Grid>
             );
           })}

--- a/src/frontend/src/pages/HomePage/components/SubtaskSection.tsx
+++ b/src/frontend/src/pages/HomePage/components/SubtaskSection.tsx
@@ -7,7 +7,7 @@ import { GridDragIcon } from '@mui/x-data-grid';
 import { useToggleChecklist } from '../../../hooks/onboarding.hook';
 import { useToast } from '../../../hooks/toasts.hooks';
 import { isChecklistChecked } from '../../../utils/onboarding.utils';
-import Markdown from 'react-markdown';
+import NERMarkdown from '../../../components/NERMarkdown';
 
 interface SubtaskSectionProps {
   parentTask: Checklist;
@@ -45,7 +45,7 @@ const SubtaskSection: React.FC<SubtaskSectionProps> = ({ parentTask, checkedChec
     >
       {subtasks.length > 0 ? (
         <Grid container sx={{ display: 'flex', alignContent: 'center', justifyContent: 'center', alignItems: 'center' }}>
-          <Grid item xs={12} md={7}>
+          <Grid item xs={12} md={5}>
             <Box display="flex" flexDirection="column" marginLeft={5} gap={1}>
               {subtasks.map((subtask) => (
                 <Box display={'flex'} alignItems={'center'}>
@@ -83,14 +83,14 @@ const SubtaskSection: React.FC<SubtaskSectionProps> = ({ parentTask, checkedChec
           <Grid
             item
             xs={12}
-            md={5}
+            md={7}
             sx={{
               backgroundColor: theme.palette.background.paper,
               padding: 2,
               borderRadius: 2
             }}
           >
-            <Markdown>{parentTask.descriptions[0]}</Markdown>
+            <NERMarkdown markdown={parentTask.descriptions[0]} />
           </Grid>
         </Grid>
       ) : (
@@ -114,7 +114,7 @@ const SubtaskSection: React.FC<SubtaskSectionProps> = ({ parentTask, checkedChec
                   margin: 'auto'
                 }}
               >
-                <Markdown>{description}</Markdown>
+                <NERMarkdown markdown={description} />
               </Grid>
             );
           })}


### PR DESCRIPTION
## Changes

Task descriptions are now stored and displayed as markdown

Also made task descriptions on onboarding page a lot wider

## Screenshots

<img width="2894" height="1574" alt="Screenshot 2025-08-16 at 10 00 48 AM" src="https://github.com/user-attachments/assets/62ca63da-d11d-4833-bcf6-bf6124eb4dc9" />
<img width="2836" height="1568" alt="Screenshot 2025-08-16 at 10 01 10 AM" src="https://github.com/user-attachments/assets/c165cdce-db23-4c4d-90cf-80547bfdb1bf" />

Closes #3529
