### PR TITLE
#3918 - Add Icon + Tooltip for Copied Materials in BOM

### DIFF
--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/BOMTable.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/BOMTable.tsx
@@ -63,7 +63,8 @@ const BOMTable: React.FC<BOMTableProps> = ({ setHideColumn, assignMaterial, colu
       subtotal: '',
       link: '',
       notes: '',
-      assemblyId: assembly.assemblyId
+      assemblyId: assembly.assemblyId,
+      isCopied: false
     });
 
     assemblyMaterials.forEach((material, indx) => materialsWithAssemblies.push(materialToRow(material, indx)));

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/BOMTableWrapper.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/BOMTableWrapper.tsx
@@ -11,7 +11,8 @@ import { useToast } from '../../../../hooks/toasts.hooks';
 import { useAssignMaterialToAssembly, useDeleteAssembly, useDeleteMaterial } from '../../../../hooks/bom.hooks';
 import LoadingIndicator from '../../../../components/LoadingIndicator';
 import EditMaterialModal from './MaterialForm/EditMaterialModal';
-import { Button, Link, Typography } from '@mui/material';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import { Button, Link, Tooltip, Typography } from '@mui/material';
 import { bomBaseColDef } from '../../../../utils/bom.utils';
 import NERModal from '../../../../components/NERModal';
 import { renderStatusBOM } from './BOMTableCustomCells';
@@ -292,10 +293,22 @@ const BOMTableWrapper: React.FC<BOMTableWrapperProps> = ({
       flex: 1.5,
       field: 'name',
       headerName: 'Name',
-      type: 'string',
       sortable: false,
       filterable: false,
-      hide: hideColumn[3]
+      hide: hideColumn[3],
+      renderCell: (params) => {
+        const material = materials.find((m) => m.materialId === params.row.materialId);
+        return (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            <Typography variant="body2">{params.value}</Typography>
+            {material?.isCopied && (
+              <Tooltip title="Copied from another BOM">
+                <ContentCopyIcon sx={{ fontSize: 14, color: 'warning.main' }} />
+              </Tooltip>
+            )}
+          </Box>
+        );
+      }
     },
     {
       ...bomBaseColDef,

--- a/src/frontend/src/utils/bom.utils.ts
+++ b/src/frontend/src/utils/bom.utils.ts
@@ -20,6 +20,7 @@ export interface BomRow extends GridValidRowModel {
   link: string;
   notes: string | undefined;
   assemblyId: string | undefined;
+  isCopied: boolean;
 }
 
 export const materialToRow = (material: Material, idx: number): BomRow => {
@@ -38,7 +39,8 @@ export const materialToRow = (material: Material, idx: number): BomRow => {
     subtotal: material.subtotal !== undefined ? `$${centsToDollar(material.subtotal)}` : '',
     link: material.linkUrl,
     notes: material.notes,
-    assemblyId: material.assemblyId ?? 'assembly-misc'
+    assemblyId: material.assemblyId ?? 'assembly-misc',
+    isCopied: material.isCopied
   };
 };
 


### PR DESCRIPTION
## Changes

- Add an icon in the name field for materials that are copied from another BOM.
- Add a tooltip explaining the material was copied when hovering over the icon.

## Screenshots

<img width="1919" height="946" alt="image" src="https://github.com/user-attachments/assets/d19d2931-b4f9-47c6-99f1-82d102f07614" />
<img width="1834" height="572" alt="image" src="https://github.com/user-attachments/assets/89c03c5e-476f-4111-b250-ff25884fd0b9" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [X] All commits are tagged with the ticket number
- [X] No linting errors / newline at end of file warnings
- [X] All code follows repository-configured prettier formatting
- [X] No merge conflicts
- [X] All checks passing
- [X] Screenshots of UI changes (see Screenshots section)
- [X] Remove any non-applicable sections of this template
- [X] Assign the PR to yourself
- [X] No `yarn.lock` changes (unless dependencies have changed)
- [X] Request reviewers & ping on Slack
- [X] PR is linked to the ticket (fill in the closes line below)

Closes #3918 
