### PR TITLE
#3991 moved Account Code above Refund Source

### DIFF
--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
@@ -439,6 +439,60 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
                   </FormControl>
                 )}
 
+                {/* Account Code */}
+                <FormControl sx={{ borderRadius: '25px', width: '100%' }}>
+                  <FormLabel
+                    sx={{
+                      color: '#dd524c',
+                      textShadow: '1.5px 0 #dd524c',
+                      letterSpacing: '0.5px',
+                      textDecoration: 'underline',
+                      textUnderlineOffset: '3.5px',
+                      textDecorationThickness: '0.6px',
+                      paddingBottom: '2px',
+                      fontSize: 'x-large',
+                      fontWeight: 'bold'
+                    }}
+                  >
+                    Account Code*
+                  </FormLabel>
+                  <Controller
+                    name="accountCodeId"
+                    control={control}
+                    render={({ field: { onChange, value } }) => {
+                      const mappedAccountCodes = allAccountCodes
+                        .filter((accountCode) => accountCode.allowed)
+                        .map(accountCodesToAutocomplete);
+                      return (
+                        <Select
+                          value={value}
+                          onChange={(e) => {
+                            onChange(e.target.value);
+                          }}
+                          displayEmpty
+                          variant="outlined"
+                          fullWidth
+                          size="small"
+                          IconComponent={KeyboardArrowDownIcon}
+                          renderValue={(selected) => {
+                            if (!selected) {
+                              return <Typography style={{ color: 'gray' }}>Select Account Code</Typography>;
+                            }
+                            return mappedAccountCodes.find((accountCode) => accountCode.id === selected)?.label;
+                          }}
+                        >
+                          {mappedAccountCodes.map((accountCode) => (
+                            <MenuItem key={accountCode.id} value={accountCode.id}>
+                              {accountCode.label}
+                            </MenuItem>
+                          ))}
+                        </Select>
+                      );
+                    }}
+                  />
+                  <FormHelperText error>{errors.accountCodeId?.message}</FormHelperText>
+                </FormControl>
+
                 {/* Refund Sources */}
                 <FormControl sx={{ borderRadius: '25px', width: '100%' }}>
                   <FormLabel
@@ -628,60 +682,6 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
             {/* Right Column */}
             <Grid item xs={12} md={6}>
               <Stack spacing={3}>
-                {/* Account Code */}
-                <FormControl sx={{ borderRadius: '25px', width: '100%' }}>
-                  <FormLabel
-                    sx={{
-                      color: '#dd524c',
-                      textShadow: '1.5px 0 #dd524c',
-                      letterSpacing: '0.5px',
-                      textDecoration: 'underline',
-                      textUnderlineOffset: '3.5px',
-                      textDecorationThickness: '0.6px',
-                      paddingBottom: '2px',
-                      fontSize: 'x-large',
-                      fontWeight: 'bold'
-                    }}
-                  >
-                    Account Code*
-                  </FormLabel>
-                  <Controller
-                    name="accountCodeId"
-                    control={control}
-                    render={({ field: { onChange, value } }) => {
-                      const mappedAccountCodes = allAccountCodes
-                        .filter((accountCode) => accountCode.allowed)
-                        .map(accountCodesToAutocomplete);
-                      return (
-                        <Select
-                          value={value}
-                          onChange={(e) => {
-                            onChange(e.target.value);
-                          }}
-                          displayEmpty
-                          variant="outlined"
-                          fullWidth
-                          size="small"
-                          IconComponent={KeyboardArrowDownIcon}
-                          renderValue={(selected) => {
-                            if (!selected) {
-                              return <Typography style={{ color: 'gray' }}>Select Account Code</Typography>;
-                            }
-                            return mappedAccountCodes.find((accountCode) => accountCode.id === selected)?.label;
-                          }}
-                        >
-                          {mappedAccountCodes.map((accountCode) => (
-                            <MenuItem key={accountCode.id} value={accountCode.id}>
-                              {accountCode.label}
-                            </MenuItem>
-                          ))}
-                        </Select>
-                      );
-                    }}
-                  />
-                  <FormHelperText error>{errors.accountCodeId?.message}</FormHelperText>
-                </FormControl>
-
                 {/* Upload Receipts */}
                 <FormControl sx={{ display: 'flex', borderRadius: '25px', width: '100%' }}>
                   <FormLabel

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
@@ -378,67 +378,6 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
                   />
                 </FormControl>
 
-                {/* Date of Expense */}
-                {(isHead(user.role) || (isEditing && isLeadershipApproved)) && (
-                  <FormControl sx={{ borderRadius: '25px', width: '100%' }}>
-                    <Box style={{ display: 'flex', verticalAlign: 'middle', alignItems: 'center' }}>
-                      <FormLabel
-                        sx={{
-                          color: '#dd524c',
-                          textShadow: '1.5px 0 #dd524c',
-                          letterSpacing: '0.5px',
-                          textDecoration: 'underline',
-                          textUnderlineOffset: '3.5px',
-                          textDecorationThickness: '0.6px',
-                          paddingBottom: '2px',
-                          fontSize: 'x-large',
-                          fontWeight: 'bold'
-                        }}
-                      >
-                        Date of Expense{isLeadershipApproved ? '*' : ''}
-                      </FormLabel>
-                      <Tooltip
-                        title="Reimbursements with Different Purchase Dates Should be on Different Requests. Leave Empty for Not Yet Purchased Items"
-                        placement="right"
-                      >
-                        <HelpIcon style={{ fontSize: 'medium', marginLeft: '5px' }} />
-                      </Tooltip>
-                    </Box>
-                    <Controller
-                      name="dateOfExpense"
-                      control={control}
-                      render={({ field: { onChange, value } }) => (
-                        <DatePicker
-                          value={value}
-                          open={datePickerOpen}
-                          onClose={() => setDatePickerOpen(false)}
-                          onOpen={() => setDatePickerOpen(true)}
-                          onChange={(newValue) => {
-                            onChange(newValue ?? new Date());
-                          }}
-                          slotProps={{
-                            textField: {
-                              error: !!errors.dateOfExpense,
-                              helperText: errors.dateOfExpense?.message,
-                              variant: 'outlined',
-                              fullWidth: true,
-                              size: 'small',
-                              InputProps: {
-                                onClick: (e) => {
-                                  const target = e.target as HTMLElement;
-                                  if (target.closest('button')) {
-                                    setDatePickerOpen(true);
-                                  }
-                                }
-                              }
-                            }
-                          }}
-                        />
-                      )}
-                    />
-                  </FormControl>
-                )}
-
                 {/* Account Code */}
                 <FormControl sx={{ borderRadius: '25px', width: '100%' }}>
                   <FormLabel
@@ -682,6 +621,98 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
             {/* Right Column */}
             <Grid item xs={12} md={6}>
               <Stack spacing={2}>
+                {/* Date of Expense */}
+                {(isHead(user.role) || (isEditing && isLeadershipApproved)) && (
+                  <FormControl sx={{ borderRadius: '25px', width: '100%' }}>
+                    <Box style={{ display: 'flex', verticalAlign: 'middle', alignItems: 'center' }}>
+                      <FormLabel
+                        sx={{
+                          color: '#dd524c',
+                          textShadow: '1.5px 0 #dd524c',
+                          letterSpacing: '0.5px',
+                          textDecoration: 'underline',
+                          textUnderlineOffset: '3.5px',
+                          textDecorationThickness: '0.6px',
+                          paddingBottom: '2px',
+                          fontSize: 'x-large',
+                          fontWeight: 'bold'
+                        }}
+                      >
+                        Date of Expense{isLeadershipApproved ? '*' : ''}
+                      </FormLabel>
+                      <Tooltip
+                        title="Reimbursements with Different Purchase Dates Should be on Different Requests. Leave Empty for Not Yet Purchased Items"
+                        placement="right"
+                      >
+                        <HelpIcon style={{ fontSize: 'medium', marginLeft: '5px' }} />
+                      </Tooltip>
+                    </Box>
+                    <Controller
+                      name="dateOfExpense"
+                      control={control}
+                      render={({ field: { onChange, value } }) => (
+                        <DatePicker
+                          value={value}
+                          open={datePickerOpen}
+                          onClose={() => setDatePickerOpen(false)}
+                          onOpen={() => setDatePickerOpen(true)}
+                          onChange={(newValue) => {
+                            onChange(newValue ?? new Date());
+                          }}
+                          slotProps={{
+                            textField: {
+                              error: !!errors.dateOfExpense,
+                              helperText: errors.dateOfExpense?.message,
+                              variant: 'outlined',
+                              fullWidth: true,
+                              size: 'small',
+                              InputProps: {
+                                onClick: (e) => {
+                                  const target = e.target as HTMLElement;
+                                  if (target.closest('button')) {
+                                    setDatePickerOpen(true);
+                                  }
+                                }
+                              }
+                            }
+                          }}
+                        />
+                      )}
+                    />
+                  </FormControl>
+                )}
+
+                {/* Description */}
+                <FormControl sx={{ borderRadius: '25px', width: '100%' }}>
+                  <FormLabel
+                    sx={{
+                      color: '#dd524c',
+                      textShadow: '1.5px 0 #dd524c',
+                      letterSpacing: '0.5px',
+                      textDecoration: 'underline',
+                      textUnderlineOffset: '3.5px',
+                      textDecorationThickness: '0.6px',
+                      fontSize: 'x-large',
+                      fontWeight: 'bold'
+                    }}
+                  >
+                    Description
+                  </FormLabel>
+                  <Controller
+                    name="description"
+                    control={control}
+                    render={({ field: { onChange, value } }) => (
+                      <TextField
+                        value={value || ''}
+                        onChange={onChange}
+                        placeholder="Enter Description"
+                        multiline
+                        rows={3}
+                      />
+                    )}
+                  />
+                </FormControl>
+
                 {/* Upload Receipts */}
                 <FormControl sx={{ display: 'flex', borderRadius: '25px', width: '100%' }}>
                   <FormLabel
@@ -856,37 +887,6 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
                       })}
                     </Box>
                   </Box>
-                </FormControl>
-
-                {/* Description */}
-                <FormControl sx={{ borderRadius: '25px', width: '100%' }}>
-                  <FormLabel
-                    sx={{
-                      color: '#dd524c',
-                      textShadow: '1.5px 0 #dd524c',
-                      letterSpacing: '0.5px',
-                      textDecoration: 'underline',
-                      textUnderlineOffset: '3.5px',
-                      textDecorationThickness: '0.6px',
-                      fontSize: 'x-large',
-                      fontWeight: 'bold'
-                    }}
-                  >
-                    Description
-                  </FormLabel>
-                  <Controller
-                    name="description"
-                    control={control}
-                    render={({ field: { onChange, value } }) => (
-                      <TextField
-                        value={value || ''}
-                        onChange={onChange}
-                        placeholder="Enter Description"
-                        multiline
-                        rows={3}
-                      />
-                    )}
-                  />
                 </FormControl>
               </Stack>
             </Grid>

--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestForm/ReimbursementFormView.tsx
@@ -285,7 +285,7 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
           <Grid container spacing={3} alignItems="flex-start">
             {/* Left Column */}
             <Grid item xs={12} md={6}>
-              <Stack spacing={3}>
+              <Stack spacing={4}>
                 {/* Vendor */}
                 <FormControl sx={{ borderRadius: '25px', width: '100%' }}>
                   <FormLabel
@@ -681,7 +681,7 @@ const ReimbursementRequestFormView: React.FC<ReimbursementRequestFormViewProps> 
 
             {/* Right Column */}
             <Grid item xs={12} md={6}>
-              <Stack spacing={3}>
+              <Stack spacing={2}>
                 {/* Upload Receipts */}
                 <FormControl sx={{ display: 'flex', borderRadius: '25px', width: '100%' }}>
                   <FormLabel


### PR DESCRIPTION
## Changes

Moved the Account Code section to the left colunn so it always appears above the Refund Source (Select Budget/Cash)

Also moved the Date of Expense to the right column and reordered it a bit.

## Screenshots

_If you made UI changes you must post a screenshot of the whole page for each change in 1) a normal sized window and 2) the smallest possible window_

<img width="1697" height="631" alt="image" src="https://github.com/user-attachments/assets/a6eb62db-dc3f-48a2-9c58-b25a54963699" />
<img width="718" height="890" alt="image" src="https://github.com/user-attachments/assets/9313120b-7a7e-4e92-b46d-5b8fe4ebf042" />




_If you did any manual testing (e.g., with Postman), put screenshots of the http request and before and after of the db_

_If none of this applies, you can delete this section_

## To Do

_Any remaining things that need to get done_

- [ ] item 1
- [ ] ...

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #3991
