### PR TITLE
3894 maintenence   add timezone to design review

### DIFF
--- a/src/backend/src/services/notifications.services.ts
+++ b/src/backend/src/services/notifications.services.ts
@@ -182,7 +182,7 @@ export default class NotificationsService {
           return (
             `${usersToSlackPings(designReview.attendees ?? [])} ${
               designReview.wbsElement.name
-            } will be having a design review today at ${meetingStartTimePipe(designReview.meetingTimes)}! ` +
+            } will be having a design review today at EST ${meetingStartTimePipe(designReview.meetingTimes)}! ` +
             zoomLink +
             questionDocLink
           );

--- a/src/backend/src/services/notifications.services.ts
+++ b/src/backend/src/services/notifications.services.ts
@@ -182,7 +182,7 @@ export default class NotificationsService {
           return (
             `${usersToSlackPings(designReview.attendees ?? [])} ${
               designReview.wbsElement.name
-            } will be having a design review today at EST ${meetingStartTimePipe(designReview.meetingTimes)}! ` +
+            } will be having a design review today at ${meetingStartTimePipe(designReview.meetingTimes)} EST! ` +
             zoomLink +
             questionDocLink
           );


### PR DESCRIPTION
## Changes

Changed slack notification for design review to include time zone (EST).

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3894
