### PR TITLE
Add isCopied Field and Modified Services, Transformers, and Types

### DIFF
--- a/src/backend/src/prisma/migrations/20260303225351_bom_improvements/migration.sql
+++ b/src/backend/src/prisma/migrations/20260303225351_bom_improvements/migration.sql
@@ -86,3 +86,6 @@ BEGIN
     );
   END LOOP;
 END $$;
+
+-- AlterTable
+ALTER TABLE "Material" ADD COLUMN "isCopied" BOOLEAN NOT NULL DEFAULT false;

--- a/src/backend/src/prisma/schema.prisma
+++ b/src/backend/src/prisma/schema.prisma
@@ -1002,6 +1002,7 @@ model Material {
   reimbursementRequest   Reimbursement_Request?  @relation(fields: [reimbursementRequestId], references: [reimbursementRequestId])
   reimbursementRequestId String?
   reimbursementProducts  Reimbursement_Product[]
+  isCopied               Boolean                 @default(false)
 
   @@index([assemblyId])
   @@index([materialTypeId])

--- a/src/backend/src/services/boms.services.ts
+++ b/src/backend/src/services/boms.services.ts
@@ -217,7 +217,8 @@ export default class BillOfMaterialsService {
             dateCreated: new Date(),
             userCreatedId: user.userId,
             wbsElementId: destinationProject.wbsElementId,
-            assemblyId: null
+            assemblyId: null,
+            isCopied: true
           },
           ...getMaterialQueryArgs(organization.organizationId)
         });

--- a/src/backend/src/transformers/material.transformer.ts
+++ b/src/backend/src/transformers/material.transformer.ts
@@ -45,7 +45,8 @@ export const materialTransformer = (material: Prisma.MaterialGetPayload<Material
     notes: material.notes ?? undefined,
     reimbursementRequest: material.reimbursementRequest
       ? reimbursementRequestTransformer(material.reimbursementRequest)
-      : undefined
+      : undefined,
+    isCopied: material.isCopied
   };
 };
 

--- a/src/backend/tests/unmocked/project.test.ts
+++ b/src/backend/tests/unmocked/project.test.ts
@@ -60,6 +60,7 @@ describe('Material Tests', () => {
       expect(material.manufacturerPartNumber).toEqual('lalsd');
       expect(material.quantity?.toString()).toEqual('5');
       expect(material.reimbursementRequest?.reimbursementRequestId).toEqual(reimbursementRequest.reimbursementRequestId);
+      expect(material.isCopied).toBe(false);
     });
 
     test('Fails on invalid reimbursement request id', async () => {
@@ -193,6 +194,9 @@ describe('Material Tests', () => {
 
       expect(copiedMat2.status).toBe('NOT_READY_TO_ORDER');
       expect(copiedMat2.reimbursementRequestId).toBeNull();
+
+      expect(copiedMat1.isCopied).toBe(true);
+      expect(copiedMat2.isCopied).toBe(true);
     });
 
     test('Fails when material does not exist', async () => {

--- a/src/shared/src/types/bom-types.ts
+++ b/src/shared/src/types/bom-types.ts
@@ -73,6 +73,7 @@ export interface Material {
   linkUrl: string;
   notes?: string;
   reimbursementRequest?: ReimbursementRequest;
+  isCopied: boolean;
 }
 
 export type MaterialPreview = Omit<


### PR DESCRIPTION
## Changes

- Made new migration.
- Added field to material in the prisma schema.
- Modified transformer, service and type to reflect schema changes.
- Modified tests to check that isCopied correctly sets to true or false.

## Test Cases

- Sets to true when material is copied from another project.
- Sets to false when material is newly created.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [X] All commits are tagged with the ticket number
- [X] No linting errors / newline at end of file warnings
- [X] All code follows repository-configured prettier formatting
- [X] No merge conflicts
- [X] All checks passing
- [X] Screenshots of UI changes (see Screenshots section)
- [X] Remove any non-applicable sections of this template
- [X] Assign the PR to yourself
- [X] No `yarn.lock` changes (unless dependencies have changed)
- [X] Request reviewers & ping on Slack
- [X] PR is linked to the ticket (fill in the closes line below)

Closes #3916 
