### PR TITLE
Availability bug fix

### DIFF
--- a/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/EditAvailability.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/EditAvailability.tsx
@@ -25,7 +25,7 @@ const EditAvailability: React.FC<EditAvailabilityProps> = ({
   canChangeDateRange = true
 }) => {
   const [currentlyDisplayedAvailabilities, setCurrentlyDisplayedAvailabilities] = useState(
-    getMostRecentAvailabilities(Array.from(editedAvailabilities.values()), initialDate)
+    Array.from(editedAvailabilities.values())
   );
 
   const [isDragging, setIsDragging] = useState(false);

--- a/src/frontend/src/pages/SettingsPage/UserScheduleSettings/UserScheduleSettingsView.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserScheduleSettings/UserScheduleSettingsView.tsx
@@ -48,7 +48,7 @@ const UserScheduleSettingsView = ({
     if (confirmedAvailabilities.size === 0 && scheduleSettings.availabilities.length > 0) {
       const confirmed = getMostRecentAvailabilities(
         scheduleSettings.availabilities,
-        designReview?.dateScheduled || new Date()
+        designReview?.initialDate || new Date()
       );
       setConfirmedAvailabilities(new Map(confirmed.map((availability) => [availability.dateSet.getTime(), availability])));
     }


### PR DESCRIPTION
## Changes

The availability dates shown to the user for a design review need to be based on the initial date of the design review to match the week that gets shown, not the shceduled date.

Also got rid of the redundant second call to getMostRecentAvailabilities because it wasted so much of my time

## Notes

_Any other notes go here_

## Test Cases

- Case A
- Edge case
- ...

## Screenshots

_If you made UI changes you must post a screenshot of the whole page for each change in 1) a normal sized window and 2) the smallest possible window_

_If you did any manual testing (e.g., with Postman), put screenshots of the http request and before and after of the db_

_If none of this applies, you can delete this section_

## To Do

_Any remaining things that need to get done_

- [ ] item 1
- [ ] ...

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #3513 
