### PR TITLE
#3945 don't send slack notif when user is assignee

### DIFF
--- a/src/backend/src/services/tasks.services.ts
+++ b/src/backend/src/services/tasks.services.ts
@@ -122,7 +122,8 @@ export default class TasksService {
 
     const newTask = taskTransformer(createdTask);
 
-    await sendSlackTaskAssignedNotificationToUsers(newTask, assignees, organization.organizationId, createdBy.userId);
+    const nonSelfAssigneeIds = assignees.filter((id) => id !== createdBy.userId);
+    await sendSlackTaskAssignedNotificationToUsers(newTask, nonSelfAssigneeIds, organization.organizationId);
 
     return newTask;
   }
@@ -254,7 +255,8 @@ export default class TasksService {
       })
     );
 
-    await sendSlackTaskAssignedNotificationToUsers(updatedTask, newAssigneeIds, organization.organizationId, user.userId);
+    const nonSelfAssigneeIds = newAssigneeIds.filter((id) => id !== user.userId);
+    await sendSlackTaskAssignedNotificationToUsers(updatedTask, nonSelfAssigneeIds, organization.organizationId);
 
     return updatedTask;
   }

--- a/src/backend/src/services/tasks.services.ts
+++ b/src/backend/src/services/tasks.services.ts
@@ -122,7 +122,7 @@ export default class TasksService {
 
     const newTask = taskTransformer(createdTask);
 
-    await sendSlackTaskAssignedNotificationToUsers(newTask, assignees, organization.organizationId);
+    await sendSlackTaskAssignedNotificationToUsers(newTask, assignees, organization.organizationId, createdBy.userId);
 
     return newTask;
   }
@@ -254,7 +254,7 @@ export default class TasksService {
       })
     );
 
-    await sendSlackTaskAssignedNotificationToUsers(updatedTask, newAssigneeIds, organization.organizationId);
+    await sendSlackTaskAssignedNotificationToUsers(updatedTask, newAssigneeIds, organization.organizationId, user.userId);
 
     return updatedTask;
   }

--- a/src/backend/src/utils/tasks.utils.ts
+++ b/src/backend/src/utils/tasks.utils.ts
@@ -22,17 +22,15 @@ export const convertTaskStatus = (status: Task_Status): TaskStatus =>
  * @param task the task the users are assigned to
  * @param assigneeIds the user ids of the users assigned to the task
  * @param orgainzationId the organization id of the current user
- * @param assignerId the user id of the user who assigned the task
  */
 export const sendSlackTaskAssignedNotificationToUsers = async (
   task: Task,
   assigneeIds: string[],
-  orgainzationId: string,
-  assignerId: string
+  orgainzationId: string
 ) => {
   const assigneeSettings = await prisma.user_Settings.findMany({ where: { userId: { in: assigneeIds } } });
   assigneeSettings.forEach(async (settings) => {
-    if (settings.slackId && settings.userId !== assignerId) {
+    if (settings.slackId) {
       await sendSlackTaskAssignedNotification(settings.slackId, task, orgainzationId);
     }
   });

--- a/src/backend/src/utils/tasks.utils.ts
+++ b/src/backend/src/utils/tasks.utils.ts
@@ -22,15 +22,17 @@ export const convertTaskStatus = (status: Task_Status): TaskStatus =>
  * @param task the task the users are assigned to
  * @param assigneeIds the user ids of the users assigned to the task
  * @param orgainzationId the organization id of the current user
+ * @param assignerId the user id of the user who assigned the task
  */
 export const sendSlackTaskAssignedNotificationToUsers = async (
   task: Task,
   assigneeIds: string[],
-  orgainzationId: string
+  orgainzationId: string,
+  assignerId: string
 ) => {
   const assigneeSettings = await prisma.user_Settings.findMany({ where: { userId: { in: assigneeIds } } });
   assigneeSettings.forEach(async (settings) => {
-    if (settings.slackId) {
+    if (settings.slackId && settings.userId !== assignerId) {
       await sendSlackTaskAssignedNotification(settings.slackId, task, orgainzationId);
     }
   });


### PR DESCRIPTION
## Changes

Added a check for user id when sending a slack task assignment notification such that no notification is sent when assigning tasks to oneself

## Notes

- There are 2 backend tests failing but they're not related so I think that's not my circus not my monkeys?
- There is a typo in the params on this function but I didn't change it since I assume it's not in the scope of this ticket. But if it is I will happily fix the typo!!!

## Test Cases

- Manually tested assigning myself a task, and no notif was sent as expected
- Manually tested assigning another user a task and notif was sent as expected
- Manually tested reassigning a task from myself to another user and notif was sent as expected
- Manually tested reassigning a task from another user to myself and no notif was sent as expected

## Screenshots

Not sure if I need to include screenshots for manual e2e tests but here's the slack dm output
<img width="1060" height="548" alt="image" src="https://github.com/user-attachments/assets/92c32c23-79d9-4ecd-898c-fa0a0e91bae3" />


## Checklist

- [X] All commits are tagged with the ticket number
- [X] No linting errors / newline at end of file warnings
- [X] All code follows repository-configured prettier formatting
- [X] No merge conflicts
- [X] All checks passing
- [X] Screenshots of UI changes (see Screenshots section)
- [X] Remove any non-applicable sections of this template
- [X] Assign the PR to yourself
- [X] No `yarn.lock` changes (unless dependencies have changed)
- [X] Request reviewers & ping on Slack
- [X] PR is linked to the ticket (fill in the closes line below)

Closes #3945 
