### PR TITLE
#3885 - Create Confirmation Modal for Bulk BOM Copy

### DIFF
--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/CopyBOM/CopyBOMModal.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/CopyBOM/CopyBOMModal.tsx
@@ -2,35 +2,58 @@ import { WbsNumber, wbsPipe } from 'shared';
 import CopyBOMView from './CopyBOMView';
 import { useGetAllCars } from '../../../../../hooks/cars.hooks';
 import { useAllProjects } from '../../../../../hooks/projects.hooks';
-import { useCopyMaterialsToProject } from '../../../../../hooks/bom.hooks';
-import React from 'react';
+import React, { useState } from 'react';
 import ErrorPage from '../../../../ErrorPage';
 import LoadingIndicator from '../../../../../components/LoadingIndicator';
+import BOMCopyConfirmModal from '../MaterialForm/BOMCopyConfirmModal';
 
 export interface CopyBOMModalProps {
   open: boolean;
   onHide: () => void;
   destinationWbsNum: WbsNumber;
+  currentProjectName: string;
 }
 
-const CopyBOMModal: React.FC<CopyBOMModalProps> = ({ open, onHide, destinationWbsNum }) => {
+const CopyBOMModal: React.FC<CopyBOMModalProps> = ({ open, onHide, destinationWbsNum, currentProjectName }) => {
   const { data: cars, isLoading: isLoadingCars, isError: carsIsError, error: carsError } = useGetAllCars();
   const { data: projects, isLoading: isLoadingProjects, isError: projectsIsError, error: projectsError } = useAllProjects();
-  const { mutateAsync: copyMaterials } = useCopyMaterialsToProject();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [confirmedMaterialIds, setConfirmedMaterialIds] = useState<string[]>([]);
+  const [confirmedSourceProjectName, setConfirmedSourceProjectName] = useState('');
 
   if (isLoadingCars || !cars || isLoadingProjects || !projects) return <LoadingIndicator />;
   if (carsIsError) return <ErrorPage message={carsError?.message} />;
   if (projectsIsError) return <ErrorPage message={projectsError?.message} />;
 
-  const handleCopy = async (materialIds: string[]) => {
-    await copyMaterials({
-      materialIds,
-      destinationWbsNum: wbsPipe(destinationWbsNum)
-    });
-    onHide();
-  };
+  const destinationWbs = wbsPipe(destinationWbsNum);
 
-  return <CopyBOMView open={open} onHide={onHide} cars={cars} projects={projects} onCopy={handleCopy} />;
+  return (
+    <>
+      <CopyBOMView
+        open={open}
+        onHide={onHide}
+        cars={cars}
+        projects={projects}
+        onCopy={(materialIds, sourceProjectName) => {
+          setConfirmedMaterialIds(materialIds);
+          setConfirmedSourceProjectName(sourceProjectName);
+          setConfirmOpen(true);
+        }}
+      />
+      <BOMCopyConfirmModal
+        open={confirmOpen}
+        onHide={() => setConfirmOpen(false)}
+        onSuccess={() => {
+          onHide();
+          setConfirmOpen(false);
+        }}
+        materialIds={confirmedMaterialIds}
+        sourceProjectName={confirmedSourceProjectName}
+        currentProjectName={`${wbsPipe(destinationWbsNum)} - ${currentProjectName}`}
+        destinationWbsNum={destinationWbs}
+      />
+    </>
+  );
 };
 
 export default CopyBOMModal;

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/CopyBOM/CopyBOMView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/CopyBOM/CopyBOMView.tsx
@@ -10,7 +10,7 @@ interface CopyBOMViewProps {
   onHide: () => void;
   cars: Car[];
   projects: ProjectPreview[];
-  onCopy: (materialIds: string[]) => Promise<void>;
+  onCopy: (materialIds: string[], sourceProjectName: string) => void;
 }
 
 const CopyBOMView: React.FC<CopyBOMViewProps> = ({ open, onHide, cars, projects, onCopy }) => {
@@ -34,7 +34,9 @@ const CopyBOMView: React.FC<CopyBOMViewProps> = ({ open, onHide, cars, projects,
   }));
 
   const handleSubmit = async () => {
-    await onCopy(selectedMaterialIdsRef.current);
+    if (!selectedProject) return;
+    const sourceProjectName = `${wbsPipe(selectedProject.wbsNum)} - ${selectedProject.name}`;
+    onCopy(selectedMaterialIdsRef.current, sourceProjectName);
   };
 
   return (

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/BOMCopyConfirmModal.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/BOMCopyConfirmModal.tsx
@@ -1,25 +1,45 @@
 import NERModal from '../../../../../components/NERModal';
+import { useCopyMaterialsToProject } from '../../../../../hooks/bom.hooks';
 
 export interface BOMCopyConfirmModalProps {
   open: boolean;
   onHide: () => void;
-  onSuccess?: () => void;
-  materialsCount: number;
+  onSuccess: () => void;
+  materialIds: string[];
   sourceProjectName: string;
   currentProjectName: string;
+  destinationWbsNum: string;
 }
 
 const BOMCopyConfirmModal = ({
   open,
   onHide,
   onSuccess,
-  materialsCount,
+  materialIds,
   sourceProjectName,
-  currentProjectName
+  currentProjectName,
+  destinationWbsNum
 }: BOMCopyConfirmModalProps) => {
-  const message = `Are you sure you want to copy ${materialsCount} materials from ${sourceProjectName} to ${currentProjectName}?`;
+  const copyMaterials = useCopyMaterialsToProject();
+
+  const handleConfirm = () => {
+    copyMaterials.mutate(
+      {
+        materialIds,
+        destinationWbsNum
+      },
+      {
+        onSuccess: () => {
+          onSuccess();
+          onHide();
+        }
+      }
+    );
+  };
+
+  const message = `Are you sure you want to copy ${materialIds.length} materials from ${sourceProjectName} to ${currentProjectName}?`;
   return (
-    <NERModal open={open} onHide={onHide} onSubmit={onSuccess} title="Confirm Copy">
+    <NERModal open={open} onHide={onHide} onSubmit={handleConfirm} title="Confirm Copy">
       <p>{message}</p>
     </NERModal>
   );

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/BOMCopyConfirmModal.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/BOMCopyConfirmModal.tsx
@@ -1,0 +1,19 @@
+import { Console } from 'console';
+import NERModal from '../../../../../components/NERModal';
+
+export interface BOMCopyConfirmModalProps {
+  open: boolean;
+  onHide: () => void;
+  onSuccess?: () => void;
+}
+
+const BOMCopyConfirmModal = ({ open, onHide, onSuccess }: BOMCopyConfirmModalProps) => {
+  // TODO: make the actual message
+  return (
+    <NERModal open={open} onHide={onHide} onSubmit={onSuccess} title="Confirm Copy">
+      Are you sure you want to copy [X] materials from [Source Project Name] to [Current Project Name]?
+    </NERModal>
+  );
+};
+
+export default BOMCopyConfirmModal;

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/BOMCopyConfirmModal.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/BOMCopyConfirmModal.tsx
@@ -1,17 +1,26 @@
-import { Console } from 'console';
 import NERModal from '../../../../../components/NERModal';
 
 export interface BOMCopyConfirmModalProps {
   open: boolean;
   onHide: () => void;
   onSuccess?: () => void;
+  materialsCount: number;
+  sourceProjectName: string;
+  currentProjectName: string;
 }
 
-const BOMCopyConfirmModal = ({ open, onHide, onSuccess }: BOMCopyConfirmModalProps) => {
-  // TODO: make the actual message
+const BOMCopyConfirmModal = ({
+  open,
+  onHide,
+  onSuccess,
+  materialsCount,
+  sourceProjectName,
+  currentProjectName
+}: BOMCopyConfirmModalProps) => {
+  const message = `Are you sure you want to copy ${materialsCount} materials from ${sourceProjectName} to ${currentProjectName}?`;
   return (
     <NERModal open={open} onHide={onHide} onSubmit={onSuccess} title="Confirm Copy">
-      Are you sure you want to copy [X] materials from [Source Project Name] to [Current Project Name]?
+      <p>{message}</p>
     </NERModal>
   );
 };

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
@@ -1,5 +1,4 @@
 import {
-  Button,
   FormControl,
   FormHelperText,
   FormLabel,
@@ -23,7 +22,6 @@ import { displayEnum } from '../../../../../utils/pipes';
 import { MaterialStatus } from 'shared';
 import React from 'react';
 import { AddCircle } from '@mui/icons-material';
-import BOMCopyConfirmModal from './BOMCopyConfirmModal';
 
 export interface MaterialFormViewProps {
   submitText: 'Add' | 'Edit';
@@ -72,7 +70,6 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
   const quantity = watch('quantity');
   const price = watch('price');
   const subtotal = quantity && price ? quantity * price : 0;
-  const [bomConfirmOpen, setBomConfirmOpen] = React.useState(false);
 
   return (
     <NERFormModal
@@ -487,7 +484,7 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
               pt: 1
             }}
           >
-            <Button
+            {/* <Button
               variant="contained"
               disableElevation
               onClick={() => {
@@ -503,17 +500,10 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
               }}
             >
               COPY FROM EXISTING BOM
-            </Button>
+            </Button> */}
           </Box>
         </Grid>
       )}
-      <BOMCopyConfirmModal
-        open={bomConfirmOpen}
-        onHide={() => {
-          setBomConfirmOpen(false);
-        }}
-        onSuccess={() => {}}
-      ></BOMCopyConfirmModal>
     </NERFormModal>
   );
 };

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
@@ -14,7 +14,7 @@ import {
 } from '@mui/material';
 import { Box } from '@mui/system';
 import { Control, Controller, FieldErrors, UseFormHandleSubmit, UseFormSetValue, UseFormWatch } from 'react-hook-form';
-import { Assembly, Manufacturer, MaterialType, ReimbursementRequest, Unit } from 'shared';
+import { Assembly, Manufacturer, MaterialType, Unit } from 'shared';
 import ReactHookTextField from '../../../../../components/ReactHookTextField';
 import { MaterialFormInput } from './MaterialForm';
 import NERFormModal from '../../../../../components/NERFormModal';
@@ -44,7 +44,6 @@ export interface MaterialFormViewProps {
   setValue: UseFormSetValue<MaterialFormInput>;
   copyFromExistingBomAction?: React.ReactNode;
   fromRRForm?: boolean;
-  reimbursementRequests?: any[];
 }
 
 const manufacturersToAutocomplete = (manufacturer: Manufacturer): { label: string; id: string } => {
@@ -70,8 +69,7 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
   watch,
   createManufacturer,
   setValue,
-  fromRRForm = false,
-  reimbursementRequests = []
+  fromRRForm = false
 }) => {
   const [additionalDetailsOpen, setAdditionalDetailsOpen] = useState(!fromRRForm);
 
@@ -506,94 +504,19 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
           )}
         </Grid>
       </Grid>
-      <Grid item xs={12}>
-        <Grid item xs={12} mt={2}>
-          <FormControl fullWidth>
-            <Controller
-              name="reimbursementRequestId"
-              control={control}
-              defaultValue={control._defaultValues.reimbursementRequestId}
-              render={({ field }) => (
-                <TextField
-                  {...field}
-                  select
-                  variant="outlined"
-                  error={!!errors.reimbursementRequestId}
-                  helperText={errors.reimbursementRequestId?.message}
-                  SelectProps={{
-                    displayEmpty: true,
-                    renderValue: (selected) =>
-                      selected ? (
-                        reimbursementRequests.find((rr) => rr.reimbursementRequestId === selected)?.identifier
-                      ) : (
-                        <Typography sx={{ fontSize: '1rem', color: 'lightgray', opacity: 0.6 }}>
-                          Select Corresponding Reimbursement Request Number
-                        </Typography>
-                      )
-                  }}
-                >
-                  {reimbursementRequests.map((rr: ReimbursementRequest) => (
-                    <MenuItem key={rr.reimbursementRequestId} value={rr.reimbursementRequestId}>
-                      {rr.identifier}
-                    </MenuItem>
-                  ))}
-                </TextField>
-              )}
-            />
-          </FormControl>
-        </Grid>
-        <Box display={'flex'} justifyContent={'flex-end'} mt={2}>
-          <FormControl fullWidth>
-            <Controller
-              name="assemblyId"
-              control={control}
-              defaultValue={control._defaultValues.assemblyId}
-              render={({ field }) => (
-                <TextField
-                  {...field}
-                  select
-                  variant="outlined"
-                  error={!!errors.assemblyId}
-                  helperText={errors.assemblyId?.message}
-                  SelectProps={{
-                    displayEmpty: true,
-                    renderValue: (selected) =>
-                      selected ? (
-                        assemblies?.find((a) => a.assemblyId === selected)?.name
-                      ) : (
-                        <Typography sx={{ fontSize: '1rem', color: 'lightgray', opacity: 0.6 }}>
-                          Enter Assembly Details
-                        </Typography>
-                      )
-                  }}
-                >
-                  {assemblies?.map((assembly) => (
-                    <MenuItem key={assembly.assemblyId} value={assembly.assemblyId}>
-                      {assembly.name}
-                    </MenuItem>
-                  ))}
-                </TextField>
-              )}
-            />
-          </FormControl>
-        </Box>
-      </Grid>
-      {submitText === 'Add' && (
+      {/*submitText === 'Add' && (
         <Grid item xs={12} sx={{ pl: 0, pr: 0 }}>
           <Box
             sx={{
               pt: 1
             }}
           >
-            {/* <Button
+            <Button
               variant="contained"
               disableElevation
-              onClick={() => {
-                setBomConfirmOpen(true);
-              }}
+              onClick={() => {}}
               sx={{
                 mx: 0,
-                my: 1,
                 textTransform: 'none',
                 bgcolor: '#EF4345',
                 color: (t) => t.palette.getContrastText('#EF4345'),
@@ -601,10 +524,10 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
               }}
             >
               COPY FROM EXISTING BOM
-            </Button> */}
+            </Button>
           </Box>
         </Grid>
-      )}
+      )*/}
     </NERFormModal>
   );
 };

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
@@ -2,7 +2,6 @@ import {
   Accordion,
   AccordionDetails,
   AccordionSummary,
-  Button,
   FormControl,
   FormHelperText,
   FormLabel,

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/MaterialForm/MaterialFormView.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   FormControl,
   FormHelperText,
   FormLabel,
@@ -22,6 +23,7 @@ import { displayEnum } from '../../../../../utils/pipes';
 import { MaterialStatus } from 'shared';
 import React from 'react';
 import { AddCircle } from '@mui/icons-material';
+import BOMCopyConfirmModal from './BOMCopyConfirmModal';
 
 export interface MaterialFormViewProps {
   submitText: 'Add' | 'Edit';
@@ -70,6 +72,7 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
   const quantity = watch('quantity');
   const price = watch('price');
   const subtotal = quantity && price ? quantity * price : 0;
+  const [bomConfirmOpen, setBomConfirmOpen] = React.useState(false);
 
   return (
     <NERFormModal
@@ -477,7 +480,7 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
           </FormControl>
         </Box>
       </Grid>
-      {/*submitText === 'Add' && (
+      {submitText === 'Add' && (
         <Grid item xs={12} sx={{ pl: 0, pr: 0 }}>
           <Box
             sx={{
@@ -487,9 +490,12 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
             <Button
               variant="contained"
               disableElevation
-              onClick={() => {}}
+              onClick={() => {
+                setBomConfirmOpen(true);
+              }}
               sx={{
                 mx: 0,
+                my: 1,
                 textTransform: 'none',
                 bgcolor: '#EF4345',
                 color: (t) => t.palette.getContrastText('#EF4345'),
@@ -500,7 +506,14 @@ const MaterialFormView: React.FC<MaterialFormViewProps> = ({
             </Button>
           </Box>
         </Grid>
-      )*/}
+      )}
+      <BOMCopyConfirmModal
+        open={bomConfirmOpen}
+        onHide={() => {
+          setBomConfirmOpen(false);
+        }}
+        onSuccess={() => {}}
+      ></BOMCopyConfirmModal>
     </NERFormModal>
   );
 };

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOMTab.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOMTab.tsx
@@ -111,9 +111,10 @@ const BOMTab = ({ project }: { project: Project }) => {
               setBomConfirmOpen(false);
             }}
             onSuccess={() => {}}
-            materialsCount={1}
+            materialIds={materials.map((m) => m.materialId)} // Test: right now, it just copies everything to itself
             sourceProjectName={'Source Project'}
             currentProjectName={'Target Project'}
+            destinationWbsNum={'0.7.0'} // Or any project to copy to
           ></BOMCopyConfirmModal>
           <Box display="flex" gap="20px" alignItems="center">
             <Box sx={{ backgroundColor: theme.palette.background.paper, padding: '8px 14px 8px 14px', borderRadius: '6px' }}>

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOMTab.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOMTab.tsx
@@ -150,16 +150,17 @@ const BOMTab = ({ project }: { project: Project }) => {
               Copy Existing BOM
             </NERButton>
           </Box>
-          <BOMCopyConfirmModal
+          {/* <BOMCopyConfirmModal
             open={bomConfirmOpen}
             onHide={() => {
               setBomConfirmOpen(false);
             }}
             onSuccess={() => {}}
-            materialsCount={1}
-            sourceProjectName={'Source Project'}
-            currentProjectName={'Target Project'}
-          ></BOMCopyConfirmModal>
+            materialIds={materials.map((m) => m.materialId)} // Test: right now, it just copies everything to destination
+            sourceProjectName={'This Project'}
+            currentProjectName={'0.7.0 - Laser Cannon Prototype'}
+            destinationWbsNum={'0.7.0'}
+          ></BOMCopyConfirmModal> */}
           <Box display="flex" gap="20px" alignItems="center">
             <Box sx={{ backgroundColor: theme.palette.background.paper, padding: '8px 14px 8px 14px', borderRadius: '6px' }}>
               Budget: ${project.budget}

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOMTab.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOMTab.tsx
@@ -2,8 +2,8 @@ import { Box } from '@mui/system';
 import { MaterialPreview, Project, isGuest } from 'shared';
 import { NERButton } from '../../../components/NERButton';
 import WarningIcon from '@mui/icons-material/Warning';
+import React, { useState } from 'react';
 import { Tooltip, useTheme } from '@mui/material';
-import { useState } from 'react';
 import BOMTableWrapper from './BOM/BOMTableWrapper';
 import CreateMaterialModal from './BOM/MaterialForm/CreateMaterialModal';
 import CreateAssemblyModal from './BOM/AssemblyForm/CreateAssemblyModal';
@@ -13,6 +13,7 @@ import { useCurrentUser } from '../../../hooks/users.hooks';
 import LoadingIndicator from '../../../components/LoadingIndicator';
 import ErrorPage from '../../ErrorPage';
 import { useGetAssembliesForWbsElement, useGetMaterialsForWbsElement } from '../../../hooks/bom.hooks';
+import BOMCopyConfirmModal from './BOM/MaterialForm/BOMCopyConfirmModal';
 
 export const addMaterialCosts = (accumulator: number, currentMaterial: MaterialPreview) =>
   currentMaterial.subtotal ?? 0 + accumulator;
@@ -22,8 +23,9 @@ const BOMTab = ({ project }: { project: Project }) => {
   const [hideColumn, setHideColumn] = useState<boolean[]>(initialHideColumn);
   const [showAddMaterial, setShowAddMaterial] = useState(false);
   const [showAddAssembly, setShowAddAssembly] = useState(false);
-  const theme = useTheme();
+  const [bomConfirmOpen, setBomConfirmOpen] = React.useState(false);
 
+  const theme = useTheme();
   const user = useCurrentUser();
 
   const {
@@ -93,12 +95,26 @@ const BOMTab = ({ project }: { project: Project }) => {
             >
               Show All Columns
             </NERButton>
-            {/*
-            <NERButton variant="contained" onClick={() => {}} disabled={isGuest(user.role)}>
+            <NERButton
+              variant="contained"
+              onClick={() => {
+                setBomConfirmOpen(true);
+              }}
+              disabled={isGuest(user.role)}
+            >
               Copy Existing BOM
             </NERButton>
-            */}
           </Box>
+          <BOMCopyConfirmModal
+            open={bomConfirmOpen}
+            onHide={() => {
+              setBomConfirmOpen(false);
+            }}
+            onSuccess={() => {}}
+            materialsCount={1}
+            sourceProjectName={'Source Project'}
+            currentProjectName={'Target Project'}
+          ></BOMCopyConfirmModal>
           <Box display="flex" gap="20px" alignItems="center">
             <Box sx={{ backgroundColor: theme.palette.background.paper, padding: '8px 14px 8px 14px', borderRadius: '6px' }}>
               Budget: ${project.budget}

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOMTab.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOMTab.tsx
@@ -13,7 +13,7 @@ import { useCurrentUser } from '../../../hooks/users.hooks';
 import LoadingIndicator from '../../../components/LoadingIndicator';
 import ErrorPage from '../../ErrorPage';
 import { useGetAssembliesForWbsElement, useGetMaterialsForWbsElement } from '../../../hooks/bom.hooks';
-import BOMCopyConfirmModal from './BOM/MaterialForm/BOMCopyConfirmModal';
+// import BOMCopyConfirmModal from './BOM/MaterialForm/BOMCopyConfirmModal';
 
 export const addMaterialCosts = (accumulator: number, currentMaterial: MaterialPreview) =>
   currentMaterial.subtotal ?? 0 + accumulator;
@@ -23,7 +23,7 @@ const BOMTab = ({ project }: { project: Project }) => {
   const [hideColumn, setHideColumn] = useState<boolean[]>(initialHideColumn);
   const [showAddMaterial, setShowAddMaterial] = useState(false);
   const [showAddAssembly, setShowAddAssembly] = useState(false);
-  const [bomConfirmOpen, setBomConfirmOpen] = React.useState(false);
+  // const [bomConfirmOpen, setBomConfirmOpen] = React.useState(false);
 
   const theme = useTheme();
   const user = useCurrentUser();
@@ -95,7 +95,7 @@ const BOMTab = ({ project }: { project: Project }) => {
             >
               Show All Columns
             </NERButton>
-            <NERButton
+            {/* <NERButton
               variant="contained"
               onClick={() => {
                 setBomConfirmOpen(true);
@@ -103,19 +103,19 @@ const BOMTab = ({ project }: { project: Project }) => {
               disabled={isGuest(user.role)}
             >
               Copy Existing BOM
-            </NERButton>
+            </NERButton> */}
           </Box>
-          <BOMCopyConfirmModal
+          {/* <BOMCopyConfirmModal
             open={bomConfirmOpen}
             onHide={() => {
               setBomConfirmOpen(false);
             }}
             onSuccess={() => {}}
-            materialIds={materials.map((m) => m.materialId)} // Test: right now, it just copies everything to itself
-            sourceProjectName={'Source Project'}
-            currentProjectName={'Target Project'}
-            destinationWbsNum={'0.7.0'} // Or any project to copy to
-          ></BOMCopyConfirmModal>
+            materialIds={materials.map((m) => m.materialId)} // Test: right now, it just copies everything to destination
+            sourceProjectName={'This Project'}
+            currentProjectName={'0.7.0 - Laser Cannon Prototype'}
+            destinationWbsNum={'0.7.0'}
+          ></BOMCopyConfirmModal> */}
           <Box display="flex" gap="20px" alignItems="center">
             <Box sx={{ backgroundColor: theme.palette.background.paper, padding: '8px 14px 8px 14px', borderRadius: '6px' }}>
               Budget: ${project.budget}

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOMTab.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOMTab.tsx
@@ -20,7 +20,6 @@ import {
   useGetMaterialsForWbsElement
 } from '../../../hooks/bom.hooks';
 import ImportBOMModal from './BOM/ImportBOMModal';
-import BOMCopyConfirmModal from './BOM/MaterialForm/BOMCopyConfirmModal';
 
 export const addMaterialCosts = (accumulator: number, currentMaterial: MaterialPreview) =>
   (currentMaterial.subtotal ?? 0) + accumulator;
@@ -32,7 +31,6 @@ const BOMTab = ({ project }: { project: Project }) => {
   const [showAddAssembly, setShowAddAssembly] = useState(false);
   const [showCopyBOM, setShowCopyBOM] = useState(false);
   const [showImportBOM, setShowImportBOM] = useState(false);
-  const [bomConfirmOpen, setBomConfirmOpen] = useState(false);
 
   const theme = useTheme();
   const user = useCurrentUser();
@@ -101,7 +99,12 @@ const BOMTab = ({ project }: { project: Project }) => {
         allUnits={units}
         assemblies={assemblies}
       />
-      <CopyBOMModal open={showCopyBOM} onHide={() => setShowCopyBOM(false)} destinationWbsNum={project.wbsNum} />
+      <CopyBOMModal
+        open={showCopyBOM}
+        onHide={() => setShowCopyBOM(false)}
+        destinationWbsNum={project.wbsNum}
+        currentProjectName={project.name}
+      />
       <Box sx={{ display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}>
         <BOMTableWrapper
           project={project}
@@ -150,17 +153,6 @@ const BOMTab = ({ project }: { project: Project }) => {
               Copy Existing BOM
             </NERButton>
           </Box>
-          {/* <BOMCopyConfirmModal
-            open={bomConfirmOpen}
-            onHide={() => {
-              setBomConfirmOpen(false);
-            }}
-            onSuccess={() => {}}
-            materialIds={materials.map((m) => m.materialId)} // Test: right now, it just copies everything to destination
-            sourceProjectName={'This Project'}
-            currentProjectName={'0.7.0 - Laser Cannon Prototype'}
-            destinationWbsNum={'0.7.0'}
-          ></BOMCopyConfirmModal> */}
           <Box display="flex" gap="20px" alignItems="center">
             <Box sx={{ backgroundColor: theme.palette.background.paper, padding: '8px 14px 8px 14px', borderRadius: '6px' }}>
               Budget: ${project.budget}


### PR DESCRIPTION
## Changes

Modal with "Are you sure you want to copy [X] materials from [Source Project Name] to [Current Project Name]?" that confirms and completes the actions with parameters being the materials/projects. Success/failure toast upon triggering the copy operation.

## Notes
The screenshots were created in a testing environment, and not what's actually being pushed. 

## Screenshots
**Mock use case:**

<img width="1726" height="421" alt="image" src="https://github.com/user-attachments/assets/84eec406-1fa2-4436-8707-159c03cb9949" />

_This will be commented out, as the modal that utilizes this modal hasn't been created yet, so choosing the target project/destination project can't be selected from the website._ 

**Modal:**

<img width="2503" height="1446" alt="image" src="https://github.com/user-attachments/assets/ce2ac235-197c-4b56-bffd-9ba02fc94bd0" />


**Before, in the destination project:**

<img width="2475" height="1456" alt="image" src="https://github.com/user-attachments/assets/86d96747-5e22-48c3-95ec-6e800a69de99" />

_After clicking confirm..._

**In the source project:**

<img width="2473" height="1459" alt="image" src="https://github.com/user-attachments/assets/e0133fae-a71a-4a2e-ae88-2e76d2f01e35" />

**In the previously empty destination project:**

<img width="2482" height="1450" alt="image" src="https://github.com/user-attachments/assets/5fe8b98b-31b0-45b0-a953-adf42e723423" />

Closes #3885 