### PR TITLE
#3695 get rulesets by type

### DIFF
--- a/src/backend/src/controllers/rules.controllers.ts
+++ b/src/backend/src/controllers/rules.controllers.ts
@@ -69,6 +69,16 @@ export default class RulesController {
     }
   }
 
+  static async getRulesetsByRulesetType(req: Request, res: Response, next: NextFunction) {
+    try {
+      const rulesetTypeId = req.body;
+      const rulesets = await RulesService.getRulesetsByRulesetType(rulesetTypeId);
+      res.status(200).json(rulesets);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
   static async deleteRuleset(req: Request, res: Response, next: NextFunction) {
     try {
       const { rulesetId } = req.params;

--- a/src/backend/src/controllers/rules.controllers.ts
+++ b/src/backend/src/controllers/rules.controllers.ts
@@ -72,7 +72,7 @@ export default class RulesController {
   static async getRulesetsByRulesetType(req: Request, res: Response, next: NextFunction) {
     try {
       const rulesetTypeId = req.body;
-      const rulesets = await RulesService.getRulesetsByRulesetType(rulesetTypeId);
+      const rulesets = await RulesService.getRulesetsByRulesetType(rulesetTypeId, req.organization.organizationId);
       res.status(200).json(rulesets);
     } catch (error: unknown) {
       next(error);

--- a/src/backend/src/prisma-query-args/rules.query-args.ts
+++ b/src/backend/src/prisma-query-args/rules.query-args.ts
@@ -93,3 +93,18 @@ export const getRulesetQueryArgs = (organizationId: string) =>
       createdBy: getUserQueryArgs(organizationId)
     }
   });
+
+export const getRulesetPreviewQueryArgs = () =>
+  Prisma.validator<Prisma.RulesetDefaultArgs>()({
+    select: {
+      name: true,
+      dateCreated: true,
+      rulesetType: true,
+      active: true,
+      car: {
+        select: {
+          wbsElement: true
+        }
+      }
+    }
+  });

--- a/src/backend/src/routes/rules.routes.ts
+++ b/src/backend/src/routes/rules.routes.ts
@@ -34,4 +34,6 @@ rulesRouter.post(
 rulesRouter.get('/rulesetTypes', RulesController.getAllRulesetTypes);
 rulesRouter.post('/ruleset/:rulesetId/delete', RulesController.deleteRuleset);
 
+rulesRouter.get('/rulesetType/:rulesetTypeId', RulesController.getRulesetsByRulesetType);
+
 export default rulesRouter;

--- a/src/backend/src/routes/rules.routes.ts
+++ b/src/backend/src/routes/rules.routes.ts
@@ -34,6 +34,6 @@ rulesRouter.post(
 rulesRouter.get('/rulesetTypes', RulesController.getAllRulesetTypes);
 rulesRouter.post('/ruleset/:rulesetId/delete', RulesController.deleteRuleset);
 
-rulesRouter.get('/rulesetType/:rulesetTypeId', RulesController.getRulesetsByRulesetType);
+rulesRouter.get('/rulesets/:rulesetTypeId', RulesController.getRulesetsByRulesetType);
 
 export default rulesRouter;

--- a/src/backend/src/services/rules.services.ts
+++ b/src/backend/src/services/rules.services.ts
@@ -1,5 +1,5 @@
 import { Organization, Rule, User } from '@prisma/client';
-import { isAdmin, isLeadership, ProjectRule, RuleCompletion, RulesetType, notGuest } from 'shared';
+import { isAdmin, isLeadership, ProjectRule, RuleCompletion, RulesetType, notGuest, RulesetPreview } from 'shared';
 import prisma from '../prisma/prisma';
 import {
   AccessDeniedAdminOnlyException,
@@ -10,12 +10,18 @@ import {
   NotFoundException
 } from '../utils/errors.utils';
 import { userHasPermission } from '../utils/users.utils';
-import { getRuleQueryArgs, getProjectRuleQueryArgs, getRulesetQueryArgs } from '../prisma-query-args/rules.query-args';
+import {
+  getRuleQueryArgs,
+  getProjectRuleQueryArgs,
+  getRulesetQueryArgs,
+  getRulesetPreviewQueryArgs
+} from '../prisma-query-args/rules.query-args';
 import {
   ruleTransformer,
   projectRuleTransformer,
   rulesetTransformer,
-  rulesetTypeTransformer
+  rulesetTypeTransformer,
+  rulesetPreviewTransformer
 } from '../transformers/rules.transformer';
 
 export default class RulesService {
@@ -367,5 +373,22 @@ export default class RulesService {
       }
     });
     return rulesets.map(rulesetTypeTransformer);
+  }
+
+  /**
+   * Gets rulesets for a given ruleset type
+   * @param rulesetTypeId id of ruleset type
+   * @returns rulesets associated with provided ruleset type
+   */
+  static async getRulesetsByRulesetType(rulesetTypeId: string): Promise<RulesetPreview[]> {
+    const rulesets = await prisma.ruleset.findMany({
+      where: {
+        rulesetTypeId,
+        deletedBy: null,
+        active: true
+      },
+      ...getRulesetPreviewQueryArgs()
+    });
+    return rulesets.map(rulesetPreviewTransformer);
   }
 }

--- a/src/backend/src/services/rules.services.ts
+++ b/src/backend/src/services/rules.services.ts
@@ -384,8 +384,7 @@ export default class RulesService {
     const rulesets = await prisma.ruleset.findMany({
       where: {
         rulesetTypeId,
-        deletedBy: null,
-        active: true
+        deletedBy: null
       },
       ...getRulesetPreviewQueryArgs()
     });

--- a/src/backend/src/services/rules.services.ts
+++ b/src/backend/src/services/rules.services.ts
@@ -389,6 +389,7 @@ export default class RulesService {
       },
       ...getRulesetPreviewQueryArgs()
     });
+
     return rulesets.map(rulesetPreviewTransformer);
   }
 }

--- a/src/backend/src/services/rules.services.ts
+++ b/src/backend/src/services/rules.services.ts
@@ -380,11 +380,14 @@ export default class RulesService {
    * @param rulesetTypeId id of ruleset type
    * @returns rulesets associated with provided ruleset type
    */
-  static async getRulesetsByRulesetType(rulesetTypeId: string): Promise<RulesetPreview[]> {
+  static async getRulesetsByRulesetType(rulesetTypeId: string, organizationId: string): Promise<RulesetPreview[]> {
     const rulesets = await prisma.ruleset.findMany({
       where: {
         rulesetTypeId,
-        deletedBy: null
+        deletedBy: null,
+        rulesetType: {
+          organizationId
+        }
       },
       ...getRulesetPreviewQueryArgs()
     });

--- a/src/backend/src/services/rules.services.ts
+++ b/src/backend/src/services/rules.services.ts
@@ -395,7 +395,7 @@ export default class RulesService {
 
     return rulesets.map(rulesetPreviewTransformer);
   }
-  
+
   /**
    * Updates the status of a project rule
    * Such as changing a project rule from INCOMPLETE to COMPLETED

--- a/src/backend/src/transformers/rules.transformer.ts
+++ b/src/backend/src/transformers/rules.transformer.ts
@@ -1,5 +1,5 @@
 import { Prisma } from '@prisma/client';
-import { Rule, RuleCompletion, ProjectRule, Ruleset, RulesetType } from 'shared';
+import { Rule, RuleCompletion, ProjectRule, Ruleset, RulesetType, RulesetPreview } from 'shared';
 import { RuleQueryArgs, RulesetQueryArgs } from '../prisma-query-args/rules.query-args';
 import { userTransformer } from './user.transformer';
 
@@ -76,6 +76,21 @@ export const rulesetTransformer = (ruleset: Prisma.RulesetGetPayload<RulesetQuer
     active: ruleset.active,
     assignedPercentage: teamsPercentage,
     rulesetType: rulesetTypeTransformer(ruleset.rulesetType),
+    car: {
+      carId: ruleset.car.carId,
+      name: ruleset.car.wbsElementId
+    }
+  };
+};
+
+export const rulesetPreviewTransformer = (ruleset: any): RulesetPreview => {
+  const teamsPercentage = 0;
+
+  return {
+    name: ruleset.name,
+    dateCreated: ruleset.dateCreated,
+    active: ruleset.active,
+    assignedPercentage: teamsPercentage,
     car: {
       carId: ruleset.car.carId,
       name: ruleset.car.wbsElementId

--- a/src/backend/tests/unit/rule.test.ts
+++ b/src/backend/tests/unit/rule.test.ts
@@ -20,6 +20,7 @@ describe('Create Rules Tests', () => {
   let wonderwoman: User;
   let rulesetId: string;
   let carId: string;
+  let rulesetType: Ruleset_Type;
 
   beforeEach(async () => {
     organization = await createTestOrganization();
@@ -44,7 +45,7 @@ describe('Create Rules Tests', () => {
     });
     ({ carId } = car);
 
-    const rulesetType = await prisma.ruleset_Type.create({
+    rulesetType = await prisma.ruleset_Type.create({
       data: {
         name: 'FSAE Rules',
         createdBy: { connect: { userId: batman.userId } },
@@ -296,6 +297,39 @@ describe('Create Rules Tests', () => {
       });
 
       expect(wheelRuleFromDb?.referencedBy.some((r) => r.ruleId === brakingSystemRule.ruleId)).toBe(true);
+    });
+  });
+
+  describe('Get rulesets by ruleset type', () => {
+    it('Successful get rulesets by ruleset types', async () => {
+      const rulesets = await RulesService.getRulesetsByRulesetType(rulesetType.rulesetTypeId);
+      expect(rulesets.length).toBe(1);
+      expect(rulesets[0].name).toBe('2025 FSAE Rules');
+      expect(rulesets[0].active).toBeTruthy();
+      expect(rulesets[0].assignedPercentage).toBe(0);
+    });
+
+    it('Successful get rulesets by ruleset types after deleting ruleset', async () => {
+      await RulesService.deleteRuleset(rulesetId, batman.userId, orgId);
+      const rulesets = await RulesService.getRulesetsByRulesetType(rulesetType.rulesetTypeId);
+      expect(rulesets.length).toBe(0);
+    });
+
+    it('Successful get rulesets by ruleset types after adding ruleset', async () => {
+      await prisma.ruleset.create({
+        data: {
+          fileId: 'test-file-id2',
+          name: '2025 FSAE Rules2',
+          active: true,
+          rulesetType: { connect: { rulesetTypeId: rulesetType.rulesetTypeId } },
+          car: { connect: { carId } },
+          createdBy: { connect: { userId: batman.userId } }
+        }
+      });
+      const rulesets = await RulesService.getRulesetsByRulesetType(rulesetType.rulesetTypeId);
+      expect(rulesets.length).toBe(2);
+      expect(rulesets[0].name).toBe('2025 FSAE Rules');
+      expect(rulesets[1].name).toBe('2025 FSAE Rules2');
     });
   });
 });

--- a/src/backend/tests/unit/rule.test.ts
+++ b/src/backend/tests/unit/rule.test.ts
@@ -302,7 +302,7 @@ describe('Create Rules Tests', () => {
 
   describe('Get rulesets by ruleset type', () => {
     it('Successful get rulesets by ruleset types', async () => {
-      const rulesets = await RulesService.getRulesetsByRulesetType(rulesetType.rulesetTypeId);
+      const rulesets = await RulesService.getRulesetsByRulesetType(rulesetType.rulesetTypeId, orgId);
       expect(rulesets.length).toBe(1);
       expect(rulesets[0].name).toBe('2025 FSAE Rules');
       expect(rulesets[0].active).toBeTruthy();
@@ -311,7 +311,7 @@ describe('Create Rules Tests', () => {
 
     it('Successful get rulesets by ruleset types after deleting ruleset', async () => {
       await RulesService.deleteRuleset(rulesetId, batman.userId, orgId);
-      const rulesets = await RulesService.getRulesetsByRulesetType(rulesetType.rulesetTypeId);
+      const rulesets = await RulesService.getRulesetsByRulesetType(rulesetType.rulesetTypeId, orgId);
       expect(rulesets.length).toBe(0);
     });
 
@@ -326,7 +326,7 @@ describe('Create Rules Tests', () => {
           createdBy: { connect: { userId: batman.userId } }
         }
       });
-      const rulesets = await RulesService.getRulesetsByRulesetType(rulesetType.rulesetTypeId);
+      const rulesets = await RulesService.getRulesetsByRulesetType(rulesetType.rulesetTypeId, orgId);
       expect(rulesets.length).toBe(2);
       expect(rulesets[0].name).toBe('2025 FSAE Rules');
       expect(rulesets[1].name).toBe('2025 FSAE Rules2');

--- a/src/shared/src/types/rules-types.ts
+++ b/src/shared/src/types/rules-types.ts
@@ -67,3 +67,14 @@ export interface ProjectRule {
   currentStatus: RuleCompletion;
   statusHistory: RuleStatusChange[];
 }
+
+export interface RulesetPreview {
+  name: string;
+  dateCreated: Date;
+  active: boolean;
+  assignedPercentage: number;
+  car: {
+    carId: string;
+    name: string;
+  };
+}


### PR DESCRIPTION
## Changes

Created get rulesets by type endpoint

## Test Cases

- Successful get rulesets
- Successful get rulesets after adding new ruleset to type
- Successful get rulesets after deleting ruleset 

## Screenshots
<img width="763" height="601" alt="Screenshot 2025-11-07 at 2 55 59 PM" src="https://github.com/user-attachments/assets/c439081e-1750-40a8-b0ea-6859fc2f1774" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3695
