### PR TITLE
#2743: user's availability calendar now reflects RSVP'd meetings

### DIFF
--- a/src/backend/src/services/design-reviews.services.ts
+++ b/src/backend/src/services/design-reviews.services.ts
@@ -427,6 +427,7 @@ export default class DesignReviewsService {
 
         // Check if user has availability already for the scheduled date
         // TODO: Due to the off-by-one date bug, need to adjust one day from the scheduled date
+        // might need to make another ticket for this
         const existingAvailability = userSettings.availabilities.find((availability) => {
           const availabilityDate = new Date(availability.dateSet);
           const scheduledDate = new Date(updatedDesignReview.dateScheduled);

--- a/src/backend/src/services/design-reviews.services.ts
+++ b/src/backend/src/services/design-reviews.services.ts
@@ -396,6 +396,76 @@ export default class DesignReviewsService {
           updatedDesignReview.wbsElement
         );
       }
+
+      // Mark all attendees as unavailable during the scheduled meeting time
+      for (const member of updatedDesignReview.confirmedMembers) {
+        let userSettings = await prisma.schedule_Settings.findUnique({
+          where: { userId: member.userId },
+          ...getUserScheduleSettingsQueryArgs()
+        });
+
+        if (!userSettings) {
+          userSettings = await prisma.schedule_Settings.create({
+            data: {
+              userId: member.userId,
+              availabilities: {
+                createMany: {
+                  data: [
+                    {
+                      availability: [],
+                      dateSet: dateScheduled
+                    }
+                  ]
+                }
+              },
+              personalGmail: '',
+              personalZoomLink: ''
+            },
+            ...getUserScheduleSettingsQueryArgs()
+          });
+        }
+
+        // Check if user has availability already for the scheduled date
+        // TODO: Due to the off-by-one date bug, need to adjust one day from the scheduled date
+        const existingAvailability = userSettings.availabilities.find((availability) => {
+          const availabilityDate = new Date(availability.dateSet);
+          const scheduledDate = new Date(updatedDesignReview.dateScheduled);
+          // Subtract one day from scheduledDate
+          const dayAfterScheduled = new Date(scheduledDate);
+          dayAfterScheduled.setDate(scheduledDate.getDate() + 1);
+          return availabilityDate.toDateString() === dayAfterScheduled.toDateString();
+        });
+
+        // const existingAvailability = userSettings.availabilities.find(
+        //   (availability) => availability.dateSet.toDateString() === updatedDesignReview.dateScheduled.toDateString()
+        // );
+
+        if (existingAvailability) {
+          // Remove meeting times from existing availability
+          const updatedAvailability = existingAvailability.availability.filter((time) => !meetingTimes.includes(time));
+
+          await prisma.availability.update({
+            where: { availabilityId: existingAvailability.availabilityId },
+            data: {
+              availability: updatedAvailability
+            }
+          });
+
+          await prisma.schedule_Settings.update({
+            where: { userId: member.userId },
+            data: {
+              availabilities: {
+                update: {
+                  where: { availabilityId: existingAvailability.availabilityId },
+                  data: {
+                    availability: updatedAvailability
+                  }
+                }
+              }
+            }
+          });
+        }
+      }
     }
 
     return designReviewTransformer(updatedDesignReview);

--- a/src/backend/tests/test-utils.ts
+++ b/src/backend/tests/test-utils.ts
@@ -147,6 +147,7 @@ export const resetUsers = async () => {
   await prisma.user_Settings.deleteMany();
   await prisma.session.deleteMany();
   await prisma.user_Secure_Settings.deleteMany();
+  await prisma.availability.deleteMany();
   await prisma.schedule_Settings.deleteMany();
   await prisma.role.deleteMany();
   await prisma.design_Review.deleteMany();


### PR DESCRIPTION
## Changes

When users RSVP to a meeting (i.e. provide their availability for a design review meeting), as soon as the meeting time is selected by the host, all attendee's availability calendars get updated to reflect the meeting, i.e. the time block of the meeting shows as no longer available.

## Notes

It seems that availability dates stored in the db are typically off by ~1 day, so as a temporary measure until this behavior is fixed, I offset the date/time by 1 day to account for the error, but once resolved, that logic can simply be removed (I left in the code that _should_ work as a comment).

I'm putting up this PR now just to have progress and so I can move onto other ticket, but might want to wait on merging this until that date bug gets resolved.

## Screenshots

Here's a walkthrough of the full process, just so it's clear when the availability gets adjusted and how it appears to the user:

https://github.com/user-attachments/assets/958d7aaf-464b-4d7f-83b7-03e8e59b84ea


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #2743 