### PR TITLE
View rulesets fixed with actual data

### DIFF
--- a/src/backend/src/controllers/rules.controllers.ts
+++ b/src/backend/src/controllers/rules.controllers.ts
@@ -273,4 +273,14 @@ export default class RulesController {
       next(error);
     }
   }
+
+  static async getSingleRuleset(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { rulesetId } = req.params;
+      const ruleset = await RulesService.getSingleRuleset(req.currentUser, rulesetId, req.organization);
+      res.status(200).json(ruleset);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
 }

--- a/src/backend/src/routes/rules.routes.ts
+++ b/src/backend/src/routes/rules.routes.ts
@@ -88,5 +88,6 @@ rulesRouter.get('/ruleset/:rulesetId/project/:projectId/rules', RulesController.
 
 rulesRouter.get('/:ruleId/subrules', RulesController.getChildRules);
 rulesRouter.get('/:rulesetId/parentRules', RulesController.getTopLevelRules);
+rulesRouter.get('/ruleset/:rulesetId', RulesController.getSingleRuleset);
 
 export default rulesRouter;

--- a/src/backend/src/services/rules.services.ts
+++ b/src/backend/src/services/rules.services.ts
@@ -1239,4 +1239,35 @@ export default class RulesService {
 
     return rules.map(ruleTransformer);
   }
+
+  /**
+   * Gets a single ruleset by ID
+   * @param rulesetId the id of the ruleset
+   * @param user the user requesting the ruleset
+   * @param organization the organization the user belongs to
+   * @returns the ruleset with the given id
+   */
+  static async getSingleRuleset(user: User, rulesetId: string, organization: Organization): Promise<Ruleset> {
+    if (!(await userHasPermission(user.userId, organization.organizationId, notGuest)))
+      throw new AccessDeniedException('Only members and above can view rulesets!');
+
+    const ruleset = await prisma.ruleset.findUnique({
+      where: { rulesetId },
+      ...getRulesetQueryArgs()
+    });
+
+    if (!ruleset) {
+      throw new NotFoundException('Ruleset', rulesetId);
+    }
+
+    if (ruleset.deletedByUserId) {
+      throw new DeletedException('Ruleset', rulesetId);
+    }
+
+    if (ruleset.car.wbsElement.organizationId !== organization.organizationId) {
+      throw new InvalidOrganizationException('Ruleset');
+    }
+
+    return rulesetTransformer(ruleset);
+  }
 }

--- a/src/frontend/src/apis/rules.api.ts
+++ b/src/frontend/src/apis/rules.api.ts
@@ -172,3 +172,14 @@ export const deleteRuleset = (rulesetId: string) => {
 export const deleteRulesetType = (rulesetTypeId: string) => {
   return axios.post(apiUrls.rulesetTypeDelete(rulesetTypeId));
 };
+
+/**
+ * Gets a single ruleset by ID
+ *
+ * @param rulesetId The ID of the ruleset.
+ */
+export const getSingleRuleset = (rulesetId: string) => {
+  return axios.get<Ruleset>(apiUrls.singleRuleset(rulesetId), {
+    transformResponse: (data) => rulesetTransformer(JSON.parse(data))
+  });
+};

--- a/src/frontend/src/hooks/rules.hooks.ts
+++ b/src/frontend/src/hooks/rules.hooks.ts
@@ -22,7 +22,8 @@ import {
   deleteRule,
   updateRuleset,
   deleteRuleset,
-  deleteRulesetType
+  deleteRulesetType,
+  getSingleRuleset
 } from '../apis/rules.api';
 import { useToast } from './toasts.hooks';
 
@@ -308,5 +309,54 @@ export const useDeleteRulesetType = () => {
         queryClient.invalidateQueries(['rulesetTypes']);
       }
     }
+  );
+};
+
+/**
+ * Hook to get a single ruleset by ID
+ */
+export const useSingleRuleset = (rulesetId: string) => {
+  return useQuery<Ruleset, Error>(
+    ['rules', 'ruleset', rulesetId],
+    async () => {
+      const { data } = await getSingleRuleset(rulesetId);
+      return data;
+    },
+    { enabled: !!rulesetId }
+  );
+};
+
+/**
+ * Helper function to recursively fetch all child rules
+ */
+const fetchAllChildRules = async (rule: Rule, allRules: Rule[]): Promise<void> => {
+  if (rule.subRuleIds.length === 0) return;
+
+  const { data: children } = await getChildRules(rule.ruleId);
+  allRules.push(...children);
+
+  for (const child of children) {
+    await fetchAllChildRules(child, allRules);
+  }
+};
+
+/**
+ * Hook to get all rules for a ruleset by fetching top-level rules
+ * and recursively fetching all children
+ */
+export const useAllRulesForRuleset = (rulesetId: string) => {
+  return useQuery<Rule[], Error>(
+    ['rules', 'allRules', rulesetId],
+    async () => {
+      const { data: topLevelRules } = await getTopLevelRules(rulesetId);
+      const allRules: Rule[] = [...topLevelRules];
+
+      for (const rule of topLevelRules) {
+        await fetchAllChildRules(rule, allRules);
+      }
+
+      return allRules;
+    },
+    { enabled: !!rulesetId }
   );
 };

--- a/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
@@ -19,189 +19,8 @@ import AddRuleModal from './components/AddRuleModal';
 import { AddRuleBox } from './components/AddRuleBox';
 import AssignRulesTab from './AssignRulesTab';
 import DeleteRuleModal from './components/DeleteRuleModal';
-import { useDeleteRule } from '../../hooks/rules.hooks';
+import { useDeleteRule, useSingleRuleset, useAllRulesForRuleset } from '../../hooks/rules.hooks';
 import { countRulesToDelete } from '../../utils/rules.utils';
-
-/**
- * Placeholder hook to fetch a single ruleset.
- * @param rulesetId - The ID of the ruleset to fetch.
- * @returns The ruleset data.
- */
-export const useSingleRuleset = (rulesetId: string) => {
-  const placeholderRules: Rule[] = [
-    {
-      ruleId: '1',
-      ruleCode: 'GR - General Regulations',
-      ruleContent: '',
-      imageFileIds: [],
-      parentRule: undefined,
-      subRuleIds: ['1.1'],
-      referencedRuleIds: []
-    },
-    {
-      ruleId: '1.1',
-      ruleCode: 'G.1',
-      ruleContent: 'Content for G.1 Rule',
-      imageFileIds: [],
-      parentRule: { ruleId: '1', ruleCode: 'GR - General Regulations' },
-      subRuleIds: ['1.1.1'],
-      referencedRuleIds: []
-    },
-    {
-      ruleId: '1.1.1',
-      ruleCode: 'G.1.1',
-      ruleContent: 'Content for G.1.1 Rule',
-      imageFileIds: [],
-      parentRule: { ruleId: '1.1', ruleCode: 'G.1' },
-      subRuleIds: [],
-      referencedRuleIds: []
-    },
-    {
-      ruleId: '2',
-      ruleCode: 'AD - Administrative Regulations',
-      ruleContent: '',
-      imageFileIds: [],
-      parentRule: undefined,
-      subRuleIds: ['2.1'],
-      referencedRuleIds: []
-    },
-    {
-      ruleId: '2.1',
-      ruleCode: 'AD.1',
-      ruleContent: 'Content for AD.1 Rule',
-      imageFileIds: [],
-      parentRule: { ruleId: '2', ruleCode: 'AD - Administrative Regulations' },
-      subRuleIds: [],
-      referencedRuleIds: []
-    },
-    {
-      ruleId: '3',
-      ruleCode: 'DR - Document Requirements',
-      ruleContent: '',
-      imageFileIds: [],
-      parentRule: undefined,
-      subRuleIds: ['3.1'],
-      referencedRuleIds: []
-    },
-    {
-      ruleId: '3.1',
-      ruleCode: 'DR.1',
-      ruleContent: 'Content for DR.1 Rule',
-      imageFileIds: [],
-      parentRule: { ruleId: '3', ruleCode: 'DR - Document Requirements' },
-      subRuleIds: [],
-      referencedRuleIds: []
-    },
-    {
-      ruleId: '4',
-      ruleCode: 'V - Vehicle Requirements',
-      ruleContent: '',
-      imageFileIds: [],
-      parentRule: undefined,
-      subRuleIds: ['5', '6', '7'],
-      referencedRuleIds: []
-    },
-    {
-      ruleId: '5',
-      ruleCode: 'V.1 - Configuration',
-      ruleContent: '',
-      imageFileIds: [],
-      parentRule: { ruleId: '4', ruleCode: 'V - Vehicle Requirements' },
-      subRuleIds: [],
-      referencedRuleIds: []
-    },
-    {
-      ruleId: '6',
-      ruleCode: 'V.2 - Driver',
-      ruleContent: '',
-      imageFileIds: [],
-      parentRule: { ruleId: '4', ruleCode: 'V - Vehicle Requirements' },
-      subRuleIds: [],
-      referencedRuleIds: []
-    },
-    {
-      ruleId: '7',
-      ruleCode: 'V.3 - Suspension and Steering',
-      ruleContent: '',
-      imageFileIds: [],
-      parentRule: { ruleId: '4', ruleCode: 'V - Vehicle Requirements' },
-      subRuleIds: ['8', '9'],
-      referencedRuleIds: []
-    },
-    {
-      ruleId: '8',
-      ruleCode: 'V.3.1 - Suspension',
-      ruleContent: '',
-      imageFileIds: [],
-      parentRule: { ruleId: '7', ruleCode: 'V.3 - Suspension and Steering' },
-      subRuleIds: [],
-      referencedRuleIds: []
-    },
-    {
-      ruleId: '9',
-      ruleCode: 'V.3.2 - Steering',
-      ruleContent: '',
-      imageFileIds: [],
-      parentRule: { ruleId: '7', ruleCode: 'V.3 - Suspension and Steering' },
-      subRuleIds: ['10', '11', '12'],
-      referencedRuleIds: []
-    },
-    {
-      ruleId: '10',
-      ruleCode: 'V.3.2.1',
-      ruleContent:
-        'Some super long rule content that should wrap to the next line, Some super long rule content that should wrap to the next line, Some super long rule content that should wrap to the next line, Some super long rule content that should wrap to the next line',
-      imageFileIds: [],
-      parentRule: { ruleId: '9', ruleCode: 'V.3.2 - Steering' },
-      subRuleIds: [],
-      referencedRuleIds: []
-    },
-    {
-      ruleId: '11',
-      ruleCode: 'V.3.2.2',
-      ruleContent: 'Electrically actuated steering of the front wheels is prohibited',
-      imageFileIds: [],
-      parentRule: { ruleId: '9', ruleCode: 'V.3.2 - Steering' },
-      subRuleIds: [],
-      referencedRuleIds: []
-    },
-    {
-      ruleId: '12',
-      ruleCode: 'V.3.2.3',
-      ruleContent:
-        'Steering systems must use a rigid mechanical linkage capable of tension and compression loads for operation',
-      imageFileIds: [],
-      parentRule: { ruleId: '9', ruleCode: 'V.3.2 - Steering' },
-      subRuleIds: [],
-      referencedRuleIds: []
-    },
-    {
-      ruleId: '13',
-      ruleCode: 'F - Chassis and Structural',
-      ruleContent: '',
-      imageFileIds: [],
-      parentRule: undefined,
-      subRuleIds: ['13.1'],
-      referencedRuleIds: []
-    },
-    {
-      ruleId: '13.1',
-      ruleCode: 'F.1',
-      ruleContent: 'Content for F.1 Rule',
-      imageFileIds: [],
-      parentRule: { ruleId: '13', ruleCode: 'F - Chassis and Structural' },
-      subRuleIds: [],
-      referencedRuleIds: []
-    }
-  ];
-
-  return {
-    data: { name: 'FSAE Original Version', rulesetId, rules: placeholderRules },
-    isLoading: false,
-    isError: false,
-    error: undefined
-  };
-};
 
 /**
  * RulesetPage component for displaying and managing ruleset rules.
@@ -224,7 +43,18 @@ const RulesetEditPage: React.FC = () => {
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [ruleToDelete, setRuleToDelete] = useState<Rule | null>(null);
 
-  const { data: ruleset, isError, error, isLoading } = useSingleRuleset(rulesetId);
+  const {
+    data: ruleset,
+    isError: isRulesetError,
+    error: rulesetError,
+    isLoading: isRulesetLoading
+  } = useSingleRuleset(rulesetId!);
+  const {
+    data: allRules,
+    isError: isRulesError,
+    error: rulesError,
+    isLoading: isRulesLoading
+  } = useAllRulesForRuleset(rulesetId!);
   const { mutateAsync: deleteRuleMutation } = useDeleteRule();
 
   const tabs = [
@@ -232,11 +62,15 @@ const RulesetEditPage: React.FC = () => {
     { tabUrlValue: 'assign-rules', tabName: 'Assign Rules' }
   ];
 
-  if (isError) {
-    return <ErrorPage error={error} />;
+  if (isRulesetError) {
+    return <ErrorPage error={rulesetError} />;
   }
 
-  if (isLoading || !ruleset) {
+  if (isRulesError) {
+    return <ErrorPage error={rulesError} />;
+  }
+
+  if (isRulesetLoading || isRulesLoading || !ruleset || !allRules) {
     return <LoadingIndicator />;
   }
 
@@ -273,7 +107,7 @@ const RulesetEditPage: React.FC = () => {
   };
 
   const handleRemoveRule = (ruleId: string) => {
-    const rule = ruleset.rules.find((r) => r.ruleId === ruleId);
+    const rule = allRules.find((r) => r.ruleId === ruleId);
     if (rule) {
       setRuleToDelete(rule);
       setDeleteModalOpen(true);
@@ -302,10 +136,10 @@ const RulesetEditPage: React.FC = () => {
     console.log('Edit rule:', ruleId);
   };
 
-  const totalRulesToDelete = ruleToDelete ? countRulesToDelete(ruleToDelete, ruleset.rules) : 0;
+  const totalRulesToDelete = ruleToDelete ? countRulesToDelete(ruleToDelete, allRules) : 0;
 
   // Filter to only show top-level rules
-  const topLevelRules = ruleset.rules.filter((rule) => !rule.parentRule);
+  const topLevelRules = allRules.filter((rule) => !rule.parentRule);
 
   return (
     <PageLayout
@@ -315,7 +149,7 @@ const RulesetEditPage: React.FC = () => {
           <FullPageTabs
             setTab={setTabValue}
             tabsLabels={tabs}
-            baseUrl={routes.RULESET_EDIT.replace(':rulesetId', rulesetId)}
+            baseUrl={routes.RULESET_EDIT.replace(':rulesetId', rulesetId!)}
             defaultTab={defaultTab}
             id="rules-tabs"
           />
@@ -332,7 +166,7 @@ const RulesetEditPage: React.FC = () => {
                     <RuleRow
                       key={rule.ruleId}
                       rule={rule}
-                      allRules={ruleset.rules}
+                      allRules={allRules}
                       rightContent={(currentRule) => (
                         <RuleActions
                           ruleId={currentRule.ruleId}
@@ -414,7 +248,7 @@ const RulesetEditPage: React.FC = () => {
             </Box>
           </Box>
         ) : (
-          <AssignRulesTab rules={ruleset.rules} />
+          <AssignRulesTab rules={allRules} />
         )}
       </Box>
     </PageLayout>

--- a/src/frontend/src/pages/RulesPage/RulesetViewPage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetViewPage.tsx
@@ -4,55 +4,20 @@ import PageLayout from '../../components/PageLayout';
 import { routes } from '../../utils/routes';
 import { Box } from '@mui/system';
 import { useParams } from 'react-router-dom';
-import { useSingleRuleset } from './RulesetEditPage';
 import ErrorPage from '../ErrorPage';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import RulesetGeneralView from './components/RulesetGeneralView';
 import { Rule } from 'shared';
 import RulesetTeamView, { TeamRules } from './components/RulesetTeamView';
+import { useSingleRuleset, useAllRulesForRuleset } from '../../hooks/rules.hooks';
 
 /**
- * Mock function to organize rules by team and project
- * TODO: Replace with actual API calls after parsing PR is merged
- * Will need to call:
- * - GET /rules/:rulesetTypeId/team/:teamId for team rules
- * - GET /rules/ruleset/:rulesetId/project/:projectId/rules for project rules
- * - GET /rules/ruleset/:rulesetId/team/:teamId/rules/unassigned for unassigned team rules
+ * Organizes rules by team and project assignments.
+ * Rules without team assignments are shown in the unassigned section.
  */
-const getMockTeamOrganization = (allRules: Rule[]): { teamRules: TeamRules[]; unassignedToTeam: Rule[] } => {
-  const teamRules: TeamRules[] = [
-    {
-      teamId: 'team1',
-      teamName: 'Chassis Team',
-      projects: [
-        {
-          projectId: 'proj1',
-          projectName: 'NER-24 Chassis',
-          rules: allRules.filter((r) => ['1', '13'].includes(r.ruleId)) // GR and F
-        },
-        {
-          projectId: 'proj2',
-          projectName: 'Suspension Design',
-          rules: allRules.filter((r) => r.ruleId === '8') // V.3.1
-        }
-      ],
-      unassignedRules: allRules.filter((r) => r.ruleId === '2') // AD
-    },
-    {
-      teamId: 'team2',
-      teamName: 'Electrical Team',
-      projects: [
-        {
-          projectId: 'proj3',
-          projectName: 'Battery Management System',
-          rules: allRules.filter((r) => ['5', '6'].includes(r.ruleId)) // V.1, V.2
-        }
-      ],
-      unassignedRules: []
-    }
-  ];
-
-  const unassignedToTeam = allRules.filter((r) => ['4', '7', '9'].includes(r.ruleId));
+const getTeamOrganization = (allRules: Rule[]): { teamRules: TeamRules[]; unassignedToTeam: Rule[] } => {
+  const teamRules: TeamRules[] = [];
+  const unassignedToTeam = allRules.filter((r) => !r.parentRule);
 
   return { teamRules, unassignedToTeam };
 };
@@ -65,18 +30,36 @@ const RulesetViewPage = () => {
   ];
 
   const { rulesetId } = useParams<{ rulesetId: string }>();
-  const { data: ruleset, isError, error, isLoading } = useSingleRuleset(rulesetId);
+  const {
+    data: ruleset,
+    isError: isRulesetError,
+    error: rulesetError,
+    isLoading: isRulesetLoading
+  } = useSingleRuleset(rulesetId!);
+  const {
+    data: allRules,
+    isError: isRulesError,
+    error: rulesError,
+    isLoading: isRulesLoading
+  } = useAllRulesForRuleset(rulesetId!);
 
-  // team organization mock for now
-  const { teamRules, unassignedToTeam } = getMockTeamOrganization(ruleset.rules);
-
-  if (isError) {
-    return <ErrorPage error={error} />;
-  }
-
-  if (isLoading || !ruleset) {
+  if (isRulesetLoading || isRulesLoading) {
     return <LoadingIndicator />;
   }
+
+  if (isRulesetError) {
+    return <ErrorPage error={rulesetError} />;
+  }
+
+  if (isRulesError) {
+    return <ErrorPage error={rulesError} />;
+  }
+
+  if (!ruleset || !allRules) {
+    return <LoadingIndicator />;
+  }
+
+  const { teamRules, unassignedToTeam } = getTeamOrganization(allRules);
 
   return (
     <Box>
@@ -88,7 +71,7 @@ const RulesetViewPage = () => {
               noUnderline
               setTab={setTabIndex}
               tabsLabels={tabs}
-              baseUrl={routes.RULESET_VIEW.replace(':rulesetId', rulesetId)}
+              baseUrl={routes.RULESET_VIEW.replace(':rulesetId', rulesetId!)}
               defaultTab={'teamView'}
               id="rules-view-tabs"
             />
@@ -97,9 +80,9 @@ const RulesetViewPage = () => {
       >
         <Box sx={{ width: '100%', borderRadius: '8px 8px 0 0' }}>
           {tabIndex === 0 ? (
-            <RulesetTeamView allRules={ruleset.rules} teamRules={teamRules} unassignedToTeam={unassignedToTeam} />
+            <RulesetTeamView allRules={allRules} teamRules={teamRules} unassignedToTeam={unassignedToTeam} />
           ) : (
-            <RulesetGeneralView allRules={ruleset.rules} />
+            <RulesetGeneralView allRules={allRules} />
           )}
         </Box>
       </PageLayout>

--- a/src/frontend/src/utils/urls.ts
+++ b/src/frontend/src/utils/urls.ts
@@ -458,6 +458,7 @@ const rulesEditProjectRuleStatus = (projectRuleId: string) => `${rules()}/projec
 const rulesetUpdate = (rulesetId: string) => `${ruleset()}/${rulesetId}/update`;
 const rulesetDelete = (rulesetId: string) => `${ruleset()}/${rulesetId}/delete`;
 const rulesetTypeDelete = (rulesetTypeId: string) => `${rules()}/rulesetType/${rulesetTypeId}/delete`;
+const singleRuleset = (rulesetId: string) => `${rules()}/ruleset/${rulesetId}`;
 
 /**************** Other Endpoints ****************/
 const version = () => `https://api.github.com/repos/Northeastern-Electric-Racing/FinishLine/releases/latest`;
@@ -780,6 +781,7 @@ export const apiUrls = {
   rulesetUpdate,
   rulesetDelete,
   rulesetTypeDelete,
+  singleRuleset,
 
   version
 };


### PR DESCRIPTION
## Changes

Added backend endpoint and frontend hooks to make the Ruleset View page functional with real API data instead of mock data.

## Notes

Cannot test, my finish line docker is having a lot of weird problems


## Screenshots

<img width="1526" height="1029" alt="Screenshot 2026-01-14 at 23 19 56" src="https://github.com/user-attachments/assets/7fa2818e-9096-4f2d-8eaf-99ec3ef89bc5" />

<img width="1728" height="1074" alt="Screenshot 2026-01-18 at 18 08 39" src="https://github.com/user-attachments/assets/73cd9f27-7a09-4cec-a448-debfb717b8e2" />



## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #3866
