### PR TITLE
#3761 changed assemblyId to name to have correct display information

### DIFF
--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
@@ -475,7 +475,7 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
                     displayEmpty: true,
                     renderValue: (selected) =>
                       selected ? (
-                        assemblies.find((a) => a.assemblyId === selected)?.assemblyId
+                        assemblies.find((a) => a.assemblyId === selected)?.name
                       ) : (
                         <Typography sx={{ fontSize: '1rem', color: 'lightgray', opacity: 0.6 }}>
                           Enter Assembly Details


### PR DESCRIPTION
## Changes

- Changed the display to show the name instead of the assemblyId.

## Screenshots

<img width="912" height="816" alt="image" src="https://github.com/user-attachments/assets/0a9cb852-3c60-4010-a0e9-ecddbcc872e3" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [X] All commits are tagged with the ticket number
- [X] No linting errors / newline at end of file warnings
- [X] All code follows repository-configured prettier formatting
- [X] No merge conflicts
- [X] All checks passing
- [X] Screenshots of UI changes (see Screenshots section)
- [X] Remove any non-applicable sections of this template
- [X] Assign the PR to yourself
- [X] No `yarn.lock` changes (unless dependencies have changed)
- [X] Request reviewers & ping on Slack
- [X] PR is linked to the ticket (fill in the closes line below)

Closes #3761
