### PR TITLE
#3650 edit rules table page

### DIFF
--- a/src/frontend/src/pages/RulesPage/RulesPage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesPage.tsx
@@ -6,10 +6,12 @@
 import { Route, Switch } from 'react-router-dom';
 import { routes } from '../../utils/routes';
 import RulesetTypePage from './RulesetTypePage';
+import RulesetPage from './RulesetPage';
 
 const RulesPage: React.FC = () => {
   return (
     <Switch>
+      <Route path={routes.RULESET_BY_ID} component={RulesetPage} />
       <Route path={routes.RULES} component={RulesetTypePage} />
     </Switch>
   );

--- a/src/frontend/src/pages/RulesPage/RulesetPage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetPage.tsx
@@ -1,1 +1,278 @@
-// Edit Rules/Assign Rules Page
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { Box, Button, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from '@mui/material';
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import PageLayout from '../../components/PageLayout';
+import FullPageTabs from '../../components/FullPageTabs';
+import { routes } from '../../utils/routes';
+import LoadingIndicator from '../../components/LoadingIndicator';
+import ErrorPage from '../ErrorPage';
+
+// Placeholder
+const useSingleRuleset = (rulesetId: string) => {
+  const placeholderRules = [
+    {
+      ruleId: '1',
+      ruleCode: 'GR - General Regulations',
+      ruleContent: 'General Regulations',
+      imageFileIds: [],
+      parentRule: undefined,
+      subRuleIds: [],
+      referencedRuleIds: []
+    },
+    {
+      ruleId: '2',
+      ruleCode: 'AD - Administrative Regulations',
+      ruleContent: 'Administrative Regulations',
+      imageFileIds: [],
+      parentRule: undefined,
+      subRuleIds: [],
+      referencedRuleIds: []
+    },
+    {
+      ruleId: '3',
+      ruleCode: 'DR - Document Requirements',
+      ruleContent: 'Document Requirements',
+      imageFileIds: [],
+      parentRule: undefined,
+      subRuleIds: [],
+      referencedRuleIds: []
+    },
+    {
+      ruleId: '4',
+      ruleCode: 'V - Vehicle Requirements',
+      ruleContent: 'Vehicle Requirements',
+      imageFileIds: [],
+      parentRule: undefined,
+      subRuleIds: ['5', '6', '7'],
+      referencedRuleIds: []
+    },
+    {
+      ruleId: '5',
+      ruleCode: 'V.1 - Configuration',
+      ruleContent: 'Configuration',
+      imageFileIds: [],
+      parentRule: { ruleId: '4', ruleCode: 'V - Vehicle Requirements' },
+      subRuleIds: [],
+      referencedRuleIds: []
+    },
+    {
+      ruleId: '6',
+      ruleCode: 'V.2 - Driver',
+      ruleContent: 'Driver',
+      imageFileIds: [],
+      parentRule: { ruleId: '4', ruleCode: 'V - Vehicle Requirements' },
+      subRuleIds: [],
+      referencedRuleIds: []
+    },
+    {
+      ruleId: '7',
+      ruleCode: 'V.3 - Suspension and Steering',
+      ruleContent: 'Suspension and Steering',
+      imageFileIds: [],
+      parentRule: { ruleId: '4', ruleCode: 'V - Vehicle Requirements' },
+      subRuleIds: ['8', '9'],
+      referencedRuleIds: []
+    },
+    {
+      ruleId: '8',
+      ruleCode: 'V.3.1 - Suspension',
+      ruleContent: 'Suspension',
+      imageFileIds: [],
+      parentRule: { ruleId: '7', ruleCode: 'V.3 - Suspension and Steering' },
+      subRuleIds: [],
+      referencedRuleIds: []
+    },
+    {
+      ruleId: '9',
+      ruleCode: 'V.3.2 - Steering',
+      ruleContent: 'Steering',
+      imageFileIds: [],
+      parentRule: { ruleId: '7', ruleCode: 'V.3 - Suspension and Steering' },
+      subRuleIds: ['10', '11', '12'],
+      referencedRuleIds: []
+    },
+    {
+      ruleId: '10',
+      ruleCode: 'V.3.2.1',
+      ruleContent: 'The Steering Wheel must be mechanically connected to the front wheels',
+      imageFileIds: [],
+      parentRule: { ruleId: '9', ruleCode: 'V.3.2 - Steering' },
+      subRuleIds: [],
+      referencedRuleIds: []
+    },
+    {
+      ruleId: '11',
+      ruleCode: 'V.3.2.2',
+      ruleContent: 'Electrically actuated steering of the front wheels is prohibited',
+      imageFileIds: [],
+      parentRule: { ruleId: '9', ruleCode: 'V.3.2 - Steering' },
+      subRuleIds: [],
+      referencedRuleIds: []
+    },
+    {
+      ruleId: '12',
+      ruleCode: 'V.3.2.3',
+      ruleContent:
+        'Steering systems must use a rigid mechanical linkage capable of tension and compression loads for operation',
+      imageFileIds: [],
+      parentRule: { ruleId: '9', ruleCode: 'V.3.2 - Steering' },
+      subRuleIds: [],
+      referencedRuleIds: []
+    },
+    {
+      ruleId: '13',
+      ruleCode: 'F - Chassis and Structural',
+      ruleContent: 'Chassis and Structural',
+      imageFileIds: [],
+      parentRule: undefined,
+      subRuleIds: [],
+      referencedRuleIds: []
+    }
+  ];
+
+  return {
+    data: { name: 'FSAE Original Version', rulesetId, rules: placeholderRules },
+    isLoading: false,
+    isError: false,
+    error: undefined
+  };
+};
+
+const RulesetPage: React.FC = () => {
+  const { rulesetId } = useParams<{ rulesetId: string; tabValue?: string }>();
+  const [tabValue, setTabValue] = useState(0);
+  const defaultTab = 'edit-rules';
+
+  const { data: ruleset, isLoading, isError, error } = useSingleRuleset(rulesetId || '');
+
+  const tabs = [
+    { tabUrlValue: 'edit-rules', tabName: 'Edit Rules' },
+    { tabUrlValue: 'assign-rules', tabName: 'Assign Rules' }
+  ];
+
+  if (isError) {
+    return <ErrorPage error={error} />;
+  }
+
+  if (isLoading || !ruleset) {
+    return <LoadingIndicator />;
+  }
+
+  const handleAddRuleSection = () => {
+    // Placeholder
+  };
+
+  return (
+    <PageLayout
+      title={`${ruleset.name} Rules`}
+      tabs={
+        <Box sx={{ width: 'fit-content', mt: 2 }}>
+          <FullPageTabs
+            setTab={setTabValue}
+            tabsLabels={tabs}
+            baseUrl={`${routes.RULES}/${rulesetId}`}
+            defaultTab={defaultTab}
+            id="rules-tabs"
+          />
+        </Box>
+      }
+    >
+      <Box sx={{ width: '100%', borderRadius: '8px 8px 0 0' }}>
+        {tabValue === 0 ? (
+          <Box sx={{ paddingBottom: '100px' }}>
+            <TableContainer component={Paper} sx={{ borderRadius: '8px', overflow: 'hidden' }}>
+              <Table>
+                <TableHead
+                  sx={{
+                    backgroundColor: '#dd514c'
+                  }}
+                >
+                  <TableRow>
+                    <TableCell align="left" sx={{ fontSize: '16px', fontWeight: 600 }}>
+                      Rule Code
+                    </TableCell>
+                    <TableCell align="left" sx={{ fontSize: '16px', fontWeight: 600 }}>
+                      Rule Content
+                    </TableCell>
+                    <TableCell align="center" sx={{ fontSize: '16px', fontWeight: 600 }}>
+                      Actions
+                    </TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody sx={{ backgroundColor: '#9d9d9d' }}>
+                  {ruleset.rules?.map((rule) => (
+                    <TableRow
+                      key={rule.ruleId}
+                      sx={{
+                        '&:last-child td, &:last-child th': { border: 0 },
+                        '&:hover': { backgroundColor: '#5e5e5e' }
+                      }}
+                    >
+                      <TableCell align="left" sx={{ color: '#000000', fontSize: '16px' }}>
+                        {rule.ruleCode}
+                      </TableCell>
+                      <TableCell align="left" sx={{ color: '#000000', fontSize: '16px' }}>
+                        {rule.ruleContent}
+                      </TableCell>
+                      <TableCell align="center" sx={{ color: '#000000', fontSize: '16px' }}>
+                        {/* Actions will be added in a future ticket */}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+
+            <Box
+              sx={{
+                backgroundColor: '#121313',
+                position: 'fixed',
+                bottom: 0,
+                left: 0,
+                right: 0,
+                width: '100%'
+              }}
+            >
+              <Box
+                sx={{
+                  borderBottom: '2px solid white',
+                  mb: 2,
+                  ml: '30px'
+                }}
+              />
+              <Box sx={{ display: 'flex', justifyContent: 'flex-end', pr: '30px', pb: 1 }}>
+                <Button
+                  variant="contained"
+                  onClick={handleAddRuleSection}
+                  sx={{
+                    borderRadius: '8px',
+                    color: '#ededed',
+                    backgroundColor: '#dd514c',
+                    padding: '2px 15px',
+                    fontSize: '16px',
+                    fontWeight: 700,
+                    textTransform: 'none',
+                    '&:hover': {
+                      backgroundColor: '#c74340'
+                    }
+                  }}
+                >
+                  Add Rule Section
+                </Button>
+              </Box>
+            </Box>
+          </Box>
+        ) : (
+          <Box>{/* Assign Rules tab content will be added in a future ticket */}</Box>
+        )}
+      </Box>
+    </PageLayout>
+  );
+};
+
+export default RulesetPage;

--- a/src/frontend/src/pages/RulesPage/RulesetPage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetPage.tsx
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { Box, Button, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from '@mui/material';
+import { Box, Button, Paper, Table, TableBody, TableCell, TableContainer, TableRow } from '@mui/material';
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import PageLayout from '../../components/PageLayout';
@@ -187,23 +187,6 @@ const RulesetPage: React.FC = () => {
           <Box sx={{ paddingBottom: '100px' }}>
             <TableContainer component={Paper} sx={{ borderRadius: '8px', overflow: 'hidden' }}>
               <Table>
-                <TableHead
-                  sx={{
-                    backgroundColor: '#dd514c'
-                  }}
-                >
-                  <TableRow>
-                    <TableCell align="left" sx={{ fontSize: '16px', fontWeight: 600 }}>
-                      Rule Code
-                    </TableCell>
-                    <TableCell align="left" sx={{ fontSize: '16px', fontWeight: 600 }}>
-                      Rule Content
-                    </TableCell>
-                    <TableCell align="center" sx={{ fontSize: '16px', fontWeight: 600 }}>
-                      Actions
-                    </TableCell>
-                  </TableRow>
-                </TableHead>
                 <TableBody sx={{ backgroundColor: '#9d9d9d' }}>
                   {ruleset.rules?.map((rule) => (
                     <TableRow

--- a/src/frontend/src/utils/routes.ts
+++ b/src/frontend/src/utils/routes.ts
@@ -82,6 +82,7 @@ const RETROSPECTIVE = `/retrospective`;
 
 /**************** Rules ****************/
 const RULES = `/rules`;
+const RULESET_BY_ID = RULES + `/:rulesetId`;
 
 export const routes = {
   BASE,
@@ -150,5 +151,6 @@ export const routes = {
 
   RETROSPECTIVE,
 
-  RULES
+  RULES,
+  RULESET_BY_ID
 };


### PR DESCRIPTION
## Changes

Implemented the rules table page for editing rules within a ruleset. The page displays rules in a table with rule code and Content columns. Also includes navigation tabs and placeholder add rule section button.

## Notes

- The useSingleRuleset hook currently uses mock data and will need to be replaced with actual endpoint in a future ticket.
- The Add Rule Section button is a placeholder and does not have functionality.
- The table row needs to be built properly as discussed in the design review.
- The Assign Rules tab content is a placeholder for future.

## Screenshots

<img width="1496" height="882" alt="Screenshot 2025-11-19 at 3 46 59 PM" src="https://github.com/user-attachments/assets/29cec6c1-54b1-49ef-bca1-0e203247bbdc" />
<img width="465" height="887" alt="Screenshot 2025-11-19 at 3 49 23 PM" src="https://github.com/user-attachments/assets/c4e64494-ca2c-46ae-875e-8883f2eba8cc" />

## To Do

- [ ] Replace placeholder useSingleRuleset hook with actual endpoint
- [ ] Implement Add Rule Section button
- [ ] Add dropdown rows
- [ ] Implement Assign Rules tab

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #3650 
