### PR TITLE
fixed reimbursement request bugs

### DIFF
--- a/src/backend/src/utils/reimbursement-requests.utils.ts
+++ b/src/backend/src/utils/reimbursement-requests.utils.ts
@@ -160,14 +160,27 @@ export const updateReimbursementProducts = async (
  * @param products the products to update
  */
 const updateExistingProducts = async (products: ReimbursementProductCreateArgs[]) => {
-  //updates the cost and name of the remaining products, which should be products that existed before that were not deleted
+  //updates the cost, name, and refund sources of the remaining products, which should be products that existed before that were not deleted
   // Does not update wbs element id because we are requiring the user on the frontend to delete it from the wbs number and then adding it to another one
   for (const product of products) {
+    // Delete old refund sources for this product
+    await prisma.refund_Source.deleteMany({
+      where: { reimbursementProductId: product.id }
+    });
+
+    const refundSources = product.refundSources.map((rs) => ({
+      indexCode: { connect: { indexCodeId: rs.indexCode.indexCodeId } },
+      amount: rs.amount
+    }));
+
     await prisma.reimbursement_Product.update({
       where: { reimbursementProductId: product.id },
       data: {
         name: product.name,
-        cost: product.cost
+        cost: product.cost,
+        refundSources: {
+          create: refundSources
+        }
       }
     });
   }

--- a/src/backend/src/utils/reimbursement-requests.utils.ts
+++ b/src/backend/src/utils/reimbursement-requests.utils.ts
@@ -125,17 +125,21 @@ export const updateReimbursementProducts = async (
   }
 
   //if a product has an id that means it existed before and was updated
-  const updatedOtherExistingProducts = updatedOtherReimbursementProducts.filter((product) => product.id);
-
-  const updatedWbsExistingProducts = updatedWbsReimbursementProducts.filter((product) => product.id);
-
-  const updatedExistingProducts = (updatedOtherExistingProducts as ReimbursementProductCreateArgs[]).concat(
-    updatedWbsExistingProducts as ReimbursementProductCreateArgs[]
+  const updatedOtherExistingProducts = updatedOtherReimbursementProducts.filter(
+    (product): product is OtherReimbursementProductCreateArgs & { id: string } => !!product.id
   );
+
+  const updatedWbsExistingProducts = updatedWbsReimbursementProducts.filter(
+    (product): product is WbsReimbursementProductCreateArgs & { id: string } => !!product.id
+  );
+
+  const updatedExistingProducts = (
+    updatedOtherExistingProducts as (ReimbursementProductCreateArgs & { id: string })[]
+  ).concat(updatedWbsExistingProducts as (ReimbursementProductCreateArgs & { id: string })[]);
 
   validateUpdatedProductsExistInDatabase(currentReimbursementProducts, updatedExistingProducts);
 
-  const updatedExistingProductIds = updatedExistingProducts.map((product) => product.id!);
+  const updatedExistingProductIds = updatedExistingProducts.map((product) => product.id);
 
   //if the product does not have an id that means it is new
   const newOtherProducts = updatedOtherReimbursementProducts.filter((product) => !product.id);
@@ -159,26 +163,23 @@ export const updateReimbursementProducts = async (
  *
  * @param products the products to update
  */
-const updateExistingProducts = async (products: ReimbursementProductCreateArgs[]) => {
+const updateExistingProducts = async (products: (ReimbursementProductCreateArgs & { id: string })[]) => {
   //updates the cost, name, and refund sources of the remaining products, which should be products that existed before that were not deleted
   // Does not update wbs element id because we are requiring the user on the frontend to delete it from the wbs number and then adding it to another one
   for (const product of products) {
-    // Delete old refund sources for this product
-    await prisma.refund_Source.deleteMany({
-      where: { reimbursementProductId: product.id }
-    });
-
     const refundSources = product.refundSources.map((rs) => ({
       indexCode: { connect: { indexCodeId: rs.indexCode.indexCodeId } },
       amount: rs.amount
     }));
 
+    // Delete old refund sources and update product atomically
     await prisma.reimbursement_Product.update({
       where: { reimbursementProductId: product.id },
       data: {
         name: product.name,
         cost: product.cost,
         refundSources: {
+          deleteMany: {},
           create: refundSources
         }
       }

--- a/src/backend/tests/unmocked/reimbursement-requests.test.ts
+++ b/src/backend/tests/unmocked/reimbursement-requests.test.ts
@@ -1125,4 +1125,153 @@ describe('Reimbursement Requests', () => {
       expect(updatedVendor.taxExempt).toBe(true);
     });
   });
+
+  describe('Editing a reimbursement request', () => {
+    test('editing preserves refund sources on existing products', async () => {
+      // Get the original product info
+      const [originalProduct] = reimbursementRequest.reimbursementProducts;
+
+      // Edit the request, updating the product name but keeping the same refund source
+      await ReimbursementRequestService.editReimbursementRequest(
+        reimbursementRequest.reimbursementRequestId,
+        createdVendor.vendorId,
+        createdIndexCode.indexCodeId,
+        createdAccountCode.accountCodeId,
+        reimbursementRequest.totalCost,
+        [],
+        [
+          {
+            id: originalProduct.reimbursementProductId,
+            name: 'UPDATED GLUE',
+            reason: {
+              carNumber: 0,
+              projectNumber: 0,
+              workPackageNumber: 0
+            },
+            cost: 200000,
+            refundSources: [
+              {
+                indexCode: createdIndexCode,
+                amount: 200
+              }
+            ]
+          }
+        ],
+        [],
+        createdUser,
+        org,
+        new Date()
+      );
+
+      // Fetch the updated request and verify refund sources are preserved
+      const updatedRR = await ReimbursementRequestService.getSingleReimbursementRequest(
+        createdUser,
+        reimbursementRequest.reimbursementRequestId,
+        org
+      );
+
+      expect(updatedRR.reimbursementProducts).toHaveLength(1);
+      expect(updatedRR.reimbursementProducts[0].name).toEqual('UPDATED GLUE');
+      expect(updatedRR.reimbursementProducts[0].cost).toEqual(200000);
+      expect(updatedRR.reimbursementProducts[0].refundSources).toHaveLength(1);
+      expect(updatedRR.reimbursementProducts[0].refundSources[0].amount).toEqual(200);
+      expect(updatedRR.reimbursementProducts[0].refundSources[0].indexCode.indexCodeId).toEqual(
+        createdIndexCode.indexCodeId
+      );
+    });
+
+    test('editing updates refund source amounts on existing products', async () => {
+      const [originalProduct] = reimbursementRequest.reimbursementProducts;
+
+      // Edit with a different refund source amount
+      await ReimbursementRequestService.editReimbursementRequest(
+        reimbursementRequest.reimbursementRequestId,
+        createdVendor.vendorId,
+        createdIndexCode.indexCodeId,
+        createdAccountCode.accountCodeId,
+        reimbursementRequest.totalCost,
+        [],
+        [
+          {
+            id: originalProduct.reimbursementProductId,
+            name: 'GLUE',
+            reason: {
+              carNumber: 0,
+              projectNumber: 0,
+              workPackageNumber: 0
+            },
+            cost: 300000,
+            refundSources: [
+              {
+                indexCode: createdIndexCode,
+                amount: 300
+              }
+            ]
+          }
+        ],
+        [],
+        createdUser,
+        org,
+        new Date()
+      );
+
+      const updatedRR = await ReimbursementRequestService.getSingleReimbursementRequest(
+        createdUser,
+        reimbursementRequest.reimbursementRequestId,
+        org
+      );
+
+      expect(updatedRR.reimbursementProducts).toHaveLength(1);
+      expect(updatedRR.reimbursementProducts[0].cost).toEqual(300000);
+      expect(updatedRR.reimbursementProducts[0].refundSources).toHaveLength(1);
+      expect(updatedRR.reimbursementProducts[0].refundSources[0].amount).toEqual(300);
+    });
+
+    test('editing with new products (no id) creates them with refund sources', async () => {
+      // Edit the request, replacing the old product with a new one (no id)
+      await ReimbursementRequestService.editReimbursementRequest(
+        reimbursementRequest.reimbursementRequestId,
+        createdVendor.vendorId,
+        createdIndexCode.indexCodeId,
+        createdAccountCode.accountCodeId,
+        reimbursementRequest.totalCost,
+        [],
+        [
+          {
+            name: 'NEW TAPE',
+            reason: {
+              carNumber: 0,
+              projectNumber: 0,
+              workPackageNumber: 0
+            },
+            cost: 500,
+            refundSources: [
+              {
+                indexCode: createdIndexCode,
+                amount: 500
+              }
+            ]
+          }
+        ],
+        [],
+        createdUser,
+        org,
+        new Date()
+      );
+
+      const updatedRR = await ReimbursementRequestService.getSingleReimbursementRequest(
+        createdUser,
+        reimbursementRequest.reimbursementRequestId,
+        org
+      );
+
+      // Old product should be soft-deleted, new one created
+      const activeProducts = updatedRR.reimbursementProducts;
+      expect(activeProducts).toHaveLength(1);
+      expect(activeProducts[0].name).toEqual('NEW TAPE');
+      expect(activeProducts[0].cost).toEqual(500);
+      expect(activeProducts[0].refundSources).toHaveLength(1);
+      expect(activeProducts[0].refundSources[0].amount).toEqual(500);
+    });
+  });
 });

--- a/src/frontend/src/pages/FinancePage/EditReimbursementRequest/EditReimbursementRequestRenderedDefaultValues.tsx
+++ b/src/frontend/src/pages/FinancePage/EditReimbursementRequest/EditReimbursementRequestRenderedDefaultValues.tsx
@@ -43,6 +43,7 @@ const EditReimbursementRequestRenderedDefaultValues: React.FC<{
           dateOfExpense: reimbursementRequest.dateOfExpense ? new Date(reimbursementRequest.dateOfExpense) : undefined,
           accountCodeId: reimbursementRequest.accountCode.accountCodeId,
           reimbursementProducts: reimbursementRequest.reimbursementProducts.map((product) => ({
+            id: product.reimbursementProductId,
             reason: (product.reimbursementProductReason as WBSElementData).wbsNum
               ? (product.reimbursementProductReason as WBSElementData).wbsNum
               : (product.reimbursementProductReason as OtherProductReason),

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
@@ -121,10 +121,17 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
   const { mutateAsync: createVendor } = useCreateVendor();
   const user = useCurrentUser();
 
-  // to grab all the proper refund sources
-  const refundSources: CreateRefundSourceArgs[] = Array.from(
-    new Set(reimbursementProducts.flatMap((product) => product.refundSources).filter((source) => source.amount > 0))
-  );
+  // to grab all the proper refund sources, deduplicated by indexCodeId
+  const refundSources: CreateRefundSourceArgs[] = (() => {
+    const allSources = reimbursementProducts.flatMap((product) => product.refundSources).filter((source) => source.amount > 0);
+    const seen = new Set<string>();
+    return allSources.filter((source) => {
+      const id = source.indexCode.indexCodeId;
+      if (seen.has(id)) return false;
+      seen.add(id);
+      return true;
+    });
+  })();
 
   const [hasConfirmedFinance, setHasConfirmedFinance] = useState(refundSources.length > 1);
   const toast = useToast();

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
@@ -123,7 +123,9 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
 
   // to grab all the proper refund sources, deduplicated by indexCodeId
   const refundSources: CreateRefundSourceArgs[] = (() => {
-    const allSources = reimbursementProducts.flatMap((product) => product.refundSources).filter((source) => source.amount > 0);
+    const allSources = reimbursementProducts
+      .flatMap((product) => product.refundSources)
+      .filter((source) => source.amount > 0);
     const seen = new Set<string>();
     return allSources.filter((source) => {
       const id = source.indexCode.indexCodeId;


### PR DESCRIPTION
## Changes
- Fixed `Set` deduplication issue which caused cost data to be removed and "ghost" refund sources to be added
- added missing id to form defaults (new reimbursement products were being created on every edit)
- `updateExistingProducts` wasn't handling refund sources but it is now

## Test Cases
Mess around with multiple refund sources by creating and updating
