### PR TITLE
#3549 Add ruleset type modal

### DIFF
--- a/src/frontend/src/apis/rules.api.ts
+++ b/src/frontend/src/apis/rules.api.ts
@@ -1,1 +1,13 @@
-// write api functions below here!
+import { RulesetType } from 'shared';
+import axios from '../utils/axios';
+import { apiUrls } from '../utils/urls';
+
+/**
+ * Creates a new ruleset type
+ *
+ * @param payload the data for creating the ruleset type
+ * @returns the created ruleset type
+ */
+export const createRulesetType = (payload: { name: string }) => {
+  return axios.post<RulesetType>(apiUrls.rulesetTypeCreate(), payload);
+};

--- a/src/frontend/src/hooks/rules.hooks.ts
+++ b/src/frontend/src/hooks/rules.hooks.ts
@@ -1,1 +1,26 @@
-// write hooks below here!
+import { useMutation, useQueryClient } from 'react-query';
+import { RulesetType } from 'shared';
+import { createRulesetType } from '../apis/rules.api';
+
+interface CreateRulesetTypePayload {
+  name: string;
+}
+
+/**
+ * Custom React Hook to create a new ruleset type
+ */
+export const useCreateRulesetType = () => {
+  const queryClient = useQueryClient();
+  return useMutation<RulesetType, Error, CreateRulesetTypePayload>(
+    ['rulesetTypes', 'create'],
+    async (payload: CreateRulesetTypePayload) => {
+      const { data } = await createRulesetType(payload);
+      return data;
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(['rulesetTypes']);
+      }
+    }
+  );
+};

--- a/src/frontend/src/pages/RulesPage/RulesetTypePage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetTypePage.tsx
@@ -20,6 +20,9 @@ import { datePipe } from '../../utils/pipes';
 import { NERButton } from '../../components/NERButton';
 import { useHistory } from 'react-router-dom';
 import { routes } from '../../utils/routes';
+import AddRulesetTypeModal from './components/AddRulesetTypeModal';
+import { useState } from 'react';
+import { useCreateRulesetType } from '../../hooks/rules.hooks';
 
 type RulesetTypeColumnId = 'id' | 'name' | 'lastUpdated' | 'revisions' | 'actions';
 
@@ -32,6 +35,8 @@ const RulesetTypePage: React.FC = () => {
   const history = useHistory();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+
+  const [addRulesetTypeModalShow, setAddRulesetTypeModalShow] = useState(false);
 
   const headCells: readonly RulesetTypeHeadCell[] = [
     {
@@ -57,6 +62,16 @@ const RulesetTypePage: React.FC = () => {
     { id: '1', name: 'Ruleset 1', lastUpdated: new Date('2024-01-15'), revisions: 5, actions: 'Edit' },
     { id: '2', name: 'Ruleset 2', lastUpdated: new Date('2024-01-14'), revisions: 3, actions: 'Edit' }
   ];
+
+  const { mutateAsync: createRulesetType } = useCreateRulesetType();
+
+  const handleAddRulesetTypeConfirm = async (data: { name: string }) => {
+    await createRulesetType({ name: data.name });
+  };
+
+  const handleAddRulesetTypeCancel = () => {
+    setAddRulesetTypeModalShow(false);
+  };
 
   return (
     <PageLayout title="Ruleset Types">
@@ -165,29 +180,14 @@ const RulesetTypePage: React.FC = () => {
               justifyContent: { xs: 'center', md: 'flex-end' }
             }}
           >
-            <Button
-              className="viewButton"
-              variant="contained"
-              sx={{
-                borderRadius: '8px',
-                color: '#ededed',
-                backgroundColor: '#dd514c',
-                padding: { xs: '8px 16px', md: '2px 20px' },
-                mb: 1,
-                mr: { xs: 0, md: 2 },
-                display: 'flex',
-                fontSize: { xs: '14px', md: '16px' },
-                fontWeight: 700,
-                textTransform: 'none',
-                width: { xs: '100%', sm: 'auto' },
-                maxWidth: { xs: '300px', sm: 'none' },
-                '&:hover': {
-                  backgroundColor: '#c74340'
-                }
-              }}
-            >
-              Add Ruleset
-            </Button>
+            <NERButton variant="contained" onClick={() => setAddRulesetTypeModalShow(!addRulesetTypeModalShow)}>
+              Add Ruleset Type
+            </NERButton>
+            <AddRulesetTypeModal
+              open={addRulesetTypeModalShow}
+              onHide={handleAddRulesetTypeCancel}
+              onFormSubmit={handleAddRulesetTypeConfirm}
+            />
             {/* Temporary for navigation */}
             <NERButton onClick={() => history.push(`${routes.RULES}/placeholder_ruleset_id`)}>FSAE Ruleset</NERButton>
           </Box>

--- a/src/frontend/src/pages/RulesPage/components/AddRulesetTypeModal.tsx
+++ b/src/frontend/src/pages/RulesPage/components/AddRulesetTypeModal.tsx
@@ -1,0 +1,105 @@
+import { FormControl, FormHelperText, FormLabel, TextField } from '@mui/material';
+import { Box } from '@mui/system';
+import * as yup from 'yup';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { Controller, useForm } from 'react-hook-form';
+import NERFormModal from '../../../components/NERFormModal';
+import { useToast } from '../../../hooks/toasts.hooks';
+
+interface RulesetTypeFormData {
+  name: string;
+}
+
+interface AddRulesetTypeModalProps {
+  open: boolean;
+  onHide: () => void;
+  onFormSubmit: (data: RulesetTypeFormData) => Promise<void>;
+}
+
+const sectionHeaderStyle = {
+  fontWeight: 'bold',
+  color: '#ef4345',
+  textDecoration: 'underline',
+  fontSize: '1rem',
+  textUnderlineOffset: '5px',
+  marginBottom: '10px'
+};
+
+const schema = yup.object({
+  name: yup.string().required('Name is required')
+});
+
+const AddRulesetTypeModal: React.FC<AddRulesetTypeModalProps> = ({ open, onHide, onFormSubmit }) => {
+  const toast = useToast();
+
+  const {
+    formState: { errors },
+    handleSubmit,
+    reset,
+    control
+  } = useForm<RulesetTypeFormData>({
+    resolver: yupResolver(schema),
+    defaultValues: {
+      name: ''
+    }
+  });
+
+  const handleFormSubmit = async (data: RulesetTypeFormData) => {
+    try {
+      await onFormSubmit(data);
+      toast.success('Ruleset Type Successfully Added');
+      reset();
+      onHide();
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        toast.error(error.message);
+      }
+    }
+  };
+
+  const handleModalClose = () => {
+    reset();
+    onHide();
+  };
+
+  const handleReset = () => {
+    reset();
+  };
+
+  return (
+    <NERFormModal
+      open={open}
+      onHide={handleModalClose}
+      title="Add Ruleset Type"
+      reset={handleReset}
+      handleUseFormSubmit={handleSubmit}
+      onFormSubmit={handleFormSubmit}
+      formId={'add-ruleset-type-form'}
+      showCloseButton
+      submitText="Add Ruleset"
+    >
+      <Box>
+        <FormControl fullWidth error={!!errors.name}>
+          <FormLabel sx={sectionHeaderStyle}>Name Ruleset:</FormLabel>
+          <Controller
+            name="name"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                autoComplete="off"
+                placeholder="Name Ruleset"
+                error={!!errors.name}
+                fullWidth
+                sx={{ minWidth: '400px' }}
+              />
+            )}
+          />
+          <FormHelperText error>{errors.name?.message}</FormHelperText>
+        </FormControl>
+      </Box>
+    </NERFormModal>
+  );
+};
+
+export default AddRulesetTypeModal;

--- a/src/frontend/src/pages/RulesPage/components/AddRulesetTypeModal.tsx
+++ b/src/frontend/src/pages/RulesPage/components/AddRulesetTypeModal.tsx
@@ -76,7 +76,6 @@ const AddRulesetTypeModal: React.FC<AddRulesetTypeModalProps> = ({ open, onHide,
       onFormSubmit={handleFormSubmit}
       formId={'add-ruleset-type-form'}
       showCloseButton
-      submitText="Add Ruleset"
     >
       <Box>
         <FormControl fullWidth error={!!errors.name}>

--- a/src/frontend/src/utils/urls.ts
+++ b/src/frontend/src/utils/urls.ts
@@ -436,6 +436,12 @@ const retrospectiveTimelines = (startDate?: Date, endDate?: Date) =>
   (endDate ? `end=${encodeURIComponent(endDate.toISOString())}` : '');
 const retrospectiveBudgets = () => `${API_URL}/retrospective/budgets`;
 
+/************** Rule Endpoints ***************/
+const rules = () => `${API_URL}/rules`;
+const ruleset = () => `${rules()}/ruleset`;
+const rulesetTypeCreate = () => `${rules()}/rulesetType/create`;
+const rulesetsCreate = () => `${ruleset()}/create`;
+
 /**************** Other Endpoints ****************/
 const version = () => `https://api.github.com/repos/Northeastern-Electric-Racing/FinishLine/releases/latest`;
 
@@ -737,6 +743,10 @@ export const apiUrls = {
 
   retrospectiveTimelines,
   retrospectiveBudgets,
+
+  ruleset,
+  rulesetTypeCreate,
+  rulesetsCreate,
 
   version
 };


### PR DESCRIPTION
## Changes

Modal on rules landing page for adding ruleset type. Allows user to input ruleset type name

Added hook, api, modal file. Modal added to rulesetTypePage

## Screenshots

<img width="1414" height="816" alt="Screenshot 2025-12-24 at 1 55 44 PM" src="https://github.com/user-attachments/assets/a19b76da-6bae-423c-8935-c8703bbda350" />


<img width="1434" height="468" alt="Screenshot 2025-12-24 at 1 51 08 PM" src="https://github.com/user-attachments/assets/abdbb948-5148-44f9-a567-eda6d7c09ab1" />

<img width="596" height="374" alt="Screenshot 2025-12-24 at 1 51 19 PM" src="https://github.com/user-attachments/assets/c4b73ee9-b5c4-458e-9daf-97f6aa33e118" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3549 
