### PR TITLE
#3853 Rules Team View

### DIFF
--- a/src/frontend/src/pages/RulesPage/RuleRow.tsx
+++ b/src/frontend/src/pages/RulesPage/RuleRow.tsx
@@ -25,6 +25,7 @@ interface RuleRowProps {
   leftWidth?: string;
   middleWidth?: string;
   rightWidth?: string;
+  initiallyExpanded?: boolean;
 }
 
 /**
@@ -47,9 +48,10 @@ const RuleRow: React.FC<RuleRowProps> = ({
   horizontalPadding = '16px',
   leftWidth = '20%',
   middleWidth = '70%',
-  rightWidth = '10%'
+  rightWidth = '10%',
+  initiallyExpanded = false
 }) => {
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(initiallyExpanded);
   const hasSubRules = rule.subRuleIds.length > 0;
   const subRules = allRules.filter((r) => rule.subRuleIds.includes(r.ruleId));
 

--- a/src/frontend/src/pages/RulesPage/RulesetViewPage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetViewPage.tsx
@@ -8,6 +8,54 @@ import { useParams } from 'react-router-dom';
 import { useSingleRuleset } from './RulesetEditPage';
 import ErrorPage from '../ErrorPage';
 import LoadingIndicator from '../../components/LoadingIndicator';
+import { Rule } from 'shared';
+import RulesetTeamView, { TeamRules } from './components/RulesetTeamView';
+
+/**
+ * Mock function to organize rules by team and project
+ * TODO: Replace with actual API calls after parsing PR is merged
+ * Will need to call:
+ * - GET /rules/:rulesetTypeId/team/:teamId for team rules
+ * - GET /rules/ruleset/:rulesetId/project/:projectId/rules for project rules
+ * - GET /rules/ruleset/:rulesetId/team/:teamId/rules/unassigned for unassigned team rules
+ */
+const getMockTeamOrganization = (allRules: Rule[]): { teamRules: TeamRules[]; unassignedToTeam: Rule[] } => {
+  const teamRules: TeamRules[] = [
+    {
+      teamId: 'team1',
+      teamName: 'Chassis Team',
+      projects: [
+        {
+          projectId: 'proj1',
+          projectName: 'NER-24 Chassis',
+          rules: allRules.filter((r) => ['1', '13'].includes(r.ruleId)) // GR and F
+        },
+        {
+          projectId: 'proj2',
+          projectName: 'Suspension Design',
+          rules: allRules.filter((r) => r.ruleId === '8') // V.3.1
+        }
+      ],
+      unassignedRules: allRules.filter((r) => r.ruleId === '2') // AD
+    },
+    {
+      teamId: 'team2',
+      teamName: 'Electrical Team',
+      projects: [
+        {
+          projectId: 'proj3',
+          projectName: 'Battery Management System',
+          rules: allRules.filter((r) => ['5', '6'].includes(r.ruleId)) // V.1, V.2
+        }
+      ],
+      unassignedRules: []
+    }
+  ];
+
+  const unassignedToTeam = allRules.filter((r) => ['4', '7', '9'].includes(r.ruleId));
+
+  return { teamRules, unassignedToTeam };
+};
 
 const RulesetViewPage = () => {
   const [tabIndex, setTabIndex] = useState<number>(0);
@@ -19,6 +67,9 @@ const RulesetViewPage = () => {
   const { rulesetId } = useParams<{ rulesetId: string }>();
 
   const { data: ruleset, isError, error, isLoading } = useSingleRuleset(rulesetId);
+
+  // team organization mock for now
+  const { teamRules, unassignedToTeam } = getMockTeamOrganization(ruleset.rules);
 
   if (isError) {
     return <ErrorPage error={error} />;
@@ -45,11 +96,13 @@ const RulesetViewPage = () => {
           </Box>
         }
       >
-        {tabIndex === 0 ? (
-          <Typography>Team View rules table PLACEHOLDER</Typography>
-        ) : (
-          <Typography>General View rules table PLACEHOLDER</Typography>
-        )}
+        <Box sx={{ width: '100%', borderRadius: '8px 8px 0 0' }}>
+          {tabIndex === 0 ? (
+            <RulesetTeamView allRules={ruleset.rules} teamRules={teamRules} unassignedToTeam={unassignedToTeam} />
+          ) : (
+            <Typography>General View rules table PLACEHOLDER</Typography>
+          )}
+        </Box>
       </PageLayout>
     </Box>
   );

--- a/src/frontend/src/pages/RulesPage/components/RulesetTeamView.tsx
+++ b/src/frontend/src/pages/RulesPage/components/RulesetTeamView.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { Box, Paper, Table, TableBody, TableContainer } from '@mui/material';
+import { Rule } from 'shared';
+import RuleRow from '../RuleRow';
+
+interface TeamProject {
+  projectId: string;
+  projectName: string;
+  rules: Rule[];
+}
+
+interface TeamRules {
+  teamId: string;
+  teamName: string;
+  projects: TeamProject[];
+  unassignedRules: Rule[];
+}
+
+interface RulesetTeamViewProps {
+  allRules: Rule[];
+  teamRules: TeamRules[];
+  unassignedToTeam: Rule[];
+}
+
+/**
+ * Displays rules organized by team and project
+ * Teams and projects are rendered as RuleRows for consistent formatting
+ */
+const RulesetTeamView: React.FC<RulesetTeamViewProps> = ({ allRules, teamRules, unassignedToTeam }) => {
+  // Convert teams to mock rules for rendering with RuleRow
+  const teamRulesAsRules: Rule[] = teamRules.map((team) => ({
+    ruleId: `team-${team.teamId}`,
+    ruleCode: `${team.teamName}`,
+    ruleContent: '',
+    imageFileIds: [],
+    parentRule: undefined,
+    subRuleIds: [
+      ...team.projects.map((p) => `project-${p.projectId}`),
+      ...(team.unassignedRules.length > 0 ? [`team-${team.teamId}-unassigned`] : [])
+    ],
+    referencedRuleIds: []
+  }));
+
+  // Convert projects to mock rules for rendering with RuleRow
+  const projectRulesAsRules: Rule[] = teamRules.flatMap((team) =>
+    team.projects.map((project) => ({
+      ruleId: `project-${project.projectId}`,
+      ruleCode: `${project.projectName}`,
+      ruleContent: '',
+      imageFileIds: [],
+      parentRule: {
+        ruleId: `team-${team.teamId}`,
+        ruleCode: `${team.teamName}`
+      },
+      subRuleIds: project.rules.map((r) => r.ruleId),
+      referencedRuleIds: []
+    }))
+  );
+
+  // Convert unassigned to project sections to mock rules
+  const unassignedToProjectRules: Rule[] = teamRules
+    .filter((team) => team.unassignedRules.length > 0)
+    .map((team) => ({
+      ruleId: `team-${team.teamId}-unassigned`,
+      ruleCode: 'Unassigned Rules - Unassigned to Project',
+      ruleContent: '',
+      imageFileIds: [],
+      parentRule: {
+        ruleId: `team-${team.teamId}`,
+        ruleCode: `${team.teamName}`
+      },
+      subRuleIds: team.unassignedRules.map((r) => r.ruleId),
+      referencedRuleIds: []
+    }));
+
+  // Create unassigned to team mock rule
+  const unassignedToTeamRule: Rule | null =
+    unassignedToTeam.length > 0
+      ? {
+          ruleId: 'unassigned-to-team',
+          ruleCode: 'Unassigned Rules - Unassigned to Team',
+          ruleContent: '',
+          imageFileIds: [],
+          parentRule: undefined,
+          subRuleIds: unassignedToTeam.map((r) => r.ruleId),
+          referencedRuleIds: []
+        }
+      : null;
+
+  // mock team/project rules + actual rules
+  const allRulesIncludingMock = [
+    ...teamRulesAsRules,
+    ...projectRulesAsRules,
+    ...unassignedToProjectRules,
+    ...(unassignedToTeamRule ? [unassignedToTeamRule] : []),
+    ...allRules
+  ];
+
+  // Top level items are teams and unassigned to team
+  const topLevelItems = [...teamRulesAsRules, ...(unassignedToTeamRule ? [unassignedToTeamRule] : [])];
+
+  return (
+    <Box>
+      <TableContainer component={Paper} sx={{ borderRadius: '8px', overflow: 'hidden' }}>
+        <Table sx={{ borderCollapse: 'collapse' }}>
+          <TableBody sx={{ backgroundColor: '#9d9d9d' }}>
+            {topLevelItems.map((item) => (
+              <RuleRow
+                key={item.ruleId}
+                rule={item}
+                allRules={allRulesIncludingMock}
+                rightContent={() => null}
+                backgroundColor="#9d9d9d"
+                textColor="#000000"
+                hoverColor="#5e5e5e"
+                rowHeight="10px"
+                verticalPadding="5px"
+                initiallyExpanded={item.ruleId.startsWith('team-')}
+              />
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Box>
+  );
+};
+
+export default RulesetTeamView;
+export type { TeamProject, TeamRules };


### PR DESCRIPTION
## Changes

Team View for ruleset (with mock data currently until parsing pr merged). Used RuleRow component for all teams, projects, and rules in their categories.

Team dropdowns are by default open when the page loads

## Notes

Compared to the epic the formatting is a bit different just bc I used the already existing RuleRow but we can always update this later to look better

## Screenshots

<img width="829" height="226" alt="Screenshot 2026-01-03 at 8 05 40 PM" src="https://github.com/user-attachments/assets/efd3e7ea-b7a0-4f03-81f3-7192e5cbe5dc" />

<img width="793" height="443" alt="Screenshot 2026-01-03 at 8 05 49 PM" src="https://github.com/user-attachments/assets/0c36474e-9610-48bc-a6db-c7b34f4d0fe8" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3853
