### PR TITLE
#3651 rule deletion modal 2

### DIFF
--- a/src/frontend/src/apis/rules.api.ts
+++ b/src/frontend/src/apis/rules.api.ts
@@ -67,3 +67,11 @@ export const getRulesetsByRulesetType = (rulesetTypeId: string) => {
     transformResponse: (data) => JSON.parse(data)
   });
 };
+
+/**
+ * Deletes a rule by its ID
+ * @param ruleId - The ID of the rule to delete
+ */
+export const deleteRule = (ruleId: string) => {
+  return axios.post(`/rules/rule/${ruleId}/delete`);
+};

--- a/src/frontend/src/hooks/rules.hooks.ts
+++ b/src/frontend/src/hooks/rules.hooks.ts
@@ -12,8 +12,10 @@ import {
   getTeamRulesInRulesetType,
   createRulesetType,
   getAllRulesetTypes,
-  getRulesetsByRulesetType
+  getRulesetsByRulesetType,
+  deleteRule
 } from '../apis/rules.api';
+import { useToast } from './toasts.hooks';
 
 interface CreateRulesetTypePayload {
   name: string;
@@ -98,4 +100,29 @@ export const useRulesetsByType = (rulesetTypeId: string) => {
     const { data } = await getRulesetsByRulesetType(rulesetTypeId);
     return data;
   });
+};
+
+/**
+ * React Query hook to delete a rule
+ */
+export const useDeleteRule = () => {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+
+  return useMutation<void, Error, string>(
+    ['rules', 'delete'],
+    async (ruleId: string) => {
+      await deleteRule(ruleId);
+    },
+    {
+      onSuccess: () => {
+        toast.success('Rule deleted successfully');
+        queryClient.invalidateQueries(['rules']);
+        queryClient.invalidateQueries(['rulesets']);
+      },
+      onError: (error: Error) => {
+        toast.error(error.message);
+      }
+    }
+  );
 };

--- a/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
@@ -18,6 +18,9 @@ import AddRuleSectionModal from './components/AddRuleSectionModal';
 import AddRuleModal from './components/AddRuleModal';
 import { AddRuleBox } from './components/AddRuleBox';
 import AssignRulesTab from './AssignRulesTab';
+import DeleteRuleModal from './components/DeleteRuleModal';
+import { useDeleteRule } from '../../hooks/rules.hooks';
+import { countRulesToDelete } from '../../utils/rules.utils';
 
 /**
  * Placeholder hook to fetch a single ruleset.
@@ -172,7 +175,12 @@ const RulesetEditPage: React.FC = () => {
   const [showAddRuleSectionModal, setShowAddRuleSectionModal] = useState(false);
   const [showAddRuleModal, setShowAddRuleModal] = useState(false);
 
+  // Delete modal state
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+  const [ruleToDelete, setRuleToDelete] = useState<Rule | null>(null);
+
   const { data: ruleset, isError, error, isLoading } = useSingleRuleset(rulesetId);
+  const { mutateAsync: deleteRuleMutation } = useDeleteRule();
 
   const tabs = [
     { tabUrlValue: 'edit-rules', tabName: 'Edit Rules' },
@@ -220,14 +228,36 @@ const RulesetEditPage: React.FC = () => {
   };
 
   const handleRemoveRule = (ruleId: string) => {
-    // Placeholder
-    console.log('Remove rule:', ruleId);
+    const rule = ruleset.rules.find((r) => r.ruleId === ruleId);
+    if (rule) {
+      setRuleToDelete(rule);
+      setDeleteModalOpen(true);
+    }
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!ruleToDelete) return;
+
+    try {
+      await deleteRuleMutation(ruleToDelete.ruleId);
+      setDeleteModalOpen(false);
+      setRuleToDelete(null);
+    } catch (err) {
+      console.error('Failed to delete rule:', err);
+    }
+  };
+
+  const handleDeleteCancel = () => {
+    setDeleteModalOpen(false);
+    setRuleToDelete(null);
   };
 
   const handleEditRule = (ruleId: string) => {
     // Placeholder
     console.log('Edit rule:', ruleId);
   };
+
+  const totalRulesToDelete = ruleToDelete ? countRulesToDelete(ruleToDelete, ruleset.rules) : 0;
 
   // Filter to only show top-level rules
   const topLevelRules = ruleset.rules.filter((rule) => !rule.parentRule);
@@ -288,6 +318,16 @@ const RulesetEditPage: React.FC = () => {
 
             <AddRuleSectionModal open={showAddRuleSectionModal} onClose={() => setShowAddRuleSectionModal(false)} />
             <AddRuleModal open={showAddRuleModal} onClose={() => setShowAddRuleModal(false)} />
+
+            {ruleToDelete && (
+              <DeleteRuleModal
+                open={deleteModalOpen}
+                onHide={handleDeleteCancel}
+                onConfirm={handleDeleteConfirm}
+                rule={ruleToDelete}
+                totalRulesToDelete={totalRulesToDelete}
+              />
+            )}
 
             <Box
               sx={{

--- a/src/frontend/src/pages/RulesPage/components/DeleteRuleModal.tsx
+++ b/src/frontend/src/pages/RulesPage/components/DeleteRuleModal.tsx
@@ -49,4 +49,3 @@ const DeleteRuleModal = ({ open, onHide, onConfirm, rule, totalRulesToDelete }: 
 };
 
 export default DeleteRuleModal;
-

--- a/src/frontend/src/pages/RulesPage/components/DeleteRuleModal.tsx
+++ b/src/frontend/src/pages/RulesPage/components/DeleteRuleModal.tsx
@@ -1,0 +1,52 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { Box, Typography } from '@mui/material';
+import { Rule } from 'shared';
+import WarningIcon from '@mui/icons-material/Warning';
+import NERModal from '../../../components/NERModal';
+
+interface DeleteRuleModalProps {
+  open: boolean;
+  onHide: () => void;
+  onConfirm: () => void;
+  rule: Rule;
+  totalRulesToDelete: number;
+}
+
+const DeleteRuleModal = ({ open, onHide, onConfirm, rule, totalRulesToDelete }: DeleteRuleModalProps) => {
+  const hasChildren = rule.subRuleIds.length > 0;
+  const titlePrefix = hasChildren ? 'Delete Rule Section:' : 'Delete Rule:';
+
+  const modalTitle = rule.ruleContent
+    ? `${titlePrefix} ${rule.ruleCode} - ${rule.ruleContent}`
+    : `${titlePrefix} ${rule.ruleCode}`;
+
+  return (
+    <NERModal
+      open={open}
+      onHide={onHide}
+      title="Confirm Deletion"
+      cancelText="Cancel"
+      submitText="Delete"
+      onSubmit={onConfirm}
+      formId="delete-rule-form"
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <Typography sx={{ fontWeight: 400, fontSize: '1.25rem' }}>{modalTitle}</Typography>
+
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <WarningIcon sx={{ color: '#ef4345', fontSize: 30 }} />
+          <Typography sx={{ fontWeight: 600, fontSize: '1.25rem' }}>
+            {totalRulesToDelete} {totalRulesToDelete === 1 ? 'rule' : 'rules'} will be deleted
+          </Typography>
+        </Box>
+      </Box>
+    </NERModal>
+  );
+};
+
+export default DeleteRuleModal;
+

--- a/src/frontend/src/utils/rules.utils.ts
+++ b/src/frontend/src/utils/rules.utils.ts
@@ -20,4 +20,3 @@ export const countRulesToDelete = (rule: Rule, allRules: Rule[]): number => {
   }
   return count;
 };
-

--- a/src/frontend/src/utils/rules.utils.ts
+++ b/src/frontend/src/utils/rules.utils.ts
@@ -1,0 +1,23 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { Rule } from 'shared';
+
+/**
+ * Counts the total number of rules that will be deleted when deleting a rule
+ * (including the rule itself and all its descendants)
+ * @param rule - The rule to delete
+ * @param allRules - All rules in the ruleset
+ * @returns The total number of rules that will be deleted
+ */
+export const countRulesToDelete = (rule: Rule, allRules: Rule[]): number => {
+  let count = 1;
+  const children = allRules.filter((r) => rule.subRuleIds.includes(r.ruleId));
+  for (const child of children) {
+    count += countRulesToDelete(child, allRules);
+  }
+  return count;
+};
+


### PR DESCRIPTION
## Changes

Fixed the delete modal to use the NER modal (all other features from previous PR still there)

## Notes

**IMPORTANT**: Deletion does not actually occur yet just because the current ruleset page does not actually fetch rulesets in the database (there is a placeholder hook right now so real rules are not fetched yet so they can't be deleted) so that needs to be implemented in a future ticket. RIght now, there is just a 404 error.

## Screenshots

<img width="1496" height="941" alt="Screenshot 2026-01-04 at 9 32 16 AM" src="https://github.com/user-attachments/assets/263ec55c-f401-43ac-8cd4-294f1f16e11c" />
<img width="1496" height="889" alt="Screenshot 2026-01-04 at 9 32 29 AM" src="https://github.com/user-attachments/assets/30b5182c-7e15-4042-bf17-c0e91c8cf593" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #3651 )