### PR TITLE
Add backend support for global car filtering

### DIFF
--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -3,6 +3,7 @@ import cors from 'cors';
 import cookieParser from 'cookie-parser';
 import { getUserAndOrganization, prodHeaders, requireJwtDev, requireJwtProd } from './src/utils/auth.utils.js';
 import { errorHandler } from './src/utils/errors.utils.js';
+import { getCurrentCar } from './src/utils/car.utils.js';
 import userRouter from './src/routes/users.routes.js';
 import projectRouter from './src/routes/projects.routes.js';
 import teamsRouter from './src/routes/teams.routes.js';
@@ -80,6 +81,9 @@ app.use(isProd ? requireJwtProd : requireJwtDev);
 
 // get user and organization
 app.use(getUserAndOrganization);
+
+// get current car
+app.use(getCurrentCar);
 
 // routes
 app.use('/users', userRouter);

--- a/src/backend/src/utils/car.utils.ts
+++ b/src/backend/src/utils/car.utils.ts
@@ -1,0 +1,26 @@
+import { Request, Response, NextFunction } from 'express';
+import prisma from '../prisma/prisma.js';
+import { NotFoundException } from './errors.utils.js';
+
+export const getCurrentCar = async (req: Request, _res: Response, next: NextFunction) => {
+  const carId = req.headers.carid;
+
+  if (!carId || typeof carId !== 'string') {
+    return next();
+  }
+
+  try {
+    const car = await prisma.car.findUnique({
+      where: { carId }
+    });
+
+    if (!car) {
+      throw new NotFoundException('Car', carId);
+    }
+
+    req.currentCar = car;
+    return next();
+  } catch (error) {
+    return next(error);
+  }
+};

--- a/src/frontend/src/utils/axios.ts
+++ b/src/frontend/src/utils/axios.ts
@@ -37,6 +37,8 @@ axios.interceptors.request.use(
     if (import.meta.env.MODE === 'development') request.headers!['Authorization'] = localStorage.getItem('devUserId') || '';
     const organizationId = localStorage.getItem('organizationId');
     request.headers!['organizationId'] = organizationId ?? '';
+    const carId = sessionStorage.getItem('selectedCarId');
+    request.headers!['carId'] = carId ?? '';
     return request;
   },
   (error) => {


### PR DESCRIPTION
## Changes

Added middleware to read carId from request headers

Loaded the corresponding car from the database and set req.currentCar

Updated project endpoints to pass req.currentCar?.carId into service queries

Updated project service queries to optionally filter by carId



## Screenshots

<img width="1871" height="671" alt="Screenshot 2026-03-06 091817" src="https://github.com/user-attachments/assets/950f3278-77e0-4726-961c-325ec18c9b92" />


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #4011 
