### PR TITLE
notifications include project name

### DIFF
--- a/src/backend/src/services/design-reviews.services.ts
+++ b/src/backend/src/services/design-reviews.services.ts
@@ -196,11 +196,14 @@ export default class DesignReviewsService {
     for (const memberUserSetting of memberUserSettings) {
       if (memberUserSetting.slackId) {
         try {
+          if (!project) {
+            throw new Error('Could not find work package project');
+          }
           await sendSlackDesignReviewConfirmNotification(
             memberUserSetting.slackId,
             designReview.designReviewId,
             designReview.wbsElement.name,
-            project!.wbsElement.name
+            project.wbsElement.name
           );
         } catch (err: unknown) {
           if (err instanceof Error) {

--- a/src/backend/src/services/design-reviews.services.ts
+++ b/src/backend/src/services/design-reviews.services.ts
@@ -189,6 +189,9 @@ export default class DesignReviewsService {
       throw new NotFoundException('User Settings', 'Cannot find settings of members');
     }
 
+    const project = wbsElement.workPackage?.project;
+    const teams = project?.teams;
+
     // send a slack message to all leadership invited to the design review
     for (const memberUserSetting of memberUserSettings) {
       if (memberUserSetting.slackId) {
@@ -196,7 +199,8 @@ export default class DesignReviewsService {
           await sendSlackDesignReviewConfirmNotification(
             memberUserSetting.slackId,
             designReview.designReviewId,
-            designReview.wbsElement.name
+            designReview.wbsElement.name,
+            project!.wbsElement.name
           );
         } catch (err: unknown) {
           if (err instanceof Error) {
@@ -208,10 +212,8 @@ export default class DesignReviewsService {
 
     await sendDrPopUp(designReview, members, submitter, wbsElement.name, organization.organizationId);
 
-    const project = wbsElement.workPackage?.project;
-    const teams = project?.teams;
     if (teams && teams.length > 0) {
-      await sendSlackDRNotifications(teams, designReview, submitter, wbsElement.name);
+      await sendSlackDRNotifications(teams, designReview, submitter, wbsElement.name, project.wbsElement.name);
     }
 
     return designReviewTransformer(designReview);

--- a/src/backend/src/utils/slack.utils.ts
+++ b/src/backend/src/utils/slack.utils.ts
@@ -220,11 +220,12 @@ export const sendSubmittedToSaboNotification = async (threads: SlackMessageThrea
 export const sendSlackDesignReviewConfirmNotification = async (
   slackId: string,
   designReviewId: string,
-  designReviewName: string
+  designReviewName: string,
+  projectName: string
 ) => {
   const isProduction = process.env.NODE_ENV === 'production';
-  if (!isProduction) return; // don't send msgs unless in prod
-  const msg = `You have been invited to the ${designReviewName} Design Review!`;
+  if (process.env.NODE_ENV !== 'production') return; // don't send msgs unless in prod
+  const msg = `You have been invited to the ${designReviewName} Design Review in project ${projectName}!`;
   const fullLink = isProduction
     ? `https://finishlinebyner.com/settings/preferences?drId=${designReviewId}`
     : `http://localhost:3000/settings/preferences?drId=${designReviewId}`;
@@ -323,10 +324,12 @@ export const sendSlackDRNotifications = async (
   teams: Team[],
   designReview: Design_Review,
   submitter: User,
-  workPackageName: string
+  workPackageName: string,
+  projectName: string
 ) => {
+  if (process.env.NODE_ENV !== 'production') return []; // don't send msgs unless in prod
   const notifications: { channelId: string; ts: string }[] = [];
-  const message = `:spiral_calendar_pad: Design Review for *${workPackageName}* is being scheduled by ${submitter.firstName} ${submitter.lastName}`;
+  const message = `:spiral_calendar_pad: Design Review for *${workPackageName}* is being scheduled by ${submitter.firstName} ${submitter.lastName} in project ${projectName}`;
 
   const completion: Promise<void>[] = teams.map(async (team) => {
     const sentNotifications: { channelId: string; ts: string }[] = await sendSlackDesignReviewNotification(team, message);

--- a/src/backend/src/utils/slack.utils.ts
+++ b/src/backend/src/utils/slack.utils.ts
@@ -224,7 +224,7 @@ export const sendSlackDesignReviewConfirmNotification = async (
   projectName: string
 ) => {
   const isProduction = process.env.NODE_ENV === 'production';
-  if (process.env.NODE_ENV !== 'production') return; // don't send msgs unless in prod
+  if (!isProduction) return; // don't send msgs unless in prod
   const msg = `You have been invited to the ${designReviewName} Design Review in project ${projectName}!`;
   const fullLink = isProduction
     ? `https://finishlinebyner.com/settings/preferences?drId=${designReviewId}`


### PR DESCRIPTION
## Changes

dr notifications now include project name as requested

## Screenshots
<img width="694" height="83" alt="Screenshot 2025-08-23 at 1 05 41 PM" src="https://github.com/user-attachments/assets/33109cb7-33b3-4bcf-8aba-3e13aa70f93d" />

<img width="658" height="75" alt="Screenshot 2025-08-23 at 1 05 57 PM" src="https://github.com/user-attachments/assets/9f0c6ef7-858a-4bd0-a1a3-d225bed586c9" />


## To Do

_Any remaining things that need to get done_

- [ ] item 1
- [ ] ...

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #3543 
