### PR TITLE
#3943 descriptive finance slack msg

### DIFF
--- a/src/backend/src/services/reimbursement-requests.services.ts
+++ b/src/backend/src/services/reimbursement-requests.services.ts
@@ -293,7 +293,6 @@ export default class ReimbursementRequestService {
 
     await sendReimbursementRequestCreatedNotificationAndCreateMessageInfo(
       createdReimbursementRequest.reimbursementRequestId,
-      createdReimbursementRequest.identifier,
       recipient.userId,
       organization.organizationId
     );

--- a/src/backend/src/utils/slack.utils.ts
+++ b/src/backend/src/utils/slack.utils.ts
@@ -141,7 +141,16 @@ export const sendReimbursementRequestCreatedNotificationAndCreateMessageInfo = a
 
   const reimbursementRequest = await prisma.reimbursement_Request.findUnique({
     where: { reimbursementRequestId: requestId },
-    ...getReimbursementRequestQueryArgs(organizationId)
+    select: {
+      identifier: true,
+      totalCost: true,
+      description: true,
+      vendor: {
+        select: {
+          name: true
+        }
+      }
+    }
   });
 
   if (!reimbursementRequest) throw new HttpException(500, 'Reimbursement request does not exist!');
@@ -173,7 +182,7 @@ export const sendReimbursementRequestCreatedNotificationAndCreateMessageInfo = a
   const { messageInfoId, channelId, timestamp } = createdMessageInfo;
 
   // send reimbursement request description in slack thread
-  if (description !== '') {
+  if (description) {
     await sendThreadResponse(
       [{ messageInfoId, channelId, timestamp, changeRequestId: null }],
       `Description: ${description}`

--- a/src/backend/src/utils/slack.utils.ts
+++ b/src/backend/src/utils/slack.utils.ts
@@ -31,7 +31,6 @@ import { Prisma } from '@prisma/client';
 import { userTransformer } from '../transformers/user.transformer.js';
 import { SlackRichTextBlock } from '../services/slack.services.js';
 import UsersService from '../services/users.services.js';
-import { getReimbursementRequestQueryArgs } from '../prisma-query-args/reimbursement-requests.query-args.js';
 
 interface SlackMessageThread {
   messageInfoId: string;

--- a/src/backend/src/utils/slack.utils.ts
+++ b/src/backend/src/utils/slack.utils.ts
@@ -32,6 +32,7 @@ import { userTransformer } from '../transformers/user.transformer.js';
 import { SlackRichTextBlock } from '../services/slack.services.js';
 import UsersService from '../services/users.services.js';
 import { getReimbursementRequestQueryArgs } from '../prisma-query-args/reimbursement-requests.query-args.js';
+import { create } from 'domain';
 
 interface SlackMessageThread {
   messageInfoId: string;
@@ -148,9 +149,8 @@ export const sendReimbursementRequestCreatedNotificationAndCreateMessageInfo = a
 
   const { identifier, totalCost, description, vendor } = reimbursementRequest;
   const formattedCost = `$${(totalCost / 100).toFixed(2)}`; // convert from cents to dollars and cents
-  const formattedDesc = description !== '' ? `for ${description} ` : '';
 
-  const msg = `${await getUserSlackMentionOrName(submitterId)} created a reimbursement request for ${formattedCost} ${formattedDesc}from ${vendor.name} (ID#: ${identifier}) 💲`;
+  const msg = `${await getUserSlackMentionOrName(submitterId)} created a reimbursement request for ${formattedCost} at ${vendor.name} (ID#: ${identifier}) 💲`;
   const link = `https://finishlinebyner.com/finance/reimbursement-requests/${requestId}`;
   const linkButtonText = 'View Reimbursement Request';
 
@@ -163,13 +163,23 @@ export const sendReimbursementRequestCreatedNotificationAndCreateMessageInfo = a
   const messageInfo = await sendMessage(financeTeam.slackId, msg, link, linkButtonText);
   if (!messageInfo) return;
 
-  await prisma.message_Info.create({
+  const createdMessageInfo = await prisma.message_Info.create({
     data: {
       reimbursementRequestId: requestId,
       channelId: messageInfo.channelId,
       timestamp: messageInfo.ts
     }
   });
+
+  const { messageInfoId, channelId, timestamp } = createdMessageInfo;
+
+  // send reimbursement request description in slack thread
+  if (description !== '') {
+    await sendThreadResponse(
+      [{ messageInfoId, channelId, timestamp, changeRequestId: null }],
+      `Description: ${description}`
+    );
+  }
 };
 
 /**

--- a/src/backend/src/utils/slack.utils.ts
+++ b/src/backend/src/utils/slack.utils.ts
@@ -134,7 +134,6 @@ export const sendSlackTaskAssignedNotification = async (
  */
 export const sendReimbursementRequestCreatedNotificationAndCreateMessageInfo = async (
   requestId: string,
-  requestIdentifier: number,
   submitterId: string,
   organizationId: string
 ): Promise<void> => {
@@ -147,10 +146,11 @@ export const sendReimbursementRequestCreatedNotificationAndCreateMessageInfo = a
 
   if (!reimbursementRequest) throw new HttpException(500, 'Reimbursement request does not exist!');
 
-  const { totalCost, description, vendor } = reimbursementRequest;
-  const formattedTotalCost = `$${(totalCost / 100).toFixed(2)}`; // convert from cents to dollars and limit to 2 decimal places
+  const { identifier, totalCost, description, vendor } = reimbursementRequest;
+  const formattedCost = `$${(totalCost / 100).toFixed(2)}`; // convert from cents to dollars and cents
+  const formattedDesc = description !== '' ? `for ${description} ` : '';
 
-  const msg = `${await getUserSlackMentionOrName(submitterId)} created a reimbursement request (ID#: ${requestIdentifier}) 💲`;
+  const msg = `${await getUserSlackMentionOrName(submitterId)} created a reimbursement request for ${formattedCost} ${formattedDesc}from ${vendor.name} (ID#: ${identifier}) 💲`;
   const link = `https://finishlinebyner.com/finance/reimbursement-requests/${requestId}`;
   const linkButtonText = 'View Reimbursement Request';
 

--- a/src/backend/src/utils/slack.utils.ts
+++ b/src/backend/src/utils/slack.utils.ts
@@ -31,6 +31,7 @@ import { Prisma } from '@prisma/client';
 import { userTransformer } from '../transformers/user.transformer.js';
 import { SlackRichTextBlock } from '../services/slack.services.js';
 import UsersService from '../services/users.services.js';
+import { getReimbursementRequestQueryArgs } from '../prisma-query-args/reimbursement-requests.query-args.js';
 
 interface SlackMessageThread {
   messageInfoId: string;
@@ -127,8 +128,9 @@ export const sendSlackTaskAssignedNotification = async (
 
 /**
  * Send a notification to users that a reimbursement request is created on Slack
- * @param requestId the id if the reimbursement request
+ * @param requestId the id of the reimbursement request
  * @param submitterId the id of the user who created the reimbursement request
+ * @param organizationId the organization id of the current user
  */
 export const sendReimbursementRequestCreatedNotificationAndCreateMessageInfo = async (
   requestId: string,
@@ -137,6 +139,16 @@ export const sendReimbursementRequestCreatedNotificationAndCreateMessageInfo = a
   organizationId: string
 ): Promise<void> => {
   if (process.env.NODE_ENV !== 'production' && !DEV_TESTING_OVERRIDE) return; // don't send msgs unless in prod
+
+  const reimbursementRequest = await prisma.reimbursement_Request.findUnique({
+    where: { reimbursementRequestId: requestId },
+    ...getReimbursementRequestQueryArgs(organizationId)
+  });
+
+  if (!reimbursementRequest) throw new HttpException(500, 'Reimbursement request does not exist!');
+
+  const { totalCost, description, vendor } = reimbursementRequest;
+  const formattedTotalCost = `$${(totalCost / 100).toFixed(2)}`; // convert from cents to dollars and limit to 2 decimal places
 
   const msg = `${await getUserSlackMentionOrName(submitterId)} created a reimbursement request (ID#: ${requestIdentifier}) 💲`;
   const link = `https://finishlinebyner.com/finance/reimbursement-requests/${requestId}`;

--- a/src/backend/src/utils/slack.utils.ts
+++ b/src/backend/src/utils/slack.utils.ts
@@ -32,7 +32,6 @@ import { userTransformer } from '../transformers/user.transformer.js';
 import { SlackRichTextBlock } from '../services/slack.services.js';
 import UsersService from '../services/users.services.js';
 import { getReimbursementRequestQueryArgs } from '../prisma-query-args/reimbursement-requests.query-args.js';
-import { create } from 'domain';
 
 interface SlackMessageThread {
   messageInfoId: string;


### PR DESCRIPTION
## Changes

Updated sendReimbursementRequestCreatedNotificationAndCreateMessageInfo in slack utils to send a more descriptive message in the slack notification that gets sent when a reimbursement request is created.

## Notes
Do they also want more info in the other notifications, like if a reimbursement request is rejected? I didn't change any of those but tbh they might want more details on those too.

## Test Cases
I just kinda made sure it worked. Didn't test edge cases cause not sure what those would be.

## Screenshots
<img width="1080" height="213" alt="image" src="https://github.com/user-attachments/assets/def5e8b9-beb0-4ed8-b2eb-75f8293795c8" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [X] All commits are tagged with the ticket number
- [X] No linting errors / newline at end of file warnings
- [X] All code follows repository-configured prettier formatting
- [X] No merge conflicts
- [X] All checks passing
- [X] Screenshots of UI changes (see Screenshots section)
- [X] Remove any non-applicable sections of this template
- [X] Assign the PR to yourself
- [X] No `yarn.lock` changes (unless dependencies have changed)
- [X] Request reviewers & ping on Slack
- [X] PR is linked to the ticket (fill in the closes line below)

Closes #3943 
