### PR TITLE
Fix Diff for New Project Change Requests

### DIFF
--- a/src/backend/src/transformers/change-requests.transformer.ts
+++ b/src/backend/src/transformers/change-requests.transformer.ts
@@ -8,7 +8,6 @@ import {
   WbsElementStatus,
   WorkPackageProposedChanges,
   WorkPackageStage,
-  isProjectWbs,
   BudgetChangeRequest,
   isWorkPackageWbs
 } from 'shared';

--- a/src/backend/src/transformers/change-requests.transformer.ts
+++ b/src/backend/src/transformers/change-requests.transformer.ts
@@ -9,7 +9,8 @@ import {
   WorkPackageProposedChanges,
   WorkPackageStage,
   isProjectWbs,
-  BudgetChangeRequest
+  BudgetChangeRequest,
+  isWorkPackageWbs
 } from 'shared';
 import { wbsNumOf } from '../utils/utils.js';
 import { calculateChangeRequestStatus, convertCRScopeWhyType } from '../utils/change-requests.utils.js';
@@ -132,7 +133,7 @@ const changeRequestTransformer = (
   const status = calculateChangeRequestStatus(changeRequest);
 
   const wbsName = changeRequest.wbsElement
-    ? isProjectWbs(changeRequest.wbsElement)
+    ? !isWorkPackageWbs(changeRequest.wbsElement)
       ? changeRequest.wbsElement?.name
       : `${changeRequest.wbsElement?.workPackage?.project.wbsElement.name} - ${changeRequest.wbsElement?.name}`
     : undefined;

--- a/src/frontend/src/pages/ChangeRequestDetailPage/DiffSection/DiffSection.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/DiffSection/DiffSection.tsx
@@ -1,11 +1,13 @@
 import { Box } from '@mui/system';
 import InfoBlock from '../../../components/InfoBlock';
-import { StandardChangeRequest } from 'shared';
+import { isProjectWbs, StandardChangeRequest } from 'shared';
 import ProjectDiffSection from './ProjectDiffSection';
 import WorkPackageDiffSection from './WorkPackageDiffSection';
 import LoadingIndicator from '../../../components/LoadingIndicator';
 import DiffSectionEdit from './DiffSectionEdit';
 import { getChangesForWorkPackage } from '../../../utils/diff-page.utils';
+import NewProjectDiffSection from './NewProjectDiffSection';
+
 interface DiffSectionProps {
   changeRequest: StandardChangeRequest;
 }
@@ -18,7 +20,11 @@ const DiffSection: React.FC<DiffSectionProps> = ({ changeRequest }) => {
       <InfoBlock title={`Proposed Changes`} />
       {wbsNum ? (
         projectProposedChanges ? (
-          <ProjectDiffSection projectProposedChanges={projectProposedChanges} wbsNum={wbsNum} />
+          isProjectWbs(wbsNum) ? (
+            <ProjectDiffSection projectProposedChanges={projectProposedChanges} wbsNum={wbsNum} />
+          ) : (
+            <NewProjectDiffSection projectProposedChanges={projectProposedChanges} />
+          )
         ) : workPackageProposedChanges ? (
           wbsNum.workPackageNumber === 0 ? (
             <DiffSectionEdit collections={[getChangesForWorkPackage(undefined, workPackageProposedChanges)]} />

--- a/src/frontend/src/pages/ChangeRequestDetailPage/DiffSection/NewProjectDiffSection.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/DiffSection/NewProjectDiffSection.tsx
@@ -1,0 +1,16 @@
+import { ProjectProposedChanges } from 'shared';
+import DiffSectionEdit from './DiffSectionEdit';
+import { ComparableCollection, getChangesForProject } from '../../../utils/diff-page.utils';
+import { useEffect, useState } from 'react';
+
+const NewProjectDiffSection = ({ projectProposedChanges }: { projectProposedChanges: ProjectProposedChanges }) => {
+  const [collections, setCollections] = useState<ComparableCollection[]>([]);
+
+  useEffect(() => {
+    setCollections(getChangesForProject(projectProposedChanges, undefined));
+  }, [projectProposedChanges, setCollections]);
+
+  return <DiffSectionEdit collections={collections} />;
+};
+
+export default NewProjectDiffSection;

--- a/src/frontend/src/pages/ChangeRequestDetailPage/DiffSection/ProjectDiffSection.tsx
+++ b/src/frontend/src/pages/ChangeRequestDetailPage/DiffSection/ProjectDiffSection.tsx
@@ -18,7 +18,7 @@ const ProjectDiffSection = ({
 
   useEffect(() => {
     if (originalProject) {
-      setCollections(getChangesForProject(originalProject, projectProposedChanges));
+      setCollections(getChangesForProject(projectProposedChanges, originalProject));
     }
   }, [originalProject, projectProposedChanges, setCollections]);
 

--- a/src/frontend/src/utils/diff-page.utils.ts
+++ b/src/frontend/src/utils/diff-page.utils.ts
@@ -199,16 +199,16 @@ export const getWbsChanges = (
 };
 
 export const getChangesForProject = (
-  originalProject: Project,
-  proposedChanges: ProjectProposedChanges
+  proposedChanges: ProjectProposedChanges,
+  originalProject?: Project
 ): ComparableCollection[] => {
   const projectLines: ComparableLine[] = [...getWbsChanges(originalProject, proposedChanges)];
 
   projectLines.push(
     genChange(
       'Summary',
-      originalProject.summary !== proposedChanges.summary,
-      originalProject.summary,
+      originalProject?.summary !== proposedChanges.summary,
+      originalProject ? originalProject.summary : '',
       proposedChanges.summary
     )
   );
@@ -216,8 +216,8 @@ export const getChangesForProject = (
   projectLines.push(
     genChange(
       'Budget',
-      originalProject.budget !== proposedChanges.budget,
-      `$${originalProject.budget}`,
+      originalProject?.budget !== proposedChanges.budget,
+      originalProject ? `$${originalProject.budget}` : '',
       `$${proposedChanges.budget}`
     )
   );
@@ -226,9 +226,11 @@ export const getChangesForProject = (
     genListChange(
       'Teams',
       '',
-      originalProject.teams
-        .map((team) => ({ ...team, value: team.teamName }))
-        .sort((a, b) => a.teamName.localeCompare(b.teamName)),
+      originalProject
+        ? originalProject.teams
+            .map((team) => ({ ...team, value: team.teamName }))
+            .sort((a, b) => a.teamName.localeCompare(b.teamName))
+        : [],
       proposedChanges.teams
         .map((team) => ({ ...team, value: team.teamName }))
         .sort((a, b) => a.teamName.localeCompare(b.teamName)),
@@ -238,7 +240,7 @@ export const getChangesForProject = (
 
   const workPackageCollections: ComparableCollection[] = [];
 
-  originalProject.workPackages.forEach((workPackage) => {
+  originalProject?.workPackages.forEach((workPackage) => {
     const newWorkPackage = proposedChanges.workPackageProposedChanges.find((wp) => wp.name === workPackage.name); // TODO ideally do this based on something unique, maybe add a reference to original wbsElementid or something this also just doesnt work if the name has changed so... I dont see another way to identify them though
     if (newWorkPackage) {
       const workPackageLines = getChangesForWorkPackage(workPackage, newWorkPackage);
@@ -253,7 +255,7 @@ export const getChangesForProject = (
     workPackageCollections.push(getChangesForWorkPackage(undefined, wp));
   });
 
-  return [{ label: originalProject.name, lines: projectLines }, ...workPackageCollections];
+  return [{ label: originalProject ? originalProject.name : '', lines: projectLines }, ...workPackageCollections];
 };
 
 export const getChangesForWorkPackage = (


### PR DESCRIPTION
## Changes

useGetSingleProject will throw an error if the project isnt found, so instead I created a new page that doesnt call that hook if its a change request made off of a car. Also fixed a bug where change requests on car read undefined - fergus. 

## Screenshots
<img width="1728" height="437" alt="Screenshot 2026-02-08 at 12 11 41 PM" src="https://github.com/user-attachments/assets/3fd21265-34df-4a3c-b6d8-2f68cebc929b" />

<img width="1728" height="663" alt="Screenshot 2026-02-08 at 12 12 35 PM" src="https://github.com/user-attachments/assets/4abbae78-54bd-4745-ac79-a62ac2fd1a58" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
