### PR TITLE
#3854 rules general view

### DIFF
--- a/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
@@ -32,6 +32,24 @@ export const useSingleRuleset = (rulesetId: string) => {
       ruleContent: '',
       imageFileIds: [],
       parentRule: undefined,
+      subRuleIds: ['1.1'],
+      referencedRuleIds: []
+    },
+    {
+      ruleId: '1.1',
+      ruleCode: 'G.1',
+      ruleContent: 'Content for G.1 Rule',
+      imageFileIds: [],
+      parentRule: { ruleId: '1', ruleCode: 'GR - General Regulations' },
+      subRuleIds: ['1.1.1'],
+      referencedRuleIds: []
+    },
+    {
+      ruleId: '1.1.1',
+      ruleCode: 'G.1.1',
+      ruleContent: 'Content for G.1.1 Rule',
+      imageFileIds: [],
+      parentRule: { ruleId: '1.1', ruleCode: 'G.1' },
       subRuleIds: [],
       referencedRuleIds: []
     },
@@ -41,6 +59,15 @@ export const useSingleRuleset = (rulesetId: string) => {
       ruleContent: '',
       imageFileIds: [],
       parentRule: undefined,
+      subRuleIds: ['2.1'],
+      referencedRuleIds: []
+    },
+    {
+      ruleId: '2.1',
+      ruleCode: 'AD.1',
+      ruleContent: 'Content for AD.1 Rule',
+      imageFileIds: [],
+      parentRule: { ruleId: '2', ruleCode: 'AD - Administrative Regulations' },
       subRuleIds: [],
       referencedRuleIds: []
     },
@@ -50,6 +77,15 @@ export const useSingleRuleset = (rulesetId: string) => {
       ruleContent: '',
       imageFileIds: [],
       parentRule: undefined,
+      subRuleIds: ['3.1'],
+      referencedRuleIds: []
+    },
+    {
+      ruleId: '3.1',
+      ruleCode: 'DR.1',
+      ruleContent: 'Content for DR.1 Rule',
+      imageFileIds: [],
+      parentRule: { ruleId: '3', ruleCode: 'DR - Document Requirements' },
       subRuleIds: [],
       referencedRuleIds: []
     },
@@ -142,6 +178,15 @@ export const useSingleRuleset = (rulesetId: string) => {
       ruleContent: '',
       imageFileIds: [],
       parentRule: undefined,
+      subRuleIds: ['13.1'],
+      referencedRuleIds: []
+    },
+    {
+      ruleId: '13.1',
+      ruleCode: 'F.1',
+      ruleContent: 'Content for F.1 Rule',
+      imageFileIds: [],
+      parentRule: { ruleId: '13', ruleCode: 'F - Chassis and Structural' },
       subRuleIds: [],
       referencedRuleIds: []
     }

--- a/src/frontend/src/pages/RulesPage/RulesetViewPage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetViewPage.tsx
@@ -3,7 +3,6 @@ import FullPageTabs from '../../components/FullPageTabs';
 import PageLayout from '../../components/PageLayout';
 import { routes } from '../../utils/routes';
 import { Box } from '@mui/system';
-import { Typography } from '@mui/material';
 import { useParams } from 'react-router-dom';
 import { useSingleRuleset } from './RulesetEditPage';
 import ErrorPage from '../ErrorPage';

--- a/src/frontend/src/pages/RulesPage/RulesetViewPage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetViewPage.tsx
@@ -8,6 +8,7 @@ import { useParams } from 'react-router-dom';
 import { useSingleRuleset } from './RulesetEditPage';
 import ErrorPage from '../ErrorPage';
 import LoadingIndicator from '../../components/LoadingIndicator';
+import RulesetGeneralView from './components/RulesetGeneralView';
 
 const RulesetViewPage = () => {
   const [tabIndex, setTabIndex] = useState<number>(0);
@@ -48,7 +49,7 @@ const RulesetViewPage = () => {
         {tabIndex === 0 ? (
           <Typography>Team View rules table PLACEHOLDER</Typography>
         ) : (
-          <Typography>General View rules table PLACEHOLDER</Typography>
+          <RulesetGeneralView allRules={ruleset.rules} />
         )}
       </PageLayout>
     </Box>

--- a/src/frontend/src/pages/RulesPage/components/RulesetGeneralView.tsx
+++ b/src/frontend/src/pages/RulesPage/components/RulesetGeneralView.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Box, Paper, Table, TableBody, TableContainer } from '@mui/material';
+import { Rule } from 'shared';
+import RuleRow from '../RuleRow';
+
+interface RulesetGeneralViewProps {
+  allRules: Rule[];
+}
+
+/**
+ * general view for displaying all top-level rules as dropdowns
+ */
+const RulesetGeneralView: React.FC<RulesetGeneralViewProps> = ({ allRules }) => {
+  const topLevelRules = allRules.filter((rule) => !rule.parentRule);
+
+  return (
+    <Box>
+      <TableContainer component={Paper} sx={{ borderRadius: '8px', overflow: 'hidden' }}>
+        <Table sx={{ borderCollapse: 'collapse' }}>
+          <TableBody>
+            {topLevelRules.map((rule) => (
+              <RuleRow
+                key={rule.ruleId}
+                rule={rule}
+                allRules={allRules}
+                rightContent={() => null}
+                backgroundColor="#9d9d9d"
+                textColor="#000000"
+                hoverColor="#5e5e5e"
+                rowHeight="10px"
+                verticalPadding="5px"
+              />
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Box>
+  );
+};
+
+export default RulesetGeneralView;


### PR DESCRIPTION
## Changes

General view using RuleRow component and mock data

## Notes

Again since the RuleRow component was used this looks a bit different than the epic but the style can be updated later

## Screenshots
<img width="1642" height="375" alt="Screenshot 2026-01-04 at 11 06 54 AM" src="https://github.com/user-attachments/assets/4f0c7bd8-84a5-4591-bd8e-1ec1c6a26f8f" />

<img width="1120" height="977" alt="Screenshot 2026-01-04 at 11 04 58 AM" src="https://github.com/user-attachments/assets/517a3d91-6906-45d5-b281-0743293d84ec" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3854