### PR TITLE
added lead and manager defaults for wps

### DIFF
--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -173,13 +173,36 @@ export default class WorkPackagesService {
     // and what number work package this should be
     const { carNumber, projectNumber } = projectWbsNum;
 
-    const project = await ProjectsService.getSingleProject(projectWbsNum, organization);
+    const project = await prisma.project.findFirst({
+      where: {
+        wbsElement: {
+          carNumber,
+          projectNumber,
+          organizationId: organization.organizationId
+        }
+      },
+      include: {
+        workPackages: {
+          where: { wbsElement: { dateDeleted: null } },
+          include: {
+            wbsElement: true
+          }
+        },
+        wbsElement: true
+      }
+    });
 
-    const { id: projectId } = project;
+    if (!project) {
+      throw new NotFoundException('Project', `${carNumber}.${projectNumber}.0`);
+    }
+
+    const { projectId } = project;
+
+    const { leadId, managerId } = project.wbsElement;
 
     const newWorkPackageNumber: number =
       project.workPackages
-        .map((element) => element.wbsNum.workPackageNumber)
+        .map((element) => element.wbsElement.workPackageNumber)
         .reduce((prev, curr) => Math.max(prev, curr), 0) + 1;
 
     // make the date object but add 12 hours so that the time isn't 00:00 to avoid timezone problems
@@ -208,7 +231,9 @@ export default class WorkPackagesService {
             changes: {
               createMany: { data: changesToCreate }
             },
-            organizationId: organization.organizationId
+            organizationId: organization.organizationId,
+            leadId,
+            managerId
           }
         },
         stage,
@@ -233,9 +258,9 @@ export default class WorkPackagesService {
       [],
       blockedByElements,
       null,
+      leadId,
       null,
-      null,
-      null,
+      managerId,
       [],
       descriptionBullets,
       crId,

--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -34,7 +34,6 @@ import {
 import { getBlockingWorkPackages, validateBlockedBys } from '../utils/work-packages.utils';
 import { getDescriptionBulletQueryArgs } from '../prisma-query-args/description-bullets.query-args';
 import { userHasPermission } from '../utils/users.utils';
-import ProjectsService from './projects.services';
 
 /** Service layer containing logic for work package controller functions. */
 export default class WorkPackagesService {
@@ -178,7 +177,8 @@ export default class WorkPackagesService {
         wbsElement: {
           carNumber,
           projectNumber,
-          organizationId: organization.organizationId
+          organizationId: organization.organizationId,
+          dateDeleted: null
         }
       },
       include: {

--- a/src/backend/src/utils/projects.utils.ts
+++ b/src/backend/src/utils/projects.utils.ts
@@ -70,6 +70,10 @@ export const updateProjectAndCreateChanges = async (
           links: { where: { dateDeleted: null }, ...getLinkQueryArgs(organizationId) },
           descriptionBullets: { where: { dateDeleted: null }, ...getDescriptionBulletQueryArgs(organizationId) }
         }
+      },
+      workPackages: {
+        where: { wbsElement: { dateDeleted: null } },
+        include: { wbsElement: true }
       }
     }
   });
@@ -79,7 +83,7 @@ export const updateProjectAndCreateChanges = async (
   if (originalProject.wbsElement.dateDeleted) throw new DeletedException('Project', projectId);
   if (originalProject.wbsElement.organizationId !== organizationId) throw new InvalidOrganizationException('Project');
 
-  const { wbsElementId } = originalProject;
+  const { wbsElementId, workPackages: originalWorkPackages } = originalProject;
 
   const nameChangeJson = createChange(
     'name',
@@ -157,6 +161,48 @@ export const updateProjectAndCreateChanges = async (
   );
 
   changesJson = changesJson.concat(descriptionBulletChanges.changes).concat(linkChanges.changes);
+
+  // if the project has no managerId and a managerId is provided, we need to update the work packages
+  // that do not have a managerId and create changes for them
+  // this is so that project manager is the default manager for all work packages
+  if (!originalProject.wbsElement.managerId && managerId) {
+    const wpToUpdate = originalWorkPackages.filter((wp) => !wp.wbsElement.managerId);
+
+    const wpChanges = (
+      await Promise.all(
+        wpToUpdate.map(async (wp) =>
+          createChange('manager', null, await getUserFullName(managerId), crId, implementerId, wp.wbsElementId, null, null)
+        )
+      )
+    ).filter((change) => change !== undefined);
+
+    changesJson = changesJson.concat(wpChanges);
+
+    await prisma.wBS_Element.updateMany({
+      where: { wbsElementId: { in: wpToUpdate.map((wp) => wp.wbsElementId) } },
+      data: { managerId }
+    });
+  }
+
+  // same goes for the project lead
+  if (!originalProject.wbsElement.leadId && leadId) {
+    const wpToUpdate = originalWorkPackages.filter((wp) => !wp.wbsElement.leadId);
+
+    const wpChanges = (
+      await Promise.all(
+        wpToUpdate.map(async (wp) =>
+          createChange('lead', null, await getUserFullName(leadId), crId, implementerId, wp.wbsElementId, null, null)
+        )
+      )
+    ).filter((change) => change !== undefined);
+
+    changesJson = changesJson.concat(wpChanges);
+
+    await prisma.wBS_Element.updateMany({
+      where: { wbsElementId: { in: wpToUpdate.map((wp) => wp.wbsElementId) } },
+      data: { leadId }
+    });
+  }
 
   // update the project with the input fields
   const updatedProject = await prisma.project.update({


### PR DESCRIPTION
## Changes

Based on a product request: 
- made leads and managers for a WP default to that of the project when they are created
- if a project gains a manager and/or lead after creation, any WP without a lead and/or manager will have them assigned to that of the project

## Notes

I'm sure there are some optimizations that could be done in querying and/or updating, please lmk if you spot any

## Test Cases

- create WP with project and assign lead/manager
- Create Project, create WP, assign lead/manager

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
