### PR TITLE
#2267 fixed legend

### DIFF
--- a/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/UserAvailabilitesView.tsx
+++ b/src/frontend/src/pages/CalendarPage/DesignReviewDetailPage/UserAvailabilitesView.tsx
@@ -60,7 +60,7 @@ const UserAvailabilites: React.FC<UserAvailabilitiesProps> = ({
         }}
       >
         <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-          <Typography style={{ marginRight: '10px' }}>0/0</Typography>
+          <Typography style={{ marginRight: '10px' }}>0/{totalUsers}</Typography>
           {Array.from({ length: 6 }, (_, i) => (
             <Box
               sx={{


### PR DESCRIPTION
## Changes

For the legend on the DRC page, the value now shows 0/total number of users instead of 0/0.

## Screenshots

<img width="1504" height="838" alt="Screenshot 2025-09-24 at 7 34 56 PM" src="https://github.com/user-attachments/assets/1c4b455e-015b-417c-b0dd-7d32a596bdb0" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #2267

