### PR TITLE
Green availability and Login instructions

### DIFF
--- a/src/frontend/src/pages/LoginPage/LoginPage.tsx
+++ b/src/frontend/src/pages/LoginPage/LoginPage.tsx
@@ -31,7 +31,11 @@ const LoginPage: React.FC<LoginPageProps> = ({ devSetUser, devFormSubmit, prodSu
       <CardContent>
         <Typography variant="h5">FinishLine by NER</Typography>
         <Typography variant="body1" sx={{ mb: 1 }}>
-          Login Required. Students must use their Husky Google account.
+          Students must use their Husky Google account to login.
+          <br />
+          <br />
+          This means if your email is 'last.first@northeastern.edu', login to Google with the email
+          'last.first@husky.neu.edu'
         </Typography>
         {import.meta.env.MODE === 'development' ? loginDev : googleLogin}
       </CardContent>

--- a/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/EditAvailability.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/EditAvailability.tsx
@@ -105,7 +105,7 @@ const EditAvailability: React.FC<EditAvailabilityProps> = ({
     <Grid container>
       <Grid container justifyContent="space-between" mb={1}>
         <Typography display={'flex'} justifyContent={'flex-start'} mt={1} variant="subtitle1">
-          Available times in red
+          Available times in green
         </Typography>
         <NERButton variant="outlined" sx={{ display: 'flex', justifyContent: 'flex-end' }} onClick={invertAvailabilities}>
           Invert Availability

--- a/src/frontend/src/utils/design-review.utils.ts
+++ b/src/frontend/src/utils/design-review.utils.ts
@@ -50,7 +50,7 @@ export enum REVIEW_TIMES {
 
 export const HOURS: number[] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
 
-export const HeatmapColors = ['#D9D9D9', '#E0C0C1', '#E89A9B', '#E4797A', '#EF4345', '#D70C0F'];
+export const HeatmapColors = ['#D9D9D9', '#C1E0C1', '#9BE89B', '#7AE47A', '#45EF45', '#0FD70F'];
 
 export const NUMBER_OF_TIME_SLOTS = enumToArray(REVIEW_TIMES).length * enumToArray(DAY_NAMES).length;
 


### PR DESCRIPTION
Two feature requests:
1. People get very confused about red = available on the DRC, we've received many requests to change this because people just use when2meet instead
2. First years often don't know what a husky email is. Based on requests for instruction, I added a clear description on the login screen explaining how to login for those who haven't used their NEU gmail before

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/4d897a95-9a7f-42ee-b684-466c08d1fae0" />
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/0ab75ac5-6052-4606-8fab-6a731b3a9393" />
