### PR TITLE
Feature/create calendar endpoint clean

### DIFF
--- a/src/backend/src/controllers/calendar.controllers.ts
+++ b/src/backend/src/controllers/calendar.controllers.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Request, Response } from 'express';
 import CalendarService from '../services/calendar.services';
+import { validationResult } from 'express-validator';
 
 export default class CalendarController {
   static async createEventType(req: Request, res: Response, next: NextFunction) {
@@ -42,6 +43,41 @@ export default class CalendarController {
         description
       );
       res.status(200).json(eventType);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+  static async createCalendar(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const errors = validationResult(req);
+      if (!errors.isEmpty()) {
+        res.status(400).json({ errors: errors.array() });
+        return;
+      }
+
+      if (!req.currentUser) {
+        res.status(401).json({
+          message: 'Unauthorized: Authentication required'
+        });
+        return;
+      }
+
+      if (!req.currentUser.additionalPermissions || !req.currentUser.additionalPermissions.includes('admin')) {
+        res.status(403).json({
+          message: 'Forbidden: Admin access required to create calendars'
+        });
+        return;
+      }
+
+      const { name, description, color } = req.body;
+      const calendar = await CalendarService.createCalendar({
+        name,
+        description,
+        colorHexCode: color,
+        userCreatedId: req.currentUser.userId
+      });
+
+      res.status(201).json(calendar);
     } catch (error: unknown) {
       next(error);
     }

--- a/src/backend/src/prisma/seed.ts
+++ b/src/backend/src/prisma/seed.ts
@@ -51,7 +51,6 @@ import OnboardingServices from '../services/onboarding.services';
 import { dbSeedAllParts, dbSeedAllPartTags } from './seed-data/parts.seed';
 import FinanceServices from '../services/finance.services';
 import CalendarService from '../services/calendar.services';
-import { truncateByDomain } from 'recharts/types/util/ChartUtils';
 
 const prisma = new PrismaClient();
 
@@ -3155,6 +3154,56 @@ const performSeed: () => Promise<void> = async () => {
     false,
     true
   );
+
+  const companyEventsCalendar = await prisma.calendar.create({
+    data: {
+      name: 'Company Events',
+      description: 'Official company-wide events and meetings',
+      colorHexCode: '#3B82F6',
+      userCreated: { connect: { userId: thomasEmrax.userId } },
+      dateCreated: new Date()
+    }
+  });
+
+  const teamMeetingsCalendar = await prisma.calendar.create({
+    data: {
+      name: 'Team Meetings',
+      description: 'Regular team meetings and standups',
+      colorHexCode: '#10B981',
+      userCreated: { connect: { userId: thomasEmrax.userId } },
+      dateCreated: new Date()
+    }
+  });
+
+  const projectDeadlinesCalendar = await prisma.calendar.create({
+    data: {
+      name: 'Project Deadlines',
+      description: 'Important project milestones and deadlines',
+      colorHexCode: '#EF4444',
+      userCreated: { connect: { userId: thomasEmrax.userId } },
+      dateCreated: new Date()
+    }
+  });
+
+  const trainingCalendar = await prisma.calendar.create({
+    data: {
+      name: 'Training Sessions',
+      description: 'Employee training and development sessions',
+      colorHexCode: '#8B5CF6',
+      userCreated: { connect: { userId: thomasEmrax.userId } },
+      dateCreated: new Date()
+    }
+  });
+
+  const maintenanceCalendar = await prisma.calendar.create({
+    data: {
+      name: 'Maintenance Windows',
+      description: 'System maintenance and downtime schedules',
+      colorHexCode: '#F59E0B',
+      userCreated: { connect: { userId: thomasEmrax.userId } },
+      dateCreated: new Date()
+    }
+  });
 };
 
 performSeed()

--- a/src/backend/src/routes/calendar.routes.ts
+++ b/src/backend/src/routes/calendar.routes.ts
@@ -27,4 +27,13 @@ calendarRouter.post(
   CalendarController.createEventType
 );
 
+calendarRouter.post(
+  '/create',
+  nonEmptyString(body('name')),
+  nonEmptyString(body('description')),
+  nonEmptyString(body('color')),
+  validateInputs,
+  CalendarController.createCalendar
+);
+
 export default calendarRouter;

--- a/src/backend/src/services/calendar.services.ts
+++ b/src/backend/src/services/calendar.services.ts
@@ -6,6 +6,13 @@ import { userHasPermission } from '../utils/users.utils';
 import { eventTypeTransformer } from '../transformers/calendar.transformer';
 import { getEventTypeQueryArgs } from '../prisma-query-args/event-type.query-args';
 
+interface CreateCalendarData {
+  name: string;
+  description?: string;
+  colorHexCode: string;
+  userCreatedId: string;
+}
+
 export default class CalendarService {
   /**
    * Creates a new event type.
@@ -72,7 +79,6 @@ export default class CalendarService {
         shop,
         machinery,
         workPackage,
-        questionDocument,
         documents,
         description
       },
@@ -80,5 +86,37 @@ export default class CalendarService {
     });
 
     return eventTypeTransformer(newEventType);
+  }
+
+  static async createCalendar(
+    submitter: User,
+    name: string,
+    description: string | undefined,
+    colorHexCode: string,
+    organization: Organization
+  ) {
+    if (!(await userHasPermission(submitter.userId, organization.organizationId, isAdmin))) {
+      throw new AccessDeniedAdminOnlyException('create calendar');
+    }
+
+    return await prisma.calendar.create({
+      data: {
+        name,
+        description: description ?? '',
+        colorHexCode,
+        userCreatedId: submitter.userId,
+        dateCreated: new Date()
+      },
+      include: {
+        userCreated: {
+          select: {
+            userId: true,
+            firstName: true,
+            lastName: true,
+            email: true
+          }
+        }
+      }
+    });
   }
 }

--- a/src/backend/tests/unit/calendar.test.ts
+++ b/src/backend/tests/unit/calendar.test.ts
@@ -162,3 +162,5 @@ describe('Calendar Tests', () => {
     });
   });
 });
+
+//commit again

--- a/src/backend/tests/unit/calendar.test.ts
+++ b/src/backend/tests/unit/calendar.test.ts
@@ -91,4 +91,74 @@ describe('Calendar Tests', () => {
       expect(result.description).toBe(true);
     });
   });
+
+  describe('Create Calendar', () => {
+    it('Fails if user is not an admin', async () => {
+      const guestUser = await createTestUser(wonderwomanGuest, orgId);
+
+      await expect(
+        async () =>
+          await CalendarService.createCalendar(guestUser, 'Test Calendar', 'A test calendar', '#FF5733', organization)
+      ).rejects.toThrow(new AccessDeniedAdminOnlyException('create calendar'));
+    });
+
+    it('Succeeds and creates a calendar with all fields', async () => {
+      const adminUser = await createTestUser(batmanAppAdmin, orgId);
+
+      const result = await CalendarService.createCalendar(
+        adminUser,
+        'New Test Calendar',
+        'Calendar for testing purposes',
+        '#10B981',
+        organization
+      );
+
+      expect(result.name).toEqual('New Test Calendar');
+      expect(result.description).toEqual('Calendar for testing purposes');
+      expect(result.colorHexCode).toEqual('#10B981');
+      expect(result.userCreatedId).toEqual(adminUser.userId);
+      expect(result.calendarId).toBeDefined();
+      expect(result.dateCreated).toBeDefined();
+    });
+
+    it('Succeeds and creates a calendar without description', async () => {
+      const adminUser = await createTestUser(supermanAdmin, orgId);
+
+      const result = await CalendarService.createCalendar(
+        adminUser,
+        'Calendar Without Description',
+        undefined,
+        '#EF4444',
+        organization
+      );
+
+      expect(result.name).toEqual('Calendar Without Description');
+      expect(result.description).toBe('');
+      expect(result.colorHexCode).toEqual('#EF4444');
+      expect(result.userCreatedId).toEqual(adminUser.userId);
+    });
+
+    it('Validates hex color format', async () => {
+      const adminUser = await createTestUser(batmanAppAdmin, orgId);
+
+      await expect(
+        async () =>
+          await CalendarService.createCalendar(
+            adminUser,
+            'Invalid Color Calendar',
+            'A test calendar',
+            'invalid-color',
+            organization
+          )
+      ).rejects.toThrow();
+    });
+
+    it('Handles empty name validation', async () => {
+      const adminUser = await createTestUser(supermanAdmin, orgId);
+
+      await expect(
+        async () => await CalendarService.createCalendar(adminUser, '', 'A test calendar', '#8B5CF6', organization)
+      ).rejects.toThrow();
+    });
+  });
 });


### PR DESCRIPTION
## Changes

Implements createCalendar endpoint with admin only access control. Users can create calendars with name, description, and color properties.

## Notes

_Any other notes go here_

## Test Cases

- Case A
- Edge case
- ...

## Screenshots

_If you made UI changes you must post a screenshot of the whole page for each change in 1) a normal sized window and 2) the smallest possible window_

_If you did any manual testing (e.g., with Postman), put screenshots of the http request and before and after of the db_

_If none of this applies, you can delete this section_

## To Do

_Any remaining things that need to get done_

- [ ] item 1
- [ ] ...

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #3552 )
