### PR TITLE
#3680 add new file modal

### DIFF
--- a/src/frontend/src/pages/RulesPage/RulesetTypePage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetTypePage.tsx
@@ -6,19 +6,19 @@ import React from 'react';
 import PageLayout from '../../components/PageLayout';
 import { Box } from '@mui/material';
 import AddNewFileModal from './components/AddNewFileModal';
+import { NERButton } from '../../components/NERButton';
 
 // FSAE or FHE page
 const RulesetTypePage: React.FC = () => {
   // testing for modal
-  const handleConfirm = async () => {
-    console.log('test');
+  const handleConfirm = async (data: { file: File; name: string; car: string; isActive: boolean }) => {
+    console.log('Form submitted with:', data);
   };
   const [open, setOpen] = React.useState(false);
   return (
     <PageLayout title="Rules">
-      <button onClick={() => setOpen(!open)}> modal test </button>
+      <NERButton onClick={() => setOpen(!open)}> Add New File </NERButton>
       <AddNewFileModal open={open} onHide={() => setOpen(false)} onConfirm={handleConfirm} />
-
       <Box></Box>
     </PageLayout>
   );

--- a/src/frontend/src/pages/RulesPage/RulesetTypePage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetTypePage.tsx
@@ -11,15 +11,15 @@ import { NERButton } from '../../components/NERButton';
 // FSAE or FHE page
 const RulesetTypePage: React.FC = () => {
   // testing for modal
-  const handleConfirm = async (data: { file: File; name: string; car: string; isActive: boolean }) => {
+  const handleFileConfirm = async (data: { file: File; name: string; car: string; isActive: boolean }) => {
     console.log('Form submitted with:', data);
+    setOpen(false);
   };
   const [open, setOpen] = React.useState(false);
   return (
     <PageLayout title="Rules">
       <NERButton onClick={() => setOpen(!open)}> Add New File </NERButton>
-      <AddNewFileModal open={open} onHide={() => setOpen(false)} onConfirm={handleConfirm} />
-      <Box></Box>
+      <AddNewFileModal open={open} onHide={() => setOpen(false)} onConfirm={handleFileConfirm} carOptions={['1', '2']} />
     </PageLayout>
   );
 };

--- a/src/frontend/src/pages/RulesPage/RulesetTypePage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetTypePage.tsx
@@ -4,7 +4,6 @@
  */
 import React from 'react';
 import PageLayout from '../../components/PageLayout';
-import { Box } from '@mui/material';
 import AddNewFileModal from './components/AddNewFileModal';
 import { NERButton } from '../../components/NERButton';
 

--- a/src/frontend/src/pages/RulesPage/RulesetTypePage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetTypePage.tsx
@@ -12,10 +12,6 @@ import { NERButton } from '../../components/NERButton';
 const RulesetTypePage: React.FC = () => {
   // testing for modal
   const handleFileConfirm = async (data: { file: File; name: string; car: string; isActive: boolean }) => {
-    if (!data.file) {
-      alert('Please upload a PDF file!');
-      return;
-    }
     console.log('Form submitted with:', data);
     setOpen(false);
   };

--- a/src/frontend/src/pages/RulesPage/RulesetTypePage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetTypePage.tsx
@@ -2,13 +2,23 @@
  * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
  * See the LICENSE file in the repository root folder for details.
  */
+import React from 'react';
 import PageLayout from '../../components/PageLayout';
 import { Box } from '@mui/material';
+import AddNewFileModal from './components/AddNewFileModal';
 
 // FSAE or FHE page
 const RulesetTypePage: React.FC = () => {
+  // testing for modal
+  const handleConfirm = async () => {
+    console.log('test');
+  };
+  const [open, setOpen] = React.useState(false);
   return (
     <PageLayout title="Rules">
+      <button onClick={() => setOpen(!open)}> modal test </button>
+      <AddNewFileModal open={open} onHide={() => setOpen(false)} onConfirm={handleConfirm} />
+
       <Box></Box>
     </PageLayout>
   );

--- a/src/frontend/src/pages/RulesPage/RulesetTypePage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetTypePage.tsx
@@ -12,6 +12,10 @@ import { NERButton } from '../../components/NERButton';
 const RulesetTypePage: React.FC = () => {
   // testing for modal
   const handleFileConfirm = async (data: { file: File; name: string; car: string; isActive: boolean }) => {
+    if (!data.file) {
+      alert('Please upload a PDF file!');
+      return;
+    }
     console.log('Form submitted with:', data);
     setOpen(false);
   };

--- a/src/frontend/src/pages/RulesPage/RulesetTypePage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetTypePage.tsx
@@ -11,14 +11,21 @@ import { NERButton } from '../../components/NERButton';
 const RulesetTypePage: React.FC = () => {
   // testing for modal
   const handleFileConfirm = async (data: { file: File; name: string; car: string; isActive: boolean }) => {
-    console.log('Form submitted with:', data);
-    setOpen(false);
+    setAddFileModalShow(false);
   };
-  const [open, setOpen] = React.useState(false);
+
+  const [AddFileModalShow, setAddFileModalShow] = React.useState(false);
   return (
     <PageLayout title="Rules">
-      <NERButton onClick={() => setOpen(!open)}> Add New File </NERButton>
-      <AddNewFileModal open={open} onHide={() => setOpen(false)} onConfirm={handleFileConfirm} carOptions={['1', '2']} />
+      <NERButton variant="contained" onClick={() => setAddFileModalShow(!AddFileModalShow)}>
+        Add New File
+      </NERButton>
+      <AddNewFileModal
+        open={AddFileModalShow}
+        onHide={() => setAddFileModalShow(false)}
+        onConfirm={handleFileConfirm}
+        carOptions={['1', '2']}
+      />
     </PageLayout>
   );
 };

--- a/src/frontend/src/pages/RulesPage/RulesetTypePage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetTypePage.tsx
@@ -9,9 +9,10 @@ import { NERButton } from '../../components/NERButton';
 
 // FSAE or FHE page
 const RulesetTypePage: React.FC = () => {
-  // testing for modal
+  // testing for AddNewFileModal
   const handleFileConfirm = async (data: { file: File; name: string; car: string; isActive: boolean }) => {
     setAddFileModalShow(false);
+    console.log('Added data: ' + data); // delete this later, once data is used properly
   };
 
   const [AddFileModalShow, setAddFileModalShow] = React.useState(false);

--- a/src/frontend/src/pages/RulesPage/components/AddNewFileModal.tsx
+++ b/src/frontend/src/pages/RulesPage/components/AddNewFileModal.tsx
@@ -79,7 +79,6 @@ const AddNewFileModal: React.FC<AddNewFileModalProps> = ({ open, onHide, onConfi
     register,
     handleSubmit,
     reset,
-    watch,
     setValue,
     control
   } = useForm<NewFileFormData>({

--- a/src/frontend/src/pages/RulesPage/components/AddNewFileModal.tsx
+++ b/src/frontend/src/pages/RulesPage/components/AddNewFileModal.tsx
@@ -92,8 +92,6 @@ const AddNewFileModal: React.FC<AddNewFileModalProps> = ({ open, onHide, onConfi
     }
   });
 
-  const isActive = watch('isActive');
-
   // For file inputs
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const handleAddFileClick = () => {

--- a/src/frontend/src/pages/RulesPage/components/AddNewFileModal.tsx
+++ b/src/frontend/src/pages/RulesPage/components/AddNewFileModal.tsx
@@ -130,7 +130,7 @@ const AddNewFileModal: React.FC<AddNewFileModalProps> = ({ open, onHide, onConfi
                     field.ref(e);
                   }}
                   onChange={(e) => {
-                    const files = e.target.files;
+                    const { files } = e.target;
                     if (files && files.length > 0) {
                       onChange(files[0]);
                     }

--- a/src/frontend/src/pages/RulesPage/components/AddNewFileModal.tsx
+++ b/src/frontend/src/pages/RulesPage/components/AddNewFileModal.tsx
@@ -1,11 +1,8 @@
 import NERFormModal from '../../../components/NERFormModal';
 import Checkbox from '@mui/material/Checkbox';
-import { useForm } from 'react-hook-form';
+import { useForm, Controller } from 'react-hook-form';
 import { Box, TextField, Typography } from '@mui/material';
-import { flexbox } from '@mui/system';
-import { useState } from 'react';
-import { Console } from 'console';
-import { NERButton } from '../../../components/NERButton';
+import { useState, useRef } from 'react';
 
 interface AddNewFileModalProps {
   open: boolean;
@@ -42,7 +39,7 @@ const ButtonGroup: React.FC<ButtonGroupProps> = ({ options, onChange }) => {
   };
 
   return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+    <div style={{ display: 'flex', gap: '4px' }}>
       {options.map((option) => (
         <button
           type="button"
@@ -50,6 +47,7 @@ const ButtonGroup: React.FC<ButtonGroupProps> = ({ options, onChange }) => {
           onClick={() => handleClick(option)}
           style={{
             borderRadius: 6,
+            height: 25,
             border: 0,
             backgroundColor: selected === option ? '#ef4345' : '#c7c7c7ff',
             transition: 'background-color 120ms ease'
@@ -63,15 +61,30 @@ const ButtonGroup: React.FC<ButtonGroupProps> = ({ options, onChange }) => {
 };
 
 const AddNewFileModal: React.FC<AddNewFileModalProps> = ({ open, onHide, onConfirm, carOptions }) => {
-  const { register, handleSubmit, reset, watch, setValue } = useForm<NewFileFormData>({
+  // For general information in the form
+  const {
+    formState: { errors },
+    register,
+    handleSubmit,
+    reset,
+    watch,
+    setValue,
+    control
+  } = useForm<NewFileFormData>({
     defaultValues: {
+      file: undefined,
       name: '',
       car: '',
       isActive: false
     }
   });
-
   const isActive = watch('isActive');
+
+  // For file inputs
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const handleAddFileClick = () => {
+    fileInputRef.current?.click();
+  };
 
   return (
     <NERFormModal
@@ -86,32 +99,89 @@ const AddNewFileModal: React.FC<AddNewFileModalProps> = ({ open, onHide, onConfi
       formId={'add-new-file-form'}
     >
       <Box>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <Box sx={{ display: 'flex', gap: 3, mb: 2 }}>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+            <Typography variant="h6" sx={sectionHeaderStyle}>
+              Upload Ruleset File:
+            </Typography>
+            <button
+              type="button"
+              onClick={handleAddFileClick}
+              style={{
+                borderRadius: 6,
+                border: 0,
+                backgroundColor: '#c7c7c7ff',
+                transition: 'background-color 120ms ease'
+              }}
+            >
+              <Typography> Select File</Typography>
+            </button>
+            <Controller
+              name="file"
+              control={control}
+              rules={{ required: 'File is required' }}
+              render={({ field: { onChange, ...field } }) => (
+                <input
+                  type="file"
+                  accept="application/pdf"
+                  style={{ display: 'none' }}
+                  ref={(e) => {
+                    fileInputRef.current = e;
+                    field.ref(e);
+                  }}
+                  onChange={(e) => {
+                    const files = e.target.files;
+                    if (files && files.length > 0) {
+                      onChange(files[0]);
+                    }
+                  }}
+                />
+              )}
+            />
+            {errors.file && (
+              <Typography color="error" sx={{ fontSize: 12, mt: 0.5 }}>
+                {errors.file.message as string}
+              </Typography>
+            )}
+          </Box>
+          <Box sx={{ display: 'flex', gap: 1 }}>
             <Typography variant="h6" sx={sectionHeaderStyle}>
               Car:
             </Typography>
-            <ButtonGroup options={carOptions} onChange={(value) => setValue('car', value)}></ButtonGroup>
+            <ButtonGroup
+              options={carOptions}
+              onChange={(value) => setValue('car', value, { shouldValidate: true })}
+            ></ButtonGroup>
+            <input type="hidden" {...register('car', { required: 'Car is required' })} />
+            {errors.car && (
+              <Typography color="error" sx={{ fontSize: 12, mt: 0.5 }}>
+                {errors.car.message as string}
+              </Typography>
+            )}
           </Box>
-          <Box sx={{ display: 'flex', alignItems: 'center' }}>
-            <Typography variant="h6" sx={sectionHeaderStyle}>
+          <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 0 }}>
+            <Typography variant="h6" sx={{ ...sectionHeaderStyle, lineHeight: '27.5px' }}>
               Active:
             </Typography>
-            <Checkbox {...register('isActive')} checked={isActive} />
+            <Checkbox {...register('isActive')} checked={isActive} sx={{ mt: '-5.5px' }} />
           </Box>
         </Box>
       </Box>
       <Box>
-        <Typography variant="h6" sx={{ ...sectionHeaderStyle, pb: 1 }}>
+        <Typography variant="h6" sx={{ ...sectionHeaderStyle, pb: 0.5 }}>
           Name Ruleset File:
         </Typography>
         <TextField
           inputProps={{ style: { fontSize: 13 } }}
-          required
           autoComplete="off"
           placeholder={'Name File'}
-          {...register('name')}
+          {...register('name', { required: 'Name is required' })}
         />
+        {errors.name && (
+          <Typography color="error" sx={{ fontSize: 12, mt: 0.5 }}>
+            {errors.name.message}
+          </Typography>
+        )}
       </Box>
     </NERFormModal>
   );

--- a/src/frontend/src/pages/RulesPage/components/AddNewFileModal.tsx
+++ b/src/frontend/src/pages/RulesPage/components/AddNewFileModal.tsx
@@ -1,0 +1,19 @@
+import NERModal from '../../../components/NERModal';
+
+interface AddNewFileModalProps {
+  open: boolean;
+  onHide: () => void;
+  onConfirm: (data: { file: File; name: string; car: string; isActive: boolean }) => Promise<void>;
+
+  isActive?: boolean;
+}
+
+const AddNewFileModal: React.FC<AddNewFileModalProps> = ({ open, onHide, onConfirm }) => {
+  return (
+    <NERModal open={open} onHide={onHide} title="Add New File" hideFormButtons showCloseButton>
+      <text> basic modal visualization </text>
+    </NERModal>
+  );
+};
+
+export default AddNewFileModal;

--- a/src/frontend/src/pages/RulesPage/components/AddNewFileModal.tsx
+++ b/src/frontend/src/pages/RulesPage/components/AddNewFileModal.tsx
@@ -48,18 +48,31 @@ const AddNewFileModal: React.FC<AddNewFileModalProps> = ({ open, onHide, onConfi
       formId={'add-new-file-form'}
     >
       <Box>
-        <Box sx={{ display: 'flex', alignItems: 'center' }}>
-          <Typography variant="h6" sx={sectionHeaderStyle}>
-            Active:
-          </Typography>
-          <Checkbox {...register('isActive')} checked={isActive} />
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+            <Typography variant="h6" sx={sectionHeaderStyle}>
+              Car:
+            </Typography>
+          </Box>
+          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+            <Typography variant="h6" sx={sectionHeaderStyle}>
+              Active:
+            </Typography>
+            <Checkbox {...register('isActive')} checked={isActive} />
+          </Box>
         </Box>
       </Box>
       <Box>
-        <Typography variant="h6" sx={sectionHeaderStyle}>
+        <Typography variant="h6" sx={{ ...sectionHeaderStyle, pb: 1 }}>
           Name Ruleset File:
         </Typography>
-        <TextField required autoComplete="off" placeholder={'Name File'} {...register('name')} />
+        <TextField
+          inputProps={{ style: { fontSize: 13 } }}
+          required
+          autoComplete="off"
+          placeholder={'Name File'}
+          {...register('name')}
+        />
       </Box>
     </NERFormModal>
   );

--- a/src/frontend/src/pages/RulesPage/components/AddNewFileModal.tsx
+++ b/src/frontend/src/pages/RulesPage/components/AddNewFileModal.tsx
@@ -3,11 +3,15 @@ import Checkbox from '@mui/material/Checkbox';
 import { useForm } from 'react-hook-form';
 import { Box, TextField, Typography } from '@mui/material';
 import { flexbox } from '@mui/system';
+import { useState } from 'react';
+import { Console } from 'console';
+import { NERButton } from '../../../components/NERButton';
 
 interface AddNewFileModalProps {
   open: boolean;
   onHide: () => void;
   onConfirm: (data: NewFileFormData) => Promise<void>;
+  carOptions: string[];
 }
 
 interface NewFileFormData {
@@ -17,6 +21,11 @@ interface NewFileFormData {
   isActive: boolean;
 }
 
+interface ButtonGroupProps {
+  options: string[];
+  onChange: (option: string) => any;
+}
+
 const sectionHeaderStyle = {
   fontWeight: 'bold',
   color: '#ef4345',
@@ -24,8 +33,37 @@ const sectionHeaderStyle = {
   fontSize: '1rem'
 };
 
-const AddNewFileModal: React.FC<AddNewFileModalProps> = ({ open, onHide, onConfirm }) => {
-  const { register, handleSubmit, reset, watch } = useForm<NewFileFormData>({
+const ButtonGroup: React.FC<ButtonGroupProps> = ({ options, onChange }) => {
+  const [selected, setSelected] = useState('');
+
+  const handleClick = (option: string) => {
+    setSelected(option);
+    onChange(option);
+  };
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+      {options.map((option) => (
+        <button
+          type="button"
+          key={option}
+          onClick={() => handleClick(option)}
+          style={{
+            borderRadius: 6,
+            border: 0,
+            backgroundColor: selected === option ? '#ef4345' : '#c7c7c7ff',
+            transition: 'background-color 120ms ease'
+          }}
+        >
+          {<Typography> {option} </Typography>}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+const AddNewFileModal: React.FC<AddNewFileModalProps> = ({ open, onHide, onConfirm, carOptions }) => {
+  const { register, handleSubmit, reset, watch, setValue } = useForm<NewFileFormData>({
     defaultValues: {
       name: '',
       car: '',
@@ -49,10 +87,11 @@ const AddNewFileModal: React.FC<AddNewFileModalProps> = ({ open, onHide, onConfi
     >
       <Box>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
             <Typography variant="h6" sx={sectionHeaderStyle}>
               Car:
             </Typography>
+            <ButtonGroup options={carOptions} onChange={(value) => setValue('car', value)}></ButtonGroup>
           </Box>
           <Box sx={{ display: 'flex', alignItems: 'center' }}>
             <Typography variant="h6" sx={sectionHeaderStyle}>

--- a/src/frontend/src/pages/RulesPage/components/AddNewFileModal.tsx
+++ b/src/frontend/src/pages/RulesPage/components/AddNewFileModal.tsx
@@ -1,14 +1,15 @@
 import NERFormModal from '../../../components/NERFormModal';
 import { useForm } from 'react-hook-form';
-import { TextField } from '@mui/material';
+import { Box, TextField, Typography } from '@mui/material';
+import { FormatUnderlined, Title } from '@mui/icons-material';
 
 interface AddNewFileModalProps {
   open: boolean;
   onHide: () => void;
-  onConfirm: (data: FormData) => Promise<void>;
+  onConfirm: (data: NewFileFormData) => Promise<void>;
 }
 
-interface FormData {
+interface NewFileFormData {
   file: File;
   name: string;
   car: string;
@@ -16,7 +17,7 @@ interface FormData {
 }
 
 const AddNewFileModal: React.FC<AddNewFileModalProps> = ({ open, onHide, onConfirm }) => {
-  const { register, handleSubmit, reset } = useForm<FormData>({
+  const { register, handleSubmit, reset } = useForm<NewFileFormData>({
     defaultValues: {
       name: '',
       car: '',
@@ -36,7 +37,21 @@ const AddNewFileModal: React.FC<AddNewFileModalProps> = ({ open, onHide, onConfi
       onFormSubmit={onConfirm}
       formId={'add-new-file-form'}
     >
-      <TextField required autoComplete="off" placeholder={'Name File'} {...register('name')} />
+      <Box></Box>
+      <Box>
+        <Typography
+          variant="h6"
+          sx={{
+            fontWeight: 'bold',
+            color: '#ef4345',
+            textDecoration: 'underline',
+            fontSize: '1rem'
+          }}
+        >
+          Name Ruleset File:
+        </Typography>
+        <TextField required autoComplete="off" placeholder={'Name File'} {...register('name')} />
+      </Box>
     </NERFormModal>
   );
 };

--- a/src/frontend/src/pages/RulesPage/components/AddNewFileModal.tsx
+++ b/src/frontend/src/pages/RulesPage/components/AddNewFileModal.tsx
@@ -3,6 +3,8 @@ import Checkbox from '@mui/material/Checkbox';
 import { useForm, Controller } from 'react-hook-form';
 import { Box, TextField, Typography } from '@mui/material';
 import { useState, useRef } from 'react';
+import * as yup from 'yup';
+import { yupResolver } from '@hookform/resolvers/yup';
 
 interface AddNewFileModalProps {
   open: boolean;
@@ -29,6 +31,16 @@ const sectionHeaderStyle = {
   textDecoration: 'underline',
   fontSize: '1rem'
 };
+
+const schema = yup.object({
+  file: yup
+    .mixed<File>()
+    .required('File is required')
+    .test('is-pdf', 'File must be a PDF', (file) => (file ? file.type === 'application/pdf' : false)),
+  name: yup.string().required('Name is required'),
+  car: yup.string().required('Car is required'),
+  isActive: yup.boolean().required()
+});
 
 const ButtonGroup: React.FC<ButtonGroupProps> = ({ options, onChange }) => {
   const [selected, setSelected] = useState('');
@@ -71,6 +83,7 @@ const AddNewFileModal: React.FC<AddNewFileModalProps> = ({ open, onHide, onConfi
     setValue,
     control
   } = useForm<NewFileFormData>({
+    resolver: yupResolver(schema),
     defaultValues: {
       file: undefined,
       name: '',
@@ -78,6 +91,7 @@ const AddNewFileModal: React.FC<AddNewFileModalProps> = ({ open, onHide, onConfi
       isActive: false
     }
   });
+
   const isActive = watch('isActive');
 
   // For file inputs
@@ -119,7 +133,6 @@ const AddNewFileModal: React.FC<AddNewFileModalProps> = ({ open, onHide, onConfi
             <Controller
               name="file"
               control={control}
-              rules={{ required: 'File is required' }}
               render={({ field: { onChange, ...field } }) => (
                 <input
                   type="file"
@@ -152,7 +165,7 @@ const AddNewFileModal: React.FC<AddNewFileModalProps> = ({ open, onHide, onConfi
               options={carOptions}
               onChange={(value) => setValue('car', value, { shouldValidate: true })}
             ></ButtonGroup>
-            <input type="hidden" {...register('car', { required: 'Car is required' })} />
+            <input type="hidden" {...register('car')} />
             {errors.car && (
               <Typography color="error" sx={{ fontSize: 12, mt: 0.5 }}>
                 {errors.car.message as string}
@@ -163,7 +176,7 @@ const AddNewFileModal: React.FC<AddNewFileModalProps> = ({ open, onHide, onConfi
             <Typography variant="h6" sx={{ ...sectionHeaderStyle, lineHeight: '27.5px' }}>
               Active:
             </Typography>
-            <Checkbox {...register('isActive')} checked={isActive} sx={{ mt: '-5.5px' }} />
+            <Checkbox {...register('isActive')} sx={{ mt: '-5.5px' }} />
           </Box>
         </Box>
       </Box>
@@ -175,7 +188,7 @@ const AddNewFileModal: React.FC<AddNewFileModalProps> = ({ open, onHide, onConfi
           inputProps={{ style: { fontSize: 13 } }}
           autoComplete="off"
           placeholder={'Name File'}
-          {...register('name', { required: 'Name is required' })}
+          {...register('name')}
         />
         {errors.name && (
           <Typography color="error" sx={{ fontSize: 12, mt: 0.5 }}>

--- a/src/frontend/src/pages/RulesPage/components/AddNewFileModal.tsx
+++ b/src/frontend/src/pages/RulesPage/components/AddNewFileModal.tsx
@@ -1,7 +1,8 @@
 import NERFormModal from '../../../components/NERFormModal';
+import Checkbox from '@mui/material/Checkbox';
 import { useForm } from 'react-hook-form';
 import { Box, TextField, Typography } from '@mui/material';
-import { FormatUnderlined, Title } from '@mui/icons-material';
+import { flexbox } from '@mui/system';
 
 interface AddNewFileModalProps {
   open: boolean;
@@ -16,14 +17,23 @@ interface NewFileFormData {
   isActive: boolean;
 }
 
+const sectionHeaderStyle = {
+  fontWeight: 'bold',
+  color: '#ef4345',
+  textDecoration: 'underline',
+  fontSize: '1rem'
+};
+
 const AddNewFileModal: React.FC<AddNewFileModalProps> = ({ open, onHide, onConfirm }) => {
-  const { register, handleSubmit, reset } = useForm<NewFileFormData>({
+  const { register, handleSubmit, reset, watch } = useForm<NewFileFormData>({
     defaultValues: {
       name: '',
       car: '',
       isActive: false
     }
   });
+
+  const isActive = watch('isActive');
 
   return (
     <NERFormModal
@@ -37,17 +47,16 @@ const AddNewFileModal: React.FC<AddNewFileModalProps> = ({ open, onHide, onConfi
       onFormSubmit={onConfirm}
       formId={'add-new-file-form'}
     >
-      <Box></Box>
       <Box>
-        <Typography
-          variant="h6"
-          sx={{
-            fontWeight: 'bold',
-            color: '#ef4345',
-            textDecoration: 'underline',
-            fontSize: '1rem'
-          }}
-        >
+        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+          <Typography variant="h6" sx={sectionHeaderStyle}>
+            Active:
+          </Typography>
+          <Checkbox {...register('isActive')} checked={isActive} />
+        </Box>
+      </Box>
+      <Box>
+        <Typography variant="h6" sx={sectionHeaderStyle}>
           Name Ruleset File:
         </Typography>
         <TextField required autoComplete="off" placeholder={'Name File'} {...register('name')} />

--- a/src/frontend/src/pages/RulesPage/components/AddNewFileModal.tsx
+++ b/src/frontend/src/pages/RulesPage/components/AddNewFileModal.tsx
@@ -1,18 +1,43 @@
-import NERModal from '../../../components/NERModal';
+import NERFormModal from '../../../components/NERFormModal';
+import { useForm } from 'react-hook-form';
+import { TextField } from '@mui/material';
 
 interface AddNewFileModalProps {
   open: boolean;
   onHide: () => void;
-  onConfirm: (data: { file: File; name: string; car: string; isActive: boolean }) => Promise<void>;
+  onConfirm: (data: FormData) => Promise<void>;
+}
 
-  isActive?: boolean;
+interface FormData {
+  file: File;
+  name: string;
+  car: string;
+  isActive: boolean;
 }
 
 const AddNewFileModal: React.FC<AddNewFileModalProps> = ({ open, onHide, onConfirm }) => {
+  const { register, handleSubmit, reset } = useForm<FormData>({
+    defaultValues: {
+      name: '',
+      car: '',
+      isActive: false
+    }
+  });
+
   return (
-    <NERModal open={open} onHide={onHide} title="Add New File" hideFormButtons showCloseButton>
-      <text> basic modal visualization </text>
-    </NERModal>
+    <NERFormModal
+      open={open}
+      onHide={onHide}
+      title="Add New File"
+      hideFormButtons
+      showCloseButton
+      reset={reset}
+      handleUseFormSubmit={handleSubmit}
+      onFormSubmit={onConfirm}
+      formId={'add-new-file-form'}
+    >
+      <TextField required autoComplete="off" placeholder={'Name File'} {...register('name')} />
+    </NERFormModal>
   );
 };
 


### PR DESCRIPTION
## Changes

Added the change file modal. 

## Screenshots
<img width="2879" height="1699" alt="image" src="https://github.com/user-attachments/assets/9cc08d2e-84f1-4024-85eb-779a168a0a0b" />
<img width="1028" height="781" alt="image" src="https://github.com/user-attachments/assets/80ed994a-7163-47ae-b8c5-783af643c95a" />
<img width="770" height="786" alt="image" src="https://github.com/user-attachments/assets/fbd0c459-136c-4245-a394-7d54370fe5fd" />
<img width="899" height="194" alt="image" src="https://github.com/user-attachments/assets/c182d658-713b-48da-9072-d815737998e1" />



## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [ ] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3680 
