### PR TITLE
#3778 created rule history modal

### DIFF
--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectRules/ProjectRulesTab.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectRules/ProjectRulesTab.tsx
@@ -34,8 +34,6 @@ import {
 } from '../../../../hooks/rules.hooks';
 import { useToast } from '../../../../hooks/toasts.hooks';
 import { InfoOutlined } from '@mui/icons-material';
-import NERModal from '../../../../components/NERModal';
-import NERFailButton from '../../../../components/NERFailButton';
 import { RuleHistoryModal } from './RuleHistoryModal';
 
 interface ProjectRulesTabProps {

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectRules/ProjectRulesTab.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectRules/ProjectRulesTab.tsx
@@ -66,8 +66,8 @@ export const ProjectRulesTab = ({ project }: ProjectRulesTabProps) => {
   const [addRuleModalOpen, setAddRuleModalOpen] = useState(false);
   const [selectedProjectRule, setSelectedProjectRule] = useState<ProjectRule | null>(null);
 
-  const [selectedRuleForHistory, setSelectedRuleForHistory] = React.useState<Rule | null>(null);
-  const [showHistoryModal, setShowHistoryModal] = React.useState(false);
+  const [selectedRuleForHistory, setSelectedRuleForHistory] = useState<Rule | null>(null);
+  const [showHistoryModal, setShowHistoryModal] = useState(false);
 
   // Fetch all ruleset types
   const { data: rulesetTypes, isLoading: rulesetTypesLoading, isError: rulesetTypesError } = useAllRulesetTypes();
@@ -324,10 +324,28 @@ export const ProjectRulesTab = ({ project }: ProjectRulesTabProps) => {
         hideFormButtons={true}
         showCloseButton={false}
       >
-        <Box sx={{ minWidth: '400px' }}>
-          {statusHistory.length === 0 ? (
-            <Typography color="text.secondary">No status history available.</Typography>
-          ) : (
+        <Box sx={{ minWidth: '400px', display: 'flex', flexDirection: 'column' }}>
+          <Box
+            sx={{
+              maxHeight: '300px',
+              overflowY: 'auto',
+              mb: 3,
+              '&::-webkit-scrollbar': {
+                width: '8px'
+              },
+              '&::-webkit-scrollbar-track': {
+                backgroundColor: 'rgba(0,0,0,0.1)',
+                borderRadius: '4px'
+              },
+              '&::-webkit-scrollbar-thumb': {
+                backgroundColor: 'rgba(0,0,0,0.3)',
+                borderRadius: '4px',
+                '&:hover': {
+                  backgroundColor: 'rgba(0,0,0,0.5)'
+                }
+              }
+            }}
+          >
             <Box component="ul" sx={{ listStyle: 'none', padding: 0, margin: 0 }}>
               {statusHistory.map((history) => (
                 <Box
@@ -336,36 +354,28 @@ export const ProjectRulesTab = ({ project }: ProjectRulesTabProps) => {
                   sx={{
                     display: 'flex',
                     alignItems: 'center',
-                    gap: 2,
-                    py: 1,
-                    '&:not(:last-child)': {
-                      borderBottom: '1px solid',
-                      borderColor: 'divider'
-                    }
+                    gap: 1,
+                    py: 1
                   }}
                 >
-                  <Typography sx={{ fontSize: '14px', color: 'text.primary' }}>•</Typography>
-                  <Typography sx={{ fontSize: '14px', color: 'text.primary', minWidth: '90px' }}>
-                    {formatDate(history.dateCreated)}
-                  </Typography>
-                  <Typography sx={{ fontSize: '14px', color: 'text.primary' }}>-</Typography>
-                  <Typography sx={{ fontSize: '14px', color: 'text.primary', flex: 1 }}>
-                    {formatUserName(history.createdBy)} Marked as {getStatusLabel(history.newStatus)}
+                  <Typography sx={{ fontSize: '25', color: 'text.primary' }}>
+                    •{formatDate(history.dateCreated)} - {formatUserName(history.createdBy)} Marked as{' '}
+                    {getStatusLabel(history.newStatus)}
                   </Typography>
                 </Box>
               ))}
             </Box>
-          )}
-        </Box>
-        <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 3 }}>
-          <NERFailButton
-            onClick={() => {
-              setShowHistoryModal(false);
-              setSelectedRuleForHistory(null);
-            }}
-          >
-            Exit
-          </NERFailButton>
+          </Box>
+          <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+            <NERFailButton
+              onClick={() => {
+                setShowHistoryModal(false);
+                setSelectedRuleForHistory(null);
+              }}
+            >
+              Exit
+            </NERFailButton>
+          </Box>
         </Box>
       </NERModal>
     );

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectRules/ProjectRulesTab.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectRules/ProjectRulesTab.tsx
@@ -16,7 +16,8 @@ import {
   TableBody,
   TableContainer,
   Paper,
-  useTheme
+  useTheme,
+  IconButton
 } from '@mui/material';
 import { Project, ProjectRule, Rule, RuleCompletion } from 'shared';
 import LoadingIndicator from '../../../../components/LoadingIndicator';
@@ -32,6 +33,9 @@ import {
   useCreateProjectRule
 } from '../../../../hooks/rules.hooks';
 import { useToast } from '../../../../hooks/toasts.hooks';
+import { InfoOutlined } from '@mui/icons-material';
+import NERModal from '../../../../components/NERModal';
+import NERFailButton from '../../../../components/NERFailButton';
 
 interface ProjectRulesTabProps {
   project: Project;
@@ -61,6 +65,9 @@ export const ProjectRulesTab = ({ project }: ProjectRulesTabProps) => {
   const [statusPopoverAnchor, setStatusPopoverAnchor] = useState<HTMLElement | null>(null);
   const [addRuleModalOpen, setAddRuleModalOpen] = useState(false);
   const [selectedProjectRule, setSelectedProjectRule] = useState<ProjectRule | null>(null);
+
+  const [selectedRuleForHistory, setSelectedRuleForHistory] = React.useState<Rule | null>(null);
+  const [showHistoryModal, setShowHistoryModal] = React.useState(false);
 
   // Fetch all ruleset types
   const { data: rulesetTypes, isLoading: rulesetTypesLoading, isError: rulesetTypesError } = useAllRulesetTypes();
@@ -224,37 +231,143 @@ export const ProjectRulesTab = ({ project }: ProjectRulesTabProps) => {
       : getAggregatedStatus(rule);
     const statusConfig = getStatusConfig(status);
 
+    const projectRule = projectRules?.find((pr) => pr.rule.ruleId === rule.ruleId);
+
     return (
-      <Box
-        onClick={
-          isLeafRule
-            ? (e: React.MouseEvent<HTMLElement>) => {
-                e.stopPropagation();
-                handleStatusClick(e, rule);
+      <>
+        <Box
+          onClick={
+            isLeafRule
+              ? (e: React.MouseEvent<HTMLElement>) => {
+                  e.stopPropagation();
+                  handleStatusClick(e, rule);
+                }
+              : undefined
+          }
+          sx={{
+            backgroundColor: statusConfig.color,
+            color: 'white',
+            fontSize: '11px',
+            fontWeight: 600,
+            px: 0.75,
+            py: 0.25,
+            borderRadius: '3px',
+            cursor: isLeafRule ? 'pointer' : 'default',
+            display: 'inline-flex',
+            alignItems: 'center',
+            whiteSpace: 'nowrap',
+            '&:hover': isLeafRule
+              ? {
+                  opacity: 0.85
+                }
+              : {}
+          }}
+        >
+          {statusConfig.label}
+        </Box>
+        {isLeafRule && projectRule && projectRule.statusHistory && projectRule.statusHistory.length > 0 && (
+          <IconButton
+            size="small"
+            onClick={(e) => {
+              e.stopPropagation();
+              setSelectedRuleForHistory(rule);
+              setShowHistoryModal(true);
+            }}
+            sx={{
+              padding: '2px',
+              color: 'text.secondary',
+              '&:hover': {
+                color: 'primary.main'
               }
-            : undefined
-        }
-        sx={{
-          backgroundColor: statusConfig.color,
-          color: 'white',
-          fontSize: '11px',
-          fontWeight: 600,
-          px: 0.75,
-          py: 0.25,
-          borderRadius: '3px',
-          cursor: isLeafRule ? 'pointer' : 'default',
-          display: 'inline-flex',
-          alignItems: 'center',
-          whiteSpace: 'nowrap',
-          '&:hover': isLeafRule
-            ? {
-                opacity: 0.85
-              }
-            : {}
+            }}
+          >
+            <InfoOutlined fontSize="small" />
+          </IconButton>
+        )}
+      </>
+    );
+  };
+
+  const RuleHistoryModal = () => {
+    if (!selectedRuleForHistory) return null;
+
+    const projectRule = projectRules?.find((pr) => pr.rule.ruleId === selectedRuleForHistory.ruleId);
+    const statusHistory = projectRule?.statusHistory || [];
+
+    // don't we have a format date util function somewhere?
+    const formatDate = (date: Date) => {
+      return new Intl.DateTimeFormat('en-US', {
+        month: 'numeric',
+        day: 'numeric',
+        year: 'numeric'
+      }).format(date);
+    };
+
+    // do we have a util function for this already?
+    const formatUserName = (user: { firstName: string; lastName: string }) => {
+      return `${user.firstName} ${user.lastName}`;
+    };
+
+    const getStatusLabel = (status: RuleCompletion) => {
+      const config = getStatusConfig(status);
+      return config.label;
+    };
+
+    return (
+      <NERModal
+        open={showHistoryModal}
+        onHide={() => {
+          setShowHistoryModal(false);
+          setSelectedRuleForHistory(null);
         }}
+        title="History"
+        hideFormButtons={true}
+        showCloseButton={false}
       >
-        {statusConfig.label}
-      </Box>
+        <Box sx={{ minWidth: '400px' }}>
+          {statusHistory.length === 0 ? (
+            <Typography color="text.secondary">No status history available.</Typography>
+          ) : (
+            <Box component="ul" sx={{ listStyle: 'none', padding: 0, margin: 0 }}>
+              {statusHistory.map((history) => (
+                <Box
+                  component="li"
+                  key={history.historyId}
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 2,
+                    py: 1,
+                    '&:not(:last-child)': {
+                      borderBottom: '1px solid',
+                      borderColor: 'divider'
+                    }
+                  }}
+                >
+                  <Typography sx={{ fontSize: '14px', color: 'text.primary' }}>•</Typography>
+                  <Typography sx={{ fontSize: '14px', color: 'text.primary', minWidth: '90px' }}>
+                    {formatDate(history.dateCreated)}
+                  </Typography>
+                  <Typography sx={{ fontSize: '14px', color: 'text.primary' }}>-</Typography>
+                  <Typography sx={{ fontSize: '14px', color: 'text.primary', flex: 1 }}>
+                    {formatUserName(history.createdBy)} Marked as {getStatusLabel(history.newStatus)}
+                  </Typography>
+                </Box>
+              ))}
+            </Box>
+          )}
+        </Box>
+        <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 3 }}>
+          <NERFailButton
+            onClick={() => {
+              setShowHistoryModal(false);
+              setSelectedRuleForHistory(null);
+            }}
+          >
+            Exit
+          </NERFailButton>
+        </Box>
+      </NERModal>
     );
   };
 
@@ -375,6 +488,8 @@ export const ProjectRulesTab = ({ project }: ProjectRulesTabProps) => {
           onStatusChange={handleStatusUpdate}
         />
       )}
+
+      <RuleHistoryModal />
 
       {/* Add Rule Modal */}
       {activeRuleset && teamId && (

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectRules/ProjectRulesTab.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectRules/ProjectRulesTab.tsx
@@ -36,6 +36,7 @@ import { useToast } from '../../../../hooks/toasts.hooks';
 import { InfoOutlined } from '@mui/icons-material';
 import NERModal from '../../../../components/NERModal';
 import NERFailButton from '../../../../components/NERFailButton';
+import { RuleHistoryModal } from './RuleHistoryModal';
 
 interface ProjectRulesTabProps {
   project: Project;
@@ -288,99 +289,6 @@ export const ProjectRulesTab = ({ project }: ProjectRulesTabProps) => {
     );
   };
 
-  const RuleHistoryModal = () => {
-    if (!selectedRuleForHistory) return null;
-
-    const projectRule = projectRules?.find((pr) => pr.rule.ruleId === selectedRuleForHistory.ruleId);
-    const statusHistory = projectRule?.statusHistory || [];
-
-    // don't we have a format date util function somewhere?
-    const formatDate = (date: Date) => {
-      return new Intl.DateTimeFormat('en-US', {
-        month: 'numeric',
-        day: 'numeric',
-        year: 'numeric'
-      }).format(date);
-    };
-
-    // do we have a util function for this already?
-    const formatUserName = (user: { firstName: string; lastName: string }) => {
-      return `${user.firstName} ${user.lastName}`;
-    };
-
-    const getStatusLabel = (status: RuleCompletion) => {
-      const config = getStatusConfig(status);
-      return config.label;
-    };
-
-    return (
-      <NERModal
-        open={showHistoryModal}
-        onHide={() => {
-          setShowHistoryModal(false);
-          setSelectedRuleForHistory(null);
-        }}
-        title="History"
-        hideFormButtons={true}
-        showCloseButton={false}
-      >
-        <Box sx={{ minWidth: '400px', display: 'flex', flexDirection: 'column' }}>
-          <Box
-            sx={{
-              maxHeight: '300px',
-              overflowY: 'auto',
-              mb: 3,
-              '&::-webkit-scrollbar': {
-                width: '8px'
-              },
-              '&::-webkit-scrollbar-track': {
-                backgroundColor: 'rgba(0,0,0,0.1)',
-                borderRadius: '4px'
-              },
-              '&::-webkit-scrollbar-thumb': {
-                backgroundColor: 'rgba(0,0,0,0.3)',
-                borderRadius: '4px',
-                '&:hover': {
-                  backgroundColor: 'rgba(0,0,0,0.5)'
-                }
-              }
-            }}
-          >
-            <Box component="ul" sx={{ listStyle: 'none', padding: 0, margin: 0 }}>
-              {statusHistory.map((history) => (
-                <Box
-                  component="li"
-                  key={history.historyId}
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 1,
-                    py: 1
-                  }}
-                >
-                  <Typography sx={{ fontSize: '25', color: 'text.primary' }}>
-                    •{formatDate(history.dateCreated)} - {formatUserName(history.createdBy)} Marked as{' '}
-                    {getStatusLabel(history.newStatus)}
-                  </Typography>
-                </Box>
-              ))}
-            </Box>
-          </Box>
-          <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
-            <NERFailButton
-              onClick={() => {
-                setShowHistoryModal(false);
-                setSelectedRuleForHistory(null);
-              }}
-            >
-              Exit
-            </NERFailButton>
-          </Box>
-        </Box>
-      </NERModal>
-    );
-  };
-
   const tableBackgroundColor = theme.palette.background.paper;
   const tableTextColor = theme.palette.text.primary;
   const tableHoverColor = theme.palette.action.hover;
@@ -499,7 +407,15 @@ export const ProjectRulesTab = ({ project }: ProjectRulesTabProps) => {
         />
       )}
 
-      <RuleHistoryModal />
+      <RuleHistoryModal
+        open={showHistoryModal}
+        onClose={() => {
+          setShowHistoryModal(false);
+          setSelectedRuleForHistory(null);
+        }}
+        rule={selectedRuleForHistory}
+        projectRules={projectRules}
+      />
 
       {/* Add Rule Modal */}
       {activeRuleset && teamId && (

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectRules/RuleHistoryModal.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectRules/RuleHistoryModal.tsx
@@ -1,0 +1,101 @@
+import { Box, Typography, IconButton } from '@mui/material';
+import NERModal from '../../../../components/NERModal';
+import NERFailButton from '../../../../components/NERFailButton';
+import { Rule, ProjectRule, RuleCompletion } from 'shared';
+
+interface RuleHistoryModalProps {
+  open: boolean;
+  onClose: () => void;
+  rule: Rule | null;
+  projectRules?: ProjectRule[];
+}
+
+/**
+ * Get the status chip configuration
+ */
+const getStatusConfig = (status: RuleCompletion) => {
+  switch (status) {
+    case RuleCompletion.COMPLETED:
+      return { label: 'Complete', color: '#4caf50' };
+    case RuleCompletion.INCOMPLETE:
+      return { label: 'Incomplete', color: '#f44336' };
+    case RuleCompletion.REVIEW:
+    default:
+      return { label: 'Review', color: '#ff9800' };
+  }
+};
+
+export const RuleHistoryModal = ({ open, onClose, rule, projectRules }: RuleHistoryModalProps) => {
+  if (!rule) return null;
+
+  const projectRule = projectRules?.find((pr) => pr.rule.ruleId === rule.ruleId);
+  const statusHistory = projectRule?.statusHistory || [];
+
+  const formatDate = (date: Date) => {
+    return new Intl.DateTimeFormat('en-US', {
+      month: 'numeric',
+      day: 'numeric',
+      year: 'numeric'
+    }).format(date);
+  };
+
+  const formatUserName = (user: { firstName: string; lastName: string }) => {
+    return `${user.firstName} ${user.lastName}`;
+  };
+
+  const getStatusLabel = (status: RuleCompletion) => {
+    const config = getStatusConfig(status);
+    return config.label;
+  };
+
+  return (
+    <NERModal open={open} onHide={onClose} title="History" hideFormButtons={true} showCloseButton={false}>
+      <Box sx={{ minWidth: '400px', display: 'flex', flexDirection: 'column' }}>
+        <Box
+          sx={{
+            maxHeight: '300px',
+            overflowY: 'auto',
+            mb: 3,
+            '&::-webkit-scrollbar': {
+              width: '8px'
+            },
+            '&::-webkit-scrollbar-track': {
+              backgroundColor: 'rgba(0,0,0,0.1)',
+              borderRadius: '4px'
+            },
+            '&::-webkit-scrollbar-thumb': {
+              backgroundColor: 'rgba(0,0,0,0.3)',
+              borderRadius: '4px',
+              '&:hover': {
+                backgroundColor: 'rgba(0,0,0,0.5)'
+              }
+            }
+          }}
+        >
+          <Box component="ul" sx={{ listStyle: 'none', padding: 0, margin: 0 }}>
+            {statusHistory.map((history) => (
+              <Box
+                component="li"
+                key={history.historyId}
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 1,
+                  py: 1
+                }}
+              >
+                <Typography sx={{ fontSize: '25', color: 'text.primary' }}>
+                  •{formatDate(history.dateCreated)} - {formatUserName(history.createdBy)} Marked as{' '}
+                  {getStatusLabel(history.newStatus)}
+                </Typography>
+              </Box>
+            ))}
+          </Box>
+        </Box>
+        <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+          <NERFailButton onClick={onClose}>Exit</NERFailButton>
+        </Box>
+      </Box>
+    </NERModal>
+  );
+};

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectRules/RuleHistoryModal.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectRules/RuleHistoryModal.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography, IconButton } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import NERModal from '../../../../components/NERModal';
 import NERFailButton from '../../../../components/NERFailButton';
 import { Rule, ProjectRule, RuleCompletion } from 'shared';

--- a/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
@@ -18,6 +18,7 @@ import AddRuleSectionModal from './components/AddRuleSectionModal';
 import AddRuleModal from './components/AddRuleModal';
 import { AddRuleBox } from './components/AddRuleBox';
 import AssignRulesTab from './AssignRulesTab';
+import { InfoOutlined } from '@mui/icons-material';
 
 /**
  * Placeholder hook to fetch a single ruleset.
@@ -192,7 +193,6 @@ const RulesetEditPage: React.FC = () => {
   };
 
   const handleOpenAddMenu = (ruleId: string, anchorEl: HTMLElement) => {
-    // trying to make tests run lol this comment can get deleted later
     if (showAddMenu && addMenuAnchorEl === anchorEl) {
       handleCloseAddMenu();
       return;

--- a/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
@@ -18,7 +18,6 @@ import AddRuleSectionModal from './components/AddRuleSectionModal';
 import AddRuleModal from './components/AddRuleModal';
 import { AddRuleBox } from './components/AddRuleBox';
 import AssignRulesTab from './AssignRulesTab';
-import { InfoOutlined } from '@mui/icons-material';
 
 /**
  * Placeholder hook to fetch a single ruleset.


### PR DESCRIPTION
## Changes

Added a history modal to the `ProjectRulesTab` file

## Notes

- Mildly tight coupling btwn RuleHistoryModal and ProjectRulesTab
- This branch is based off of Aryan's branch for the project rules tab (3827-project-rules-page). For now just going to compare my branch to Aryan's so it's easier for reviewers to see what I've changed for this ticket. Will switch it to feature/rules-dashboard
- The modal re-appears when closing it sometimes, most likely a querying issue if I had to guess? Not entirely sure though (edit: turns out it was because the RuleHistoryModal was defined inside the ProjectRulesTab component, which re-rendered any time the tab re-gained focus, thus creating an extra modal while saving state. So lesson to take away is don't define a modal inside its parent component lol)

## Screenshots

**Info icon shows up when there's a status change:**
<img width="1365" height="960" alt="Screenshot 2026-01-04 at 14 52 50" src="https://github.com/user-attachments/assets/0558275a-9fa4-4aaf-86c4-92900c4d9686" />

**History modal w/ scroll bar when number of history entries exceeds the max height of the modal**
<img width="450" height="463" alt="Screenshot 2026-01-04 at 14 53 00" src="https://github.com/user-attachments/assets/a854fb14-0ef8-42aa-9421-41ffe2b37028" />

**Modal in light mode**
<img width="1364" height="958" alt="Screenshot 2026-01-04 at 14 53 53" src="https://github.com/user-attachments/assets/47f25d1f-e7cf-432f-b9d7-20f11d924d24" />


## To Do

- [x] Get screenshots
- [x] Figure out what's causing the modal to reappear when closing it
- [x] (later down the line) uncouple history modal and project rules tab

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3778
