### PR TITLE
#3133 make edit/confirm availability modals larger

### DIFF
--- a/src/frontend/src/components/TimeSlot.tsx
+++ b/src/frontend/src/components/TimeSlot.tsx
@@ -13,6 +13,7 @@ interface TimeSlotProps {
   onMouseOver?: () => void;
   onClick?: () => void;
   heightOverride?: string;
+  widthOverride?: string;
   selected?: boolean;
 }
 
@@ -28,13 +29,14 @@ const TimeSlot: React.FC<TimeSlotProps> = ({
   onMouseOver,
   onClick,
   heightOverride = undefined,
+  widthOverride = undefined,
   selected = false
 }) => {
   return (
     <Box
       sx={{
         height: heightOverride ? heightOverride : small ? '25px' : '4.7vh',
-        width: small ? '81px' : '12.2%',
+        width: widthOverride ? widthOverride : small ? '81px' : '12.2%',
         backgroundColor,
         cursor: onMouseEnter ? 'pointer' : undefined,
         borderStyle: 'solid',

--- a/src/frontend/src/components/TimeSlot.tsx
+++ b/src/frontend/src/components/TimeSlot.tsx
@@ -28,15 +28,15 @@ const TimeSlot: React.FC<TimeSlotProps> = ({
   onMouseUp,
   onMouseOver,
   onClick,
-  heightOverride = undefined,
-  widthOverride = undefined,
+  heightOverride,
+  widthOverride,
   selected = false
 }) => {
   return (
     <Box
       sx={{
-        height: heightOverride ? heightOverride : small ? '25px' : '4.7vh',
-        width: widthOverride ? widthOverride : small ? '81px' : '12.2%',
+        height: (heightOverride ?? small) ? '25px' : '4.7vh',
+        width: (widthOverride ?? small) ? '81px' : '12.2%',
         backgroundColor,
         cursor: onMouseEnter ? 'pointer' : undefined,
         borderStyle: 'solid',

--- a/src/frontend/src/components/TimeSlot.tsx
+++ b/src/frontend/src/components/TimeSlot.tsx
@@ -2,7 +2,7 @@ import { Box } from '@mui/system';
 import { Icon } from '@mui/material';
 
 interface TimeSlotProps {
-  text?: string;
+  text?: React.ReactNode;
   fontSize?: string;
   backgroundColor?: string;
   icon?: string;

--- a/src/frontend/src/components/TimeSlot.tsx
+++ b/src/frontend/src/components/TimeSlot.tsx
@@ -35,8 +35,8 @@ const TimeSlot: React.FC<TimeSlotProps> = ({
   return (
     <Box
       sx={{
-        height: (heightOverride ?? small) ? '25px' : '4.7vh',
-        width: (widthOverride ?? small) ? '81px' : '12.2%',
+        height: heightOverride ?? (small ? '25px' : '4.7vh'),
+        width: widthOverride ?? (small ? '81px' : '12.2%'),
         backgroundColor,
         cursor: onMouseEnter ? 'pointer' : undefined,
         borderStyle: 'solid',

--- a/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/AvailabilityEditModal.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/AvailabilityEditModal.tsx
@@ -32,7 +32,14 @@ const AvailabilityEditModal: React.FC<DRCEditModalProps> = ({
   };
 
   return (
-    <NERModal open={open} onHide={onCancel} title={header} onSubmit={onSubmit} submitText="Save" paperProps={{ maxWidth: '800px' }}>
+    <NERModal
+      open={open}
+      onHide={onCancel}
+      title={header}
+      onSubmit={onSubmit}
+      submitText="Save"
+      paperProps={{ maxWidth: '800px' }}
+    >
       <EditAvailability
         editedAvailabilities={confirmedAvailabilities}
         setEditedAvailabilities={setConfirmedAvailabilities}

--- a/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/AvailabilityEditModal.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/AvailabilityEditModal.tsx
@@ -32,7 +32,7 @@ const AvailabilityEditModal: React.FC<DRCEditModalProps> = ({
   };
 
   return (
-    <NERModal open={open} onHide={onCancel} title={header} onSubmit={onSubmit} submitText="Save">
+    <NERModal open={open} onHide={onCancel} title={header} onSubmit={onSubmit} submitText="Save" paperProps={{ maxWidth: '800px' }}>
       <EditAvailability
         editedAvailabilities={confirmedAvailabilities}
         setEditedAvailabilities={setConfirmedAvailabilities}

--- a/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/AvailabilityEditModal.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/AvailabilityEditModal.tsx
@@ -38,7 +38,7 @@ const AvailabilityEditModal: React.FC<DRCEditModalProps> = ({
       title={header}
       onSubmit={onSubmit}
       submitText="Save"
-      paperProps={{ maxWidth: '800px' }}
+      paperProps={{ maxWidth: '900px', maxHeight: '680px' }}
     >
       <EditAvailability
         editedAvailabilities={confirmedAvailabilities}

--- a/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/EditAvailability.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/EditAvailability.tsx
@@ -129,14 +129,14 @@ const EditAvailability: React.FC<EditAvailabilityProps> = ({
           Invert Availability
         </NERButton>
       </Grid>
-      <TimeSlot backgroundColor={HeatmapColors[0]} widthOverride="102px" heightOverride="45px" />
+      <TimeSlot backgroundColor={HeatmapColors[0]} widthOverride="106px" heightOverride="px" />
       {currentlyDisplayedAvailabilities.map((availability) => (
         <TimeSlot
           key={availability.dateSet.getTime()}
           backgroundColor={HeatmapColors[0]}
-          widthOverride="102px"
-          heightOverride="45px"
-          text={getDayOfWeek(availability.dateSet) + ' ' + datePipe(availability.dateSet)}
+          widthOverride="106px"
+          heightOverride="px"
+          text={<>{getDayOfWeek(availability.dateSet)} <br /> {datePipe(availability.dateSet)}</>}
           fontSize={'12px'}
         />
       ))}
@@ -144,10 +144,10 @@ const EditAvailability: React.FC<EditAvailabilityProps> = ({
         <Grid container item>
           <TimeSlot
             backgroundColor={HeatmapColors[0]}
-            widthOverride="102px"
+            widthOverride="106px"
             heightOverride="32px"
             text={time}
-            fontSize={'13px'}
+            fontSize={'px'}
           />
           {currentlyDisplayedAvailabilities.map((availability, dayIndex) => {
             const backgroundColor = availability.availability.includes(timeIndex) ? HeatmapColors[3] : HeatmapColors[0];
@@ -155,7 +155,7 @@ const EditAvailability: React.FC<EditAvailabilityProps> = ({
               <TimeSlot
                 key={timeIndex * enumToArray(REVIEW_TIMES).length + dayIndex}
                 backgroundColor={backgroundColor}
-                widthOverride="102px"
+                widthOverride="106px"
                 heightOverride="32px"
                 onMouseDown={(e) => handleMouseDown(e, availability, timeIndex)}
                 onMouseEnter={(e) => handleMouseEnter(e, availability, timeIndex)}

--- a/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/EditAvailability.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/EditAvailability.tsx
@@ -129,13 +129,13 @@ const EditAvailability: React.FC<EditAvailabilityProps> = ({
           Invert Availability
         </NERButton>
       </Grid>
-      <TimeSlot backgroundColor={HeatmapColors[0]} widthOverride="106px" heightOverride="40px" />
+      <TimeSlot backgroundColor={HeatmapColors[0]} widthOverride="106px" heightOverride="50px" />
       {currentlyDisplayedAvailabilities.map((availability) => (
         <TimeSlot
           key={availability.dateSet.getTime()}
           backgroundColor={HeatmapColors[0]}
           widthOverride="106px"
-          heightOverride="40px"
+          heightOverride="50px"
           text={
             <Typography>
               {getDayOfWeek(availability.dateSet)} <br /> {datePipe(availability.dateSet)}

--- a/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/EditAvailability.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/EditAvailability.tsx
@@ -137,11 +137,10 @@ const EditAvailability: React.FC<EditAvailabilityProps> = ({
           widthOverride="106px"
           heightOverride="50px"
           text={
-            <Typography>
+            <Typography fontSize="15px" fontWeight="bold">
               {getDayOfWeek(availability.dateSet)} <br /> {datePipe(availability.dateSet)}
             </Typography>
           }
-          fontSize={'12px'}
         />
       ))}
       {enumToArray(REVIEW_TIMES).map((time, timeIndex) => (
@@ -151,7 +150,7 @@ const EditAvailability: React.FC<EditAvailabilityProps> = ({
             widthOverride="106px"
             heightOverride="32px"
             text={time}
-            fontSize={'13px'}
+            fontSize={'15px'}
           />
           {currentlyDisplayedAvailabilities.map((availability, dayIndex) => {
             const backgroundColor = availability.availability.includes(timeIndex) ? HeatmapColors[3] : HeatmapColors[0];

--- a/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/EditAvailability.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/EditAvailability.tsx
@@ -129,13 +129,13 @@ const EditAvailability: React.FC<EditAvailabilityProps> = ({
           Invert Availability
         </NERButton>
       </Grid>
-      <TimeSlot backgroundColor={HeatmapColors[0]} widthOverride="106px" heightOverride="px" />
+      <TimeSlot backgroundColor={HeatmapColors[0]} widthOverride="106px" heightOverride="40px" />
       {currentlyDisplayedAvailabilities.map((availability) => (
         <TimeSlot
           key={availability.dateSet.getTime()}
           backgroundColor={HeatmapColors[0]}
           widthOverride="106px"
-          heightOverride="px"
+          heightOverride="40px"
           text={
             <>
               {getDayOfWeek(availability.dateSet)} <br /> {datePipe(availability.dateSet)}
@@ -151,7 +151,7 @@ const EditAvailability: React.FC<EditAvailabilityProps> = ({
             widthOverride="106px"
             heightOverride="32px"
             text={time}
-            fontSize={'px'}
+            fontSize={'13px'}
           />
           {currentlyDisplayedAvailabilities.map((availability, dayIndex) => {
             const backgroundColor = availability.availability.includes(timeIndex) ? HeatmapColors[3] : HeatmapColors[0];

--- a/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/EditAvailability.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/EditAvailability.tsx
@@ -129,27 +129,34 @@ const EditAvailability: React.FC<EditAvailabilityProps> = ({
           Invert Availability
         </NERButton>
       </Grid>
-      <TimeSlot backgroundColor={HeatmapColors[0]} small={true} heightOverride="40px" />
+      <TimeSlot backgroundColor={HeatmapColors[0]} widthOverride="102px" heightOverride="45px" />
       {currentlyDisplayedAvailabilities.map((availability) => (
         <TimeSlot
           key={availability.dateSet.getTime()}
           backgroundColor={HeatmapColors[0]}
-          small={true}
-          heightOverride="40px"
+          widthOverride="102px"
+          heightOverride="45px"
           text={getDayOfWeek(availability.dateSet) + ' ' + datePipe(availability.dateSet)}
           fontSize={'12px'}
         />
       ))}
       {enumToArray(REVIEW_TIMES).map((time, timeIndex) => (
         <Grid container item>
-          <TimeSlot backgroundColor={HeatmapColors[0]} small={true} text={time} fontSize={'13px'} />
+          <TimeSlot
+            backgroundColor={HeatmapColors[0]}
+            widthOverride="102px"
+            heightOverride="32px"
+            text={time}
+            fontSize={'13px'}
+          />
           {currentlyDisplayedAvailabilities.map((availability, dayIndex) => {
             const backgroundColor = availability.availability.includes(timeIndex) ? HeatmapColors[3] : HeatmapColors[0];
             return (
               <TimeSlot
                 key={timeIndex * enumToArray(REVIEW_TIMES).length + dayIndex}
                 backgroundColor={backgroundColor}
-                small={true}
+                widthOverride="102px"
+                heightOverride="32px"
                 onMouseDown={(e) => handleMouseDown(e, availability, timeIndex)}
                 onMouseEnter={(e) => handleMouseEnter(e, availability, timeIndex)}
                 onMouseUp={handleMouseUp}

--- a/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/EditAvailability.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/EditAvailability.tsx
@@ -136,7 +136,11 @@ const EditAvailability: React.FC<EditAvailabilityProps> = ({
           backgroundColor={HeatmapColors[0]}
           widthOverride="106px"
           heightOverride="px"
-          text={<>{getDayOfWeek(availability.dateSet)} <br /> {datePipe(availability.dateSet)}</>}
+          text={
+            <>
+              {getDayOfWeek(availability.dateSet)} <br /> {datePipe(availability.dateSet)}
+            </>
+          }
           fontSize={'12px'}
         />
       ))}

--- a/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/EditAvailability.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/EditAvailability.tsx
@@ -137,9 +137,9 @@ const EditAvailability: React.FC<EditAvailabilityProps> = ({
           widthOverride="106px"
           heightOverride="40px"
           text={
-            <>
+            <Typography>
               {getDayOfWeek(availability.dateSet)} <br /> {datePipe(availability.dateSet)}
-            </>
+            </Typography>
           }
           fontSize={'12px'}
         />


### PR DESCRIPTION
## Changes

Made the edit availability modal larger. Also added widthOverride prop to TimeSlot component and changed size of time slots in the modal.

## Screenshots

Before:
<img width="986" height="996" alt="image" src="https://github.com/user-attachments/assets/83c30c20-0d50-4473-945f-9abe4d97a7ec" />
<img width="2559" height="1599" alt="image" src="https://github.com/user-attachments/assets/c0adfa40-7c5c-4e33-b729-1b644a162383" />

After:
<img width="987" height="886" alt="image" src="https://github.com/user-attachments/assets/2325f294-a01a-4787-b29f-8cedc5c7d1f5" />
<img width="2554" height="1598" alt="image" src="https://github.com/user-attachments/assets/c3ad259c-e28d-489c-89f4-c0e7265a4e21" />


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3133
