### PR TITLE
#3960 move projects leading above team's projects

### DIFF
--- a/src/frontend/src/pages/ProjectsPage/ProjectsOverview.tsx
+++ b/src/frontend/src/pages/ProjectsPage/ProjectsOverview.tsx
@@ -64,18 +64,17 @@ const ProjectsOverview: React.FC = () => {
         favoriteProjectsSet={favoriteProjectsSet}
         emptyMessage="You have no favorite projects. Click the star on a project's page to add one!"
       />
-
-      {filteredTeamsProjects.length > 0 && (
-        <ProjectsOverviewCards
-          projects={filteredTeamsProjects}
-          title="My Team's Projects"
-          favoriteProjectsSet={favoriteProjectsSet}
-        />
-      )}
       {filteredLeadingProjects.length > 0 && (
         <ProjectsOverviewCards
           projects={filteredLeadingProjects}
           title="Projects I'm Leading"
+          favoriteProjectsSet={favoriteProjectsSet}
+        />
+      )}
+      {filteredTeamsProjects.length > 0 && (
+        <ProjectsOverviewCards
+          projects={filteredTeamsProjects}
+          title="My Team's Projects"
           favoriteProjectsSet={favoriteProjectsSet}
         />
       )}


### PR DESCRIPTION
## Changes

I moved the Projects Leading block above the Team's Projects block.

## Screenshots

<img width="1464" height="859" alt="Screenshot 2026-03-26 at 7 14 37 PM" src="https://github.com/user-attachments/assets/a8611d9a-ec5a-4d3d-9466-d91e42f71b29" />

<img width="490" height="223" alt="Screenshot 2026-03-26 at 7 15 17 PM" src="https://github.com/user-attachments/assets/a07837eb-2408-4ffa-986a-5cef9084ff4f" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #3960
