### PR TITLE
#4049 - Updated Parser to handle Windows Line Endings in Frontmatter

### DIFF
--- a/src/docs-site/scripts/sync-skills.mjs
+++ b/src/docs-site/scripts/sync-skills.mjs
@@ -46,7 +46,7 @@ function parseFrontmatter(content) {
   const restOfContent = content.slice(match[0].length);
 
   // Parse YAML
-  const lines = yamlContent.split('\n');
+  const lines = yamlContent.split(/\r?\n/);
   const metadata = {};
   let currentKey = null;
   let currentValue = '';


### PR DESCRIPTION
## Changes

Changed the frontmatter parsing to handle windows line endings so that when saving the documentation files, even with the line ending modifications, you would still be able to generate the claude skills files when running yarn skills:sync.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [X] All commits are tagged with the ticket number
- [X] No linting errors / newline at end of file warnings
- [X] All code follows repository-configured prettier formatting
- [X] No merge conflicts
- [X] All checks passing
- [X] Screenshots of UI changes (see Screenshots section)
- [X] Remove any non-applicable sections of this template
- [X] Assign the PR to yourself
- [X] No `yarn.lock` changes (unless dependencies have changed)
- [X] Request reviewers & ping on Slack
- [X] PR is linked to the ticket (fill in the closes line below)

Closes #4049 
