### PR TITLE
#3795 add rules tab to project page

### DIFF
--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectRules/ProjectRulesTab.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectRules/ProjectRulesTab.tsx
@@ -1,0 +1,11 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { Box } from '@mui/material';
+import { Project } from 'shared';
+
+export const ProjectRulesTab = ({ project }: { project: Project }) => {
+  return <Box />;
+};

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectRules/ProjectRulesTab.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectRules/ProjectRulesTab.tsx
@@ -6,6 +6,6 @@
 import { Box } from '@mui/material';
 import { Project } from 'shared';
 
-export const ProjectRulesTab = ({ project }: { project: Project }) => {
+export const ProjectRulesTab = ({ project: _project }: { project: Project }) => {
   return <Box />;
 };

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
@@ -35,6 +35,7 @@ import ChangeRequestTab from '../../../components/ChangeRequestTab';
 import PartsReviewPage from './PartReview/PartsReviewPage';
 import ActionsMenu from '../../../components/ActionsMenu';
 import { useMyTeamAsHead } from '../../../hooks/teams.hooks';
+import { ProjectRulesTab } from './ProjectRules/ProjectRulesTab';
 
 interface ProjectViewContainerProps {
   project: Project;
@@ -193,7 +194,8 @@ const ProjectViewContainer: React.FC<ProjectViewContainerProps> = ({ project, en
             { tabUrlValue: 'changes', tabName: 'Changes' },
             { tabUrlValue: 'gantt', tabName: 'Gantt' },
             { tabUrlValue: 'change-requests', tabName: 'Change Requests' },
-            { tabUrlValue: 'parts-review', tabName: 'Parts Review' }
+            { tabUrlValue: 'parts-review', tabName: 'Parts Review' },
+            { tabUrlValue: 'rules', tabName: 'Rules' }
           ]}
           baseUrl={`${routes.PROJECTS}/${wbsNum}`}
           defaultTab="overview"
@@ -216,8 +218,10 @@ const ProjectViewContainer: React.FC<ProjectViewContainerProps> = ({ project, en
         <ProjectGantt workPackages={project.workPackages} />
       ) : tab === 6 ? (
         <ChangeRequestTab wbsElement={project} />
-      ) : (
+      ) : tab === 7 ? (
         <PartsReviewPage project={project} />
+      ) : (
+        <ProjectRulesTab project={project} />
       )}
       {deleteModalShow && (
         <DeleteProject modalShow={deleteModalShow} handleClose={handleDeleteClose} wbsNum={project.wbsNum} />


### PR DESCRIPTION
## Changes

Added a ProjectRules folder to the ProjectViewContainer along with a ProjectRulesTab.tsx file inside of it. 

## Notes

Had trouble running Finishline so no screenshots. 

## Screenshots

No Screenshots rn because of an error.

## To Do

...

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ✓ ] All commits are tagged with the ticket number
- [ ✓ ] No linting errors / newline at end of file warnings
- [ ✓ ] All code follows repository-configured prettier formatting
- [ ✓ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ✓ ] Remove any non-applicable sections of this template
- [ ✓ ] Assign the PR to yourself
- [ ✓ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ✓ ] Request reviewers & ping on Slack
- [ ✓ ] PR is linked to the ticket (fill in the closes line below)

Closes #3795
