### PR TITLE
Added editCalendar endpoint

### DIFF
--- a/src/backend/src/controllers/calendar.controllers.ts
+++ b/src/backend/src/controllers/calendar.controllers.ts
@@ -115,6 +115,26 @@ export default class CalendarController {
     }
   }
 
+  static async editCalendar(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { calendarId } = req.params;
+      const { name, colorHexCode, description } = req.body;
+
+      const updatedCalendar = await CalendarService.editCalendar(
+        req.currentUser,
+        calendarId,
+        name,
+        description,
+        colorHexCode,
+        req.organization
+      );
+
+      res.status(200).json(updatedCalendar);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
   static async deleteCalendar(req: Request, res: Response, next: NextFunction) {
     try {
       const { calendarId } = req.params;

--- a/src/backend/src/routes/calendar.routes.ts
+++ b/src/backend/src/routes/calendar.routes.ts
@@ -56,6 +56,15 @@ calendarRouter.put(
   CalendarController.editMachinery
 );
 
+calendarRouter.put(
+  '/:calendarId/edit',
+  nonEmptyString(body('name')),
+  nonEmptyString(body('description')),
+  nonEmptyString(body('colorHexCode')),
+  validateInputs,
+  CalendarController.editCalendar
+);
+
 calendarRouter.post(
   '/shop/create',
   nonEmptyString(body('name')),

--- a/src/backend/src/services/calendar.services.ts
+++ b/src/backend/src/services/calendar.services.ts
@@ -315,15 +315,65 @@ export default class CalendarService {
   }
 
   /**
+   * @param submitter The user submitting the request, who must be an admin.
+   * @param calendarId The id of the given calendar.
+   * @param name The name of the calendar.
+   * @param description The summary of what the calendar is used for.
+   * @param colorHexCode The color of the calendar.
+   * @param organization The organization for which the calendar is being edited.
+   *
+   * @returns The edited calendar.
+   *
+   * @throws NotFoundException If the given calendarId is not found.
+   * @throws InvalidOrganizationException If the given calendarId is not part of the same organization.
+   * @throws DeletedException If the calendar has already been deleted.
+   * @throws AccessDeniedAdminOnlyException If the submitter is not an admin.
+   */
+  static async editCalendar(
+    submitter: User,
+    calendarId: string,
+    name: string,
+    description: string,
+    colorHexCode: string,
+    organization: Organization
+  ): Promise<Calendar> {
+    const calendar = await prisma.calendar.findUnique({
+      where: { calendarId }
+    });
+
+    if (!calendar) throw new NotFoundException('Calendar', calendarId);
+    if (calendar.dateDeleted) throw new DeletedException('Calendar', calendarId);
+    if (calendar.organizationId !== organization.organizationId) throw new InvalidOrganizationException('Calendar');
+
+    const hasPermission = await userHasPermission(submitter.userId, organization.organizationId, isAdmin);
+
+    if (!hasPermission) {
+      throw new AccessDeniedException('Only admins can edit calendars');
+    }
+
+    const newCalendar = await prisma.calendar.update({
+      where: { calendarId },
+      data: {
+        name,
+        description,
+        colorHexCode
+      },
+      ...getCalendarQueryArgs(organization.organizationId)
+    });
+
+    return calendarTransformer(newCalendar);
+  }
+
+  /**
    * Delete calendar in the database
-   * @param submitter The user submitting the request, who must be a head or above.
+   * @param submitter The user submitting the request, who must be an admin.
    * @param calendarId The id of the given calendar.
    * @param organization The organization for which the calendar is being deleted.
    *
-   * @returns The deleted calendar ID.
+   * @returns The deleted calendar.
    *
-   * @throws NotFoundException If the given calendarIds are not found.
-   * @throws InvalidOrganizationException If the given calendarIds are not part of the same organization.
+   * @throws NotFoundException If the given calendarId is not found.
+   * @throws InvalidOrganizationException If the given calendarId is not part of the same organization.
    * @throws DeletedException If the calendar has already been deleted.
    * @throws AccessDeniedAdminOnlyException If the submitter is not an admin.
    */

--- a/src/backend/tests/unit/calendar.test.ts
+++ b/src/backend/tests/unit/calendar.test.ts
@@ -59,8 +59,98 @@ describe('Calendar Tests', () => {
     await resetUsers();
   });
 
+  describe('edit calendar', () => {
+    it('fails if user is not an admin', async () => {
+      const member = await createTestUser(wonderwomanGuest, orgId);
+
+      const calendar = await prisma.calendar.create({
+        data: {
+          name: 'Test Calendar',
+          description: 'Test',
+          colorHexCode: '#000000',
+          userCreatedId: member.userId,
+          organizationId: orgId
+        }
+      });
+
+      await expect(
+        CalendarService.editCalendar(
+          member,
+          calendar.calendarId,
+          'Updated Name',
+          'Updated Description',
+          '#FF0000',
+          organization
+        )
+      ).rejects.toThrow(new AccessDeniedException('Only admins can edit calendars'));
+    });
+
+    it('succeeds for admin', async () => {
+      const calendar = await prisma.calendar.create({
+        data: {
+          name: 'Original Calendar',
+          description: 'Original Description',
+          colorHexCode: '#00FF00',
+          userCreatedId: adminUser.userId,
+          organizationId: orgId
+        }
+      });
+
+      const result = await CalendarService.editCalendar(
+        adminUser,
+        calendar.calendarId,
+        'Updated Calendar',
+        'Updated Description',
+        '#0000FF',
+        organization
+      );
+
+      expect(result.calendarId).toBe(calendar.calendarId);
+      expect(result.name).toBe('Updated Calendar');
+      expect(result.description).toBe('Updated Description');
+      expect(result.color).toBe('#0000FF');
+    });
+
+    it('fails if calendar not found', async () => {
+      await expect(
+        CalendarService.editCalendar(
+          adminUser,
+          'non-existent-id',
+          'Updated Name',
+          'Updated Description',
+          '#FF0000',
+          organization
+        )
+      ).rejects.toThrow(new NotFoundException('Calendar', 'non-existent-id'));
+    });
+
+    it('fails if calendar already deleted', async () => {
+      const calendar = await prisma.calendar.create({
+        data: {
+          name: 'Already Deleted',
+          description: 'Test',
+          colorHexCode: '#0000FF',
+          userCreatedId: adminUser.userId,
+          organizationId: orgId,
+          dateDeleted: new Date()
+        }
+      });
+
+      await expect(
+        CalendarService.editCalendar(
+          adminUser,
+          calendar.calendarId,
+          'Updated Name',
+          'Updated Description',
+          '#FF0000',
+          organization
+        )
+      ).rejects.toThrow(new DeletedException('Calendar', calendar.calendarId));
+    });
+  });
+
   describe('delete calendar', () => {
-    it('fails if user is not a head or admin', async () => {
+    it('fails if user is not an admin', async () => {
       const member = await createTestUser(wonderwomanGuest, orgId);
 
       const calendar = await prisma.calendar.create({


### PR DESCRIPTION
## Changes

Implemented editCalendar endpoint

## Test Cases
<img width="1121" height="832" alt="Screenshot 2025-10-13 at 15 10 18" src="https://github.com/user-attachments/assets/98a3de20-29c0-43d5-ab5e-7393f23d5553" />
<img width="1112" height="825" alt="Screenshot 2025-10-13 at 15 11 20" src="https://github.com/user-attachments/assets/471aac84-97f4-4cf1-8dd0-f0d6a7de5608" />
<img width="1120" height="787" alt="Screenshot 2025-10-13 at 15 12 43" src="https://github.com/user-attachments/assets/3caa4132-7e19-48ea-bfda-e171a11885c6" />
<img width="1111" height="825" alt="Screenshot 2025-10-13 at 15 13 19" src="https://github.com/user-attachments/assets/f20e9e65-9d77-43b2-9419-48befaa792ab" />

- Successful editing
- Fails when user who is not admin tries to delete
- Fails when calendar has already been deleted
- Fails when invalid calendar id is provided

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3571