### PR TITLE
#3832: fixed backend over-calculating budget deductions from RRs that a project has an item on

### DIFF
--- a/src/backend/src/services/finance.services.ts
+++ b/src/backend/src/services/finance.services.ts
@@ -434,13 +434,31 @@ export default class FinanceServices {
       },
       select: {
         reimbursementStatuses: true,
-        totalCost: true
+        totalCost: true,
+        reimbursementProducts: {
+          where: {
+            reimbursementProductReason: {
+              wbsElement: {
+                project: {
+                  projectId
+                }
+              }
+            }
+          },
+          select: {
+            cost: true
+          }
+        }
       }
     });
 
     const { pendingFinance, pendingLeadership, submittedToSabo, reimbursed } = computeRRTotals(reimbursementRequests);
 
-    const totalBalance = reimbursementRequests.reduce((acc, curr) => acc + curr.totalCost, 0) / 100;
+    const totalBalance =
+      reimbursementRequests.reduce((acc, curr) => {
+        const projectProductsCost = curr.reimbursementProducts.reduce((prodAcc, prod) => prodAcc + prod.cost, 0);
+        return acc + projectProductsCost;
+      }, 0) / 100;
 
     const available = project.budget - totalBalance;
 
@@ -507,7 +525,25 @@ export default class FinanceServices {
       },
       select: {
         reimbursementStatuses: true,
-        totalCost: true
+        totalCost: true,
+        reimbursementProducts: {
+          where: {
+            reimbursementProductReason: {
+              wbsElement: {
+                project: {
+                  teams: {
+                    some: {
+                      teamId
+                    }
+                  }
+                }
+              }
+            }
+          },
+          select: {
+            cost: true
+          }
+        }
       }
     });
 
@@ -515,7 +551,11 @@ export default class FinanceServices {
 
     const { pendingFinance, pendingLeadership, submittedToSabo, reimbursed } = computeRRTotals(reimbursementRequests);
 
-    const totalBalance = reimbursementRequests.reduce((acc, curr) => acc + curr.totalCost, 0) / 100;
+    const totalBalance =
+      reimbursementRequests.reduce((acc, curr) => {
+        const teamProductsCost = curr.reimbursementProducts.reduce((prodAcc, prod) => prodAcc + prod.cost, 0);
+        return acc + teamProductsCost;
+      }, 0) / 100;
 
     const available = totalBudget - totalBalance;
 
@@ -910,7 +950,17 @@ export default class FinanceServices {
       },
       select: {
         reimbursementStatuses: true,
-        totalCost: true
+        totalCost: true,
+        reimbursementProducts: {
+          where: {
+            reimbursementProductReason: {
+              otherReasonId
+            }
+          },
+          select: {
+            cost: true
+          }
+        }
       }
     });
 
@@ -935,7 +985,8 @@ export default class FinanceServices {
       const lastStatus = req.reimbursementStatuses.at(-1)?.type;
 
       if (lastStatus && totals[lastStatus] !== undefined) {
-        totals[lastStatus] += req.totalCost;
+        const categoryProductsCost = req.reimbursementProducts.reduce((prodAcc, prod) => prodAcc + prod.cost, 0);
+        totals[lastStatus] += categoryProductsCost;
       }
     });
 
@@ -944,7 +995,10 @@ export default class FinanceServices {
     const submittedToSabo = totals[Reimbursement_Status_Type.SABO_SUBMITTED] ?? 0;
     const reimbursed = totals[Reimbursement_Status_Type.REIMBURSED] ?? 0;
 
-    const totalBalance = reimbursementRequests.reduce((acc, curr) => acc + curr.totalCost, 0);
+    const totalBalance = reimbursementRequests.reduce((acc, curr) => {
+      const categoryProductsCost = curr.reimbursementProducts.reduce((prodAcc, prod) => prodAcc + prod.cost, 0);
+      return acc + categoryProductsCost;
+    }, 0);
 
     const available = totalBudget - totalBalance;
 

--- a/src/backend/src/utils/finance.utils.ts
+++ b/src/backend/src/utils/finance.utils.ts
@@ -114,6 +114,7 @@ export const computeRRTotals = (
       reimbursementStatusId: string;
       userId: string;
     }[];
+    reimbursementProducts?: { cost: number }[];
   }[]
 ): {
   pendingFinance: number;
@@ -132,7 +133,11 @@ export const computeRRTotals = (
     const lastStatus = req.reimbursementStatuses.at(-1)?.type;
 
     if (lastStatus && totals[lastStatus] !== undefined) {
-      totals[lastStatus] += req.totalCost;
+      // If reimbursementProducts are provided, sum their costs; otherwise use totalCost
+      const costToAdd = req.reimbursementProducts
+        ? req.reimbursementProducts.reduce((acc, prod) => acc + prod.cost, 0)
+        : req.totalCost;
+      totals[lastStatus] += costToAdd;
     }
   });
 


### PR DESCRIPTION
## Changes

Fixed budget calculation bug where reimbursement requests with products from multiple projects/teams incorrectly deducted the total RR cost from each project's budget instead of only the relevant product costs.

## Notes

Should fix future + existing budget calculations

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3832 
