### PR TITLE
#3996 added z-index to Tooltip popup

### DIFF
--- a/src/frontend/src/pages/FinancePage/FinanceComponents/PieChart.tsx
+++ b/src/frontend/src/pages/FinancePage/FinanceComponents/PieChart.tsx
@@ -5,6 +5,7 @@ import ArrowDropUp from '@mui/icons-material/ArrowDropUp';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import { Box } from '@mui/system';
 import { Button, List, ListItem, Typography } from '@mui/material';
+import zIndex from '@mui/material/styles/zIndex';
 
 interface FinancePieChartProps {
   totalBalance: number;
@@ -231,6 +232,7 @@ const FinancePieChart: React.FC<FinancePieChartProps> = ({
                 />
               </Pie>
               <Tooltip
+                wrapperStyle={{ zIndex: 10 }}
                 contentStyle={{
                   backgroundColor: '#333',
                   color: '#fff',

--- a/src/frontend/src/pages/FinancePage/FinanceComponents/PieChart.tsx
+++ b/src/frontend/src/pages/FinancePage/FinanceComponents/PieChart.tsx
@@ -5,7 +5,6 @@ import ArrowDropUp from '@mui/icons-material/ArrowDropUp';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import { Box } from '@mui/system';
 import { Button, List, ListItem, Typography } from '@mui/material';
-import zIndex from '@mui/material/styles/zIndex';
 
 interface FinancePieChartProps {
   totalBalance: number;
@@ -232,7 +231,7 @@ const FinancePieChart: React.FC<FinancePieChartProps> = ({
                 />
               </Pie>
               <Tooltip
-                wrapperStyle={{ zIndex: 10 }}
+                wrapperStyle={{ zIndex: 10 }} // added z index to make the div pop up in front of the legend items
                 contentStyle={{
                   backgroundColor: '#333',
                   color: '#fff',


### PR DESCRIPTION
## Changes

Added z-index of 10 to the Tooltip.

## Notes

In order to change the styling of the Tooltip, we needed to use wrapperStyle and set the zIndex to something bigger than zero so it would know 

## Screenshots

![Screenshot 2026-03-24 at 5 30 55 PM](https://github.com/user-attachments/assets/92fe0d80-dc5b-4864-9b08-2181aa26ce58)

## Checklist

- [ x] All commits are tagged with the ticket number
- [x ] No linting errors / newline at end of file warnings
- [x ] All code follows repository-configured prettier formatting
- [ x] No merge conflicts
- [ ] All checks passing
- [ x] Screenshots of UI changes (see Screenshots section)
- [x ] Remove any non-applicable sections of this template
- [ x] Assign the PR to yourself
- [x ] No `yarn.lock` changes (unless dependencies have changed)
- [ x] Request reviewers & ping on Slack
- [ x] PR is linked to the ticket (fill in the closes line below)

Closes #3996 