### PR TITLE
Edit rules

### DIFF
--- a/src/backend/src/routes/rules.routes.ts
+++ b/src/backend/src/routes/rules.routes.ts
@@ -23,9 +23,9 @@ rulesRouter.post(
 rulesRouter.post(
   '/rule/:ruleId/edit',
   nonEmptyString(body('ruleContent')),
-  nonEmptyString(body('ruleCode')),
-  body('imageFileIds').isArray(),
-  nonEmptyString(body('imageFileIds.*')),
+  body('ruleCode').optional().isString(),
+  body('imageFileIds').optional().isArray(),
+  body('imageFileIds.*').optional().isString(),
   body('parentRuleId').optional().isString(),
   validateInputs,
   RulesController.editRule

--- a/src/backend/src/services/rules.services.ts
+++ b/src/backend/src/services/rules.services.ts
@@ -379,7 +379,7 @@ export default class RulesService {
    * @param ruleCode The rule code to update (optional, keeps existing if not provided)
    * @param imageFileIds The image files to update (optional, keeps existing if not provided)
    * @param parentRuleId The parent rule ID to update
-   * @param organizationId the organization Id
+   * @param organization the organization the rule belongs to
    * @returns the edited rule
    */
   static async editRule(

--- a/src/backend/src/services/rules.services.ts
+++ b/src/backend/src/services/rules.services.ts
@@ -376,8 +376,8 @@ export default class RulesService {
    * @param submitter a user who is making this request
    * @param ruleContent the rule content to edit
    * @param ruleId The rule ID being edited
-   * @param ruleCode The rule code to update
-   * @param imageFileIds The image files to update
+   * @param ruleCode The rule code to update (optional, keeps existing if not provided)
+   * @param imageFileIds The image files to update (optional, keeps existing if not provided)
    * @param parentRuleId The parent rule ID to update
    * @param organizationId the organization Id
    * @returns the edited rule
@@ -386,8 +386,8 @@ export default class RulesService {
     submitter: User,
     ruleContent: string,
     ruleId: string,
-    ruleCode: string,
-    imageFileIds: string[],
+    ruleCode: string | undefined,
+    imageFileIds: string[] | undefined,
     organization: Organization,
     parentRuleId?: string
   ) {
@@ -440,8 +440,8 @@ export default class RulesService {
       },
       data: {
         ruleContent,
-        ruleCode,
-        imageFileIds,
+        ...(ruleCode !== undefined && { ruleCode }),
+        ...(imageFileIds !== undefined && { imageFileIds }),
         ...(parentRuleId && { parentRuleId }),
         dateUpdated: new Date(),
         updatedByUserId: submitter.userId

--- a/src/frontend/src/apis/rules.api.ts
+++ b/src/frontend/src/apis/rules.api.ts
@@ -153,6 +153,15 @@ export const deleteRule = (ruleId: string) => {
 };
 
 /**
+ * Edits a rule's content
+ * @param ruleId - The ID of the rule to edit
+ * @param ruleContent - The new content for the rule
+ */
+export const editRule = (ruleId: string, ruleContent: string) => {
+  return axios.post<Rule>(apiUrls.rulesEdit(ruleId), { ruleContent });
+};
+
+/**
  * Updates a rulesets active status
  */
 export const updateRuleset = (rulesetId: string, name: string, isActive: boolean) => {

--- a/src/frontend/src/hooks/rules.hooks.ts
+++ b/src/frontend/src/hooks/rules.hooks.ts
@@ -20,6 +20,7 @@ import {
   getTeamRulesInRulesetType,
   getRulesetsByRulesetType,
   deleteRule,
+  editRule,
   updateRuleset,
   deleteRuleset,
   deleteRulesetType
@@ -263,6 +264,32 @@ export const useDeleteRule = () => {
       },
       onError: (error: Error) => {
         toast.error(error.message);
+      }
+    }
+  );
+};
+
+/**
+ * React Query hook to edit a rule's content
+ */
+export const useEditRule = () => {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+
+  return useMutation<Rule, Error, { ruleId: string; ruleContent: string }>(
+    ['rules', 'edit'],
+    async ({ ruleId, ruleContent }) => {
+      const { data } = await editRule(ruleId, ruleContent);
+      return data;
+    },
+    {
+      onSuccess: () => {
+        toast.success('Rule updated successfully');
+        queryClient.invalidateQueries(['rules']);
+        queryClient.invalidateQueries(['rulesets']);
+      },
+      onError: (error: Error) => {
+        toast.error(`Failed to update rule: ${error.message}`);
       }
     }
   );

--- a/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
@@ -387,7 +387,9 @@ const RulesetEditPage: React.FC = () => {
                             />
                           );
                         }
-                        return currentRule.ruleContent && <span style={{ color: '#000000' }}>{currentRule.ruleContent}</span>;
+                        return (
+                          currentRule.ruleContent && <span style={{ color: '#000000' }}>{currentRule.ruleContent}</span>
+                        );
                       }}
                       rightContent={(currentRule) => (
                         <RuleActions
@@ -398,7 +400,7 @@ const RulesetEditPage: React.FC = () => {
                           iconColor="#000000"
                         />
                       )}
-                      backgroundColor={(currentRule) => editingRuleId === currentRule.ruleId ? '#c0c0c0' : '#9d9d9d'}
+                      backgroundColor={(currentRule) => (editingRuleId === currentRule.ruleId ? '#c0c0c0' : '#9d9d9d')}
                       textColor="#000000"
                       hoverColor="#5e5e5e"
                       rowHeight="10px"

--- a/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { Box, Button, Paper, Table, TableBody, TableContainer } from '@mui/material';
+import { Box, Button, Paper, Table, TableBody, TableContainer, TextField } from '@mui/material';
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import PageLayout from '../../components/PageLayout';
@@ -19,7 +19,7 @@ import AddRuleModal from './components/AddRuleModal';
 import { AddRuleBox } from './components/AddRuleBox';
 import AssignRulesTab from './AssignRulesTab';
 import DeleteRuleModal from './components/DeleteRuleModal';
-import { useDeleteRule } from '../../hooks/rules.hooks';
+import { useDeleteRule, useEditRule } from '../../hooks/rules.hooks';
 import { countRulesToDelete } from '../../utils/rules.utils';
 
 /**
@@ -224,8 +224,13 @@ const RulesetEditPage: React.FC = () => {
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [ruleToDelete, setRuleToDelete] = useState<Rule | null>(null);
 
+  // Editing state
+  const [editingRuleId, setEditingRuleId] = useState<string | null>(null);
+  const [editedContent, setEditedContent] = useState<string>('');
+
   const { data: ruleset, isError, error, isLoading } = useSingleRuleset(rulesetId);
   const { mutateAsync: deleteRuleMutation } = useDeleteRule();
+  const { mutateAsync: editRuleMutation } = useEditRule();
 
   const tabs = [
     { tabUrlValue: 'edit-rules', tabName: 'Edit Rules' },
@@ -298,8 +303,28 @@ const RulesetEditPage: React.FC = () => {
   };
 
   const handleEditRule = (ruleId: string) => {
-    // Placeholder
-    console.log('Edit rule:', ruleId);
+    const rule = ruleset.rules.find((r) => r.ruleId === ruleId);
+    if (rule) {
+      setEditingRuleId(ruleId);
+      setEditedContent(rule.ruleContent);
+    }
+  };
+
+  const handleSaveEdit = async () => {
+    if (!editingRuleId) return;
+
+    try {
+      await editRuleMutation({ ruleId: editingRuleId, ruleContent: editedContent });
+      setEditingRuleId(null);
+      setEditedContent('');
+    } catch (err) {
+      console.error('Failed to update rule:', err);
+    }
+  };
+
+  const handleCancelEdit = () => {
+    setEditingRuleId(null);
+    setEditedContent('');
   };
 
   const totalRulesToDelete = ruleToDelete ? countRulesToDelete(ruleToDelete, ruleset.rules) : 0;
@@ -333,6 +358,37 @@ const RulesetEditPage: React.FC = () => {
                       key={rule.ruleId}
                       rule={rule}
                       allRules={ruleset.rules}
+                      middleContent={(currentRule) => {
+                        const isEditing = editingRuleId === currentRule.ruleId;
+                        if (isEditing) {
+                          return (
+                            <TextField
+                              fullWidth
+                              multiline
+                              value={editedContent}
+                              onChange={(e) => setEditedContent(e.target.value)}
+                              variant="outlined"
+                              size="small"
+                              autoFocus
+                              sx={{
+                                backgroundColor: '#ffffff',
+                                '& .MuiOutlinedInput-root': {
+                                  '& fieldset': {
+                                    borderColor: '#dd514c'
+                                  },
+                                  '&:hover fieldset': {
+                                    borderColor: '#dd514c'
+                                  },
+                                  '&.Mui-focused fieldset': {
+                                    borderColor: '#dd514c'
+                                  }
+                                }
+                              }}
+                            />
+                          );
+                        }
+                        return currentRule.ruleContent && <span style={{ color: '#000000' }}>{currentRule.ruleContent}</span>;
+                      }}
                       rightContent={(currentRule) => (
                         <RuleActions
                           ruleId={currentRule.ruleId}
@@ -342,7 +398,7 @@ const RulesetEditPage: React.FC = () => {
                           iconColor="#000000"
                         />
                       )}
-                      backgroundColor="#9d9d9d"
+                      backgroundColor={(currentRule) => editingRuleId === currentRule.ruleId ? '#c0c0c0' : '#9d9d9d'}
                       textColor="#000000"
                       hoverColor="#5e5e5e"
                       rowHeight="10px"
@@ -391,25 +447,67 @@ const RulesetEditPage: React.FC = () => {
                   ml: '30px'
                 }}
               />
-              <Box sx={{ display: 'flex', justifyContent: 'flex-end', pr: '30px', pb: 1 }}>
-                <Button
-                  variant="contained"
-                  onClick={handleAddRuleSection}
-                  sx={{
-                    borderRadius: '8px',
-                    color: '#ededed',
-                    backgroundColor: '#dd514c',
-                    padding: '2px 15px',
-                    fontSize: '16px',
-                    fontWeight: 700,
-                    textTransform: 'none',
-                    '&:hover': {
-                      backgroundColor: '#c74340'
-                    }
-                  }}
-                >
-                  Add Rule Section
-                </Button>
+              <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 2, pr: '30px', pb: 1 }}>
+                {editingRuleId ? (
+                  <>
+                    <Button
+                      variant="outlined"
+                      onClick={handleCancelEdit}
+                      sx={{
+                        borderRadius: '8px',
+                        color: '#ededed',
+                        borderColor: '#ededed',
+                        padding: '2px 15px',
+                        fontSize: '16px',
+                        fontWeight: 700,
+                        textTransform: 'none',
+                        '&:hover': {
+                          borderColor: '#ededed',
+                          backgroundColor: 'rgba(237, 237, 237, 0.1)'
+                        }
+                      }}
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      variant="contained"
+                      onClick={handleSaveEdit}
+                      sx={{
+                        borderRadius: '8px',
+                        color: '#ededed',
+                        backgroundColor: '#dd514c',
+                        padding: '2px 15px',
+                        fontSize: '16px',
+                        fontWeight: 700,
+                        textTransform: 'none',
+                        '&:hover': {
+                          backgroundColor: '#c74340'
+                        }
+                      }}
+                    >
+                      Save
+                    </Button>
+                  </>
+                ) : (
+                  <Button
+                    variant="contained"
+                    onClick={handleAddRuleSection}
+                    sx={{
+                      borderRadius: '8px',
+                      color: '#ededed',
+                      backgroundColor: '#dd514c',
+                      padding: '2px 15px',
+                      fontSize: '16px',
+                      fontWeight: 700,
+                      textTransform: 'none',
+                      '&:hover': {
+                        backgroundColor: '#c74340'
+                      }
+                    }}
+                  >
+                    Add Rule Section
+                  </Button>
+                )}
               </Box>
             </Box>
           </Box>

--- a/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { Box, Button, Paper, Table, TableBody, TableContainer, TextField } from '@mui/material';
+import { Box, Button, Paper, Table, TableBody, TableContainer, TextField, useTheme } from '@mui/material';
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import PageLayout from '../../components/PageLayout';
@@ -46,6 +46,8 @@ const RulesetEditPage: React.FC = () => {
   // Editing state
   const [editingRuleId, setEditingRuleId] = useState<string | null>(null);
   const [editedContent, setEditedContent] = useState<string>('');
+
+  const theme = useTheme();
 
   const {
     data: ruleset,
@@ -136,7 +138,7 @@ const RulesetEditPage: React.FC = () => {
   };
 
   const handleEditRule = (ruleId: string) => {
-    const rule = ruleset.rules.find((r) => r.ruleId === ruleId);
+    const rule = allRules.find((r) => r.ruleId === ruleId);
     if (rule) {
       setEditingRuleId(ruleId);
       setEditedContent(rule.ruleContent);
@@ -190,7 +192,7 @@ const RulesetEditPage: React.FC = () => {
                     <RuleRow
                       key={rule.ruleId}
                       rule={rule}
-                      allRules={ruleset.rules}
+                      allRules={allRules}
                       middleContent={(currentRule) => {
                         const isEditing = editingRuleId === currentRule.ruleId;
                         if (isEditing) {
@@ -204,8 +206,9 @@ const RulesetEditPage: React.FC = () => {
                               size="small"
                               autoFocus
                               sx={{
-                                backgroundColor: '#ffffff',
+                                backgroundColor: theme.palette.grey[100],
                                 '& .MuiOutlinedInput-root': {
+                                  color: '#000000',
                                   '& fieldset': {
                                     borderColor: '#dd514c'
                                   },

--- a/src/frontend/src/utils/urls.ts
+++ b/src/frontend/src/utils/urls.ts
@@ -455,6 +455,7 @@ const rulesGetUnassignedRulesForRuleset = (rulesetId: string, teamId: string) =>
 const rulesCreateProjectRule = () => `${rules()}/projectRule/create`;
 const rulesDeleteProjectRule = (projectRuleId: string) => `${rules()}/projectRule/${projectRuleId}/delete`;
 const rulesEditProjectRuleStatus = (projectRuleId: string) => `${rules()}/projectRule/${projectRuleId}/editStatus`;
+const rulesEdit = (ruleId: string) => `${rules()}/rule/${ruleId}/edit`;
 const rulesetUpdate = (rulesetId: string) => `${ruleset()}/${rulesetId}/update`;
 const rulesetDelete = (rulesetId: string) => `${ruleset()}/${rulesetId}/delete`;
 const rulesetTypeDelete = (rulesetTypeId: string) => `${rules()}/rulesetType/${rulesetTypeId}/delete`;
@@ -777,6 +778,7 @@ export const apiUrls = {
   rulesCreateProjectRule,
   rulesDeleteProjectRule,
   rulesEditProjectRuleStatus,
+  rulesEdit,
   rulesetUpdate,
   rulesetDelete,
   rulesetTypeDelete,


### PR DESCRIPTION
## Changes

Implemented inline editing for rules on the Edit Rules page - clicking the pencil icon highlights the rule and displays an editable TextField, with Save/Cancel buttons appearing in the bottom bar. Updated the backend to support partial rule updates (editing only `ruleContent` without requiring all fields).

## Notes

Could not test due to finishline issues, Zach will have to test it
 
## Screenshots

<img width="1366" height="911" alt="Screenshot 2026-01-19 at 18 17 58" src="https://github.com/user-attachments/assets/be2dfc88-e36d-4b1a-988a-b3bfc2e639ac" />
<img width="684" height="457" alt="Screenshot 2026-01-19 at 18 18 10" src="https://github.com/user-attachments/assets/8f4c207c-2bd4-418e-b455-21e1fd373bf4" />
<img width="1365" height="915" alt="Screenshot 2026-01-19 at 18 18 26" src="https://github.com/user-attachments/assets/97961361-6f92-49e1-8ff2-970886725f54" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #3725