### PR TITLE
#3620 empty availability bug fixed

### DIFF
--- a/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/EditAvailability.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/EditAvailability.tsx
@@ -24,9 +24,27 @@ const EditAvailability: React.FC<EditAvailabilityProps> = ({
   initialDate,
   canChangeDateRange = true
 }) => {
-  const [currentlyDisplayedAvailabilities, setCurrentlyDisplayedAvailabilities] = useState(
-    Array.from(editedAvailabilities.values())
-  );
+  const [currentlyDisplayedAvailabilities, setCurrentlyDisplayedAvailabilities] = useState(() => {
+    const availabilities = Array.from(editedAvailabilities.values());
+    if (availabilities.length === 0) {
+      const defaultAvailabilities: Availability[] = [];
+      for (let i = 0; i < 7; i++) {
+        const date = addDaysToDate(initialDate, i);
+        defaultAvailabilities.push({
+          dateSet: date,
+          availability: []
+        });
+      }
+
+      defaultAvailabilities.forEach((availability) => {
+        editedAvailabilities.set(availability.dateSet.getTime(), availability);
+      });
+      setEditedAvailabilities(editedAvailabilities);
+
+      return defaultAvailabilities;
+    }
+    return availabilities;
+  });
 
   const [isDragging, setIsDragging] = useState(false);
 


### PR DESCRIPTION
## Changes

- added default values for users that have not set general availability
- default values populate only if availabilites returns empty set from the guessing function
- Before, it was just pulling values from the guessing function with no validation

## Screenshots
<img width="699" height="593" alt="Screenshot 2025-09-25 at 7 51 00 PM" src="https://github.com/user-attachments/assets/fb021457-c326-4167-ab6f-91014c13030a" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3620
