### PR TITLE
#3582 delete ruleset

### DIFF
--- a/src/backend/src/controllers/rules.controllers.ts
+++ b/src/backend/src/controllers/rules.controllers.ts
@@ -29,4 +29,14 @@ export default class RulesController {
       next(error);
     }
   }
+
+  static async deleteRuleset(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { rulesetId } = req.params;
+      await RulesService.deleteRuleset(rulesetId, req.currentUser.userId, req.organization.organizationId);
+      res.status(204).json({ message: `Successfully deleted ruleset #${rulesetId}` });
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
 }

--- a/src/backend/src/controllers/rules.controllers.ts
+++ b/src/backend/src/controllers/rules.controllers.ts
@@ -33,8 +33,8 @@ export default class RulesController {
   static async deleteRuleset(req: Request, res: Response, next: NextFunction) {
     try {
       const { rulesetId } = req.params;
-      await RulesService.deleteRuleset(rulesetId, req.currentUser.userId, req.organization.organizationId);
-      res.status(204).json({ message: `Successfully deleted ruleset #${rulesetId}` });
+      const ruleset = await RulesService.deleteRuleset(rulesetId, req.currentUser.userId, req.organization.organizationId);
+      res.status(200).json(ruleset);
     } catch (error: unknown) {
       next(error);
     }

--- a/src/backend/src/prisma-query-args/rules.query-args.ts
+++ b/src/backend/src/prisma-query-args/rules.query-args.ts
@@ -1,4 +1,5 @@
 import { Prisma } from '@prisma/client';
+import { getUserQueryArgs } from './user.query-args';
 // write types and query args below here
 
 // preview for rule display
@@ -30,5 +31,18 @@ export const getProjectRuleQueryArgs = () =>
           updatedAt: 'desc'
         }
       }
+    }
+  });
+
+export type RulesetQueryArgs = ReturnType<typeof getRulesetQueryArgs>;
+
+export const getRulesetQueryArgs = (organizationId: string) =>
+  Prisma.validator<Prisma.RulesetDefaultArgs>()({
+    include: {
+      rules: { where: { dateDeleted: null } },
+      rulesetType: true,
+      car: true,
+      createdBy: getUserQueryArgs(organizationId),
+      deletedBy: getUserQueryArgs(organizationId)
     }
   });

--- a/src/backend/src/prisma-query-args/rules.query-args.ts
+++ b/src/backend/src/prisma-query-args/rules.query-args.ts
@@ -39,7 +39,17 @@ export type RulesetQueryArgs = ReturnType<typeof getRulesetQueryArgs>;
 export const getRulesetQueryArgs = (organizationId: string) =>
   Prisma.validator<Prisma.RulesetDefaultArgs>()({
     include: {
-      rules: { where: { dateDeleted: null } },
+      rules: {
+        where: { dateDeleted: null },
+        select: {
+          ruleId: true,
+          _count: {
+            select: {
+              teams: true
+            }
+          }
+        }
+      },
       rulesetType: true,
       car: true,
       createdBy: getUserQueryArgs(organizationId),

--- a/src/backend/src/prisma-query-args/rules.query-args.ts
+++ b/src/backend/src/prisma-query-args/rules.query-args.ts
@@ -52,7 +52,6 @@ export const getRulesetQueryArgs = (organizationId: string) =>
       },
       rulesetType: true,
       car: true,
-      createdBy: getUserQueryArgs(organizationId),
-      deletedBy: getUserQueryArgs(organizationId)
+      createdBy: getUserQueryArgs(organizationId)
     }
   });

--- a/src/backend/src/routes/rules.routes.ts
+++ b/src/backend/src/routes/rules.routes.ts
@@ -15,4 +15,6 @@ rulesRouter.post(
   RulesController.createProjectRule
 );
 
+rulesRouter.post('/ruleset/:rulesetId/delete', RulesController.deleteRuleset);
+
 export default rulesRouter;

--- a/src/backend/src/services/rules.services.ts
+++ b/src/backend/src/services/rules.services.ts
@@ -105,6 +105,7 @@ export default class RulesService {
    * Given a ruleset id, retrieves the ruleset and throws errors if
    * it does not exist or is already deleted
    * @param rulesetId the id of the ruleset
+   * @param organizationId the id of the organization
    * @returns the ruleset with query args
    */
   static async getRulesetWithQueryArgs(rulesetId: string, organizationId: string) {

--- a/src/backend/src/services/rules.services.ts
+++ b/src/backend/src/services/rules.services.ts
@@ -1,4 +1,4 @@
-import { ProjectRule, isLeadership, RuleCompletion } from 'shared';
+import { ProjectRule, isLeadership, RuleCompletion, isAdmin } from 'shared';
 import { userHasPermission } from '../utils/users.utils';
 import {
   AccessDeniedException,
@@ -8,8 +8,8 @@ import {
   InvalidOrganizationException
 } from '../utils/errors.utils';
 import prisma from '../prisma/prisma';
-import { projectRuleTransformer } from '../transformers/rules.transformer';
-import { getProjectRuleQueryArgs } from '../prisma-query-args/rules.query-args';
+import { projectRuleTransformer, rulesetTransformer } from '../transformers/rules.transformer';
+import { getProjectRuleQueryArgs, getRulesetQueryArgs } from '../prisma-query-args/rules.query-args';
 import { Organization, User } from '@prisma/client';
 
 export default class RulesService {
@@ -99,5 +99,47 @@ export default class RulesService {
     });
 
     return projectRuleTransformer(projectRule);
+  }
+
+  /**
+   * Given a ruleset id, retrieves the ruleset and throws errors if
+   * it does not exist or is already deleted
+   * @param rulesetId the id of the ruleset
+   * @returns the ruleset with query args
+   */
+  static async getRulesetWithQueryArgs(rulesetId: string, organizationId: string) {
+    const ruleset = await prisma.ruleset.findUnique({
+      where: { rulesetId },
+      ...getRulesetQueryArgs(organizationId)
+    });
+
+    if (!ruleset) throw new NotFoundException('Ruleset', rulesetId);
+    if (ruleset.deletedByUserId) throw new DeletedException('Ruleset', rulesetId);
+
+    return ruleset;
+  }
+
+  /**
+   * Deletes a specific Ruleset
+   * @param rulesetId the id of the ruleset to be deleted
+   * @param deleterId the id of the user deleting the ruleset
+   * @param organizationID the organization id
+   * @returns the deleted Ruleset
+   */
+  static async deleteRuleset(rulesetId: string, deleterId: string, organizationId: string) {
+    const ruleset = await RulesService.getRulesetWithQueryArgs(rulesetId, organizationId);
+
+    const hasPermission =
+      (await userHasPermission(deleterId, organizationId, isAdmin)) || deleterId === ruleset.createdBy.userId;
+
+    if (!hasPermission) throw new AccessDeniedException('Only admins (including the ruleset creator) can delete a ruleset.');
+
+    const deletedRuleset = await prisma.ruleset.update({
+      where: { rulesetId },
+      data: { deletedBy: { connect: { userId: deleterId } } },
+      ...getRulesetQueryArgs(organizationId)
+    });
+
+    return rulesetTransformer(deletedRuleset);
   }
 }

--- a/src/backend/src/services/rules.services.ts
+++ b/src/backend/src/services/rules.services.ts
@@ -132,7 +132,7 @@ export default class RulesService {
     const hasPermission =
       (await userHasPermission(deleterId, organizationId, isAdmin)) || deleterId === ruleset.createdBy.userId;
 
-    if (!hasPermission) throw new AccessDeniedException('Only admins (including the ruleset creator) can delete a ruleset.');
+    if (!hasPermission) throw new AccessDeniedException('Only admins can delete a ruleset.');
 
     const deletedRuleset = await prisma.ruleset.update({
       where: { rulesetId },

--- a/src/backend/src/services/rules.services.ts
+++ b/src/backend/src/services/rules.services.ts
@@ -105,7 +105,7 @@ export default class RulesService {
    * Given a ruleset id, retrieves the ruleset and throws errors if
    * it does not exist or is already deleted
    * @param rulesetId the id of the ruleset
-   * @param organizationId the id of the organization
+   * @param organizationId the id of the organization the ruleset is being deleted in
    * @returns the ruleset with query args
    */
   static async getRulesetWithQueryArgs(rulesetId: string, organizationId: string) {
@@ -124,7 +124,7 @@ export default class RulesService {
    * Deletes a specific Ruleset
    * @param rulesetId the id of the ruleset to be deleted
    * @param deleterId the id of the user deleting the ruleset
-   * @param organizationID the organization id
+   * @param organizationID the id of the organization the ruleset is being deleted in
    * @returns the deleted Ruleset
    */
   static async deleteRuleset(rulesetId: string, deleterId: string, organizationId: string) {

--- a/src/backend/src/transformers/rules.transformer.ts
+++ b/src/backend/src/transformers/rules.transformer.ts
@@ -15,7 +15,6 @@ export const projectRuleTransformer = (projectRule: any): ProjectRule => {
 };
 
 export const rulesetTransformer = (ruleset: Prisma.RulesetGetPayload<RulesetQueryArgs>): Ruleset => {
-  // calculating the percentage of rules with one or more teams in the ruleset
   const rulesWithTeams = ruleset.rules.filter((rule) => rule._count.teams > 0).length;
   const totalRulesLength = ruleset.rules.length;
   const assignedPercentage = totalRulesLength > 0 ? (rulesWithTeams / totalRulesLength) * 100 : 0;

--- a/src/backend/src/transformers/rules.transformer.ts
+++ b/src/backend/src/transformers/rules.transformer.ts
@@ -17,7 +17,7 @@ export const projectRuleTransformer = (projectRule: any): ProjectRule => {
 export const rulesetTransformer = (ruleset: Prisma.RulesetGetPayload<RulesetQueryArgs>): Ruleset => {
   const rulesWithTeams = ruleset.rules.filter((rule) => rule._count.teams > 0).length;
   const totalRulesLength = ruleset.rules.length;
-  const assignedPercentage = totalRulesLength > 0 ? (rulesWithTeams / totalRulesLength) * 100 : 0;
+  const teamsPercentage = totalRulesLength > 0 ? (rulesWithTeams / totalRulesLength) * 100 : 0;
 
   return {
     fileId: ruleset.fileId,
@@ -25,7 +25,7 @@ export const rulesetTransformer = (ruleset: Prisma.RulesetGetPayload<RulesetQuer
     name: ruleset.name,
     dateCreated: ruleset.dateCreated,
     active: ruleset.active,
-    rules: assignedPercentage,
+    assignedPercentage: teamsPercentage,
     rulesetType: {
       ...ruleset.rulesetType,
       lastUpdated: ruleset.rulesetType.lastUpdated,

--- a/src/backend/src/transformers/rules.transformer.ts
+++ b/src/backend/src/transformers/rules.transformer.ts
@@ -1,4 +1,7 @@
-import { ProjectRule } from 'shared';
+import { ProjectRule, Ruleset } from 'shared';
+import { Prisma } from '@prisma/client';
+import { RulesetQueryArgs } from '../prisma-query-args/rules.query-args';
+import { userTransformer } from './user.transformer';
 
 // transformer functions go below here
 
@@ -9,5 +12,37 @@ export const projectRuleTransformer = (projectRule: any): ProjectRule => {
     projectId: projectRule.projectId,
     currentStatus: projectRule.currentStatus,
     statusHistory: projectRule.statusHistory
+  };
+};
+
+export const rulesetTransformer = (ruleset: Prisma.RulesetGetPayload<RulesetQueryArgs>): Ruleset => {
+  return {
+    fileId: ruleset.fileId,
+    rulesetId: ruleset.rulesetId,
+    name: ruleset.name,
+    dateCreated: ruleset.dateCreated,
+    active: ruleset.active,
+    rules: ruleset.rules.map((rule) => ({
+      ...rule,
+      ruleset: {
+        rulesetId: ruleset.rulesetId,
+        name: ruleset.name
+      },
+      subRuleIds: [],
+      referencedRules: [],
+      referencedBy: [],
+      projects: []
+    })),
+    rulesetType: {
+      ...ruleset.rulesetType,
+      lastUpdated: new Date(),
+      revisionFiles: []
+    },
+    car: {
+      carId: ruleset.car.carId,
+      name: ruleset.car.wbsElementId
+    },
+    deletedBy: ruleset.deletedBy ? userTransformer(ruleset.deletedBy) : null,
+    deletedByUserId: ruleset.deletedByUserId
   };
 };

--- a/src/backend/src/transformers/rules.transformer.ts
+++ b/src/backend/src/transformers/rules.transformer.ts
@@ -1,7 +1,6 @@
 import { ProjectRule, Ruleset } from 'shared';
 import { Prisma } from '@prisma/client';
 import { RulesetQueryArgs } from '../prisma-query-args/rules.query-args';
-import { userTransformer } from './user.transformer';
 
 // transformer functions go below here
 

--- a/src/backend/src/transformers/rules.transformer.ts
+++ b/src/backend/src/transformers/rules.transformer.ts
@@ -35,14 +35,12 @@ export const rulesetTransformer = (ruleset: Prisma.RulesetGetPayload<RulesetQuer
     })),
     rulesetType: {
       ...ruleset.rulesetType,
-      lastUpdated: new Date(),
+      lastUpdated: ruleset.rulesetType.lastUpdated,
       revisionFiles: []
     },
     car: {
       carId: ruleset.car.carId,
       name: ruleset.car.wbsElementId
-    },
-    deletedBy: ruleset.deletedBy ? userTransformer(ruleset.deletedBy) : null,
-    deletedByUserId: ruleset.deletedByUserId
+    }
   };
 };

--- a/src/backend/src/transformers/rules.transformer.ts
+++ b/src/backend/src/transformers/rules.transformer.ts
@@ -16,23 +16,18 @@ export const projectRuleTransformer = (projectRule: any): ProjectRule => {
 };
 
 export const rulesetTransformer = (ruleset: Prisma.RulesetGetPayload<RulesetQueryArgs>): Ruleset => {
+  // calculating the percentage of rules with one or more teams in the ruleset
+  const rulesWithTeams = ruleset.rules.filter((rule) => rule._count.teams > 0).length;
+  const totalRulesLength = ruleset.rules.length;
+  const assignedPercentage = totalRulesLength > 0 ? (rulesWithTeams / totalRulesLength) * 100 : 0;
+
   return {
     fileId: ruleset.fileId,
     rulesetId: ruleset.rulesetId,
     name: ruleset.name,
     dateCreated: ruleset.dateCreated,
     active: ruleset.active,
-    rules: ruleset.rules.map((rule) => ({
-      ...rule,
-      ruleset: {
-        rulesetId: ruleset.rulesetId,
-        name: ruleset.name
-      },
-      subRuleIds: [],
-      referencedRules: [],
-      referencedBy: [],
-      projects: []
-    })),
+    rules: assignedPercentage,
     rulesetType: {
       ...ruleset.rulesetType,
       lastUpdated: ruleset.rulesetType.lastUpdated,

--- a/src/backend/src/utils/errors.utils.ts
+++ b/src/backend/src/utils/errors.utils.ts
@@ -162,4 +162,5 @@ export type ExceptionObjectNames =
   | 'Reimbursement Product Other Reason'
   | 'Encryption Key'
   | 'Reimbursement Request Comment'
-  | 'Rule';
+  | 'Rule'
+  | 'Ruleset';

--- a/src/backend/tests/unit/rule.test.ts
+++ b/src/backend/tests/unit/rule.test.ts
@@ -1,32 +1,40 @@
-import { Car, Organization, Rule, Ruleset, Ruleset_Type, User, Project, Rule_Completion } from '@prisma/client';
+import RulesService from '../../src/services/rules.services';
+import { Organization, User, Project, Car, Ruleset_Type, Rule_Completion } from '@prisma/client';
+import { supermanAdmin, financeMember, wonderwomanGuest, batmanAppAdmin } from '../test-data/users.test-data';
 import { createTestOrganization, createTestProject, createTestUser, resetUsers } from '../test-utils';
 import prisma from '../../src/prisma/prisma';
-import RulesService from '../../src/services/rules.services';
-import { supermanAdmin, financeMember, wonderwomanGuest, batmanAppAdmin } from '../test-data/users.test-data';
-import {
-  AccessDeniedAdminOnlyException,
-  AccessDeniedException,
-  DeletedException,
-  HttpException,
-  InvalidOrganizationException,
-  NotFoundException
-} from '../../src/utils/errors.utils';
+import { AccessDeniedException, DeletedException, HttpException, NotFoundException } from '../../src/utils/errors.utils';
 
-describe('Rules Tests', () => {
-  let deletedRule: Rule;
-  let rule: Rule;
-  let user: User;
-  let organization: Organization;
+describe('Rule Tests', () => {
   let orgId: string;
-  let car: Car;
-  let rulesetType: Ruleset_Type;
-  let ruleset: Ruleset;
-  let subRule: Rule;
-  let project: Project;
+  let organization: Organization;
+  let admin: User;
   let nonLeadership: User;
-  let carCounter = 1;
+  let project: Project;
+  let fsaeRulesetType: Ruleset_Type;
+
+  beforeEach(async () => {
+    organization = await createTestOrganization();
+    orgId = organization.organizationId;
+    admin = await createTestUser(supermanAdmin, organization.organizationId);
+    nonLeadership = await createTestUser(financeMember, organization.organizationId);
+    project = await createTestProject(admin, organization.organizationId);
+
+    fsaeRulesetType = await prisma.ruleset_Type.create({
+      data: {
+        name: 'FSAE',
+        createdBy: { connect: { userId: admin.userId } }
+      }
+    });
+  });
+
+  afterEach(async () => {
+    await resetUsers();
+  });
 
   const createUniqueCar = async (orgId: string) => {
+    let carCounter = 1;
+
     const car = await prisma.car.create({
       data: {
         wbsElement: {
@@ -47,162 +55,56 @@ describe('Rules Tests', () => {
     return car;
   };
 
-  beforeEach(async () => {
-    await resetUsers();
-
-    organization = await createTestOrganization();
-    orgId = organization.organizationId;
-    user = await createTestUser(supermanAdmin, orgId);
-    nonLeadership = await createTestUser(financeMember, orgId);
-
-    rulesetType = await prisma.ruleset_Type.create({
+  const setupRules = async (car: Car) => {
+    const ruleset1 = await prisma.ruleset.create({
       data: {
-        name: 'FSAE',
-        createdByUserId: user.userId
-      }
-    });
-
-    car = await createUniqueCar(orgId);
-    project = await createTestProject(user, orgId);
-
-    ruleset = await prisma.ruleset.create({
-      data: {
-        name: 'ruleset name',
-        fileId: 'fileId',
+        name: 'FSAE Rules 2025',
+        fileId: 'fsae-rules-2025',
         active: true,
         dateCreated: new Date(),
-        rulesetTypeId: rulesetType.rulesetTypeId,
-        createdByUserId: user.userId,
-        carId: car.carId
+        car: { connect: { carId: car.carId } },
+        createdBy: { connect: { userId: admin.userId } },
+        rulesetType: { connect: { rulesetTypeId: fsaeRulesetType.rulesetTypeId } }
       }
     });
 
-    rule = await prisma.rule.create({
+    const topLevelRule = await prisma.rule.create({
       data: {
-        ruleCode: 'rule code',
-        ruleContent: 'rule contenet',
+        ruleCode: 'T',
+        ruleContent: 'PART T - GENERAL TECHNICAL REQUIREMENTS',
         imageFileIds: [],
-        ruleset: { connect: { rulesetId: ruleset.rulesetId } },
-        createdBy: { connect: { userId: user.userId } }
+        dateCreated: new Date(),
+        ruleset: { connect: { rulesetId: ruleset1.rulesetId } },
+        createdBy: { connect: { userId: admin.userId } }
       }
     });
 
-    subRule = await prisma.rule.create({
+    const leafRule1 = await prisma.rule.create({
       data: {
-        ruleCode: 'parent rule code',
-        ruleContent: 'parent rule contenet',
+        ruleCode: 'T2',
+        ruleContent: 'The vehicle must be open-wheeled and open-cockpit...',
         imageFileIds: [],
-        ruleset: { connect: { rulesetId: ruleset.rulesetId } },
-        createdBy: { connect: { userId: user.userId } },
-        parentRule: {
-          connect: { ruleId: rule.ruleId }
-        }
+        dateCreated: new Date(),
+        ruleset: { connect: { rulesetId: ruleset1.rulesetId } },
+        createdBy: { connect: { userId: admin.userId } },
+        parentRule: { connect: { ruleId: topLevelRule.ruleId } }
       }
     });
-  });
 
-  afterEach(async () => {
-    await resetUsers();
-  });
-
-  describe('Delete rule', () => {
-    it('Successful deletion', async () => {
-      deletedRule = await RulesService.deleteRule(rule.ruleId, user, organization);
-      expect(deletedRule.dateDeleted).toBeTruthy();
-      expect(deletedRule).toMatchObject({
-        ...rule,
-        dateUpdated: deletedRule.dateUpdated,
-        dateDeleted: deletedRule.dateDeleted,
-        deletedByUserId: user.userId
-      });
-
-      const deletedSubRule = await prisma.rule.findUnique({
-        where: {
-          ruleId: subRule.ruleId
-        }
-      });
-
-      expect(deletedSubRule).toMatchObject({
-        ...subRule,
-        dateUpdated: deletedSubRule!.dateUpdated,
-        dateDeleted: deletedSubRule!.dateDeleted,
-        deletedByUserId: user.userId
-      });
+    const leafRule2 = await prisma.rule.create({
+      data: {
+        ruleCode: 'T2.1',
+        ruleContent: 'T2.1 Vehicle Configuration',
+        imageFileIds: [],
+        dateCreated: new Date(),
+        ruleset: { connect: { rulesetId: ruleset1.rulesetId } },
+        createdBy: { connect: { userId: admin.userId } },
+        parentRule: { connect: { ruleId: topLevelRule.ruleId } }
+      }
     });
 
-    it('Fails when non admin tries to delete', async () => {
-      const guest = await createTestUser(wonderwomanGuest, orgId);
-      await expect(RulesService.deleteRule(rule.ruleId, guest, organization)).rejects.toThrow(
-        new AccessDeniedAdminOnlyException('delete rules')
-      );
-    });
-
-    it('Fails when rule has already been deleted', async () => {
-      await RulesService.deleteRule(rule.ruleId, user, organization);
-
-      await expect(RulesService.deleteRule(rule.ruleId, user, organization)).rejects.toThrow(
-        new DeletedException('Rule', rule.ruleId)
-      );
-    });
-
-    it('Fails with invalid ruleId', async () => {
-      await expect(RulesService.deleteRule('bad id', user, organization)).rejects.toThrow(
-        new NotFoundException('Rule', 'bad id')
-      );
-    });
-
-    it('Fails with inconsistent organizations', async () => {
-      const user2 = await prisma.user.create({
-        data: {
-          firstName: 'Admin2',
-          lastName: 'User2',
-          email: '2',
-          googleAuthId: 'organizationCreato2'
-        }
-      });
-
-      const org2 = await prisma.organization.create({
-        data: {
-          name: 'Org 2',
-          description: 'Org 2 description',
-          applicationLink: '',
-          userCreated: {
-            connect: {
-              userId: user2.userId
-            }
-          }
-        }
-      });
-
-      const car2 = await createUniqueCar(org2.organizationId);
-
-      const ruleset2 = await prisma.ruleset.create({
-        data: {
-          name: 'ruleset name',
-          fileId: 'fileId',
-          active: true,
-          dateCreated: new Date(),
-          rulesetTypeId: rulesetType.rulesetTypeId,
-          createdByUserId: user.userId,
-          carId: car2.carId
-        }
-      });
-
-      const rule2 = await prisma.rule.create({
-        data: {
-          ruleCode: 'rule org2',
-          ruleContent: 'rule content org2',
-          imageFileIds: [],
-          ruleset: { connect: { rulesetId: ruleset2.rulesetId } },
-          createdBy: { connect: { userId: user2.userId } }
-        }
-      });
-
-      await expect(RulesService.deleteRule(rule2.ruleId, user, organization)).rejects.toThrow(
-        new InvalidOrganizationException('Rule')
-      );
-    });
-  });
+    return { ruleset1, topLevelRule, leafRule1, leafRule2 };
+  };
 
   describe('Create Ruleset Type', () => {
     it('Fails if user is not leadership or above', async () => {
@@ -220,53 +122,58 @@ describe('Rules Tests', () => {
 
   describe('Project Rule endpoints', () => {
     it('Creates a project rule successfully', async () => {
-      const projectRule = await RulesService.createProjectRule(user, organization, rule.ruleId, project.projectId);
+      const car = await createUniqueCar(orgId);
+      const { topLevelRule } = await setupRules(car);
+      const projectRule = await RulesService.createProjectRule(admin, organization, topLevelRule.ruleId, project.projectId);
 
       expect(projectRule.projectRuleId).toBeDefined();
       expect(projectRule.rule).toBeDefined();
-      expect(projectRule.rule.ruleId).toBe(rule.ruleId);
-      expect(projectRule.rule.ruleCode).toBe(rule.ruleCode);
+      expect(projectRule.rule.ruleId).toBe(topLevelRule.ruleId);
+      expect(projectRule.rule.ruleCode).toBe(topLevelRule.ruleCode);
       expect(projectRule.projectId).toBe(project.projectId);
       expect(projectRule.statusHistory).toEqual([]);
       expect(projectRule.currentStatus).toBe(Rule_Completion.REVIEW);
     });
-
     it('Creates a project rule successfully for a leaf rule', async () => {
-      const projectRule = await RulesService.createProjectRule(user, organization, subRule.ruleId, project.projectId);
+      const car = await createUniqueCar(orgId);
+      const { leafRule1 } = await setupRules(car);
+      const projectRule = await RulesService.createProjectRule(admin, organization, leafRule1.ruleId, project.projectId);
 
       expect(projectRule.projectRuleId).toBeDefined();
       expect(projectRule.rule).toBeDefined();
-      expect(projectRule.rule.ruleId).toBe(subRule.ruleId);
-      expect(projectRule.rule.ruleCode).toBe(subRule.ruleCode);
+      expect(projectRule.rule.ruleId).toBe(leafRule1.ruleId);
+      expect(projectRule.rule.ruleCode).toBe(leafRule1.ruleCode);
       expect(projectRule.projectId).toBe(project.projectId);
       expect(projectRule.statusHistory).toEqual([]);
       expect(projectRule.currentStatus).toBe(Rule_Completion.REVIEW);
     });
-
     it('Create project rule fails if user does not have permission', async () => {
+      const car = await createUniqueCar(orgId);
+      const { leafRule1 } = await setupRules(car);
       await expect(
-        async () => await RulesService.createProjectRule(nonLeadership, organization, subRule.ruleId, project.projectId)
+        async () => await RulesService.createProjectRule(nonLeadership, organization, leafRule1.ruleId, project.projectId)
       ).rejects.toThrow(new AccessDeniedException('You do not have permissions to assign rules to projects'));
     });
-
     it('Create project rule fails if rule was deleted', async () => {
+      const car = await createUniqueCar(orgId);
+      const { leafRule2 } = await setupRules(car);
+
       await prisma.rule.update({
-        where: { ruleId: subRule.ruleId },
+        where: { ruleId: leafRule2.ruleId },
         data: { dateDeleted: new Date() }
       });
-
       await expect(
-        async () => await RulesService.createProjectRule(user, organization, subRule.ruleId, project.projectId)
-      ).rejects.toThrow(new DeletedException('Rule', subRule.ruleId));
+        async () => await RulesService.createProjectRule(admin, organization, leafRule2.ruleId, project.projectId)
+      ).rejects.toThrow(new DeletedException('Rule', leafRule2.ruleId));
     });
-
     it('Create project rule fails if rule does not exist', async () => {
       await expect(
-        async () => await RulesService.createProjectRule(user, organization, '019263825673825738', project.projectId)
+        async () => await RulesService.createProjectRule(admin, organization, '019263825673825738', project.projectId)
       ).rejects.toThrow(new NotFoundException('Rule', '019263825673825738'));
     });
-
     it('Create project rule fails if project was deleted', async () => {
+      const car = await createUniqueCar(orgId);
+      const { leafRule2 } = await setupRules(car);
       await prisma.project.update({
         where: { projectId: project.projectId },
         data: {
@@ -275,22 +182,22 @@ describe('Rules Tests', () => {
           }
         }
       });
-
       await expect(
-        async () => await RulesService.createProjectRule(user, organization, subRule.ruleId, project.projectId)
+        async () => await RulesService.createProjectRule(admin, organization, leafRule2.ruleId, project.projectId)
       ).rejects.toThrow(new DeletedException('Project', project.projectId));
     });
-
     it('Create project rule fails if project does not exist', async () => {
-      await expect(RulesService.createProjectRule(user, organization, rule.ruleId, 'fake-project-id')).rejects.toThrow(
+      const car = await createUniqueCar(orgId);
+      const { leafRule1 } = await setupRules(car);
+      await expect(RulesService.createProjectRule(admin, organization, leafRule1.ruleId, 'fake-project-id')).rejects.toThrow(
         new NotFoundException('Project', 'fake-project-id')
       );
     });
-
     it('Create project rule fails if project rule assignment already exists', async () => {
-      await RulesService.createProjectRule(user, organization, rule.ruleId, project.projectId);
-
-      await expect(RulesService.createProjectRule(user, organization, rule.ruleId, project.projectId)).rejects.toThrow(
+      const car = await createUniqueCar(orgId);
+      const { leafRule1 } = await setupRules(car);
+      await RulesService.createProjectRule(admin, organization, leafRule1.ruleId, project.projectId);
+      await expect(RulesService.createProjectRule(admin, organization, leafRule1.ruleId, project.projectId)).rejects.toThrow(
         new HttpException(400, 'This rule is already associated with the project')
       );
     });

--- a/src/backend/tests/unit/rule.test.ts
+++ b/src/backend/tests/unit/rule.test.ts
@@ -218,7 +218,7 @@ describe('Rule Tests', () => {
 
       await expect(
         async () => await RulesService.deleteRuleset(ruleset1.rulesetId, nonLeadership.userId, organization.organizationId)
-      ).rejects.toThrow(new AccessDeniedException('Only admins (including the ruleset creator) can delete a ruleset.'));
+      ).rejects.toThrow(new AccessDeniedException('Only admins can delete a ruleset.'));
     });
     it('Delete ruleset fails if ruleset was already deleted', async () => {
       const car = await createUniqueCar(orgId);

--- a/src/backend/tests/unit/rule.test.ts
+++ b/src/backend/tests/unit/rule.test.ts
@@ -211,8 +211,6 @@ describe('Rule Tests', () => {
 
       expect(deleted).toBeDefined();
       expect(deleted.rulesetId).toBe(ruleset1.rulesetId);
-      expect(deleted.deletedBy).toBeDefined();
-      expect(deleted.deletedByUserId).toBe(admin.userId);
     });
     it('Delete ruleset fails if user does not have permission', async () => {
       const car = await createUniqueCar(orgId);

--- a/src/backend/tests/unit/rule.test.ts
+++ b/src/backend/tests/unit/rule.test.ts
@@ -204,13 +204,24 @@ describe('Rule Tests', () => {
   });
 
   describe('Delete Ruleset', () => {
-    it('Deletes a ruleset successfully', async () => {
+    it('Deletes a ruleset successfully and returns the correct information', async () => {
       const car = await createUniqueCar(orgId);
       const { ruleset1 } = await setupRules(car);
+      const totalRules = await prisma.rule.count({
+        where: { rulesetId: ruleset1.rulesetId }
+      });
+      const rulesWithTeams = await prisma.rule.count({
+        where: {
+          rulesetId: ruleset1.rulesetId,
+          teams: { some: {} }
+        }
+      });
+      const expectedPercentage = totalRules > 0 ? (rulesWithTeams / totalRules) * 100 : 0;
       const deleted = await RulesService.deleteRuleset(ruleset1.rulesetId, admin.userId, organization.organizationId);
 
       expect(deleted).toBeDefined();
       expect(deleted.rulesetId).toBe(ruleset1.rulesetId);
+      expect(deleted.rules).toBeCloseTo(expectedPercentage, 2);
     });
     it('Delete ruleset fails if user does not have permission', async () => {
       const car = await createUniqueCar(orgId);

--- a/src/backend/tests/unit/rule.test.ts
+++ b/src/backend/tests/unit/rule.test.ts
@@ -202,4 +202,39 @@ describe('Rule Tests', () => {
       );
     });
   });
+
+  describe('Delete Ruleset', () => {
+    it('Deletes a ruleset successfully', async () => {
+      const car = await createUniqueCar(orgId);
+      const { ruleset1 } = await setupRules(car);
+      const deleted = await RulesService.deleteRuleset(ruleset1.rulesetId, admin.userId, organization.organizationId);
+
+      expect(deleted).toBeDefined();
+      expect(deleted.rulesetId).toBe(ruleset1.rulesetId);
+      expect(deleted.deletedBy).toBeDefined();
+      expect(deleted.deletedByUserId).toBe(admin.userId);
+    });
+    it('Delete ruleset fails if user does not have permission', async () => {
+      const car = await createUniqueCar(orgId);
+      const { ruleset1 } = await setupRules(car);
+
+      await expect(
+        async () => await RulesService.deleteRuleset(ruleset1.rulesetId, nonLeadership.userId, organization.organizationId)
+      ).rejects.toThrow(new AccessDeniedException('Only admins (including the ruleset creator) can delete a ruleset.'));
+    });
+    it('Delete ruleset fails if ruleset was already deleted', async () => {
+      const car = await createUniqueCar(orgId);
+      const { ruleset1 } = await setupRules(car);
+
+      await RulesService.deleteRuleset(ruleset1.rulesetId, admin.userId, organization.organizationId);
+      await expect(
+        async () => await RulesService.deleteRuleset(ruleset1.rulesetId, admin.userId, organization.organizationId)
+      ).rejects.toThrow(new DeletedException('Ruleset', ruleset1.rulesetId));
+    });
+    it('Delete ruleset fails if ruleset does not exist', async () => {
+      await expect(
+        async () => await RulesService.deleteRuleset('fake-ruleset-id', admin.userId, organization.organizationId)
+      ).rejects.toThrow(new NotFoundException('Ruleset', 'fake-ruleset-id'));
+    });
+  });
 });

--- a/src/backend/tests/unit/rule.test.ts
+++ b/src/backend/tests/unit/rule.test.ts
@@ -221,7 +221,7 @@ describe('Rule Tests', () => {
 
       expect(deleted).toBeDefined();
       expect(deleted.rulesetId).toBe(ruleset1.rulesetId);
-      expect(deleted.rules).toBeCloseTo(expectedPercentage, 2);
+      expect(deleted.assignedPercentage).toBeCloseTo(expectedPercentage, 2);
     });
     it('Delete ruleset fails if user does not have permission', async () => {
       const car = await createUniqueCar(orgId);

--- a/src/shared/src/types/rules-types.ts
+++ b/src/shared/src/types/rules-types.ts
@@ -30,6 +30,8 @@ export interface Ruleset {
     carId: string;
     name: string;
   };
+  deletedBy: User | null;
+  deletedByUserId: string | null;
 }
 
 export interface Rule {

--- a/src/shared/src/types/rules-types.ts
+++ b/src/shared/src/types/rules-types.ts
@@ -25,7 +25,7 @@ export interface Ruleset {
   dateCreated: Date;
   active: boolean;
   rulesetType: RulesetType;
-  rules: Rule[];
+  rules: number;
   car: {
     carId: string;
     name: string;

--- a/src/shared/src/types/rules-types.ts
+++ b/src/shared/src/types/rules-types.ts
@@ -30,8 +30,6 @@ export interface Ruleset {
     carId: string;
     name: string;
   };
-  deletedBy: User | null;
-  deletedByUserId: string | null;
 }
 
 export interface Rule {

--- a/src/shared/src/types/rules-types.ts
+++ b/src/shared/src/types/rules-types.ts
@@ -25,7 +25,7 @@ export interface Ruleset {
   dateCreated: Date;
   active: boolean;
   rulesetType: RulesetType;
-  rules: number;
+  assignedPercentage: number;
   car: {
     carId: string;
     name: string;


### PR DESCRIPTION
## Changes

Created the delete ruleset endpoint.

## Test Cases

- Ruleset can only be deleted by admins
- Rulesets that don't exist cannot be deleted
- Admins can successfully delete rulesets that do exist, and the deleted ruleset is returned
- Rulesets that have already been deleted cannot be deleted again

## Screenshots

<img width="1725" height="710" alt="Screenshot 2025-10-19 205738" src="https://github.com/user-attachments/assets/f58d4dc1-d4f2-4991-906a-b16e19b71eca" />
<img width="1727" height="707" alt="Screenshot 2025-10-19 205810" src="https://github.com/user-attachments/assets/55d47fe0-55d7-44b4-961a-e2ba3aa2476f" />
<img width="1716" height="969" alt="Screenshot 2025-10-19 205906" src="https://github.com/user-attachments/assets/8cc054d3-da77-4896-b20d-37c73b22dce9" />
Below are screenshots of the full JSON that was outputted:
<img width="2173" height="1036" alt="Screenshot 2025-10-19 210035" src="https://github.com/user-attachments/assets/6874010f-e9fe-482a-9001-d66330c4005a" />
<img width="2222" height="1033" alt="Screenshot 2025-10-19 210053" src="https://github.com/user-attachments/assets/61052b09-d293-42e2-a71c-f8a060819887" />
<img width="2235" height="872" alt="Screenshot 2025-10-19 210117" src="https://github.com/user-attachments/assets/3bff7575-8fb7-4c81-8b6f-e206709848b9" />
<img width="2280" height="540" alt="Screenshot 2025-10-19 210129" src="https://github.com/user-attachments/assets/393d7a3d-a96e-4f55-943a-5ad93ace9b0d" />
<img width="1735" height="681" alt="Screenshot 2025-10-19 210234" src="https://github.com/user-attachments/assets/c56c8040-ea81-4315-9293-b7236ea974fc" />


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3582 
