### PR TITLE
#3927 initial gantt chart filter spacing changes (NOT FINISHED)

### DIFF
--- a/src/frontend/src/pages/GanttPage/GanttChart/GanttChart.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChart/GanttChart.tsx
@@ -67,20 +67,21 @@ const GanttChart = <E, T>({
     >
       <GanttChartTimeline start={startDate} end={endDate} />
       <Box sx={{ position: 'relative' }}>
-        {collections.map((collection) => {
-          return collection.tasks ? (
-            <GanttChartCollectionSection
-              startDate={startDate}
-              endDate={endDate}
-              collection={collection}
-              shouldShowChildren={shouldShowChildren}
-              onShowChildrenToggle={onShowChildrenToggle}
-              editability={editability}
-            />
-          ) : (
-            <></>
-          );
-        })}
+        {collections
+          .filter((collection) => collection.tasks.length > 0)
+          .map((collection) => {
+            return (
+              <GanttChartCollectionSection
+                key={collection.id}
+                startDate={startDate}
+                endDate={endDate}
+                collection={collection}
+                shouldShowChildren={shouldShowChildren}
+                onShowChildrenToggle={onShowChildrenToggle}
+                editability={editability}
+              />
+            );
+          })}
 
         {currentWeekCol > 0 && (
           <Box

--- a/src/frontend/src/pages/GanttPage/GanttChart/GanttChartSection.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChart/GanttChartSection.tsx
@@ -68,9 +68,8 @@ const GanttChartSection = <T,>({
       <Box sx={{ mt: '1rem', width: 'fit-content' }}>
         {tasks.map((task) => {
           return (
-            <Box display="flex" alignItems="center">
+            <Box key={task.id} display="flex" alignItems="center">
               <GanttTaskBar
-                key={task.id}
                 days={days}
                 task={task}
                 isEditMode={isEditMode}


### PR DESCRIPTION
## Changes

Added changes to gantt chart loading such that filtering does not leave empty blocks where filtered out events are. (Fill this out with detail yeah 

## Notes

N/A

## Test Cases

- Case A
- Edge case
- ...

## Screenshots

N/A (Unable to test this really since the filters right now see m to filter by groups, which are already sectioned off, so I haven't explicitly checked whether this works onr 

## To Do

Fix gantt chart event filtering so that we can test whether this works or not 

- [ ] Check that filters do not leave empty spaces

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #3927 
