### PR TITLE
#3538 rr side bar fix

### DIFF
--- a/src/frontend/src/pages/FinancePage/FinanceComponents/ReimbursementRequestInfo.tsx
+++ b/src/frontend/src/pages/FinancePage/FinanceComponents/ReimbursementRequestInfo.tsx
@@ -284,12 +284,6 @@ const ReimbursementRequestInfo = ({
                   <TableCell align="center">{undefinedPipe(row.saboId)}</TableCell>
                   <TableCell align="center">{datePipe(row.dateSubmitted)}</TableCell>
                   <TableCell align="center">{dateUndefinedPipe(row.dateSubmittedToSabo)}</TableCell>
-                  <SidePage
-                    showPage={showSidePage}
-                    handleClose={closeSidePage}
-                    title={''}
-                    component={<ReimbursementRequestDetails onCloseEditPage={closeSidePage} />}
-                  />
                   <TableCell align="center">
                     {
                       <Button
@@ -321,6 +315,12 @@ const ReimbursementRequestInfo = ({
           </TableBody>
         </Table>
       </TableContainer>
+      <SidePage
+        showPage={showSidePage}
+        handleClose={closeSidePage}
+        title={''}
+        component={<ReimbursementRequestDetails onCloseEditPage={closeSidePage} />}
+      />
       <Box
         sx={{
           backgroundColor: '#121313',

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
@@ -330,8 +330,8 @@ const ReimbursementRequestDetailsView: React.FC<ReimbursementRequestDetailsViewP
         {reimbursementRequest.receiptPictures.map((receipt) => {
           return (
             <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-              <Link href={imageFileUrl(receipt.googleFileId)} target="_blank" underline="hover" sx={{ mr: 1, fontSize: 30 }}>
-                {receipt.name}
+              <Link href={imageFileUrl(receipt.googleFileId)} target="_blank" underline="hover" sx={{ mr: 1, fontSize: 20 }}>
+                {receipt.name.length > 20 ? receipt.name.slice(0, 30) + '...' : receipt.name}
               </Link>
               <IconButton href={imageDownloadUrl(receipt.googleFileId)}>
                 <DownloadIcon sx={{ fontSize: 30 }} />
@@ -573,7 +573,7 @@ const ReimbursementRequestDetailsView: React.FC<ReimbursementRequestDetailsViewP
           }}
         />
         <Box sx={{ display: 'flex', alignItems: 'flex-start' }}>
-          <Box sx={{ width: '900px', mt: -3, maxWidth: 400 }}>
+          <Box sx={{ mt: -3 }}>
             <ReimbursementRequestTimeline
               reimbursementRequestId={reimbursementRequest.reimbursementRequestId}
               reimbursementRequestComments={reimbursementRequest.comments}


### PR DESCRIPTION
## Changes

Don't render the sidebar component inside the map because then it tries to render 100 times if there is 100 rrs in the table

also cut off the receipt length to prevent it from squishing timeline

## Notes

_Any other notes go here_

## Test Cases

- Case A
- Edge case
- ...

## Screenshots

_If you made UI changes you must post a screenshot of the whole page for each change in 1) a normal sized window and 2) the smallest possible window_

_If you did any manual testing (e.g., with Postman), put screenshots of the http request and before and after of the db_

_If none of this applies, you can delete this section_

## To Do

_Any remaining things that need to get done_

- [ ] item 1
- [ ] ...

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #3538 
