### PR TITLE
#3752: task creators can now delete their own tasks regardless of role

### DIFF
--- a/src/backend/src/services/tasks.services.ts
+++ b/src/backend/src/services/tasks.services.ts
@@ -266,8 +266,11 @@ export default class TasksService {
 
     // this checks the current users permissions
     const isLead = wbsElement.leadId === currentUser.userId || wbsElement.managerId === currentUser.userId;
-    if (!(await userHasPermission(currentUser.userId, organization.organizationId, isAdmin)) && !isLead) {
-      throw new AccessDeniedException('Only admin, app-admins, project leads, and project managers can delete tasks');
+    const isCreator = task.createdByUserId === currentUser.userId;
+    if (!(await userHasPermission(currentUser.userId, organization.organizationId, isAdmin)) && !isLead && !isCreator) {
+      throw new AccessDeniedException(
+        'Only admin, app-admins, project leads, project managers, and the task creator can delete tasks'
+      );
     }
 
     const deletedTask = await prisma.task.update({


### PR DESCRIPTION
## Changes

Users can now delete the tasks that they have created, regardless of their leadership role.

## Notes

Although it's a permissions change that goes against typical role conventions, it feels harmless/unproblematic enough to simply allow.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3752 
