### PR TITLE
#2398 sponsor notes field and added in weeks to wp duration

### DIFF
--- a/src/backend/src/controllers/finance.controllers.ts
+++ b/src/backend/src/controllers/finance.controllers.ts
@@ -14,7 +14,8 @@ export default class FinanceController {
         taxExempt,
         sponsorContact,
         sponsorTasks,
-        discountCode
+        discountCode,
+        sponsorNotes
       } = req.body;
 
       const sponsor = await FinanceServices.createSponsor(
@@ -29,7 +30,8 @@ export default class FinanceController {
         sponsorContact,
         sponsorTasks,
         req.organization,
-        discountCode
+        discountCode,
+        sponsorNotes
       );
       res.status(200).json(sponsor);
     } catch (error: unknown) {
@@ -328,7 +330,8 @@ export default class FinanceController {
         sponsorContact,
         taxExempt,
         sponsorTasks,
-        discountCode
+        discountCode,
+        sponsorNotes
       } = req.body;
 
       const updatedSponsor = await FinanceServices.editSponsor(
@@ -344,7 +347,8 @@ export default class FinanceController {
         sponsorContact,
         taxExempt,
         sponsorTasks,
-        discountCode
+        discountCode,
+        sponsorNotes
       );
 
       res.status(200).json(updatedSponsor);

--- a/src/backend/src/prisma/migrations/20260119232358_sponsor_notes/migration.sql
+++ b/src/backend/src/prisma/migrations/20260119232358_sponsor_notes/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Sponsor" ADD COLUMN     "sponsorNotes" TEXT;

--- a/src/backend/src/prisma/schema.prisma
+++ b/src/backend/src/prisma/schema.prisma
@@ -795,6 +795,7 @@ model Sponsor {
   discountCode   String?
   activeYears    Int[]
   taxExempt      Boolean
+  sponsorNotes   String?
   sponsorTasks   Sponsor_Task[]
 
   @@unique([name, organizationId], name: "uniqueSponsor")

--- a/src/backend/src/services/finance.services.ts
+++ b/src/backend/src/services/finance.services.ts
@@ -48,6 +48,7 @@ export default class FinanceServices {
    * @param sponsorTierId The ID of the sponsor's tier.
    * @param taxExempt Boolean indicating if the sponsor is tax-exempt.
    * @param discountCode The discount code associated with the sponsor.
+   * @param sponsorNotes Additional notes about the sponsor.
    * @param sponsorContact The contact information for the sponsor.
    * @param sponsorTasks An array of sponsor tasks associated with the sponsor.
    * @param organization The organization for which the sponsor is being created.
@@ -68,7 +69,8 @@ export default class FinanceServices {
     sponsorContact: string,
     sponsorTasks: CreateSponsorTask[],
     organization: Organization,
-    discountCode?: string
+    discountCode?: string,
+    sponsorNotes?: string
   ) {
     if (!(await userHasPermission(submitter.userId, organization.organizationId, isHead)))
       throw new AccessDeniedException('Only heads can create a sponsor');
@@ -94,6 +96,7 @@ export default class FinanceServices {
         sponsorTierId,
         taxExempt,
         discountCode,
+        sponsorNotes,
         vendorContact: sponsorContact,
         sponsorTasks: {
           create: sponsorTasks.map((task) => ({
@@ -1102,6 +1105,7 @@ export default class FinanceServices {
    * @param sponsorTierId The ID of the sponsor's tier.
    * @param taxExempt Boolean indicating if the sponsor is tax-exempt.
    * @param discountCode The discount code associated with the sponsor.
+   * @param sponsorNotes Additional notes about the sponsor.
    * @param sponsorContact The contact information for the sponsor.
    * @param sponsorTasks An array of sponsor tasks associated with the sponsor.
    * @param organization The organization for which the sponsor is being edited.
@@ -1121,7 +1125,8 @@ export default class FinanceServices {
     sponsorContact: string,
     taxExempt: boolean,
     sponsorTasks: CreateSponsorTask[],
-    discountCode?: string
+    discountCode?: string,
+    sponsorNotes?: string
   ): Promise<Sponsor> {
     if (!(await userHasPermission(submitter.userId, organization.organizationId, isHead)))
       throw new AccessDeniedException('Only heads can edit sponsors.');
@@ -1202,7 +1207,8 @@ export default class FinanceServices {
         },
         vendorContact: sponsorContact,
         taxExempt,
-        discountCode
+        discountCode,
+        sponsorNotes
       },
       ...getSponsorQueryArgs(organization.organizationId)
     });

--- a/src/backend/src/transformers/finance.transformer.ts
+++ b/src/backend/src/transformers/finance.transformer.ts
@@ -7,6 +7,7 @@ export const sponsorTransformer = (sponsor: Prisma.SponsorGetPayload<SponsorQuer
   return {
     ...sponsor,
     sponsorContact: sponsor.vendorContact,
+    sponsorNotes: sponsor.sponsorNotes ?? undefined,
     discountCode: sponsor.discountCode ?? undefined,
     sponsorTasks: sponsor.sponsorTasks.map(sponsorTaskTranformer)
   };

--- a/src/frontend/src/hooks/finance.hooks.ts
+++ b/src/frontend/src/hooks/finance.hooks.ts
@@ -166,6 +166,7 @@ export interface SponsorPayload {
   sponsorContact: string;
   sponsorTasks: CreateSponsorTask[];
   discountCode?: string;
+  sponsorNotes?: string;
 }
 
 interface EditSponsorPayload extends SponsorPayload {

--- a/src/frontend/src/pages/FinancePage/FinanceComponents/CreateSponsorPage.tsx
+++ b/src/frontend/src/pages/FinancePage/FinanceComponents/CreateSponsorPage.tsx
@@ -32,6 +32,8 @@ const CreateSponsorPage = ({ showPage, handleClose }: CreateSponsorPageProps) =>
       sponsorTierId: '',
       sponsorContact: '',
       taxExempt: false,
+      discountCode: '',
+      sponsorNotes: '',
       sponsorTasks: []
     }
   });

--- a/src/frontend/src/pages/FinancePage/FinanceComponents/EditSponsorPage.tsx
+++ b/src/frontend/src/pages/FinancePage/FinanceComponents/EditSponsorPage.tsx
@@ -45,6 +45,7 @@ const EditSponsorPage = ({ showPage, handleClose, sponsor }: EditSponsorPageProp
       sponsorContact: sponsor.sponsorContact,
       taxExempt: sponsor.taxExempt,
       discountCode: sponsor.discountCode ?? undefined,
+      sponsorNotes: sponsor.sponsorNotes ?? undefined,
       sponsorTasks: defaultSponsorTasks
     }
   });

--- a/src/frontend/src/pages/FinancePage/FinanceComponents/SponsorForm.tsx
+++ b/src/frontend/src/pages/FinancePage/FinanceComponents/SponsorForm.tsx
@@ -297,12 +297,18 @@ export const SponsorForm: React.FC<SponsorFormProps> = ({ control, errors, defau
           <FormHelperText error> {errors.discountCode?.message}</FormHelperText>
         </FormControl>
       </Grid>
-      <Grid item xs={12} sm={6}>
+      <Grid item xs={12}>
         <FormControl fullWidth>
           <Typography variant="h5" color="#EF4345">
             Sponsor Notes:
           </Typography>
-          <ReactHookTextField name="sponsorNotes" control={control} placeholder="Enter Additional Information" />
+          <ReactHookTextField
+            name="sponsorNotes"
+            control={control}
+            placeholder="Enter Additional Information"
+            multiline
+            rows={4}
+          />
           <FormHelperText error> {errors.sponsorNotes?.message}</FormHelperText>
         </FormControl>
       </Grid>

--- a/src/frontend/src/pages/FinancePage/FinanceComponents/SponsorForm.tsx
+++ b/src/frontend/src/pages/FinancePage/FinanceComponents/SponsorForm.tsx
@@ -54,6 +54,7 @@ const sponsorSchema = yup.object().shape({
   sponsorContact: yup.string().required('Sponsor contact is required'),
   taxExempt: yup.boolean().required('Tax exempt is required'),
   discountCode: yup.string().trim().optional(),
+  sponsorNotes: yup.string().trim().optional(),
   sponsorTasks: yup
     .array()
     .of(
@@ -294,6 +295,15 @@ export const SponsorForm: React.FC<SponsorFormProps> = ({ control, errors, defau
           </Typography>
           <ReactHookTextField name="discountCode" control={control} sx={{ width: 1 }} placeholder="Enter Code" />
           <FormHelperText error> {errors.discountCode?.message}</FormHelperText>
+        </FormControl>
+      </Grid>
+      <Grid item xs={12} sm={6}>
+        <FormControl fullWidth>
+          <Typography variant="h5" color="#EF4345">
+            Sponsor Notes:
+          </Typography>
+          <ReactHookTextField name="sponsorNotes" control={control} placeholder="Enter Additional Information" />
+          <FormHelperText error> {errors.sponsorNotes?.message}</FormHelperText>
         </FormControl>
       </Grid>
       <Grid item xs={12} sm={12}>

--- a/src/frontend/src/pages/FinancePage/SponsorsTable.tsx
+++ b/src/frontend/src/pages/FinancePage/SponsorsTable.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { GridRenderCellParams } from '@mui/x-data-grid';
 import type { MapRowResult } from '../../components/NERDataGrid';
 import type { MouseEvent } from 'react';
-import { Box, IconButton, Checkbox } from '@mui/material';
+import { Box, IconButton, Checkbox, Tooltip } from '@mui/material';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import { useEditSponsor, useGetAllSponsors } from '../../hooks/finance.hooks';
 import ErrorPage from '../ErrorPage';
@@ -19,6 +19,7 @@ import SponsorTasksModal from './FinanceComponents/SponsorTasksModal';
 import SidePagePopup from './FinanceComponents/SidePagePopup';
 import NERDataGrid from '../../components/NERDataGrid';
 import { useCurrentUser } from '../../hooks/users.hooks';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 
 const SponsorsTable = () => {
   const { data: sponsors, isLoading: sponsorIsLoading, isError: sponsorIsError, error: sponsorError } = useGetAllSponsors();
@@ -50,11 +51,13 @@ const SponsorsTable = () => {
   };
 
   const columns = [
-    { field: 'name', headerName: 'Sponsor', flex: 1 },
+    { field: 'name', headerName: 'Sponsor', flex: 1, minWidth: 50 },
     {
       field: 'activeStatus',
       headerName: 'Active?',
-      width: 160,
+      flex: 1,
+      minWidth: 50,
+      maxWidth: 100,
       renderCell: (p: GridRenderCellParams<boolean, MapRowResult<Sponsor>>) => (
         <Checkbox
           disabled={!canEditSponsors}
@@ -69,11 +72,12 @@ const SponsorsTable = () => {
         />
       )
     },
-    { field: 'sponsorContact', headerName: 'Contact', flex: 1 },
+    { field: 'sponsorContact', headerName: 'Contact', flex: 1, minWidth: 50 },
     {
       field: 'tier',
       headerName: 'Sponsor Tier',
-      width: 140,
+      flex: 1,
+      minWidth: 100,
       renderCell: (params: GridRenderCellParams<any, MapRowResult<Sponsor>>) => (
         <SponsorTierPill tier={(params.row as MapRowResult<Sponsor>).raw!.tier} />
       )
@@ -81,21 +85,25 @@ const SponsorsTable = () => {
     {
       field: 'sponsorValue',
       headerName: 'Sponsor Value',
-      width: 160,
+      flex: 1,
+      minWidth: 50,
       renderCell: (p: GridRenderCellParams<number, MapRowResult<Sponsor>>) => `$${p.value}`
     },
     {
       field: 'joinDate',
       headerName: 'Sponsor Join Date',
-      width: 180,
+      flex: 1,
+      minWidth: 100,
       renderCell: (p: GridRenderCellParams<string | null, MapRowResult<Sponsor>>) =>
         datePipe(new Date(String(p.value ?? '')))
     },
-    { field: 'discountCode', headerName: 'Discount', flex: 1 },
+    { field: 'discountCode', headerName: 'Discount', flex: 1, minWidth: 50 },
     {
       field: 'taxExempt',
       headerName: 'Tax Exempt?',
-      width: 120,
+      flex: 1,
+      minWidth: 50,
+      maxWidth: 100,
       renderCell: (p: GridRenderCellParams<boolean, MapRowResult<Sponsor>>) => {
         return (
           <Checkbox
@@ -113,9 +121,34 @@ const SponsorsTable = () => {
       }
     },
     {
+      field: 'sponsorNotes',
+      headerName: 'Notes',
+      flex: 1,
+      minWidth: 40,
+      maxWidth: 80,
+      sortable: false,
+      filterable: false,
+      renderCell: (p: GridRenderCellParams<string | null, MapRowResult<Sponsor>>) => {
+        const notes = (p.row as MapRowResult<Sponsor>).raw?.sponsorNotes;
+
+        if (!notes || notes.trim() === '') {
+          return null;
+        }
+
+        return (
+          <Tooltip title={notes} arrow placement="left">
+            <IconButton size="small" sx={{ p: 0.5, color: 'white' }}>
+              <InfoOutlinedIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        );
+      }
+    },
+    {
       field: 'tasks',
       headerName: 'Sponsor Tasks',
-      width: 180,
+      flex: 1,
+      minWidth: 100,
       sortable: false,
       filterable: false,
       renderCell: (params: GridRenderCellParams<any, MapRowResult<Sponsor>>) => {
@@ -147,7 +180,9 @@ const SponsorsTable = () => {
     {
       field: 'actions',
       headerName: 'Delete',
-      width: 100,
+      flex: 1,
+      minWidth: 50,
+      maxWidth: 80,
       sortable: false,
       filterable: false,
       renderCell: (params: GridRenderCellParams<any, MapRowResult<Sponsor>>) => {

--- a/src/frontend/src/pages/WorkPackageForm/WorkPackageFormDetails.tsx
+++ b/src/frontend/src/pages/WorkPackageForm/WorkPackageFormDetails.tsx
@@ -112,7 +112,7 @@ const WorkPackageFormDetails: React.FC<Props> = ({
         </Grid>
         <Grid item xs={12} md={4}>
           <FormControl fullWidth>
-            <FormLabel>Duration</FormLabel>
+            <FormLabel>Duration (in weeks)</FormLabel>
             <ReactHookTextField
               name="duration"
               control={control}

--- a/src/shared/src/types/finance-types.ts
+++ b/src/shared/src/types/finance-types.ts
@@ -10,7 +10,7 @@ export interface Sponsor {
   activeYears: number[];
   taxExempt: boolean;
   discountCode?: string;
-  sponsorNotes: string;
+  sponsorNotes?: string;
   sponsorTasks: SponsorTask[];
   tier: SponsorTier;
 }

--- a/src/shared/src/types/finance-types.ts
+++ b/src/shared/src/types/finance-types.ts
@@ -10,6 +10,7 @@ export interface Sponsor {
   activeYears: number[];
   taxExempt: boolean;
   discountCode?: string;
+  sponsorNotes: string;
   sponsorTasks: SponsorTask[];
   tier: SponsorTier;
 }


### PR DESCRIPTION
## Changes

Added notes field to add/edit sponsor as well as a column in the sponsor table
- also improved column spacing in the sponsor table

combined ticket (because I pushed changes on the wrong branch but this one was so small anyway): added (in weeks) beside duration for work packages

## Tests

Works for editing and for adding a new sponsor

## Screenshots for Sponsor Notes

<img width="1427" height="549" alt="Screenshot 2026-01-19 at 7 21 38 PM" src="https://github.com/user-attachments/assets/c5c0e186-6444-432c-adc0-dc26e35488c4" />

<img width="1440" height="858" alt="Screenshot 2026-01-19 at 7 21 22 PM" src="https://github.com/user-attachments/assets/14c162f2-4993-4bae-9556-f7a0cd06886b" />

<img width="719" height="857" alt="Screenshot 2026-01-19 at 7 23 14 PM" src="https://github.com/user-attachments/assets/114190f9-504c-4b94-a77b-08e9ffffd169" />


## Screenshots for (in weeks) addition

<img width="1418" height="638" alt="Screenshot 2026-01-19 at 5 54 16 PM" src="https://github.com/user-attachments/assets/9fdfc8eb-0049-47ae-b6ec-f0472c717c50" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3899 and #2398
