### PR TITLE
#3308: drag to resize graphs

### DIFF
--- a/src/backend/src/prisma/seed.ts
+++ b/src/backend/src/prisma/seed.ts
@@ -793,21 +793,16 @@ const performSeed: () => Promise<void> = async () => {
    * Graphs
    */
 
-  /** Graph 1 */
-  const graph1 = await seedGraph(
-    new Date('12/12/2024'),
-    new Date('12/12/2027'),
-    'new graph',
-    Graph_Type.PROJECT_BUDGET_BY_DIVISION,
-    Graph_Display_Type.BAR,
-    Measure.SUM,
-    thomasEmrax,
-    ner
-  );
-
-  /**
-   * Graph Collection 1
-   */
+  const graph1 = await prisma.graph.create({
+    data: {
+      title: 'graph1',
+      graphType: Graph_Type.CHANGE_REQUESTS_BY_DIVISION,
+      displayGraphType: Graph_Display_Type.BAR,
+      measure: Measure.SUM,
+      userCreatedId: thomasEmrax.userId,
+      organizationId: ner.organizationId
+    }
+  });
   const graph2 = await prisma.graph.create({
     data: {
       title: 'graph2',
@@ -822,9 +817,8 @@ const performSeed: () => Promise<void> = async () => {
   const graphCollection1 = await prisma.graph_Collection.create({
     data: {
       title: 'Graph Collection 1',
-      viewPermissions: [SpecialPermission.FINANCE_ONLY],
       graphs: {
-        connect: [{ id: graph2.id }]
+        connect: [{ id: graph2.id }, { id: graph1.id }]
       },
       userCreatedId: thomasEmrax.userId,
       organizationId: ner.organizationId

--- a/src/frontend/src/components/StatsBarChart.tsx
+++ b/src/frontend/src/components/StatsBarChart.tsx
@@ -120,7 +120,7 @@ const StatsBarChart: React.FC<StatsBarChartProps> = ({
   };
 
   return (
-    <Box sx={{ height, width: '100%', maxWidth: width }}>
+    <Box sx={{ height, width, maxWidth: '100%', maxHeight: '100%' }}>
       <Bar data={data} options={options} />
     </Box>
   );

--- a/src/frontend/src/components/StatsPieChart.tsx
+++ b/src/frontend/src/components/StatsPieChart.tsx
@@ -97,7 +97,7 @@ const StatsPieChart: React.FC<StatsPieChartProps> = ({ xAxisData, yAxisData, wid
   };
 
   return (
-    <Box style={{ height, width: '100%', maxWidth: width }}>
+    <Box style={{ height, width, maxWidth: '100%', maxHeight: '100%' }}>
       <Pie data={data} options={options} />
     </Box>
   );

--- a/src/frontend/src/pages/StatisticsPage/GraphCollectionViewContainer/GraphCollectionViewContainer.tsx
+++ b/src/frontend/src/pages/StatisticsPage/GraphCollectionViewContainer/GraphCollectionViewContainer.tsx
@@ -1,7 +1,7 @@
 import { useHistory, useParams } from 'react-router-dom';
 import LoadingIndicator from '../../../components/LoadingIndicator';
 import ErrorPage from '../../ErrorPage';
-import { Box, Grid } from '@mui/material';
+import { Box } from '@mui/material';
 import GraphView from '../GraphView/GraphView';
 import { useGetSingleGraphCollection } from '../../../hooks/statistics.hooks';
 import { NERButton } from '../../../components/NERButton';
@@ -34,34 +34,38 @@ const GraphCollectionViewContainer = () => {
           <NERButton variant="contained" sx={{ mx: 1 }} onClick={() => setShowEditGraphCollectionModal(true)}>
             Edit Graph Collection
           </NERButton>
+          <NERButton
+            variant="outlined"
+            sx={{ mx: 1 }}
+            onClick={() => history.push(`${routes.STATISTICS}/graph-collections/${graphCollection.id}/graph/create`)}
+          >
+            Add Graph
+          </NERButton>
         </Box>
       }
     >
-      <Grid container spacing={1}>
+      <Box
+        sx={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: 2,
+          alignItems: 'flex-start'
+        }}
+      >
         {graphCollection.graphs.map((graph) => (
-          <Grid item lg={4} md={6} xs={12} overflow={'hidden'}>
-            <GraphView graph={graph} height={400} />
-          </Grid>
-        ))}
-        <Grid item lg={4} md={6} xs={12}>
           <Box
+            key={graph.graphId}
             sx={{
-              width: '100%',
-              height: 400,
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center',
-              border: '2px dashed #ef4343'
+              flex: '0 0 auto',
+              minWidth: 300,
+              minHeight: 200
             }}
           >
-            <NERButton
-              onClick={() => history.push(`${routes.STATISTICS}/graph-collections/${graphCollection.id}/graph/create`)}
-            >
-              Add Graph
-            </NERButton>
+            <GraphView graph={graph} height={400} width={600} />
           </Box>
-        </Grid>
-      </Grid>
+        ))}
+      </Box>
+
       <UpdateGraphCollectionForm
         open={showEditGraphCollectionModal}
         onHide={() => setShowEditGraphCollectionModal(false)}

--- a/src/frontend/src/pages/StatisticsPage/GraphView/GraphBarChartView.tsx
+++ b/src/frontend/src/pages/StatisticsPage/GraphView/GraphBarChartView.tsx
@@ -5,11 +5,12 @@ interface GraphBarChartViewProps {
   graph: Graph;
   height: number;
   cars: Car[];
+  width: number;
 }
 
 const colors = ['#DE1515', '#1515DE', '#15DE15'];
 
-const GraphBarChartView = ({ graph, height, cars }: GraphBarChartViewProps) => {
+const GraphBarChartView = ({ graph, height, cars, width }: GraphBarChartViewProps) => {
   return (
     <StatsBarChart
       graphTitle={`${displayEnum(graph.measure)} ${graph.title} - ${displayEnum(graph.graphType)} ${
@@ -23,6 +24,7 @@ const GraphBarChartView = ({ graph, height, cars }: GraphBarChartViewProps) => {
       xAxisData={graph.graphData[0].values.map((data) => data.label)}
       xAxisLabel={graph.xAxisLabel}
       height={height}
+      width={width}
     />
   );
 };

--- a/src/frontend/src/pages/StatisticsPage/GraphView/GraphPieChartView.tsx
+++ b/src/frontend/src/pages/StatisticsPage/GraphView/GraphPieChartView.tsx
@@ -6,9 +6,10 @@ interface GraphPieChartViewProps {
   graph: Graph;
   height: number;
   cars: Car[];
+  width: number;
 }
 
-const GraphPieChartView = ({ graph, height, cars }: GraphPieChartViewProps) => {
+const GraphPieChartView = ({ graph, height, cars, width }: GraphPieChartViewProps) => {
   return (
     <StatsPieChart
       graphTitle={`${displayEnum(graph.measure)} ${graph.title} - ${displayEnum(graph.graphType)} ${
@@ -17,6 +18,7 @@ const GraphPieChartView = ({ graph, height, cars }: GraphPieChartViewProps) => {
       xAxisData={graph.graphData[0].values.map((data) => data.label)}
       yAxisData={graph.graphData[0].values.map((data) => data.value)}
       height={height}
+      width={width}
     />
   );
 };

--- a/src/frontend/src/pages/StatisticsPage/GraphView/GraphView.tsx
+++ b/src/frontend/src/pages/StatisticsPage/GraphView/GraphView.tsx
@@ -10,13 +10,15 @@ import ErrorPage from '../../ErrorPage';
 import LoadingIndicator from '../../../components/LoadingIndicator';
 import { useRemoveGraphFromCollection } from '../../../hooks/statistics.hooks';
 import { useToast } from '../../../hooks/toasts.hooks';
+import React, { useState, useRef, useCallback, useEffect } from 'react';
 
 interface GraphViewProps {
   graph: Graph;
   height: number;
+  width: number;
 }
 
-const GraphView = ({ graph, height = 500 }: GraphViewProps) => {
+const GraphView = ({ graph, height = 500, width = 1000 }: GraphViewProps) => {
   const history = useHistory();
   const { graphCollectionId } = useParams<{ graphCollectionId: string }>();
   const { isLoading, data: cars, error, isError } = useGetCarsByIds(new Set(graph.carIds));
@@ -25,6 +27,52 @@ const GraphView = ({ graph, height = 500 }: GraphViewProps) => {
     graph.graphId
   );
   const toast = useToast();
+
+  const [dimensions, setDimensions] = useState({ width, height });
+  const [isResizing, setIsResizing] = useState(false);
+  const [resizeStart, setResizeStart] = useState({ x: 0, y: 0 });
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // resize logic:
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    setIsResizing(true);
+    setResizeStart({ x: e.clientX, y: e.clientY });
+  }, []);
+
+  const handleMouseMove = useCallback(
+    (e: MouseEvent) => {
+      if (!isResizing) return;
+
+      const deltaX = e.clientX - resizeStart.x;
+      const deltaY = e.clientY - resizeStart.y;
+
+      setDimensions((prev) => ({
+        width: Math.max(300, prev.width + deltaX),
+        height: Math.max(200, prev.height + deltaY)
+      }));
+
+      setResizeStart({ x: e.clientX, y: e.clientY });
+    },
+    [isResizing, resizeStart]
+  );
+
+  const handleMouseUp = useCallback(() => {
+    setIsResizing(false);
+  }, []);
+
+  // Add/remove event listeners
+  useEffect(() => {
+    if (isResizing) {
+      document.addEventListener('mousemove', handleMouseMove);
+      document.addEventListener('mouseup', handleMouseUp);
+      return () => {
+        document.removeEventListener('mousemove', handleMouseMove);
+        document.removeEventListener('mouseup', handleMouseUp);
+      };
+    }
+    return () => {};
+  }, [isResizing, handleMouseMove, handleMouseUp]);
 
   if (isError) {
     return <ErrorPage error={error} />;
@@ -48,37 +96,74 @@ const GraphView = ({ graph, height = 500 }: GraphViewProps) => {
   const Graph = () => {
     switch (graph.graphDisplayType) {
       case GraphDisplayType.BAR:
-        return <GraphBarChartView graph={graph} height={height} cars={cars} />;
+        return <GraphBarChartView graph={graph} height={dimensions.height - 80} cars={cars} width={dimensions.width - 80} />;
       case GraphDisplayType.PIE:
-        return <GraphPieChartView graph={graph} height={height} cars={cars} />;
+        return <GraphPieChartView graph={graph} height={dimensions.height - 80} cars={cars} width={dimensions.width - 80} />;
       default:
         return <Typography>Unsupported graph display type: {graph.graphDisplayType}</Typography>;
     }
   };
 
   return (
-    <Box justifyContent={'center'}>
-      <Box display={'flex'}>
-        <Graph />
-        <IconButton
-          sx={{ height: 40 }}
-          onClick={() =>
-            history.push('/statistics/graph-collections/' + graphCollectionId + '/graph/' + graph.graphId + '/edit')
-          }
-        >
-          <Edit />
-        </IconButton>
-        <IconButton sx={{ height: 40 }} onClick={onRemovePressed}>
-          <Delete />
-        </IconButton>
+    <Box
+      ref={containerRef}
+      sx={{
+        position: 'relative',
+        width: dimensions.width,
+        height: dimensions.height,
+        minWidth: 300,
+        minHeight: 200,
+        cursor: isResizing ? 'nw-resize' : 'default',
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden'
+      }}
+    >
+      <Box sx={{ flex: 1, position: 'relative', display: 'flex' }}>
+        <Box sx={{ flex: 1, overflow: 'hidden', position: 'relative' }}>
+          <Graph />
+        </Box>
+        <Box sx={{ display: 'flex', flexDirection: 'row', flexShrink: 0, zIndex: 1 }}>
+          <IconButton
+            sx={{ height: 40 }}
+            onClick={() =>
+              history.push('/statistics/graph-collections/' + graphCollectionId + '/graph/' + graph.graphId + '/edit')
+            }
+          >
+            <Edit />
+          </IconButton>
+          <IconButton sx={{ height: 40 }} onClick={onRemovePressed}>
+            <Delete />
+          </IconButton>
+        </Box>
       </Box>
-      <Typography textAlign={'center'} fontWeight={'regular'} fontSize={20} variant="h6" noWrap>
-        {!graph.startDate && !graph.endDate
-          ? 'All time'
-          : (graph.startDate ? datePipe(graph.startDate) : 'No start date') +
-            ' to ' +
-            (graph.endDate ? datePipe(graph.endDate) : 'no end date')}
-      </Typography>
+
+      <Box sx={{ height: 40, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Typography textAlign={'center'} fontWeight={'regular'} fontSize={20} variant="h6" noWrap>
+          {!graph.startDate && !graph.endDate
+            ? 'All time'
+            : (graph.startDate ? datePipe(graph.startDate) : 'No start date') +
+              ' to ' +
+              (graph.endDate ? datePipe(graph.endDate) : 'no end date')}
+        </Typography>
+      </Box>
+
+      {/* Resize handle */}
+      <Box
+        onMouseDown={handleMouseDown}
+        sx={{
+          position: 'absolute',
+          bottom: 0,
+          right: 0,
+          width: 20,
+          height: 20,
+          cursor: 'nwse-resize',
+          background: 'linear-gradient(-45deg, transparent 30%, #ccc 30%, #ccc 50%, transparent 50%)',
+          '&:hover': {
+            background: 'linear-gradient(-45deg, transparent 30%, #999 30%, #999 50%, transparent 50%)'
+          }
+        }}
+      />
     </Box>
   );
 };


### PR DESCRIPTION
## Changes
Implements drag-to-resize functionality for graphs on the stats page. Basically vibe-coded my way through the javascript/react functionality but essentially its just resizing the graphs based on mouse location and movement. Had to adjust the css for a few things just so that the graphs could take on like a more flex display in case of an overflow (which happens when you make graphs bigger/smaller). Also moved the `add graph` button to the top right corner I think it looks better that way and it doesn't get in the way of resizing graphs, but I can move it back if you're particular about it staying there.

Also the graph seed data was a little bit weird so I went ahead and fixed that. 

Lmk if you have any suggestions!

Video:
https://github.com/user-attachments/assets/bcb73bd6-e62c-4004-b300-17ae1750ae6f


Closes #3308
