### PR TITLE
#3568 delete machinery endpoint

### DIFF
--- a/src/backend/src/controllers/calendar.controllers.ts
+++ b/src/backend/src/controllers/calendar.controllers.ts
@@ -257,4 +257,16 @@ export default class CalendarController {
       next(error);
     }
   }
+
+  static async deleteMachinery(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { machineryId } = req.params;
+
+      const machinery = await CalendarService.deleteMachinery(req.currentUser, machineryId, req.organization);
+
+      res.status(200).json(machinery);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
 }

--- a/src/backend/src/prisma/seed.ts
+++ b/src/backend/src/prisma/seed.ts
@@ -3107,6 +3107,7 @@ const performSeed: () => Promise<void> = async () => {
     ner,
     'Rapid prototyping for electronics enclosures'
   );
+  console.log(printer.machineryId);
   await MachineryService.createMachinery(
     thomasEmrax,
     'Captain America Oscilloscope',

--- a/src/backend/src/prisma/seed.ts
+++ b/src/backend/src/prisma/seed.ts
@@ -3107,7 +3107,6 @@ const performSeed: () => Promise<void> = async () => {
     ner,
     'Rapid prototyping for electronics enclosures'
   );
-  console.log(printer.machineryId);
   await MachineryService.createMachinery(
     thomasEmrax,
     'Captain America Oscilloscope',

--- a/src/backend/src/routes/calendar.routes.ts
+++ b/src/backend/src/routes/calendar.routes.ts
@@ -92,7 +92,7 @@ calendarRouter.put(
   CalendarController.editMachinery
 );
 
-calendarRouter.post('/machinery/:machineryId/delete', validateInputs, CalendarController.deleteMachinery);
+calendarRouter.post('/machinery/:machineryId/delete', CalendarController.deleteMachinery);
 
 calendarRouter.put(
   '/:calendarId/edit',

--- a/src/backend/src/routes/calendar.routes.ts
+++ b/src/backend/src/routes/calendar.routes.ts
@@ -92,6 +92,13 @@ calendarRouter.put(
   CalendarController.editMachinery
 );
 
+calendarRouter.post(
+  '/machinery/:machineryId/delete',
+  nonEmptyString(param('machineryId')),
+  validateInputs,
+  CalendarController.deleteMachinery
+);
+
 calendarRouter.put(
   '/:calendarId/edit',
   nonEmptyString(body('name')),

--- a/src/backend/src/routes/calendar.routes.ts
+++ b/src/backend/src/routes/calendar.routes.ts
@@ -92,12 +92,7 @@ calendarRouter.put(
   CalendarController.editMachinery
 );
 
-calendarRouter.post(
-  '/machinery/:machineryId/delete',
-  nonEmptyString(param('machineryId')),
-  validateInputs,
-  CalendarController.deleteMachinery
-);
+calendarRouter.post('/machinery/:machineryId/delete', validateInputs, CalendarController.deleteMachinery);
 
 calendarRouter.put(
   '/:calendarId/edit',

--- a/src/backend/src/services/calendar.services.ts
+++ b/src/backend/src/services/calendar.services.ts
@@ -10,7 +10,8 @@ import {
   User,
   ScheduleSlotCreateArgs,
   AvailabilityCreateArgs,
-  Event
+  Event,
+  Machinery
 } from 'shared';
 import prisma from '../prisma/prisma';
 import {
@@ -775,5 +776,54 @@ export default class CalendarService {
     });
 
     return shops.map(shopTransformer);
+  }
+
+  /**
+   * Deletes a machinery by its ID.
+   * Requires the submitter to be an admin.
+   * @param submitter The user submitting the request.
+   * @param machineryid The ID of the machinery to be deleted.
+   * @param organization The organization to which the machinery belongs.
+   * @returns The deleted machinery object.
+   * @throws AccessDeniedAdminOnlyException If the submitter is not an admin.
+   * @throws NotFoundException If the machinery with the given ID does not exist.
+   * @throws InvalidOrganizationException If the machinery does not belong to the given organization.
+   *
+   */
+
+  static async deleteMachinery(submitter: User, machineryId: string, organization: Organization): Promise<Machinery> {
+    if (!(await userHasPermission(submitter.userId, organization.organizationId, isAdmin))) {
+      throw new AccessDeniedAdminOnlyException('delete machinery');
+    }
+
+    // Ensure the machinery exists
+    const existing = await prisma.machinery.findUnique({ where: { machineryId } });
+    if (!existing) throw new NotFoundException('Machinery', machineryId);
+
+    // Ensure it belongs to this org
+    if (existing.organizationId !== organization.organizationId) {
+      throw new InvalidOrganizationException('Machinery');
+    }
+
+    // not already soft-deleted
+    if (existing.dateDeleted) {
+      throw new NotFoundException('Machinery', machineryId);
+    }
+
+    // Soft delete machinery and remove shop mappings
+    await prisma.shopMachinery.deleteMany({
+      where: { machineryId }
+    });
+
+    const deleted = await prisma.machinery.update({
+      where: { machineryId },
+      data: {
+        dateDeleted: new Date(),
+        userDeletedId: submitter.userId
+      },
+      ...getMachineryQueryArgs(organization.organizationId)
+    });
+
+    return machineryTransformer(deleted);
   }
 }

--- a/src/backend/src/services/calendar.services.ts
+++ b/src/backend/src/services/calendar.services.ts
@@ -810,18 +810,20 @@ export default class CalendarService {
       throw new NotFoundException('Machinery', machineryId);
     }
 
-    // Soft delete machinery and remove shop mappings
-    await prisma.shopMachinery.deleteMany({
-      where: { machineryId }
-    });
+    // Soft delete machinery and remove shop mappings in a transaction
+    const deleted = await prisma.$transaction(async (tx) => {
+      await tx.shopMachinery.deleteMany({
+        where: { machineryId }
+      });
 
-    const deleted = await prisma.machinery.update({
-      where: { machineryId },
-      data: {
-        dateDeleted: new Date(),
-        userDeletedId: submitter.userId
-      },
-      ...getMachineryQueryArgs(organization.organizationId)
+      return await tx.machinery.update({
+        where: { machineryId },
+        data: {
+          dateDeleted: new Date(),
+          userDeletedId: submitter.userId
+        },
+        ...getMachineryQueryArgs(organization.organizationId)
+      });
     });
 
     return machineryTransformer(deleted);

--- a/src/backend/tests/unit/calendar.test.ts
+++ b/src/backend/tests/unit/calendar.test.ts
@@ -1197,4 +1197,81 @@ describe('Calendar Tests', () => {
       ).rejects.toThrow(new NotFoundException('Machinery', deletedMachinery.machineryId));
     });
   });
+
+  describe('Delete Machinery', () => {
+    let machineryToDelete: Machinery;
+    let anotherShop: Shop;
+
+    beforeEach(async () => {
+      machineryToDelete = await CalendarService.createMachinery(
+        adminUser,
+        'Deletable Machinery',
+        shop.shopId,
+        2,
+        organization,
+        'Test description'
+      );
+
+      anotherShop = await CalendarService.createShop(
+        adminUser,
+        'Secondary Shop',
+        'Another shop for deletion test',
+        organization
+      );
+
+      await prisma.shopMachinery.create({
+        data: {
+          shopId: anotherShop.shopId,
+          machineryId: machineryToDelete.machineryId,
+          quantity: 1,
+          description: 'Bridge row for deletion test'
+        }
+      });
+    });
+
+    it('fails if user is not an admin', async () => {
+      const guest = await createTestUser(wonderwomanGuest, orgId);
+      await expect(CalendarService.deleteMachinery(guest, machineryToDelete.machineryId, organization)).rejects.toThrow(
+        new AccessDeniedAdminOnlyException('delete machinery')
+      );
+    });
+
+    it('fails if machinery does not exist', async () => {
+      await expect(CalendarService.deleteMachinery(adminUser, 'non-existent-id', organization)).rejects.toThrow(
+        new NotFoundException('Machinery', 'non-existent-id')
+      );
+    });
+
+    it('fails if machinery is already deleted', async () => {
+      await prisma.machinery.update({
+        where: { machineryId: machineryToDelete.machineryId },
+        data: { dateDeleted: new Date() }
+      });
+
+      await expect(CalendarService.deleteMachinery(adminUser, machineryToDelete.machineryId, organization)).rejects.toThrow(
+        new NotFoundException('Machinery', machineryToDelete.machineryId)
+      );
+    });
+
+    it('succeeds for admin and soft deletes machinery and shopMachinery rows', async () => {
+      const bridgeBefore = await prisma.shopMachinery.count({
+        where: { machineryId: machineryToDelete.machineryId }
+      });
+      expect(bridgeBefore).toBeGreaterThan(0);
+
+      const deleted = await CalendarService.deleteMachinery(adminUser, machineryToDelete.machineryId, organization);
+
+      const row = await prisma.machinery.findUnique({ where: { machineryId: machineryToDelete.machineryId } });
+      expect(row?.dateDeleted).not.toBeNull();
+      expect(row?.userDeletedId).toBe(adminUser.userId);
+
+      expect(deleted.machineryId).toBe(machineryToDelete.machineryId);
+      expect(deleted.name).toBe(machineryToDelete.name);
+
+      const bridgeAfter = await prisma.shopMachinery.count({
+        where: { machineryId: machineryToDelete.machineryId }
+      });
+      expect(bridgeAfter).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
## Changes

Implemented a delete machinery endpoint. It also deletes all shop machinery associated with that machinery.

## Test Cases

- fails if user is not an admin
- fails if machinery does not exist
- fails if machinery is already deleted
- succeeds for admin and soft deletes machinery and shopMachinery rows

## Screenshots

<img width="924" height="736" alt="Screenshot 2025-10-19 at 8 14 07 PM" src="https://github.com/user-attachments/assets/71cb0495-a08f-4b52-929b-a57f6cd3cbbd" />


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3568
