### PR TITLE
#3844 ruleset table data

### DIFF
--- a/src/backend/src/controllers/rules.controllers.ts
+++ b/src/backend/src/controllers/rules.controllers.ts
@@ -101,7 +101,7 @@ export default class RulesController {
 
   static async getRulesetsByRulesetType(req: Request, res: Response, next: NextFunction) {
     try {
-      const rulesetTypeId = req.body;
+      const { rulesetTypeId } = req.params;
       const rulesets = await RulesService.getRulesetsByRulesetType(rulesetTypeId, req.organization.organizationId);
       res.status(200).json(rulesets);
     } catch (error: unknown) {

--- a/src/backend/src/prisma-query-args/rules.query-args.ts
+++ b/src/backend/src/prisma-query-args/rules.query-args.ts
@@ -65,22 +65,11 @@ export const getRulesetQueryArgs = (organizationId: string) =>
         }
       },
       rulesetType: true,
-      car: true,
-      createdBy: getUserQueryArgs(organizationId)
-    }
-  });
-
-export const getRulesetPreviewQueryArgs = () =>
-  Prisma.validator<Prisma.RulesetDefaultArgs>()({
-    select: {
-      name: true,
-      dateCreated: true,
-      rulesetType: true,
-      active: true,
       car: {
-        select: {
+        include: {
           wbsElement: true
         }
-      }
+      },
+      createdBy: getUserQueryArgs(organizationId)
     }
   });

--- a/src/backend/src/prisma-query-args/rules.query-args.ts
+++ b/src/backend/src/prisma-query-args/rules.query-args.ts
@@ -1,5 +1,4 @@
 import { Prisma } from '@prisma/client';
-import { getUserQueryArgs } from './user.query-args';
 
 export type RulePreviewQueryArgs = ReturnType<typeof getRulePreviewQueryArgs>;
 
@@ -50,7 +49,7 @@ export const getProjectRuleQueryArgs = () =>
 
 export type RulesetQueryArgs = ReturnType<typeof getRulesetQueryArgs>;
 
-export const getRulesetQueryArgs = (organizationId: string) =>
+export const getRulesetQueryArgs = () =>
   Prisma.validator<Prisma.RulesetDefaultArgs>()({
     include: {
       rules: {
@@ -69,7 +68,6 @@ export const getRulesetQueryArgs = (organizationId: string) =>
         include: {
           wbsElement: true
         }
-      },
-      createdBy: getUserQueryArgs(organizationId)
+      }
     }
   });

--- a/src/backend/src/routes/rules.routes.ts
+++ b/src/backend/src/routes/rules.routes.ts
@@ -34,8 +34,6 @@ rulesRouter.post('/rule/:ruleId/delete', RulesController.deleteRule);
 
 rulesRouter.post('/rulesetType/create', nonEmptyString(body('name')), validateInputs, RulesController.createRulesetType);
 
-rulesRouter.post('/rule/:ruleId/delete', RulesController.deleteRule);
-
 rulesRouter.post(
   '/projectRule/create',
   nonEmptyString(body('ruleId')),

--- a/src/backend/src/services/rules.services.ts
+++ b/src/backend/src/services/rules.services.ts
@@ -59,7 +59,7 @@ export default class RulesService {
 
     const activeRuleset = await prisma.ruleset.findFirst({
       where: { rulesetTypeId, deletedByUserId: null, active: true },
-      ...getRulesetQueryArgs(organization.organizationId)
+      ...getRulesetQueryArgs()
     });
 
     if (!activeRuleset) {
@@ -459,10 +459,10 @@ export default class RulesService {
    * @param organizationId the id of the organization the ruleset is being deleted in
    * @returns the ruleset with query args
    */
-  static async getRulesetWithQueryArgs(rulesetId: string, organizationId: string) {
+  static async getRulesetWithQueryArgs(rulesetId: string) {
     const ruleset = await prisma.ruleset.findUnique({
       where: { rulesetId },
-      ...getRulesetQueryArgs(organizationId)
+      ...getRulesetQueryArgs()
     });
 
     if (!ruleset) throw new NotFoundException('Ruleset', rulesetId);
@@ -479,7 +479,7 @@ export default class RulesService {
    * @returns the deleted Ruleset
    */
   static async deleteRuleset(rulesetId: string, deleterId: string, organizationId: string) {
-    const ruleset = await RulesService.getRulesetWithQueryArgs(rulesetId, organizationId);
+    const ruleset = await RulesService.getRulesetWithQueryArgs(rulesetId);
 
     const hasPermission =
       (await userHasPermission(deleterId, organizationId, isAdmin)) || deleterId === ruleset.createdByUserId;
@@ -489,7 +489,7 @@ export default class RulesService {
     const deletedRuleset = await prisma.ruleset.update({
       where: { rulesetId },
       data: { deletedBy: { connect: { userId: deleterId } } },
-      ...getRulesetQueryArgs(organizationId)
+      ...getRulesetQueryArgs()
     });
 
     return rulesetTransformer(deletedRuleset);
@@ -523,7 +523,7 @@ export default class RulesService {
           organizationId
         }
       },
-      ...getRulesetQueryArgs(organizationId)
+      ...getRulesetQueryArgs()
     });
 
     return rulesets.map(rulesetTransformer);
@@ -571,7 +571,7 @@ export default class RulesService {
         active: true,
         deletedBy: null
       },
-      ...getRulesetQueryArgs(organization.organizationId)
+      ...getRulesetQueryArgs()
     });
 
     if (!activeRuleset) {
@@ -782,7 +782,7 @@ export default class RulesService {
         active,
         createdByUserId: submitter.userId
       },
-      ...getRulesetQueryArgs(organization.organizationId)
+      ...getRulesetQueryArgs()
     });
 
     return rulesetTransformer(ruleset);
@@ -959,7 +959,7 @@ export default class RulesService {
         name,
         active: isActive
       },
-      ...getRulesetQueryArgs(organizationId)
+      ...getRulesetQueryArgs()
     });
 
     return rulesetTransformer(ruleset);

--- a/src/backend/src/services/rules.services.ts
+++ b/src/backend/src/services/rules.services.ts
@@ -523,6 +523,9 @@ export default class RulesService {
           organizationId
         }
       },
+      orderBy: {
+        dateCreated: 'desc'
+      },
       ...getRulesetQueryArgs()
     });
 

--- a/src/backend/src/services/rules.services.ts
+++ b/src/backend/src/services/rules.services.ts
@@ -5,10 +5,10 @@ import {
   ProjectRule,
   RulesetType,
   notGuest,
-  RulesetPreview,
   User,
   Rule as SharedRule,
-  isHead
+  isHead,
+  Ruleset
 } from 'shared';
 import prisma from '../prisma/prisma';
 import {
@@ -24,15 +24,13 @@ import { userHasPermission } from '../utils/users.utils';
 import {
   getProjectRuleQueryArgs,
   getRulesetQueryArgs,
-  getRulesetPreviewQueryArgs,
   getRulePreviewQueryArgs
 } from '../prisma-query-args/rules.query-args';
 import {
   ruleTransformer,
   projectRuleTransformer,
   rulesetTransformer,
-  rulesetTypeTransformer,
-  rulesetPreviewTransformer
+  rulesetTypeTransformer
 } from '../transformers/rules.transformer';
 
 export default class RulesService {
@@ -516,7 +514,7 @@ export default class RulesService {
    * @param organizationId id of organization
    * @returns rulesets associated with provided ruleset type
    */
-  static async getRulesetsByRulesetType(rulesetTypeId: string, organizationId: string): Promise<RulesetPreview[]> {
+  static async getRulesetsByRulesetType(rulesetTypeId: string, organizationId: string): Promise<Ruleset[]> {
     const rulesets = await prisma.ruleset.findMany({
       where: {
         rulesetTypeId,

--- a/src/backend/src/services/rules.services.ts
+++ b/src/backend/src/services/rules.services.ts
@@ -486,9 +486,13 @@ export default class RulesService {
 
     if (!hasPermission) throw new AccessDeniedException('Only admins can delete a ruleset.');
 
+    if (ruleset.active) {
+      throw new HttpException(400, 'Cannot delete an active ruleset. Please deactivate it first.');
+    }
+
     const deletedRuleset = await prisma.ruleset.update({
       where: { rulesetId },
-      data: { deletedBy: { connect: { userId: deleterId } } },
+      data: { deletedBy: { connect: { userId: deleterId } }, active: false },
       ...getRulesetQueryArgs()
     });
 
@@ -943,7 +947,7 @@ export default class RulesService {
             rulesetTypeId: rulesetExists.rulesetTypeId,
             organizationId
           },
-          dateDeleted: null
+          deletedByUserId: null
         }
       });
 

--- a/src/backend/src/services/rules.services.ts
+++ b/src/backend/src/services/rules.services.ts
@@ -525,10 +525,10 @@ export default class RulesService {
           organizationId
         }
       },
-      ...getRulesetPreviewQueryArgs()
+      ...getRulesetQueryArgs(organizationId)
     });
 
-    return rulesets.map(rulesetPreviewTransformer);
+    return rulesets.map(rulesetTransformer);
   }
 
   /**

--- a/src/backend/src/transformers/rules.transformer.ts
+++ b/src/backend/src/transformers/rules.transformer.ts
@@ -35,6 +35,8 @@ export const rulesetTypeTransformer = (rulesetType: any): RulesetType => {
     name: rulesetType.name,
     lastUpdated: rulesetType.lastUpdated,
     revisionFiles: rulesetType.revisionFiles
+      ? rulesetType.revisionFiles.filter((ruleset: any) => ruleset.deletedByUserId === null)
+      : []
   };
 };
 

--- a/src/backend/src/transformers/rules.transformer.ts
+++ b/src/backend/src/transformers/rules.transformer.ts
@@ -1,5 +1,5 @@
 import { Prisma } from '@prisma/client';
-import { Rule, ProjectRule, Ruleset, RulesetType, RulesetPreview } from 'shared';
+import { Rule, ProjectRule, Ruleset, RulesetType } from 'shared';
 import { RulesetQueryArgs, RulePreviewQueryArgs } from '../prisma-query-args/rules.query-args';
 
 export const ruleTransformer = (rule: Prisma.RuleGetPayload<RulePreviewQueryArgs>): Rule => {
@@ -53,22 +53,7 @@ export const rulesetTransformer = (ruleset: Prisma.RulesetGetPayload<RulesetQuer
     rulesetType: rulesetTypeTransformer(ruleset.rulesetType),
     car: {
       carId: ruleset.car.carId,
-      name: ruleset.car.wbsElementId
-    }
-  };
-};
-
-export const rulesetPreviewTransformer = (ruleset: any): RulesetPreview => {
-  const teamsPercentage = 0;
-
-  return {
-    name: ruleset.name,
-    dateCreated: ruleset.dateCreated,
-    active: ruleset.active,
-    assignedPercentage: teamsPercentage,
-    car: {
-      carId: ruleset.car.carId,
-      name: ruleset.car.wbsElementId
+      name: ruleset.car.wbsElement.name
     }
   };
 };

--- a/src/backend/tests/unit/rule.test.ts
+++ b/src/backend/tests/unit/rule.test.ts
@@ -377,6 +377,12 @@ describe('Create Rules Tests', () => {
     });
 
     it('Successful get rulesets by ruleset types after deleting ruleset', async () => {
+      // Deactivate the ruleset before deleting
+      await prisma.ruleset.update({
+        where: { rulesetId },
+        data: { active: false }
+      });
+
       await RulesService.deleteRuleset(rulesetId, batman.userId, orgId);
       const rulesets = await RulesService.getRulesetsByRulesetType(rulesetType.rulesetTypeId, orgId);
       expect(rulesets.length).toBe(0);
@@ -524,6 +530,11 @@ describe('Create Rules Tests', () => {
       expect(ruleset2.name).toBe('name2');
     });
     it('update ruleset status on deleted ruleset fails', async () => {
+      // Deactivate the ruleset before deleting
+      await prisma.ruleset.update({
+        where: { rulesetId },
+        data: { active: false }
+      });
       await RulesService.deleteRuleset(rulesetId, batman.userId, orgId);
       await expect(async () => await RulesService.updateRuleset(batman, orgId, rulesetId, 'name', false)).rejects.toThrow(
         new NotFoundException('Ruleset', rulesetId)
@@ -973,6 +984,13 @@ describe('Rule Tests', () => {
     it('Deletes a ruleset successfully and returns the correct information', async () => {
       const car = await createUniqueCar(orgId);
       const { ruleset1 } = await setupRules(car);
+
+      // deactivate before deleting
+      await prisma.ruleset.update({
+        where: { rulesetId: ruleset1.rulesetId },
+        data: { active: false }
+      });
+
       const totalRules = await prisma.rule.count({
         where: { rulesetId: ruleset1.rulesetId }
       });
@@ -989,6 +1007,20 @@ describe('Rule Tests', () => {
       expect(deleted.rulesetId).toBe(ruleset1.rulesetId);
       expect(deleted.assignedPercentage).toBeCloseTo(expectedPercentage, 2);
     });
+    it('Throws error when trying to delete an active ruleset', async () => {
+      const car = await createUniqueCar(orgId);
+      const { ruleset1 } = await setupRules(car);
+
+      // Ensure the ruleset is active
+      await prisma.ruleset.update({
+        where: { rulesetId: ruleset1.rulesetId },
+        data: { active: true }
+      });
+
+      await expect(
+        RulesService.deleteRuleset(ruleset1.rulesetId, admin.userId, organization.organizationId)
+      ).rejects.toThrow('Cannot delete an active ruleset. Please deactivate it first.');
+    });
     it('Delete ruleset fails if user does not have permission', async () => {
       const car = await createUniqueCar(orgId);
       const { ruleset1 } = await setupRules(car);
@@ -1000,6 +1032,12 @@ describe('Rule Tests', () => {
     it('Delete ruleset fails if ruleset was already deleted', async () => {
       const car = await createUniqueCar(orgId);
       const { ruleset1 } = await setupRules(car);
+
+      // Deactivate the ruleset before deleting
+      await prisma.ruleset.update({
+        where: { rulesetId: ruleset1.rulesetId },
+        data: { active: false }
+      });
 
       await RulesService.deleteRuleset(ruleset1.rulesetId, admin.userId, organization.organizationId);
       await expect(
@@ -1454,6 +1492,12 @@ describe('Rule Tests', () => {
     it('Fails when ruleset is deleted', async () => {
       const car = await createUniqueCar(orgId);
       const { ruleset1 } = await setupRules(car);
+
+      // Deactivate the ruleset before deleting
+      await prisma.ruleset.update({
+        where: { rulesetId: ruleset1.rulesetId },
+        data: { active: false }
+      });
 
       await RulesService.deleteRuleset(ruleset1.rulesetId, admin.userId, organization.organizationId);
 

--- a/src/backend/tests/unit/rule.test.ts
+++ b/src/backend/tests/unit/rule.test.ts
@@ -395,8 +395,8 @@ describe('Create Rules Tests', () => {
       });
       const rulesets = await RulesService.getRulesetsByRulesetType(rulesetType.rulesetTypeId, orgId);
       expect(rulesets.length).toBe(2);
-      expect(rulesets[0].name).toBe('2025 FSAE Rules');
-      expect(rulesets[1].name).toBe('2025 FSAE Rules2');
+      expect(rulesets[0].name).toBe('2025 FSAE Rules2');
+      expect(rulesets[1].name).toBe('2025 FSAE Rules');
     });
   });
 

--- a/src/frontend/src/apis/rules.api.ts
+++ b/src/frontend/src/apis/rules.api.ts
@@ -67,3 +67,10 @@ export const getRulesetsByRulesetType = (rulesetTypeId: string) => {
     transformResponse: (data) => JSON.parse(data)
   });
 };
+
+/**
+ * Updates a rulesets active status
+ */
+export const updateRuleset = (rulesetId: string, name: string, isActive: boolean) => {
+  return axios.post<Ruleset>(apiUrls.rulesetUpdate(rulesetId), { name, isActive });
+};

--- a/src/frontend/src/apis/rules.api.ts
+++ b/src/frontend/src/apis/rules.api.ts
@@ -74,3 +74,17 @@ export const getRulesetsByRulesetType = (rulesetTypeId: string) => {
 export const updateRuleset = (rulesetId: string, name: string, isActive: boolean) => {
   return axios.post<Ruleset>(apiUrls.rulesetUpdate(rulesetId), { name, isActive });
 };
+
+/**
+ * Deletes a ruleset given its ID
+ */
+export const deleteRuleset = (rulesetId: string) => {
+  return axios.post(apiUrls.rulesetDelete(rulesetId));
+};
+
+/**
+ * Deletes a ruleset type given its ID
+ */
+export const deleteRulesetType = (rulesetTypeId: string) => {
+  return axios.post(apiUrls.rulesetTypeDelete(rulesetTypeId));
+};

--- a/src/frontend/src/hooks/rules.hooks.ts
+++ b/src/frontend/src/hooks/rules.hooks.ts
@@ -12,7 +12,8 @@ import {
   getTeamRulesInRulesetType,
   createRulesetType,
   getAllRulesetTypes,
-  getRulesetsByRulesetType
+  getRulesetsByRulesetType,
+  updateRuleset
 } from '../apis/rules.api';
 
 interface CreateRulesetTypePayload {
@@ -98,4 +99,19 @@ export const useRulesetsByType = (rulesetTypeId: string) => {
     const { data } = await getRulesetsByRulesetType(rulesetTypeId);
     return data;
   });
+};
+
+export const useUpdateRuleset = () => {
+  const queryClient = useQueryClient();
+  return useMutation<Ruleset, Error, { rulesetId: string; name: string; isActive: boolean }>(
+    async ({ rulesetId, name, isActive }) => {
+      const { data } = await updateRuleset(rulesetId, name, isActive);
+      return data;
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(['rulesets']);
+      }
+    }
+  );
 };

--- a/src/frontend/src/hooks/rules.hooks.ts
+++ b/src/frontend/src/hooks/rules.hooks.ts
@@ -13,7 +13,9 @@ import {
   createRulesetType,
   getAllRulesetTypes,
   getRulesetsByRulesetType,
-  updateRuleset
+  updateRuleset,
+  deleteRuleset,
+  deleteRulesetType
 } from '../apis/rules.api';
 
 interface CreateRulesetTypePayload {
@@ -111,6 +113,34 @@ export const useUpdateRuleset = () => {
     {
       onSuccess: () => {
         queryClient.invalidateQueries(['rulesets']);
+      }
+    }
+  );
+};
+
+export const useDeleteRuleset = () => {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, string>(
+    async (rulesetId: string) => {
+      await deleteRuleset(rulesetId);
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(['rulesets']);
+      }
+    }
+  );
+};
+
+export const useDeleteRulesetType = () => {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, string>(
+    async (rulesetTypeId: string) => {
+      await deleteRulesetType(rulesetTypeId);
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(['rulesetTypes']);
       }
     }
   );

--- a/src/frontend/src/pages/RulesPage/AssignRulesTab.tsx
+++ b/src/frontend/src/pages/RulesPage/AssignRulesTab.tsx
@@ -185,7 +185,7 @@ const AssignRulesTab: React.FC<AssignRulesTabProps> = ({ rules }) => {
       toast.success(`Placeholder: Would save ${toAdd.length} additions and ${toRemove.length} removals`);
     }
 
-    history.push(`${routes.RULES}/${rulesetId}`);
+    history.push(routes.RULESET_EDIT.replace(':rulesetId', rulesetId));
   };
 
   if (teamsLoading) {

--- a/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
@@ -240,7 +240,7 @@ const RulesetEditPage: React.FC = () => {
           <FullPageTabs
             setTab={setTabValue}
             tabsLabels={tabs}
-            baseUrl={`${routes.RULES}/${rulesetId}/edit`}
+            baseUrl={routes.RULESET_EDIT.replace(':rulesetId', rulesetId)}
             defaultTab={defaultTab}
             id="rules-tabs"
           />

--- a/src/frontend/src/pages/RulesPage/RulesetPage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetPage.tsx
@@ -2,7 +2,6 @@
  * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
  * See the LICENSE file in the repository root folder for details.
  */
-import { useHistory } from 'react-router-dom';
 import React from 'react';
 import { NERButton } from '../../components/NERButton';
 import AddNewFileModal from './components/AddNewFileModal';

--- a/src/frontend/src/pages/RulesPage/RulesetPage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetPage.tsx
@@ -67,9 +67,6 @@ const RulesetPage: React.FC = () => {
                 onConfirm={handleFileConfirm}
                 carOptions={['1', '2']}
               />
-              <NERButton onClick={() => history.push(`${routes.RULES}/placeholder_ruleset_id/edit`)}>
-                MOCK edit/assign rules
-              </NERButton>
             </Box>
           </Box>
         </Box>

--- a/src/frontend/src/pages/RulesPage/RulesetPage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetPage.tsx
@@ -3,7 +3,6 @@
  * See the LICENSE file in the repository root folder for details.
  */
 import { useHistory } from 'react-router-dom';
-import { routes } from '../../utils/routes';
 import React from 'react';
 import { NERButton } from '../../components/NERButton';
 import AddNewFileModal from './components/AddNewFileModal';
@@ -16,7 +15,6 @@ import RulesetTable from './components/RulesetTable';
  * Supports editing and assigning rules to projects and teams.
  */
 const RulesetPage: React.FC = () => {
-  const history = useHistory();
   const [AddFileModalShow, setAddFileModalShow] = React.useState(false);
 
   const handleFileConfirm = async (data: { file: File; name: string; car: string; isActive: boolean }) => {

--- a/src/frontend/src/pages/RulesPage/RulesetViewPage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetViewPage.tsx
@@ -17,7 +17,6 @@ const RulesetViewPage = () => {
   ];
 
   const { rulesetId } = useParams<{ rulesetId: string }>();
-
   const { data: ruleset, isError, error, isLoading } = useSingleRuleset(rulesetId);
 
   if (isError) {
@@ -38,7 +37,7 @@ const RulesetViewPage = () => {
               noUnderline
               setTab={setTabIndex}
               tabsLabels={tabs}
-              baseUrl={`${routes.RULES}/${rulesetId}/view`}
+              baseUrl={routes.RULESET_VIEW.replace(':rulesetId', rulesetId)}
               defaultTab={'teamView'}
               id="rules-view-tabs"
             />

--- a/src/frontend/src/pages/RulesPage/components/RulesetDeleteModal.tsx
+++ b/src/frontend/src/pages/RulesPage/components/RulesetDeleteModal.tsx
@@ -1,0 +1,27 @@
+import { Typography } from '@mui/material';
+import NERModal from '../../../components/NERModal';
+
+interface RulesetDeleteModalProps {
+  rulesetName: string;
+  onDelete: () => void;
+  onHide: () => void;
+}
+
+const RulesetDeleteModal: React.FC<RulesetDeleteModalProps> = ({ rulesetName, onDelete, onHide }) => {
+  return (
+    <NERModal
+      open={true}
+      onHide={onHide}
+      title="Warning!"
+      cancelText="Cancel"
+      submitText="Delete"
+      onSubmit={onDelete}
+      formId="ruleset-delete"
+    >
+      <Typography>Are you sure you want to delete this ruleset?</Typography>
+      <Typography sx={{ mt: 1.5, fontWeight: 600 }}>{rulesetName}</Typography>
+    </NERModal>
+  );
+};
+
+export default RulesetDeleteModal;

--- a/src/frontend/src/pages/RulesPage/components/RulesetTable.tsx
+++ b/src/frontend/src/pages/RulesPage/components/RulesetTable.tsx
@@ -92,6 +92,13 @@ const RulesetTable: React.FC = () => {
   };
 
   const handleDeleteRuleset = async (rulesetId: string, name: string) => {
+    const ruleset = rulesets.find((r) => r.rulesetId === rulesetId);
+
+    if (ruleset && ruleset.active) {
+      toast.error('Cannot delete an active ruleset. Please deactivate it first.');
+      return;
+    }
+
     try {
       await deleteRuleset(rulesetId);
       toast.success(`Ruleset: ${name} deleted successfully!`);
@@ -243,7 +250,7 @@ const RulesetTable: React.FC = () => {
               {/* Table rows with ruleset data */}
               {rulesets.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={6} align="center" sx={{ color: '#999', padding: '15px' }}>
+                  <TableCell colSpan={7} align="center" sx={{ color: '#999', padding: '15px' }}>
                     No Rulesets Found
                   </TableCell>
                 </TableRow>

--- a/src/frontend/src/pages/RulesPage/components/RulesetTable.tsx
+++ b/src/frontend/src/pages/RulesPage/components/RulesetTable.tsx
@@ -18,6 +18,11 @@ import {
 } from '@mui/material';
 import { datePipe } from '../../../utils/pipes';
 import { NERButton } from '../../../components/NERButton';
+import { useHistory, useParams } from 'react-router-dom';
+import LoadingIndicator from '../../../components/LoadingIndicator';
+import ErrorPage from '../../ErrorPage';
+import { useRulesetsByType } from '../../../hooks/rules.hooks';
+import { Ruleset } from 'shared';
 
 interface RulesetRow {
   id: string;
@@ -28,12 +33,20 @@ interface RulesetRow {
   isActive: boolean;
 }
 
+interface RulesetParams {
+  rulesetId: string;
+}
+
 const RulesetTable: React.FC = () => {
+  const { rulesetId } = useParams<RulesetParams>();
+  const history = useHistory();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
   // Add file upload logic
   // const [AddFileModalShow, setAddFileModalShow] = React.useState(false);
+
+  const { data: rulesets = [], isLoading, error } = useRulesetsByType(rulesetId);
 
   // Table header configuration
   const headCells = [
@@ -45,185 +58,26 @@ const RulesetTable: React.FC = () => {
     { id: 'actions', label: 'Actions' }
   ];
 
-  // Mock data for now - will be replaced with ruleset data
-  const mockRulesets: RulesetRow[] = [
-    {
-      id: '1',
-      fileName: 'FSAE Original Version',
-      dateUploaded: new Date('2025-02-24'),
-      percentRulesAssigned: 80,
-      car: 1,
-      isActive: false
-    },
-    {
-      id: '2',
-      fileName: 'FSAE Revision 1',
-      dateUploaded: new Date('2025-02-25'),
-      percentRulesAssigned: 10,
-      car: 1,
-      isActive: true
-    },
-    {
-      id: '3',
-      fileName: 'Hi',
-      dateUploaded: new Date('2025-02-24'),
-      percentRulesAssigned: 80,
-      car: 1,
-      isActive: false
-    },
-    {
-      id: '3',
-      fileName: 'Hi',
-      dateUploaded: new Date('2025-02-24'),
-      percentRulesAssigned: 80,
-      car: 1,
-      isActive: false
-    },
-    {
-      id: '3',
-      fileName: 'Hi ',
-      dateUploaded: new Date('2025-02-24'),
-      percentRulesAssigned: 80,
-      car: 1,
-      isActive: false
-    },
-    {
-      id: '3',
-      fileName: 'Hi ',
-      dateUploaded: new Date('2025-02-24'),
-      percentRulesAssigned: 80,
-      car: 1,
-      isActive: false
-    },
-    {
-      id: '3',
-      fileName: 'Hi ',
-      dateUploaded: new Date('2025-02-24'),
-      percentRulesAssigned: 80,
-      car: 1,
-      isActive: false
-    },
-    {
-      id: '3',
-      fileName: 'Hi ',
-      dateUploaded: new Date('2025-02-24'),
-      percentRulesAssigned: 80,
-      car: 1,
-      isActive: false
-    },
-    {
-      id: '3',
-      fileName: 'Hi ',
-      dateUploaded: new Date('2025-02-24'),
-      percentRulesAssigned: 80,
-      car: 1,
-      isActive: false
-    },
-    {
-      id: '3',
-      fileName: 'Hi ',
-      dateUploaded: new Date('2025-02-24'),
-      percentRulesAssigned: 80,
-      car: 1,
-      isActive: false
-    },
-    {
-      id: '3',
-      fileName: 'Hi ',
-      dateUploaded: new Date('2025-02-24'),
-      percentRulesAssigned: 80,
-      car: 1,
-      isActive: false
-    },
-    {
-      id: '3',
-      fileName: 'Hi ',
-      dateUploaded: new Date('2025-02-24'),
-      percentRulesAssigned: 80,
-      car: 1,
-      isActive: false
-    },
-    {
-      id: '3',
-      fileName: 'Hi ',
-      dateUploaded: new Date('2025-02-24'),
-      percentRulesAssigned: 80,
-      car: 1,
-      isActive: false
-    },
-    {
-      id: '3',
-      fileName: 'Hi ',
-      dateUploaded: new Date('2025-02-24'),
-      percentRulesAssigned: 80,
-      car: 1,
-      isActive: false
-    },
-    {
-      id: '3',
-      fileName: 'Hi ',
-      dateUploaded: new Date('2025-02-24'),
-      percentRulesAssigned: 80,
-      car: 1,
-      isActive: false
-    },
-    {
-      id: '3',
-      fileName: 'Hi ',
-      dateUploaded: new Date('2025-02-24'),
-      percentRulesAssigned: 80,
-      car: 1,
-      isActive: false
-    },
-    {
-      id: '3',
-      fileName: 'Hi ',
-      dateUploaded: new Date('2025-02-24'),
-      percentRulesAssigned: 80,
-      car: 1,
-      isActive: false
-    },
-    {
-      id: '3',
-      fileName: 'Hi ',
-      dateUploaded: new Date('2025-02-24'),
-      percentRulesAssigned: 80,
-      car: 1,
-      isActive: false
-    },
-    {
-      id: '3',
-      fileName: 'Hi ',
-      dateUploaded: new Date('2025-02-24'),
-      percentRulesAssigned: 80,
-      car: 1,
-      isActive: false
-    },
-    {
-      id: '3',
-      fileName: 'Hi ',
-      dateUploaded: new Date('2025-02-24'),
-      percentRulesAssigned: 80,
-      car: 1,
-      isActive: false
-    },
-    {
-      id: '3',
-      fileName: 'Hi ',
-      dateUploaded: new Date('2025-02-24'),
-      percentRulesAssigned: 80,
-      car: 1,
-      isActive: false
-    }
-  ];
+  const handleEditRuleset = () => {
+    // Navigation logic to edit/assign rules pages
+    history.push(`/rules/${rulesetId}/edit`);
+  };
+
+  const handleViewRuleset = () => {
+    // Navigation logic to view rules pages
+    history.push(`/rules/${rulesetId}/view`);
+  };
+
+  if (isLoading) return <LoadingIndicator />;
+  if (error) return <ErrorPage message={error.message} />;
 
   return (
     <Box>
       {isMobile ? (
         <Stack spacing={2} sx={{ px: 1 }}>
-          {mockRulesets.map((ruleset) => (
+          {rulesets.map((ruleset: Ruleset) => (
             <Card
-              key={ruleset.id}
+              key={ruleset.rulesetId}
               sx={{
                 backgroundColor: '#121313',
                 borderRadius: '8px',
@@ -232,7 +86,7 @@ const RulesetTable: React.FC = () => {
             >
               <CardContent>
                 <Typography variant="h6" sx={{ color: '#dd514c', fontWeight: 600, mb: 2 }}>
-                  {ruleset.fileName}
+                  {ruleset.name}
                 </Typography>
                 <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
                   <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
@@ -240,7 +94,7 @@ const RulesetTable: React.FC = () => {
                       Date Uploaded:
                     </Typography>
                     <Typography variant="body2" sx={{ color: '#ededed' }}>
-                      {datePipe(ruleset.dateUploaded)}
+                      {datePipe(ruleset.dateCreated)}
                     </Typography>
                   </Box>
                   <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
@@ -248,7 +102,7 @@ const RulesetTable: React.FC = () => {
                       % of Rules Assigned:
                     </Typography>
                     <Typography variant="body2" sx={{ color: '#ededed' }}>
-                      {ruleset.percentRulesAssigned}
+                      {ruleset.assignedPercentage}
                     </Typography>
                   </Box>
                   <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
@@ -256,7 +110,7 @@ const RulesetTable: React.FC = () => {
                       Car:
                     </Typography>
                     <Typography variant="body2" sx={{ color: '#ededed' }}>
-                      {ruleset.car}
+                      {ruleset.car.carId}
                     </Typography>
                   </Box>
                   <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
@@ -264,10 +118,10 @@ const RulesetTable: React.FC = () => {
                       Active:
                     </Typography>
                     <Typography variant="body2" sx={{ color: '#ededed' }}>
-                      {ruleset.isActive}
+                      {ruleset.active}
                     </Typography>
                     <Checkbox
-                      checked={ruleset.isActive}
+                      checked={ruleset.active}
                       disabled // Read-only for now
                       sx={{
                         color: '#fff',
@@ -330,29 +184,29 @@ const RulesetTable: React.FC = () => {
             </TableHead>
             <TableBody sx={{ backgroundColor: '#121313' }}>
               {/* Table rows with ruleset data */}
-              {mockRulesets.length === 0 ? (
+              {rulesets.length === 0 ? (
                 <TableRow>
                   <TableCell colSpan={6} align="center" sx={{ color: '#999', padding: '15px' }}>
                     No Rulesets Found
                   </TableCell>
                 </TableRow>
               ) : (
-                mockRulesets.map((ruleset) => (
+                rulesets.map((ruleset: Ruleset) => (
                   <TableRow
-                    key={ruleset.id}
+                    key={ruleset.rulesetId}
                     sx={{
                       '&:last-child td, &:last-child th': { border: 0 }
                     }}
                   >
                     <TableCell align="center" sx={{ maxWidth: '20vw' }}>
-                      {ruleset.fileName}
+                      {ruleset.name}
                     </TableCell>
-                    <TableCell align="center">{datePipe(ruleset.dateUploaded)}</TableCell>
-                    <TableCell align="center">{ruleset.percentRulesAssigned}%</TableCell>
-                    <TableCell align="center">{ruleset.car}</TableCell>
+                    <TableCell align="center">{datePipe(ruleset.dateCreated)}</TableCell>
+                    <TableCell align="center">{ruleset.assignedPercentage}%</TableCell>
+                    <TableCell align="center">{ruleset.car.carId}</TableCell>
                     <TableCell align="center">
                       <Checkbox
-                        checked={ruleset.isActive}
+                        checked={ruleset.active}
                         disabled // Read-only for now
                         sx={{
                           color: '#fff',

--- a/src/frontend/src/pages/RulesPage/components/RulesetTable.tsx
+++ b/src/frontend/src/pages/RulesPage/components/RulesetTable.tsx
@@ -100,7 +100,7 @@ const RulesetTable: React.FC = () => {
                       Car:
                     </Typography>
                     <Typography variant="body2" sx={{ color: '#ededed' }}>
-                      {ruleset.car.carId}
+                      {ruleset.car.name}
                     </Typography>
                   </Box>
                   <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
@@ -195,7 +195,7 @@ const RulesetTable: React.FC = () => {
                     </TableCell>
                     <TableCell align="center">{datePipe(ruleset.dateCreated)}</TableCell>
                     <TableCell align="center">{ruleset.assignedPercentage}%</TableCell>
-                    <TableCell align="center">{ruleset.car.carId}</TableCell>
+                    <TableCell align="center">{ruleset.car.name}</TableCell>
                     <TableCell align="center">
                       <Checkbox
                         checked={ruleset.active}

--- a/src/frontend/src/pages/RulesPage/components/RulesetTable.tsx
+++ b/src/frontend/src/pages/RulesPage/components/RulesetTable.tsx
@@ -21,9 +21,10 @@ import { NERButton } from '../../../components/NERButton';
 import { useHistory, useParams } from 'react-router-dom';
 import LoadingIndicator from '../../../components/LoadingIndicator';
 import ErrorPage from '../../ErrorPage';
-import { useRulesetsByType } from '../../../hooks/rules.hooks';
+import { useRulesetsByType, useUpdateRuleset } from '../../../hooks/rules.hooks';
 import { Ruleset } from 'shared';
 import { routes } from '../../../utils/routes';
+import { useToast } from '../../../hooks/toasts.hooks';
 
 interface RulesetParams {
   rulesetTypeId: string;
@@ -31,6 +32,7 @@ interface RulesetParams {
 
 const RulesetTable: React.FC = () => {
   const { rulesetTypeId } = useParams<RulesetParams>();
+  const toast = useToast();
   const history = useHistory();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
@@ -39,6 +41,7 @@ const RulesetTable: React.FC = () => {
   // const [AddFileModalShow, setAddFileModalShow] = React.useState(false);
 
   const { data: rulesets = [], isLoading, error } = useRulesetsByType(rulesetTypeId);
+  const updateRuleset = useUpdateRuleset();
 
   // Table header configuration
   const headCells = [
@@ -49,6 +52,25 @@ const RulesetTable: React.FC = () => {
     { id: 'isActive', label: 'Active?' },
     { id: 'actions', label: 'Actions' }
   ];
+
+  const handleToggleActive = (ruleset: Ruleset) => {
+    updateRuleset.mutate(
+      {
+        rulesetId: ruleset.rulesetId,
+        name: ruleset.name,
+        isActive: !ruleset.active
+      },
+      {
+        onSuccess: () => {
+          toast.success(ruleset.active ? 'Ruleset deactivated' : 'Ruleset activated');
+        },
+        onError: (error: any) => {
+          const message = error.response?.data?.message || error.message;
+          toast.error(message);
+        }
+      }
+    );
+  };
 
   const handleEditRuleset = (rulesetId: string) => {
     history.push(routes.RULESET_EDIT.replace(':rulesetId', rulesetId));
@@ -112,7 +134,8 @@ const RulesetTable: React.FC = () => {
                     </Typography>
                     <Checkbox
                       checked={ruleset.active}
-                      disabled // Read-only for now
+                      onChange={() => handleToggleActive(ruleset)}
+                      disabled={updateRuleset.isLoading}
                       sx={{
                         color: '#fff',
                         '&.Mui-checked': { color: '#dd514c' }
@@ -199,7 +222,8 @@ const RulesetTable: React.FC = () => {
                     <TableCell align="center">
                       <Checkbox
                         checked={ruleset.active}
-                        disabled // Read-only for now
+                        onChange={() => handleToggleActive(ruleset)}
+                        disabled={updateRuleset.isLoading}
                         sx={{
                           color: '#fff',
                           '&.Mui-checked': { color: '#dd514c' }

--- a/src/frontend/src/pages/RulesPage/components/RulesetTable.tsx
+++ b/src/frontend/src/pages/RulesPage/components/RulesetTable.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Box,
   Paper,
@@ -14,20 +14,29 @@ import {
   CardContent,
   Typography,
   Stack,
-  Checkbox
+  Checkbox,
+  IconButton
 } from '@mui/material';
 import { datePipe } from '../../../utils/pipes';
 import { NERButton } from '../../../components/NERButton';
 import { useHistory, useParams } from 'react-router-dom';
 import LoadingIndicator from '../../../components/LoadingIndicator';
 import ErrorPage from '../../ErrorPage';
-import { useRulesetsByType, useUpdateRuleset } from '../../../hooks/rules.hooks';
+import { useDeleteRuleset, useRulesetsByType, useUpdateRuleset } from '../../../hooks/rules.hooks';
 import { Ruleset } from 'shared';
 import { routes } from '../../../utils/routes';
 import { useToast } from '../../../hooks/toasts.hooks';
+import { Delete } from '@mui/icons-material';
+import RulesetDeleteModal from './RulesetDeleteModal';
 
 interface RulesetParams {
   rulesetTypeId: string;
+}
+
+interface RulesetDeleteButtonProps {
+  rulesetId: string;
+  name: string;
+  onDelete: (rulesetId: string, name: string) => void;
 }
 
 const RulesetTable: React.FC = () => {
@@ -42,6 +51,7 @@ const RulesetTable: React.FC = () => {
 
   const { data: rulesets = [], isLoading, error } = useRulesetsByType(rulesetTypeId);
   const updateRuleset = useUpdateRuleset();
+  const { mutateAsync: deleteRuleset } = useDeleteRuleset();
 
   // Table header configuration
   const headCells = [
@@ -50,7 +60,8 @@ const RulesetTable: React.FC = () => {
     { id: 'percentRulesAssigned', label: '% of Rules Assigned' },
     { id: 'car', label: 'Car' },
     { id: 'isActive', label: 'Active?' },
-    { id: 'actions', label: 'Actions' }
+    { id: 'actions', label: 'Actions' },
+    { id: 'delete', label: '' }
   ];
 
   const handleToggleActive = (ruleset: Ruleset) => {
@@ -78,6 +89,36 @@ const RulesetTable: React.FC = () => {
 
   const handleViewRuleset = (rulesetId: string) => {
     history.push(routes.RULESET_VIEW.replace(':rulesetId', rulesetId));
+  };
+
+  const handleDeleteRuleset = async (rulesetId: string, name: string) => {
+    try {
+      await deleteRuleset(rulesetId);
+      toast.success(`Ruleset: ${name} deleted successfully!`);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        toast.error(error.message);
+      }
+    }
+  };
+
+  const RulesetDeleteButton: React.FC<RulesetDeleteButtonProps> = ({ rulesetId, name, onDelete }) => {
+    const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+    const handleDeleteSubmit = () => {
+      onDelete(rulesetId, name);
+      setShowDeleteModal(false);
+    };
+    return (
+      <>
+        <IconButton type="button" sx={{ mx: 1 }} onClick={() => setShowDeleteModal(true)}>
+          <Delete />
+        </IconButton>
+        {showDeleteModal && (
+          <RulesetDeleteModal rulesetName={name} onDelete={handleDeleteSubmit} onHide={() => setShowDeleteModal(false)} />
+        )}
+      </>
+    );
   };
 
   if (isLoading) return <LoadingIndicator />;
@@ -174,6 +215,7 @@ const RulesetTable: React.FC = () => {
                     >
                       View Rules
                     </NERButton>
+                    <RulesetDeleteButton rulesetId={ruleset.rulesetId} name={ruleset.name} onDelete={handleDeleteRuleset} />
                   </Box>
                 </Box>
               </CardContent>
@@ -262,6 +304,13 @@ const RulesetTable: React.FC = () => {
                       >
                         View Rules
                       </NERButton>
+                    </TableCell>
+                    <TableCell align="center" sx={{ width: '60px', paddingLeft: '0px' }}>
+                      <RulesetDeleteButton
+                        rulesetId={ruleset.rulesetId}
+                        name={ruleset.name}
+                        onDelete={handleDeleteRuleset}
+                      />
                     </TableCell>
                   </TableRow>
                 ))

--- a/src/frontend/src/pages/RulesPage/components/RulesetTable.tsx
+++ b/src/frontend/src/pages/RulesPage/components/RulesetTable.tsx
@@ -23,22 +23,14 @@ import LoadingIndicator from '../../../components/LoadingIndicator';
 import ErrorPage from '../../ErrorPage';
 import { useRulesetsByType } from '../../../hooks/rules.hooks';
 import { Ruleset } from 'shared';
-
-interface RulesetRow {
-  id: string;
-  fileName: string;
-  dateUploaded: Date;
-  percentRulesAssigned: number;
-  car: number;
-  isActive: boolean;
-}
+import { routes } from '../../../utils/routes';
 
 interface RulesetParams {
-  rulesetId: string;
+  rulesetTypeId: string;
 }
 
 const RulesetTable: React.FC = () => {
-  const { rulesetId } = useParams<RulesetParams>();
+  const { rulesetTypeId } = useParams<RulesetParams>();
   const history = useHistory();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
@@ -46,7 +38,7 @@ const RulesetTable: React.FC = () => {
   // Add file upload logic
   // const [AddFileModalShow, setAddFileModalShow] = React.useState(false);
 
-  const { data: rulesets = [], isLoading, error } = useRulesetsByType(rulesetId);
+  const { data: rulesets = [], isLoading, error } = useRulesetsByType(rulesetTypeId);
 
   // Table header configuration
   const headCells = [
@@ -58,14 +50,12 @@ const RulesetTable: React.FC = () => {
     { id: 'actions', label: 'Actions' }
   ];
 
-  const handleEditRuleset = () => {
-    // Navigation logic to edit/assign rules pages
-    history.push(`/rules/${rulesetId}/edit`);
+  const handleEditRuleset = (rulesetId: string) => {
+    history.push(routes.RULESET_EDIT.replace(':rulesetId', rulesetId));
   };
 
-  const handleViewRuleset = () => {
-    // Navigation logic to view rules pages
-    history.push(`/rules/${rulesetId}/view`);
+  const handleViewRuleset = (rulesetId: string) => {
+    history.push(routes.RULESET_VIEW.replace(':rulesetId', rulesetId));
   };
 
   if (isLoading) return <LoadingIndicator />;
@@ -131,6 +121,7 @@ const RulesetTable: React.FC = () => {
                   </Box>
                   <Box sx={{ display: 'flex', justifyContent: 'center' }}>
                     <NERButton
+                      onClick={() => handleEditRuleset(ruleset.rulesetId)}
                       sx={{
                         backgroundColor: theme.palette.grey[800],
                         color: theme.palette.getContrastText(theme.palette.grey[600]),
@@ -146,6 +137,7 @@ const RulesetTable: React.FC = () => {
                       Edit/Assign Rules
                     </NERButton>
                     <NERButton
+                      onClick={() => handleViewRuleset(ruleset.rulesetId)}
                       sx={{
                         backgroundColor: theme.palette.grey[800],
                         color: theme.palette.getContrastText(theme.palette.grey[600]),
@@ -216,6 +208,7 @@ const RulesetTable: React.FC = () => {
                     </TableCell>
                     <TableCell align="center">
                       <NERButton
+                        onClick={() => handleEditRuleset(ruleset.rulesetId)}
                         sx={{
                           backgroundColor: theme.palette.grey[800],
                           color: theme.palette.getContrastText(theme.palette.grey[600]),
@@ -231,6 +224,7 @@ const RulesetTable: React.FC = () => {
                         Edit/Assign Rules
                       </NERButton>
                       <NERButton
+                        onClick={() => handleViewRuleset(ruleset.rulesetId)}
                         sx={{
                           backgroundColor: theme.palette.grey[800],
                           color: theme.palette.getContrastText(theme.palette.grey[600]),

--- a/src/frontend/src/pages/RulesPage/components/RulesetTypeDeleteModal.tsx
+++ b/src/frontend/src/pages/RulesPage/components/RulesetTypeDeleteModal.tsx
@@ -1,0 +1,27 @@
+import { Typography } from '@mui/material';
+import NERModal from '../../../components/NERModal';
+
+interface RulesetTypeDeleteModalProps {
+  rulesetTypeName: string;
+  onDelete: () => void;
+  onHide: () => void;
+}
+
+const RulesetTypeDeleteModal: React.FC<RulesetTypeDeleteModalProps> = ({ rulesetTypeName, onDelete, onHide }) => {
+  return (
+    <NERModal
+      open={true}
+      onHide={onHide}
+      title="Warning!"
+      cancelText="Cancel"
+      submitText="Delete"
+      onSubmit={onDelete}
+      formId="ruleset-type-delete"
+    >
+      <Typography>Are you sure you want to delete this ruleset type?</Typography>
+      <Typography sx={{ mt: 1.5, fontWeight: 600 }}>{rulesetTypeName}</Typography>
+    </NERModal>
+  );
+};
+
+export default RulesetTypeDeleteModal;

--- a/src/frontend/src/pages/RulesPage/components/RulesetTypeTable.tsx
+++ b/src/frontend/src/pages/RulesPage/components/RulesetTypeTable.tsx
@@ -13,30 +13,42 @@ import {
   CardContent,
   Typography,
   Stack,
-  Link
+  IconButton
 } from '@mui/material';
-import { Link as RouterLink, useHistory } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import { datePipe } from '../../../utils/pipes';
 import { routes } from '../../../utils/routes';
-import { useAllRulesetTypes } from '../../../hooks/rules.hooks';
+import { useAllRulesetTypes, useDeleteRulesetType } from '../../../hooks/rules.hooks';
 import LoadingIndicator from '../../../components/LoadingIndicator';
 import ErrorPage from '../../ErrorPage';
 import { RulesetType } from 'shared';
 import { NERButton } from '../../../components/NERButton';
+import { useToast } from '../../../hooks/toasts.hooks';
+import { useState } from 'react';
+import RulesetTypeDeleteModal from './RulesetTypeDeleteModal';
+import { Delete } from '@mui/icons-material';
 
-type RulesetTypeColumnId = 'id' | 'name' | 'lastUpdated' | 'revisions' | 'actions';
+type RulesetTypeColumnId = 'id' | 'name' | 'lastUpdated' | 'revisions' | 'actions' | 'delete';
 
 interface RulesetTypeHeadCell {
   id: RulesetTypeColumnId;
   label: string;
 }
 
+interface RulesetTypeDeleteButtonProps {
+  rulesetTypeId: string;
+  name: string;
+  onDelete: (rulesetTypeId: string, name: string) => void;
+}
+
 const RulesetTypeTable: React.FC = () => {
   const history = useHistory();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+  const toast = useToast();
 
   const { data: rulesetTypes = [], isLoading, error } = useAllRulesetTypes();
+  const { mutateAsync: deleteRulesetType } = useDeleteRulesetType();
 
   const headCells: readonly RulesetTypeHeadCell[] = [
     {
@@ -54,11 +66,56 @@ const RulesetTypeTable: React.FC = () => {
     {
       id: 'actions',
       label: 'Actions'
+    },
+    {
+      id: 'delete',
+      label: ''
     }
   ];
 
   const handleViewRulesetType = (rulesetTypeId: string) => {
     history.push(routes.RULESET_BY_ID.replace(':rulesetTypeId', rulesetTypeId));
+  };
+
+  const handleDeleteRulesetType = async (rulesetTypeId: string, name: string) => {
+    const rulesetType = rulesetTypes.find((rt) => rt.rulesetTypeId === rulesetTypeId);
+    if (rulesetType && rulesetType.revisionFiles.length > 0) {
+      toast.error('Cannot delete ruleset type with existing revisions');
+      return;
+    }
+
+    try {
+      await deleteRulesetType(rulesetTypeId);
+      toast.success(`Ruleset Type: ${name} deleted successfully!`);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        toast.error(error.message);
+      }
+    }
+  };
+
+  const RulesetTypeDeleteButton: React.FC<RulesetTypeDeleteButtonProps> = ({ rulesetTypeId, name, onDelete }) => {
+    const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+    const handleDeleteSubmit = () => {
+      onDelete(rulesetTypeId, name);
+      setShowDeleteModal(false);
+    };
+
+    return (
+      <>
+        <IconButton type="button" sx={{ mx: 1 }} onClick={() => setShowDeleteModal(true)}>
+          <Delete />
+        </IconButton>
+        {showDeleteModal && (
+          <RulesetTypeDeleteModal
+            rulesetTypeName={name}
+            onDelete={handleDeleteSubmit}
+            onHide={() => setShowDeleteModal(false)}
+          />
+        )}
+      </>
+    );
   };
 
   if (isLoading) return <LoadingIndicator />;
@@ -115,6 +172,11 @@ const RulesetTypeTable: React.FC = () => {
                     >
                       View Rulesets
                     </NERButton>
+                    <RulesetTypeDeleteButton
+                      rulesetTypeId={rulesetType.rulesetTypeId}
+                      name={rulesetType.name}
+                      onDelete={handleDeleteRulesetType}
+                    />
                   </Box>
                 </Box>
               </CardContent>
@@ -154,32 +216,10 @@ const RulesetTypeTable: React.FC = () => {
                     }}
                   >
                     <TableCell align="center" sx={{ maxWidth: '20vw' }}>
-                      <Link
-                        component={RouterLink}
-                        to={routes.RULESET_BY_ID.replace(':rulesetId', rulesetType.rulesetTypeId)}
-                        sx={{ color: 'inherit', textDecoration: 'none' }}
-                      >
-                        {rulesetType.name}
-                      </Link>
+                      {rulesetType.name}
                     </TableCell>
-                    <TableCell align="center">
-                      <Link
-                        component={RouterLink}
-                        to={routes.RULESET_BY_ID.replace(':rulesetId', rulesetType.rulesetTypeId)}
-                        sx={{ color: 'inherit', textDecoration: 'none' }}
-                      >
-                        {datePipe(rulesetType.lastUpdated)}
-                      </Link>
-                    </TableCell>
-                    <TableCell align="center">
-                      <Link
-                        component={RouterLink}
-                        to={routes.RULESET_BY_ID.replace(':rulesetId', rulesetType.rulesetTypeId)}
-                        sx={{ color: 'inherit', textDecoration: 'none' }}
-                      >
-                        {rulesetType.revisionFiles.length}
-                      </Link>
-                    </TableCell>
+                    <TableCell align="center">{datePipe(rulesetType.lastUpdated)}</TableCell>
+                    <TableCell align="center">{rulesetType.revisionFiles.length}</TableCell>
                     <TableCell align="center">
                       <NERButton
                         sx={{
@@ -197,6 +237,13 @@ const RulesetTypeTable: React.FC = () => {
                       >
                         View Rulesets
                       </NERButton>
+                    </TableCell>
+                    <TableCell align="center" sx={{ width: '60px', paddingLeft: '0px' }}>
+                      <RulesetTypeDeleteButton
+                        rulesetTypeId={rulesetType.rulesetTypeId}
+                        name={rulesetType.name}
+                        onDelete={handleDeleteRulesetType}
+                      />
                     </TableCell>
                   </TableRow>
                 ))

--- a/src/frontend/src/pages/RulesPage/components/RulesetTypeTable.tsx
+++ b/src/frontend/src/pages/RulesPage/components/RulesetTypeTable.tsx
@@ -58,7 +58,7 @@ const RulesetTypeTable: React.FC = () => {
   ];
 
   const handleViewRulesetType = (rulesetTypeId: string) => {
-    history.push(routes.RULESET_BY_ID.replace(':rulesetId', rulesetTypeId));
+    history.push(routes.RULESET_BY_ID.replace(':rulesetTypeId', rulesetTypeId));
   };
 
   if (isLoading) return <LoadingIndicator />;

--- a/src/frontend/src/pages/RulesPage/components/RulesetTypeTable.tsx
+++ b/src/frontend/src/pages/RulesPage/components/RulesetTypeTable.tsx
@@ -113,7 +113,7 @@ const RulesetTypeTable: React.FC = () => {
                       }}
                       onClick={() => handleViewRulesetType(rulesetType.rulesetTypeId)}
                     >
-                      View Ruleset
+                      View Rulesets
                     </NERButton>
                   </Box>
                 </Box>
@@ -195,7 +195,7 @@ const RulesetTypeTable: React.FC = () => {
                         }}
                         onClick={() => handleViewRulesetType(rulesetType.rulesetTypeId)}
                       >
-                        View Ruleset
+                        View Rulesets
                       </NERButton>
                     </TableCell>
                   </TableRow>

--- a/src/frontend/src/pages/RulesPage/components/RulesetTypeTable.tsx
+++ b/src/frontend/src/pages/RulesPage/components/RulesetTypeTable.tsx
@@ -57,7 +57,7 @@ const RulesetTypeTable: React.FC = () => {
     }
   ];
 
-  const handleViewRuleset = (rulesetTypeId: string) => {
+  const handleViewRulesetType = (rulesetTypeId: string) => {
     history.push(routes.RULESET_BY_ID.replace(':rulesetId', rulesetTypeId));
   };
 
@@ -111,7 +111,7 @@ const RulesetTypeTable: React.FC = () => {
                         lineHeight: 1,
                         borderRadius: '6px'
                       }}
-                      onClick={() => handleViewRuleset(rulesetType.rulesetTypeId)}
+                      onClick={() => handleViewRulesetType(rulesetType.rulesetTypeId)}
                     >
                       View Ruleset
                     </NERButton>
@@ -193,7 +193,7 @@ const RulesetTypeTable: React.FC = () => {
                           lineHeight: 1,
                           borderRadius: '6px'
                         }}
-                        onClick={() => handleViewRuleset(rulesetType.rulesetTypeId)}
+                        onClick={() => handleViewRulesetType(rulesetType.rulesetTypeId)}
                       >
                         View Ruleset
                       </NERButton>

--- a/src/frontend/src/utils/routes.ts
+++ b/src/frontend/src/utils/routes.ts
@@ -82,9 +82,9 @@ const RETROSPECTIVE = `/retrospective`;
 
 /**************** Rules ****************/
 const RULES = `/rules`;
-const RULESET_BY_ID = RULES + `/:rulesetId`;
-const RULESET_VIEW = RULESET_BY_ID + `/view`;
-const RULESET_EDIT = RULESET_BY_ID + `/edit`;
+const RULESET_BY_ID = RULES + `/:rulesetTypeId`;
+const RULESET_VIEW = RULES + `/ruleset/:rulesetId/view`; 
+const RULESET_EDIT = RULES + `/ruleset/:rulesetId/edit`;
 
 export const routes = {
   BASE,

--- a/src/frontend/src/utils/routes.ts
+++ b/src/frontend/src/utils/routes.ts
@@ -83,7 +83,7 @@ const RETROSPECTIVE = `/retrospective`;
 /**************** Rules ****************/
 const RULES = `/rules`;
 const RULESET_BY_ID = RULES + `/:rulesetTypeId`;
-const RULESET_VIEW = RULES + `/ruleset/:rulesetId/view`; 
+const RULESET_VIEW = RULES + `/ruleset/:rulesetId/view`;
 const RULESET_EDIT = RULES + `/ruleset/:rulesetId/edit`;
 
 export const routes = {

--- a/src/frontend/src/utils/urls.ts
+++ b/src/frontend/src/utils/urls.ts
@@ -448,6 +448,8 @@ const ruleset = () => `${rules()}/ruleset`;
 const rulesetTypeCreate = () => `${rules()}/rulesetType/create`;
 const rulesetsCreate = () => `${ruleset()}/create`;
 const rulesetUpdate = (rulesetId: string) => `${ruleset()}/${rulesetId}/update`;
+const rulesetDelete = (rulesetId: string) => `${ruleset()}/${rulesetId}/delete`;
+const rulesetTypeDelete = (rulesetTypeId: string) => `${rules()}/rulesetType/${rulesetTypeId}/delete`;
 
 /**************** Other Endpoints ****************/
 const version = () => `https://api.github.com/repos/Northeastern-Electric-Racing/FinishLine/releases/latest`;
@@ -762,6 +764,8 @@ export const apiUrls = {
   rulesetTypeCreate,
   rulesetsCreate,
   rulesetUpdate,
+  rulesetDelete,
+  rulesetTypeDelete,
 
   version
 };

--- a/src/frontend/src/utils/urls.ts
+++ b/src/frontend/src/utils/urls.ts
@@ -447,6 +447,7 @@ const rulesetsByType = (rulesetTypeId: string) => `${rules()}/rulesets/${ruleset
 const ruleset = () => `${rules()}/ruleset`;
 const rulesetTypeCreate = () => `${rules()}/rulesetType/create`;
 const rulesetsCreate = () => `${ruleset()}/create`;
+const rulesetUpdate = (rulesetId: string) => `${ruleset()}/${rulesetId}/update`;
 
 /**************** Other Endpoints ****************/
 const version = () => `https://api.github.com/repos/Northeastern-Electric-Racing/FinishLine/releases/latest`;
@@ -760,6 +761,7 @@ export const apiUrls = {
   rulesetsByType,
   rulesetTypeCreate,
   rulesetsCreate,
+  rulesetUpdate,
 
   version
 };


### PR DESCRIPTION
## Changes

Ruleset table now displays all the rulesets for the ruleset type. Edit and view buttons are functional. Active checkbox clickable and enforces one active ruleset per ruleset type

## Notes

- Updated routes to use /:rulesetTypeId for table and /ruleset/:rulesetId for view and edit 
- ruleset **preview** query args and transformer unused so were removed

## Screenshots
<img width="1440" height="861" alt="Screenshot 2026-01-02 at 12 17 24 PM" src="https://github.com/user-attachments/assets/21da73aa-84f4-4261-a781-585f9fa6c004" />

<img width="1439" height="851" alt="Screenshot 2026-01-02 at 12 17 05 PM" src="https://github.com/user-attachments/assets/068d2fdf-2c46-405e-9543-abcd5a8035c1" />

<img width="671" height="859" alt="Screenshot 2026-01-02 at 12 17 57 PM" src="https://github.com/user-attachments/assets/218b1d4d-ef80-4fc1-9aec-60fbd3eda3de" />

<img width="828" height="861" alt="Screenshot 2026-01-01 at 10 25 46 PM" src="https://github.com/user-attachments/assets/e2bc3400-90d7-46ce-a57f-58410f2cc826" />


<img width="1432" height="371" alt="Screenshot 2026-01-02 at 11 23 28 PM" src="https://github.com/user-attachments/assets/497fe5e7-ae84-4896-b323-4f6706990e5b" />

<img width="1369" height="379" alt="Screenshot 2026-01-02 at 11 23 41 PM" src="https://github.com/user-attachments/assets/21e7d453-8db6-46e5-8121-d5509af4f6b9" />

---

**DELETION screenshots**
<img width="1435" height="551" alt="Screenshot 2026-01-03 at 7 10 19 PM" src="https://github.com/user-attachments/assets/61d7cbad-d3fb-4bfa-ba83-82236b0c399b" />
<img width="1439" height="854" alt="Screenshot 2026-01-03 at 7 10 36 PM" src="https://github.com/user-attachments/assets/cdd4aec4-1062-4cec-beb0-7efaa122f83a" />


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3844
