### PR TITLE
#3997 fixed project budget + updated rr seed data

### DIFF
--- a/src/backend/src/prisma/seed-data/reimbursement-requests.seed.ts
+++ b/src/backend/src/prisma/seed-data/reimbursement-requests.seed.ts
@@ -95,7 +95,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.equipment.accountCodeId,
-    3500,
+    350000,
     organization,
     new Date('2024-10-01'),
     'Reimbursement request for high performance battery pack'
@@ -126,7 +126,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.equipment.accountCodeId,
-    150,
+    15000,
     organization,
     new Date('2024-10-05')
   );
@@ -162,7 +162,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.equipment.accountCodeId,
-    50,
+    5000,
     organization,
     new Date('2024-09-25')
   );
@@ -203,7 +203,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.stuff.accountCodeId,
-    2000,
+    200000,
     organization,
     new Date('2024-09-20')
   );
@@ -249,7 +249,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.equipment.accountCodeId,
-    450,
+    45000,
     organization,
     new Date('2024-10-10')
   );
@@ -285,7 +285,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.stuff.accountCodeId,
-    80,
+    8000,
     organization,
     new Date('2024-09-15')
   );
@@ -326,7 +326,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.equipment.accountCodeId,
-    1250,
+    125000,
     organization,
     new Date('2024-10-12')
   );
@@ -356,7 +356,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.stuff.accountCodeId,
-    450,
+    45000,
     organization,
     new Date('2024-09-28')
   );
@@ -397,7 +397,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.equipment.accountCodeId,
-    120,
+    12000,
     organization,
     new Date('2024-10-08')
   );
@@ -433,7 +433,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.equipment.accountCodeId,
-    200,
+    20000,
     organization,
     new Date('2024-09-18')
   );
@@ -474,7 +474,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.stuff.accountCodeId,
-    50,
+    5000,
     organization,
     new Date('2024-10-11')
   );
@@ -504,7 +504,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.equipment.accountCodeId,
-    750,
+    75000,
     organization,
     new Date('2024-09-10')
   );
@@ -551,7 +551,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.equipment.accountCodeId,
-    1800,
+    180000,
     organization,
     new Date('2024-10-13')
   );
@@ -587,7 +587,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.stuff.accountCodeId,
-    250,
+    25000,
     organization,
     new Date('2024-10-07')
   );
@@ -622,7 +622,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.equipment.accountCodeId,
-    90,
+    9000,
     organization,
     new Date('2024-10-09')
   );
@@ -658,7 +658,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.stuff.accountCodeId,
-    60,
+    6000,
     organization,
     new Date('2024-10-06')
   );
@@ -699,7 +699,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.equipment.accountCodeId,
-    1500,
+    150000,
     organization,
     new Date('2024-09-22')
   );
@@ -730,7 +730,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.equipment.accountCodeId,
-    550,
+    55000,
     organization,
     new Date('2024-09-29')
   );
@@ -771,7 +771,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.stuff.accountCodeId,
-    180,
+    18000,
     organization,
     new Date('2024-10-04')
   );
@@ -807,7 +807,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.equipment.accountCodeId,
-    950,
+    95000,
     organization,
     new Date('2024-09-27')
   );
@@ -854,7 +854,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.equipment.accountCodeId,
-    75,
+    7500,
     organization,
     new Date('2024-10-10')
   );
@@ -884,7 +884,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.stuff.accountCodeId,
-    220,
+    22000,
     organization,
     new Date('2024-09-24')
   );
@@ -925,7 +925,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.equipment.accountCodeId,
-    140,
+    14000,
     organization,
     new Date('2024-10-02')
   );
@@ -991,7 +991,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.equipment.accountCodeId,
-    2350,
+    235000,
     organization,
     new Date('2024-09-12')
   );
@@ -1038,7 +1038,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.equipment.accountCodeId,
-    4250,
+    425000,
     organization,
     new Date('2024-10-14')
   );
@@ -1068,7 +1068,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.equipment.accountCodeId,
-    180,
+    18000,
     organization,
     new Date('2024-09-10')
   );
@@ -1119,7 +1119,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.equipment.accountCodeId,
-    320,
+    32000,
     organization,
     new Date('2024-09-12')
   );
@@ -1170,7 +1170,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.equipment.accountCodeId,
-    500,
+    50000,
     organization,
     new Date('2024-08-15')
   );
@@ -1227,7 +1227,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.stuff.accountCodeId,
-    120,
+    12000,
     organization,
     new Date('2024-08-18')
   );
@@ -1284,7 +1284,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.equipment.accountCodeId,
-    1500,
+    150000,
     organization,
     new Date('2024-07-10')
   );
@@ -1352,7 +1352,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.stuff.accountCodeId,
-    280,
+    28000,
     organization,
     new Date('2024-07-12')
   );
@@ -1420,7 +1420,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.equipment.accountCodeId,
-    2750,
+    275000,
     organization,
     new Date('2024-06-01')
   );
@@ -1493,7 +1493,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.equipment.accountCodeId,
-    890,
+    89000,
     organization,
     new Date('2024-05-15')
   );
@@ -1566,7 +1566,7 @@ export const seedReimbursementRequests = async (
       }
     ],
     accountCodes.stuff.accountCodeId,
-    150,
+    15000,
     organization,
     new Date('2024-05-05')
   );

--- a/src/frontend/src/pages/ProjectPage/ProjectSpendingHistory.tsx
+++ b/src/frontend/src/pages/ProjectPage/ProjectSpendingHistory.tsx
@@ -75,7 +75,7 @@ const ProjectSpendingHistory: React.FC<ProjectSpendingHistoryProps> = ({ wbsNum 
       budgetRemaining,
       budgetUsedPercentage
     };
-  }, [project, reimbursementRequests]);
+  }, [project, reimbursementRequests, wbsNum]);
 
   const columns: GridColDef[] = [
     {

--- a/src/frontend/src/pages/ProjectPage/ProjectSpendingHistory.tsx
+++ b/src/frontend/src/pages/ProjectPage/ProjectSpendingHistory.tsx
@@ -32,72 +32,16 @@ const getStatusColor = (status: ReimbursementStatusType): string => {
   }
 };
 
-const columns: GridColDef[] = [
-  {
-    field: 'identifier',
-    headerName: 'RR #',
-    flex: 0.4,
-    minWidth: 80,
-    renderCell: (params: GridRenderCellParams) => (
-      <Link
-        href={`${routes.REIMBURSEMENT_REQUESTS}/all-requests/${(params.row as any).reimbursementRequestId}`}
-        underline="hover"
-        color="primary"
-        onClick={(e) => e.stopPropagation()}
-      >
-        #{params.value}
-      </Link>
-    )
-  },
-  {
-    field: 'submitter',
-    headerName: 'Submitter',
-    flex: 1,
-    minWidth: 150,
-    valueGetter: (params: any) => fullNamePipe(params.row.submitter)
-  },
-  {
-    field: 'products',
-    headerName: 'Products',
-    flex: 2,
-    minWidth: 250,
-    valueGetter: (params: any) => params.row.reimbursementProducts?.map((p: any) => p.name).join(', ') || 'No products'
-  },
-  {
-    field: 'dateSubmitted',
-    headerName: 'Date Submitted',
-    flex: 0.7,
-    minWidth: 130,
-    valueGetter: (params: any) => datePipe(params.row.dateSubmitted)
-  },
-  {
-    field: 'status',
-    headerName: 'Status',
-    flex: 1,
-    minWidth: 220,
-    renderCell: (params: GridRenderCellParams) => (
-      <Box
-        sx={{
-          padding: '3px 8px',
-          display: 'inline-flex',
-          borderRadius: '8px',
-          backgroundColor: getStatusColor(params.value as ReimbursementStatusType),
-          fontWeight: 700,
-          whiteSpace: 'nowrap'
-        }}
-      >
-        {cleanReimbursementRequestStatus(params.value as ReimbursementStatusType)}
-      </Box>
-    )
-  },
-  {
-    field: 'amount',
-    headerName: 'Total Amount',
-    flex: 0.5,
-    minWidth: 110,
-    valueGetter: (params: any) => `$${centsToDollar(params.row.amount as number)}`
-  }
-];
+const getProjectCost = (rr: ReimbursementRequest, wbsNum: WbsNumber): number =>
+  rr.reimbursementProducts
+    .filter((product) => {
+      const reason = product.reimbursementProductReason;
+      return (
+        (reason as WBSElementData).wbsNum &&
+        equalsWbsNumber({ ...(reason as WBSElementData).wbsNum, workPackageNumber: 0 }, { ...wbsNum, workPackageNumber: 0 })
+      );
+    })
+    .reduce((sum, product) => sum + (product.cost || 0), 0);
 
 const ProjectSpendingHistory: React.FC<ProjectSpendingHistoryProps> = ({ wbsNum }) => {
   const { data: allReimbursementRequests, isLoading: rrLoading, isError: rrError } = useAllReimbursementRequests();
@@ -109,7 +53,10 @@ const ProjectSpendingHistory: React.FC<ProjectSpendingHistoryProps> = ({ wbsNum 
       rr.reimbursementProducts.some((product) => {
         const reason = product.reimbursementProductReason;
         if ((reason as WBSElementData).wbsNum) {
-          return equalsWbsNumber((reason as WBSElementData).wbsNum, { ...wbsNum, workPackageNumber: 0 });
+          return equalsWbsNumber(
+            { ...(reason as WBSElementData).wbsNum, workPackageNumber: 0 },
+            { ...wbsNum, workPackageNumber: 0 }
+          );
         }
         return false;
       })
@@ -119,7 +66,7 @@ const ProjectSpendingHistory: React.FC<ProjectSpendingHistoryProps> = ({ wbsNum 
   const budgetInfo = useMemo(() => {
     if (!project) return null;
     const totalBudget = project.budget; // already in dollars
-    const totalSpent = reimbursementRequests.reduce((sum, rr) => sum + (rr.totalCost || 0), 0) / 100; // cents → dollars
+    const totalSpent = reimbursementRequests.reduce((sum, rr) => sum + getProjectCost(rr, wbsNum), 0) / 100; // cents → dollars
     const budgetRemaining = totalBudget - totalSpent;
     const budgetUsedPercentage = totalBudget > 0 ? (totalSpent / totalBudget) * 100 : 0;
     return {
@@ -129,6 +76,80 @@ const ProjectSpendingHistory: React.FC<ProjectSpendingHistoryProps> = ({ wbsNum 
       budgetUsedPercentage
     };
   }, [project, reimbursementRequests]);
+
+  const columns: GridColDef[] = [
+    {
+      field: 'identifier',
+      headerName: 'RR #',
+      flex: 0.4,
+      minWidth: 80,
+      renderCell: (params: GridRenderCellParams) => (
+        <Link
+          href={`${routes.REIMBURSEMENT_REQUESTS}/all-requests/${(params.row as any).reimbursementRequestId}`}
+          underline="hover"
+          color="primary"
+          onClick={(e) => e.stopPropagation()}
+        >
+          #{params.value}
+        </Link>
+      )
+    },
+    {
+      field: 'submitter',
+      headerName: 'Submitter',
+      flex: 1,
+      minWidth: 150,
+      valueGetter: (params: any) => fullNamePipe(params.row.submitter)
+    },
+    {
+      field: 'products',
+      headerName: 'Products',
+      flex: 2,
+      minWidth: 250,
+      valueGetter: (params: any) => params.row.reimbursementProducts?.map((p: any) => p.name).join(', ') || 'No products'
+    },
+    {
+      field: 'dateSubmitted',
+      headerName: 'Date Submitted',
+      flex: 0.7,
+      minWidth: 130,
+      valueGetter: (params: any) => datePipe(params.row.dateSubmitted)
+    },
+    {
+      field: 'status',
+      headerName: 'Status',
+      flex: 1,
+      minWidth: 220,
+      renderCell: (params: GridRenderCellParams) => (
+        <Box
+          sx={{
+            padding: '3px 8px',
+            display: 'inline-flex',
+            borderRadius: '8px',
+            backgroundColor: getStatusColor(params.value as ReimbursementStatusType),
+            fontWeight: 700,
+            whiteSpace: 'nowrap'
+          }}
+        >
+          {cleanReimbursementRequestStatus(params.value as ReimbursementStatusType)}
+        </Box>
+      )
+    },
+    {
+      field: 'projectCost',
+      headerName: 'Project Cost',
+      flex: 0.5,
+      minWidth: 110,
+      valueGetter: (params: any) => `$${centsToDollar(getProjectCost(params.row.raw ?? params.row, wbsNum))}`
+    },
+    {
+      field: 'amount',
+      headerName: 'Total Amount',
+      flex: 0.5,
+      minWidth: 110,
+      valueGetter: (params: any) => `$${centsToDollar(params.row.amount as number)}`
+    }
+  ];
 
   const mapRow = (rr: ReimbursementRequest): MapRowResult<ReimbursementRequest> => {
     const row = createReimbursementRequestRowData(rr);


### PR DESCRIPTION
## Changes

Updates the project budget page to use the costs associated only with this project for the budget calculations. Also includes a column, in addition to the total cost column, for the $ in the rr associated with this project

- also fixed rr seed data bc totalCost is assumed to be in cents

## Screenshots

<img width="1196" height="631" alt="Screenshot 2026-03-15 at 7 05 27 PM" src="https://github.com/user-attachments/assets/0ef284c9-925b-471c-9364-3e6d86470a15" />
---
<img width="1201" height="634" alt="Screenshot 2026-03-15 at 7 11 21 PM" src="https://github.com/user-attachments/assets/eef0fcbe-5621-4504-85c9-bd00e9181c7a" />


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #3997
