### PR TITLE
#3712-End-Date-Change-Display-in-CR-Review

### DIFF
--- a/src/frontend/src/utils/diff-page.utils.ts
+++ b/src/frontend/src/utils/diff-page.utils.ts
@@ -259,8 +259,8 @@ export const getChangesForWorkPackage = (
     genChange(
       'Start Date',
       originalWorkPackage?.startDate.getTime() !== proposedChanges?.startDate.getTime(),
-      originalWorkPackage?.startDate.toLocaleString() ?? '',
-      proposedChanges?.startDate.toLocaleString() ?? ''
+      originalWorkPackage?.startDate ? datePipe(originalWorkPackage.startDate) : '',
+      proposedChanges?.startDate ? datePipe(proposedChanges.startDate) : ''
     )
   );
 
@@ -282,11 +282,9 @@ export const getChangesForWorkPackage = (
   lines.push(
     genChange(
       'End Date',
-      originalWorkPackage?.endDate && proposedChangesEndDate
-        ? originalWorkPackage.endDate.getTime() !== proposedChangesEndDate.getTime()
-        : !!originalWorkPackage?.endDate !== !!proposedChangesEndDate,
-      originalWorkPackage?.endDate ? originalWorkPackage.endDate.toLocaleString() : '',
-      proposedChangesEndDate ? proposedChangesEndDate.toLocaleString() : ''
+      originalWorkPackage?.endDate?.getTime() !== (proposedChangesEndDate as Date)?.getTime(),
+      originalWorkPackage?.endDate ? datePipe(originalWorkPackage.endDate) : '',
+      proposedChangesEndDate ? datePipe(proposedChangesEndDate as Date) : ''
     )
   );
 

--- a/src/frontend/src/utils/diff-page.utils.ts
+++ b/src/frontend/src/utils/diff-page.utils.ts
@@ -259,8 +259,8 @@ export const getChangesForWorkPackage = (
     genChange(
       'Start Date',
       originalWorkPackage?.startDate.getTime() !== proposedChanges?.startDate.getTime(),
-      originalWorkPackage?.startDate.toLocaleString() ?? '',
-      proposedChanges?.startDate.toLocaleString() ?? ''
+      datePipe(originalWorkPackage?.startDate),
+      datePipe(proposedChanges?.startDate)
     )
   );
 

--- a/src/frontend/src/utils/diff-page.utils.ts
+++ b/src/frontend/src/utils/diff-page.utils.ts
@@ -274,7 +274,7 @@ export const getChangesForWorkPackage = (
   );
 
   let proposedChangesEndDate: Date | '' = '';
-  if (proposedChanges){
+  if (proposedChanges) {
     proposedChangesEndDate = new Date(proposedChanges.startDate);
     proposedChangesEndDate.setDate(proposedChangesEndDate.getDate() + proposedChanges.duration * 7);
   }

--- a/src/frontend/src/utils/diff-page.utils.ts
+++ b/src/frontend/src/utils/diff-page.utils.ts
@@ -273,6 +273,23 @@ export const getChangesForWorkPackage = (
     )
   );
 
+  let proposedChangesEndDate: Date | '' = '';
+  if (proposedChanges){
+    proposedChangesEndDate = new Date(proposedChanges.startDate);
+    proposedChangesEndDate.setDate(proposedChangesEndDate.getDate() + proposedChanges.duration * 7);
+  }
+
+  lines.push(
+    genChange(
+      'End Date',
+      originalWorkPackage?.endDate && proposedChangesEndDate
+        ? originalWorkPackage.endDate.getTime() !== proposedChangesEndDate.getTime()
+        : !!originalWorkPackage?.endDate !== !!proposedChangesEndDate,
+      originalWorkPackage?.endDate ? originalWorkPackage.endDate.toLocaleString() : '',
+      proposedChangesEndDate ? proposedChangesEndDate.toLocaleString() : ''
+    )
+  );
+
   lines.push(
     genListChange(
       'Blocked By',

--- a/src/frontend/src/utils/diff-page.utils.ts
+++ b/src/frontend/src/utils/diff-page.utils.ts
@@ -285,8 +285,8 @@ export const getChangesForWorkPackage = (
       originalWorkPackage?.endDate && proposedChangesEndDate
         ? originalWorkPackage.endDate.getTime() !== proposedChangesEndDate.getTime()
         : !!originalWorkPackage?.endDate !== !!proposedChangesEndDate,
-      originalWorkPackage?.endDate ? originalWorkPackage.endDate.toLocaleString() : '',
-      proposedChangesEndDate ? proposedChangesEndDate.toLocaleString() : ''
+      datePipe(originalWorkPackage?.endDate ?? undefined),
+      datePipe(proposedChangesEndDate || undefined)
     )
   );
 

--- a/src/frontend/src/utils/diff-page.utils.ts
+++ b/src/frontend/src/utils/diff-page.utils.ts
@@ -273,7 +273,8 @@ export const getChangesForWorkPackage = (
     )
   );
 
-  let proposedChangesEndDate: Date | '' = '';
+  let proposedChangesEndDate;
+
   if (proposedChanges) {
     proposedChangesEndDate = new Date(proposedChanges.startDate);
     proposedChangesEndDate.setDate(proposedChangesEndDate.getDate() + proposedChanges.duration * 7);
@@ -286,7 +287,7 @@ export const getChangesForWorkPackage = (
         ? originalWorkPackage.endDate.getTime() !== proposedChangesEndDate.getTime()
         : !!originalWorkPackage?.endDate !== !!proposedChangesEndDate,
       datePipe(originalWorkPackage?.endDate ?? undefined),
-      datePipe(proposedChangesEndDate || undefined)
+      datePipe(proposedChangesEndDate)
     )
   );
 

--- a/src/frontend/src/utils/diff-page.utils.ts
+++ b/src/frontend/src/utils/diff-page.utils.ts
@@ -284,9 +284,9 @@ export const getChangesForWorkPackage = (
     genChange(
       'End Date',
       originalWorkPackage?.endDate && proposedChangesEndDate
-        ? originalWorkPackage.endDate.getTime() !== proposedChangesEndDate.getTime()
+        ? datePipe(originalWorkPackage.endDate) !== datePipe(proposedChangesEndDate)
         : !!originalWorkPackage?.endDate !== !!proposedChangesEndDate,
-      datePipe(originalWorkPackage?.endDate ?? undefined),
+      datePipe(originalWorkPackage?.endDate),
       datePipe(proposedChangesEndDate)
     )
   );


### PR DESCRIPTION
## Changes

- Calculated proposedChangesEndDate using the proposedChanges startDate and duration and use an empty string if proposedChanges is undefined.
- Added an additional endDate section to the proposedChanges area.
- Displays the original end date and the newly proposed one.

## Screenshots

<img width="982" height="650" alt="image" src="https://github.com/user-attachments/assets/8cfe276a-a06b-4936-be4c-b7af095c20c7" />
<img width="957" height="661" alt="image" src="https://github.com/user-attachments/assets/1dc20aac-5cd5-4428-9019-737277d3f937" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [X] All commits are tagged with the ticket number
- [X] No linting errors / newline at end of file warnings
- [X] All code follows repository-configured prettier formatting
- [X] No merge conflicts
- [X] All checks passing
- [X] Screenshots of UI changes (see Screenshots section)
- [X] Remove any non-applicable sections of this template
- [X] Assign the PR to yourself
- [X] No `yarn.lock` changes (unless dependencies have changed)
- [X] Request reviewers & ping on Slack
- [X] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #3712 )
