### PR TITLE
#3802 if cr has requested reviewers, only they can approve

### DIFF
--- a/src/backend/src/services/change-requests.services.ts
+++ b/src/backend/src/services/change-requests.services.ts
@@ -280,6 +280,14 @@ export default class ChangeRequestsService {
     if (reviewer.userId === foundCR.submitterId)
       throw new AccessDeniedException("You can't review your own change request!");
 
+    // verify that if there are requested reviewers, the reviewer is one of them
+    if (foundCR.requestedReviewers.length > 0) {
+      const isRequestedReviewer = foundCR.requestedReviewers.some((user) => user.userId === reviewer.userId);
+      if (!isRequestedReviewer) {
+        throw new AccessDeniedException('Only requested reviewers can review this change request!');
+      }
+    }
+
     // ScopeChange Request That Has Been Accepted Being Reviewed
     if (foundCR.scopeChangeRequest && accepted) {
       await this.reviewScopeChangeRequest(foundCR, reviewer, psId, organization);

--- a/src/backend/tests/unit/change-requests.test.ts
+++ b/src/backend/tests/unit/change-requests.test.ts
@@ -295,33 +295,52 @@ describe('Change Request Tests', () => {
     let changeRequestId: string;
 
     beforeEach(async () => {
+      // Use the existing user from the main beforeEach
       submitterUser = user;
-      leadershipUser1 = await createTestUser(aquamanLeadership, orgId);
-      leadershipUser2 = await createTestUser(greenlanternHead, orgId);
-      nonRequestedLeadership = await createTestUser(flashAdmin, orgId);
+
+      // Create users with User_Settings that include slackId (needed for requestCRReview)
+      leadershipUser1 = await createTestUser(aquamanLeadership, orgId, {
+        id: 'aquaman-settings',
+        userId: '',
+        defaultTheme: 'DARK' as any,
+        slackId: 'slack-aquaman'
+      });
+
+      leadershipUser2 = await createTestUser(greenlanternHead, orgId, {
+        id: 'greenlantern-settings',
+        userId: '',
+        defaultTheme: 'DARK' as any,
+        slackId: 'slack-greenlantern'
+      });
+
+      nonRequestedLeadership = await createTestUser(flashAdmin, orgId, {
+        id: 'flash-settings',
+        userId: '',
+        defaultTheme: 'DARK' as any,
+        slackId: 'slack-flash'
+      });
+
       memberUser = await createTestUser(robinMember, orgId);
 
-      const projPropChanges: ProjectProposedChangesCreateArgs = {
-        name: 'Test Project',
-        descriptionBullets: [],
-        links: [],
-        budget: 10,
-        summary: 'Test Summary',
-        teamIds: [],
-        workPackageProposedChanges: []
-      };
-
+      // Create a simple change request with a proposed solution
       const cr = await ChangeRequestsService.createStandardChangeRequest(
         submitterUser,
         12,
         13,
         14,
-        CR_Type.DEFINITION_CHANGE,
+        CR_Type.ISSUE,
         'What is being changed',
         [{ type: Scope_CR_Why_Type.COMPETITION, explain: 'Why it is being changed' }],
-        [],
+        [
+          {
+            description: 'Proposed solution',
+            scopeImpact: 'Low impact',
+            timelineImpact: 0,
+            budgetImpact: 0
+          }
+        ],
         organization,
-        projPropChanges,
+        null,
         null
       );
 
@@ -333,7 +352,7 @@ describe('Change Request Tests', () => {
         nonRequestedLeadership,
         changeRequestId,
         'Looks good',
-        true,
+        false,
         organization,
         null
       );
@@ -345,7 +364,7 @@ describe('Change Request Tests', () => {
       });
 
       expect(updatedCR?.reviewerId).toBe(nonRequestedLeadership.userId);
-      expect(updatedCR?.accepted).toBe(true);
+      expect(updatedCR?.accepted).toBe(false);
     });
 
     it('allows requested reviewer to review when reviewers are requested', async () => {
@@ -360,7 +379,7 @@ describe('Change Request Tests', () => {
         leadershipUser1,
         changeRequestId,
         'Approved',
-        true,
+        false,
         organization,
         null
       );
@@ -372,7 +391,7 @@ describe('Change Request Tests', () => {
       });
 
       expect(updatedCR?.reviewerId).toBe(leadershipUser1.userId);
-      expect(updatedCR?.accepted).toBe(true);
+      expect(updatedCR?.accepted).toBe(false);
     });
 
     it('rejects non-requested leadership when reviewers are requested', async () => {
@@ -418,7 +437,7 @@ describe('Change Request Tests', () => {
         leadershipUser2,
         changeRequestId,
         'Approved by second reviewer',
-        true,
+        false,
         organization,
         null
       );
@@ -430,20 +449,28 @@ describe('Change Request Tests', () => {
       });
 
       expect(updatedCR?.reviewerId).toBe(leadershipUser2.userId);
-      expect(updatedCR?.accepted).toBe(true);
+      expect(updatedCR?.accepted).toBe(false);
     });
 
-    it('rejects member user even when they are in requested reviewers', async () => {
-      await ChangeRequestsService.requestCRReview(
-        submitterUser,
-        [leadershipUser1.userId, memberUser.userId],
-        changeRequestId,
-        organization
-      );
+    it('rejects member user from being requested as a reviewer', async () => {
+      // requestCRReview should fail when trying to add a non-leadership user
+      await expect(
+        ChangeRequestsService.requestCRReview(
+          submitterUser,
+          [leadershipUser1.userId, memberUser.userId],
+          changeRequestId,
+          organization
+        )
+      ).rejects.toThrow(AccessDeniedException);
 
       await expect(
-        ChangeRequestsService.reviewChangeRequest(memberUser, changeRequestId, 'I want to review', false, organization, null)
-      ).rejects.toThrow();
+        ChangeRequestsService.requestCRReview(
+          submitterUser,
+          [leadershipUser1.userId, memberUser.userId],
+          changeRequestId,
+          organization
+        )
+      ).rejects.toThrow('The following user(s) are not leadership: Dick Grayson');
     });
 
     it('allows rejection by non-requested leadership when reviewers are requested', async () => {

--- a/src/backend/tests/unit/change-requests.test.ts
+++ b/src/backend/tests/unit/change-requests.test.ts
@@ -1,9 +1,16 @@
 import { CR_Type, Organization, Scope_CR_Why_Type, User, WBS_Element_Status } from '@prisma/client';
 import { createTestOrganization, createTestUser, resetUsers } from '../test-utils';
 import ChangeRequestsService from '../../src/services/change-requests.services';
-import { supermanAdmin } from '../test-data/users.test-data';
+import {
+  supermanAdmin,
+  aquamanLeadership,
+  greenlanternHead,
+  flashAdmin,
+  robinMember
+} from '../test-data/users.test-data';
 import { ProjectProposedChangesCreateArgs, WorkPackageProposedChangesCreateArgs } from 'shared';
 import prisma from '../../src/prisma/prisma';
+import { AccessDeniedException } from '../../src/utils/errors.utils';
 
 describe('Change Request Tests', () => {
   let orgId: string;
@@ -282,6 +289,194 @@ describe('Change Request Tests', () => {
       expect(wbsElement?.carNumber).toEqual(12);
       expect(wbsElement?.projectNumber).toEqual(13);
       expect(wbsElement?.workPackageNumber).toEqual(14);
+    });
+  });
+
+  describe('Review Change Request with Requested Reviewers', () => {
+    let submitterUser: User;
+    let leadershipUser1: User;
+    let leadershipUser2: User;
+    let nonRequestedLeadership: User;
+    let memberUser: User;
+    let changeRequestId: string;
+
+    beforeEach(async () => {
+      submitterUser = await createTestUser(supermanAdmin, orgId);
+      leadershipUser1 = await createTestUser(aquamanLeadership, orgId);
+      leadershipUser2 = await createTestUser(greenlanternHead, orgId);
+      nonRequestedLeadership = await createTestUser(flashAdmin, orgId);
+      memberUser = await createTestUser(robinMember, orgId);
+
+      const projPropChanges: ProjectProposedChangesCreateArgs = {
+        name: 'Test Project',
+        descriptionBullets: [],
+        links: [],
+        budget: 10,
+        summary: 'Test Summary',
+        teamIds: [],
+        workPackageProposedChanges: []
+      };
+
+      const cr = await ChangeRequestsService.createStandardChangeRequest(
+        submitterUser,
+        12,
+        13,
+        14,
+        CR_Type.DEFINITION_CHANGE,
+        'What is being changed',
+        [{ type: Scope_CR_Why_Type.COMPETITION, explain: 'Why it is being changed' }],
+        [],
+        organization,
+        projPropChanges,
+        null
+      );
+
+      changeRequestId = cr.crId;
+    });
+
+    it('allows any leadership to review when no reviewers are requested', async () => {
+      const reviewResult = await ChangeRequestsService.reviewChangeRequest(
+        nonRequestedLeadership,
+        changeRequestId,
+        'Looks good',
+        true,
+        organization,
+        null
+      );
+
+      expect(reviewResult).toBe(changeRequestId);
+
+      const updatedCR = await prisma.change_Request.findUnique({
+        where: { crId: changeRequestId }
+      });
+
+      expect(updatedCR?.reviewerId).toBe(nonRequestedLeadership.userId);
+      expect(updatedCR?.accepted).toBe(true);
+    });
+
+    it('allows requested reviewer to review when reviewers are requested', async () => {
+      await ChangeRequestsService.requestCRReview(
+        submitterUser,
+        [leadershipUser1.userId, leadershipUser2.userId],
+        changeRequestId,
+        organization
+      );
+
+      const reviewResult = await ChangeRequestsService.reviewChangeRequest(
+        leadershipUser1,
+        changeRequestId,
+        'Approved',
+        true,
+        organization,
+        null
+      );
+
+      expect(reviewResult).toBe(changeRequestId);
+
+      const updatedCR = await prisma.change_Request.findUnique({
+        where: { crId: changeRequestId }
+      });
+
+      expect(updatedCR?.reviewerId).toBe(leadershipUser1.userId);
+      expect(updatedCR?.accepted).toBe(true);
+    });
+
+    it('rejects non-requested leadership when reviewers are requested', async () => {
+      await ChangeRequestsService.requestCRReview(
+        submitterUser,
+        [leadershipUser1.userId, leadershipUser2.userId],
+        changeRequestId,
+        organization
+      );
+
+      await expect(
+        ChangeRequestsService.reviewChangeRequest(
+          nonRequestedLeadership,
+          changeRequestId,
+          'I want to review this',
+          true,
+          organization,
+          null
+        )
+      ).rejects.toThrow(AccessDeniedException);
+
+      await expect(
+        ChangeRequestsService.reviewChangeRequest(
+          nonRequestedLeadership,
+          changeRequestId,
+          'I want to review this',
+          true,
+          organization,
+          null
+        )
+      ).rejects.toThrow('Only requested reviewers can review this change request!');
+    });
+
+    it('allows second requested reviewer to review when reviewers are requested', async () => {
+      await ChangeRequestsService.requestCRReview(
+        submitterUser,
+        [leadershipUser1.userId, leadershipUser2.userId],
+        changeRequestId,
+        organization
+      );
+
+      const reviewResult = await ChangeRequestsService.reviewChangeRequest(
+        leadershipUser2,
+        changeRequestId,
+        'Approved by second reviewer',
+        true,
+        organization,
+        null
+      );
+
+      expect(reviewResult).toBe(changeRequestId);
+
+      const updatedCR = await prisma.change_Request.findUnique({
+        where: { crId: changeRequestId }
+      });
+
+      expect(updatedCR?.reviewerId).toBe(leadershipUser2.userId);
+      expect(updatedCR?.accepted).toBe(true);
+    });
+
+    it('rejects member user even when they are in requested reviewers', async () => {
+      await ChangeRequestsService.requestCRReview(
+        submitterUser,
+        [leadershipUser1.userId, memberUser.userId],
+        changeRequestId,
+        organization
+      );
+
+      await expect(
+        ChangeRequestsService.reviewChangeRequest(
+          memberUser,
+          changeRequestId,
+          'I want to review',
+          false,
+          organization,
+          null
+        )
+      ).rejects.toThrow();
+    });
+
+    it('allows rejection by non-requested leadership when reviewers are requested', async () => {
+      await ChangeRequestsService.requestCRReview(
+        submitterUser,
+        [leadershipUser1.userId],
+        changeRequestId,
+        organization
+      );
+
+      await expect(
+        ChangeRequestsService.reviewChangeRequest(
+          nonRequestedLeadership,
+          changeRequestId,
+          'Rejecting this',
+          false,
+          organization,
+          null
+        )
+      ).rejects.toThrow(AccessDeniedException);
     });
   });
 });

--- a/src/backend/tests/unit/change-requests.test.ts
+++ b/src/backend/tests/unit/change-requests.test.ts
@@ -1,13 +1,7 @@
 import { CR_Type, Organization, Scope_CR_Why_Type, User, WBS_Element_Status } from '@prisma/client';
 import { createTestOrganization, createTestUser, resetUsers } from '../test-utils';
 import ChangeRequestsService from '../../src/services/change-requests.services';
-import {
-  supermanAdmin,
-  aquamanLeadership,
-  greenlanternHead,
-  flashAdmin,
-  robinMember
-} from '../test-data/users.test-data';
+import { supermanAdmin, aquamanLeadership, greenlanternHead, flashAdmin, robinMember } from '../test-data/users.test-data';
 import { ProjectProposedChangesCreateArgs, WorkPackageProposedChangesCreateArgs } from 'shared';
 import prisma from '../../src/prisma/prisma';
 import { AccessDeniedException } from '../../src/utils/errors.utils';
@@ -301,7 +295,7 @@ describe('Change Request Tests', () => {
     let changeRequestId: string;
 
     beforeEach(async () => {
-      submitterUser = await createTestUser(supermanAdmin, orgId);
+      submitterUser = user;
       leadershipUser1 = await createTestUser(aquamanLeadership, orgId);
       leadershipUser2 = await createTestUser(greenlanternHead, orgId);
       nonRequestedLeadership = await createTestUser(flashAdmin, orgId);
@@ -448,24 +442,12 @@ describe('Change Request Tests', () => {
       );
 
       await expect(
-        ChangeRequestsService.reviewChangeRequest(
-          memberUser,
-          changeRequestId,
-          'I want to review',
-          false,
-          organization,
-          null
-        )
+        ChangeRequestsService.reviewChangeRequest(memberUser, changeRequestId, 'I want to review', false, organization, null)
       ).rejects.toThrow();
     });
 
     it('allows rejection by non-requested leadership when reviewers are requested', async () => {
-      await ChangeRequestsService.requestCRReview(
-        submitterUser,
-        [leadershipUser1.userId],
-        changeRequestId,
-        organization
-      );
+      await ChangeRequestsService.requestCRReview(submitterUser, [leadershipUser1.userId], changeRequestId, organization);
 
       await expect(
         ChangeRequestsService.reviewChangeRequest(

--- a/src/frontend/src/components/ActionsMenu.tsx
+++ b/src/frontend/src/components/ActionsMenu.tsx
@@ -2,7 +2,7 @@ import { Box } from '@mui/system';
 import { ElementType, ReactElement, useState } from 'react';
 import { NERButton } from './NERButton';
 import { ArrowDropDown } from '@mui/icons-material';
-import { Divider, ListItemIcon, Menu, MenuItem } from '@mui/material';
+import { Divider, ListItemIcon, Menu, MenuItem, Tooltip } from '@mui/material';
 import { isGuest } from 'shared';
 import { useCurrentUser } from '../hooks/users.hooks';
 
@@ -14,6 +14,7 @@ export type ButtonInfo = {
   dividerTop?: boolean;
   component?: ElementType<any>;
   to?: string;
+  tooltip?: string;
 };
 
 interface ActionsMenuProps {
@@ -65,8 +66,7 @@ const ActionsMenu: React.FC<ActionsMenuProps> = ({ buttons, title = 'Actions' })
         }}
       >
         {buttons.flatMap((button, index) => {
-          return [
-            button.dividerTop && <Divider key={`${index}-divider`} />,
+          const menuItem = (
             <MenuItem
               key={index}
               {...(button.component ? { component: button.component } : {})}
@@ -80,6 +80,17 @@ const ActionsMenu: React.FC<ActionsMenuProps> = ({ buttons, title = 'Actions' })
               {button.icon && <ListItemIcon>{button.icon}</ListItemIcon>}
               {button.title}
             </MenuItem>
+          );
+
+          return [
+            button.dividerTop && <Divider key={`${index}-divider`} />,
+            button.tooltip && button.disabled ? (
+              <Tooltip key={index} title={button.tooltip} placement="left" arrow>
+                <span>{menuItem}</span>
+              </Tooltip>
+            ) : (
+              menuItem
+            )
           ];
         })}
       </Menu>

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ChangeRequestActionMenu.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ChangeRequestActionMenu.tsx
@@ -22,6 +22,7 @@ import { taskUserToAutocompleteOption } from '../../utils/task.utils';
 
 interface ChangeRequestActionMenuProps {
   isUserAllowedToReview: boolean;
+  reviewDisabledTooltip?: string;
   isUserAllowedToImplement: boolean;
   isUserAllowedToDelete: boolean;
   changeRequest: ChangeRequest;
@@ -31,6 +32,7 @@ interface ChangeRequestActionMenuProps {
 
 const ChangeRequestActionMenu: React.FC<ChangeRequestActionMenuProps> = ({
   isUserAllowedToReview,
+  reviewDisabledTooltip,
   isUserAllowedToImplement,
   isUserAllowedToDelete,
   changeRequest,
@@ -77,7 +79,8 @@ const ChangeRequestActionMenu: React.FC<ChangeRequestActionMenuProps> = ({
             title: 'Review',
             onClick: handleReviewOpen,
             disabled: !isUserAllowedToReview,
-            icon: <ContentPasteIcon fontSize="small" />
+            icon: <ContentPasteIcon fontSize="small" />,
+            tooltip: reviewDisabledTooltip
           },
           {
             title: 'Delete',

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ChangeRequestDetails.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ChangeRequestDetails.tsx
@@ -23,13 +23,33 @@ const ChangeRequestDetails: React.FC = () => {
 
   if (isError) return <ErrorPage message={error?.message} />;
 
+  // Determine if user can review and why they can't
+  const isLeadership = !isNotLeadership(auth.user?.role);
+  const isSubmitter = auth.user?.userId === data?.submitter.userId;
+  const isOpen = data!.status === ChangeRequestStatus.Open;
+  const hasRequestedReviewers = data!.requestedReviewers.length > 0;
+  const isInRequestedReviewers = data!.requestedReviewers.some((reviewer) => reviewer.userId === auth.user?.userId);
+
+  const isUserAllowedToReview = isLeadership && !isSubmitter && isOpen && (!hasRequestedReviewers || isInRequestedReviewers);
+
+  // Generate tooltip message explaining why review is disabled
+  let reviewDisabledTooltip: string | undefined;
+  if (!isUserAllowedToReview) {
+    if (!isLeadership) {
+      reviewDisabledTooltip = 'You must be a leadership member to review change requests';
+    } else if (isSubmitter) {
+      reviewDisabledTooltip = 'You cannot review your own change request';
+    } else if (!isOpen) {
+      reviewDisabledTooltip = 'This change request is not open for review';
+    } else if (hasRequestedReviewers && !isInRequestedReviewers) {
+      reviewDisabledTooltip = 'Only requested reviewers can review this change request';
+    }
+  }
+
   return (
     <ChangeRequestDetailsView
-      isUserAllowedToReview={
-        !isNotLeadership(auth.user?.role) &&
-        auth.user?.userId !== data?.submitter.userId &&
-        data!.status === ChangeRequestStatus.Open
-      }
+      isUserAllowedToReview={isUserAllowedToReview}
+      reviewDisabledTooltip={reviewDisabledTooltip}
       isUserAllowedToImplement={!isGuest(auth.user?.role)}
       isUserAllowedToDelete={
         isAdmin(auth.user?.role) ||

--- a/src/frontend/src/pages/ChangeRequestDetailPage/ChangeRequestDetailsView.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/ChangeRequestDetailsView.tsx
@@ -45,6 +45,7 @@ const buildDetails = (cr: ChangeRequest): ReactElement => {
 };
 interface ChangeRequestDetailsProps {
   isUserAllowedToReview: boolean;
+  reviewDisabledTooltip?: string;
   isUserAllowedToImplement: boolean;
   isUserAllowedToDelete: boolean;
   changeRequest: ChangeRequest;
@@ -52,6 +53,7 @@ interface ChangeRequestDetailsProps {
 
 const ChangeRequestDetailsView: React.FC<ChangeRequestDetailsProps> = ({
   isUserAllowedToReview,
+  reviewDisabledTooltip,
   isUserAllowedToImplement,
   isUserAllowedToDelete,
   changeRequest
@@ -83,6 +85,7 @@ const ChangeRequestDetailsView: React.FC<ChangeRequestDetailsProps> = ({
       headerRight={
         <ChangeRequestActionMenu
           isUserAllowedToReview={isUserAllowedToReview}
+          reviewDisabledTooltip={reviewDisabledTooltip}
           isUserAllowedToImplement={isUserAllowedToImplement}
           isUserAllowedToDelete={isUserAllowedToDelete}
           changeRequest={changeRequest}


### PR DESCRIPTION
## Changes

If a CR has no requested reviewers, the functionality remains the same. If it has requested reviewers, only they can approve the CR

## Notes

also added tool tip to the actions menu to tell users why they can't approve

## Screenshots
<img width="1190" height="592" alt="Screenshot 2025-12-12 at 9 13 31 PM" src="https://github.com/user-attachments/assets/71270e7b-5cd8-49ed-9a5a-0aea4bd39e3a" />


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #3802
