### PR TITLE
#3597 - CR's to review don't include the user

### DIFF
--- a/src/backend/src/services/change-requests.services.ts
+++ b/src/backend/src/services/change-requests.services.ts
@@ -146,7 +146,7 @@ export default class ChangeRequestsService {
             dateReviewed: null
           },
           {
-            NOT: { scopeChangeRequest: null }
+            NOT: { scopeChangeRequest: null, submitterId: user.userId }
           }
         ],
         organizationId: organization.organizationId,

--- a/src/backend/src/services/change-requests.services.ts
+++ b/src/backend/src/services/change-requests.services.ts
@@ -146,7 +146,10 @@ export default class ChangeRequestsService {
             dateReviewed: null
           },
           {
-            NOT: { scopeChangeRequest: null, submitterId: user.userId }
+            NOT: [
+              { scopeChangeRequest: null },
+              { submitterId: user.userId }
+            ]
           }
         ],
         organizationId: organization.organizationId,

--- a/src/backend/src/services/change-requests.services.ts
+++ b/src/backend/src/services/change-requests.services.ts
@@ -146,10 +146,7 @@ export default class ChangeRequestsService {
             dateReviewed: null
           },
           {
-            NOT: [
-              { scopeChangeRequest: null },
-              { submitterId: user.userId }
-            ]
+            NOT: [{ scopeChangeRequest: null }, { submitterId: user.userId }]
           }
         ],
         organizationId: organization.organizationId,


### PR DESCRIPTION
## Changes

No longer include CR's made by user, in toReview endpoint

## Test Cases

- I didn't test because my setup is out of date, if someone reviewing could that would be great.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3597
