### PR TITLE
#4102 sponsor logoimageid frontend

### DIFF
--- a/src/backend/src/controllers/finance.controllers.ts
+++ b/src/backend/src/controllers/finance.controllers.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Request, Response } from 'express';
 import FinanceServices from '../services/finance.services.js';
+import { HttpException } from '../utils/errors.utils.js';
 
 export default class FinanceController {
   static async createSponsor(req: Request, res: Response, next: NextFunction) {
@@ -43,8 +44,7 @@ export default class FinanceController {
         contactPhone,
         contactPosition,
         stockDescription,
-        discountDescription,
-        req.file
+        discountDescription
       );
       res.status(200).json(sponsor);
     } catch (error: unknown) {
@@ -384,8 +384,7 @@ export default class FinanceController {
         contactPhone,
         contactPosition,
         stockDescription,
-        discountDescription,
-        req.file
+        discountDescription
       );
 
       res.status(200).json(updatedSponsor);
@@ -428,6 +427,17 @@ export default class FinanceController {
       const { sponsorTaskId } = req.params as Record<string, string>;
       const updatedTask = await FinanceServices.toggleSponsorTaskDone(req.currentUser, req.organization, sponsorTaskId);
       res.status(200).json(updatedTask);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
+  static async uploadSponsorLogo(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { sponsorId } = req.params as Record<string, string>;
+      if (!req.file) throw new HttpException(400, 'Invalid or undefined image data');
+      const updatedSponsor = await FinanceServices.uploadSponsorLogo(req.currentUser, req.organization, sponsorId, req.file);
+      res.status(200).json(updatedSponsor);
     } catch (error: unknown) {
       next(error);
     }

--- a/src/backend/src/routes/finance.routes.ts
+++ b/src/backend/src/routes/finance.routes.ts
@@ -17,7 +17,6 @@ const upload = multer({ limits: { fileSize: MAX_FILE_SIZE }, storage: memoryStor
 
 financeRouter.post(
   '/sponsor/create',
-  upload.single('logoImage'),
   nonEmptyString(body('name')),
   body('activeStatus').isBoolean(),
   body('valueTypes').isArray(),
@@ -51,6 +50,8 @@ financeRouter.get('/sponsors', FinanceController.getAllSponsors);
 financeRouter.get('/sponsor/:sponsorId/sponsorTasks', FinanceController.getSponsorTasks);
 
 financeRouter.post('/sponsor/:sponsorId/delete', FinanceController.deleteSponsor);
+
+financeRouter.post('/sponsor/:sponsorId/uploadLogo', upload.single('logoImage'), FinanceController.uploadSponsorLogo);
 
 financeRouter.post(
   '/sponsorTier/create',
@@ -146,7 +147,6 @@ financeRouter.get('/sponsorTiers', FinanceController.getAllSponsorTiers);
 
 financeRouter.post(
   '/sponsor/:sponsorId/edit',
-  upload.single('logoImage'),
   nonEmptyString(body('name')),
   body('activeStatus').isBoolean(),
   body('valueTypes').isArray(),

--- a/src/backend/src/routes/finance.routes.ts
+++ b/src/backend/src/routes/finance.routes.ts
@@ -51,7 +51,12 @@ financeRouter.get('/sponsor/:sponsorId/sponsorTasks', FinanceController.getSpons
 
 financeRouter.post('/sponsor/:sponsorId/delete', FinanceController.deleteSponsor);
 
-financeRouter.post('/sponsor/:sponsorId/uploadLogo', upload.single('logoImage'), FinanceController.uploadSponsorLogo);
+financeRouter.post(
+  '/sponsor/:sponsorId/uploadLogo',
+  upload.single('logoImage'),
+  validateInputs,
+  FinanceController.uploadSponsorLogo
+);
 
 financeRouter.post(
   '/sponsorTier/create',

--- a/src/backend/src/services/finance.services.ts
+++ b/src/backend/src/services/finance.services.ts
@@ -81,8 +81,7 @@ export default class FinanceServices {
     contactPhone?: string,
     contactPosition?: string,
     stockDescription?: string,
-    discountDescription?: string,
-    logoImage?: Express.Multer.File
+    discountDescription?: string
   ) {
     if (!(await userHasPermission(submitter.userId, organization.organizationId, isHead)))
       throw new AccessDeniedException('Only heads can create a sponsor');
@@ -106,8 +105,6 @@ export default class FinanceServices {
       data: { name: contactName, email: contactEmail, phone: contactPhone, position: contactPosition }
     });
 
-    const { id: logoImageId } = logoImage ? await uploadFile(logoImage) : { id: undefined };
-
     const sponsor = await prisma.sponsor.create({
       data: {
         name,
@@ -122,7 +119,6 @@ export default class FinanceServices {
         taxExempt,
         discountCode,
         sponsorNotes,
-        logoImageId,
         contactId: contact.sponsorContactId,
         sponsorTasks: {
           create: sponsorTasks.map((task) => ({
@@ -1230,8 +1226,7 @@ export default class FinanceServices {
     contactPhone?: string,
     contactPosition?: string,
     stockDescription?: string,
-    discountDescription?: string,
-    logoImage?: Express.Multer.File
+    discountDescription?: string
   ): Promise<Sponsor> {
     if (!(await userHasPermission(submitter.userId, organization.organizationId, isHead)))
       throw new AccessDeniedException('Only heads can edit sponsors.');
@@ -1329,8 +1324,6 @@ export default class FinanceServices {
       data: { name: contactName, email: contactEmail, phone: contactPhone, position: contactPosition }
     });
 
-    const { id: logoImageId } = logoImage ? await uploadFile(logoImage) : { id: undefined };
-
     const updatedSponsor = await prisma.sponsor.update({
       where: { sponsorId: oldSponsor.sponsorId },
       data: {
@@ -1345,9 +1338,43 @@ export default class FinanceServices {
         tier: sponsorTierId ? { connect: { sponsorTierId } } : { disconnect: true },
         taxExempt,
         discountCode,
-        sponsorNotes,
-        ...(logoImageId && { logoImageId })
+        sponsorNotes
       },
+      ...getSponsorQueryArgs(organization.organizationId)
+    });
+
+    return sponsorTransformer(updatedSponsor);
+  }
+
+  /**
+   * Uploads a logo image for a sponsor and stores the resulting image ID.
+   *
+   * @param submitter The user performing the upload
+   * @param organization The organization the sponsor belongs to
+   * @param sponsorId The id of the sponsor
+   * @param logoImage The logo image file to upload
+   * @returns The updated sponsor
+   */
+  static async uploadSponsorLogo(
+    submitter: User,
+    organization: Organization,
+    sponsorId: string,
+    logoImage: Express.Multer.File
+  ): Promise<Sponsor> {
+    if (!(await userHasPermission(submitter.userId, organization.organizationId, isHead)))
+      throw new AccessDeniedException('Only heads can update a sponsor logo');
+
+    const sponsor = await prisma.sponsor.findUnique({
+      where: { sponsorId, organizationId: organization.organizationId }
+    });
+
+    if (!sponsor) throw new NotFoundException('Sponsor', sponsorId);
+
+    const { id } = await uploadFile(logoImage);
+
+    const updatedSponsor = await prisma.sponsor.update({
+      where: { sponsorId },
+      data: { logoImageId: id },
       ...getSponsorQueryArgs(organization.organizationId)
     });
 

--- a/src/frontend/src/apis/finance.api.ts
+++ b/src/frontend/src/apis/finance.api.ts
@@ -742,6 +742,12 @@ export const editSponsor = (id: string, formData: SponsorPayload) => {
   return axios.post(apiUrls.editSponsor(id), formData);
 };
 
+export const uploadSponsorLogo = (sponsorId: string, logoImage: File) => {
+  const formData = new FormData();
+  formData.append('logoImage', logoImage);
+  return axios.post<Sponsor>(apiUrls.uploadSponsorLogo(sponsorId), formData);
+};
+
 /**
  * API call to delete a given sponsor task
  *

--- a/src/frontend/src/hooks/finance.hooks.ts
+++ b/src/frontend/src/hooks/finance.hooks.ts
@@ -69,6 +69,7 @@ import {
   assignMemberToRR,
   setTaxExemptStatus,
   toggleSponsorTaskDone,
+  uploadSponsorLogo,
   getAllProspectiveSponsors,
   createProspectiveSponsor,
   editProspectiveSponsor,
@@ -186,6 +187,7 @@ export interface SponsorPayload {
   sponsorNotes?: string;
   stockDescription?: string;
   discountDescription?: string;
+  logoImageId?: string;
 }
 
 interface EditSponsorPayload extends SponsorPayload {
@@ -1314,6 +1316,27 @@ export const useEditSponsor = () => {
     ['sponsor', 'edit'],
     async ({ sponsorId, ...formData }: EditSponsorPayload) => {
       const { data } = await editSponsor(sponsorId, formData);
+      return data;
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(['sponsor']);
+      }
+    }
+  );
+};
+
+interface UploadSponsorLogoPayload {
+  sponsorId: string;
+  logoImage: File;
+}
+
+export const useUploadSponsorLogo = () => {
+  const queryClient = useQueryClient();
+  return useMutation<Sponsor, Error, UploadSponsorLogoPayload>(
+    ['sponsor', 'uploadLogo'],
+    async ({ sponsorId, logoImage }: UploadSponsorLogoPayload) => {
+      const { data } = await uploadSponsorLogo(sponsorId, logoImage);
       return data;
     },
     {

--- a/src/frontend/src/pages/FinancePage/FinanceComponents/CreateSponsorPage.tsx
+++ b/src/frontend/src/pages/FinancePage/FinanceComponents/CreateSponsorPage.tsx
@@ -1,6 +1,6 @@
 import { useForm } from 'react-hook-form';
 import LoadingIndicator from '../../../components/LoadingIndicator';
-import { SponsorPayload, useCreateSponsor } from '../../../hooks/finance.hooks';
+import { SponsorPayload, useCreateSponsor, useUploadSponsorLogo } from '../../../hooks/finance.hooks';
 import sponsorSchema, { SponsorForm } from './SponsorForm';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Box } from '@mui/system';
@@ -18,6 +18,7 @@ interface CreateSponsorPageProps {
 const CreateSponsorPage = ({ showPage, handleClose }: CreateSponsorPageProps) => {
   const toast = useToast();
   const { isLoading, mutateAsync } = useCreateSponsor();
+  const { mutateAsync: uploadLogo } = useUploadSponsorLogo();
 
   const {
     handleSubmit,
@@ -48,12 +49,17 @@ const CreateSponsorPage = ({ showPage, handleClose }: CreateSponsorPageProps) =>
   });
 
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [logoImage, setLogoImage] = useState<File | null>(null);
+
   if (isLoading) return <LoadingIndicator />;
 
   const onFormSubmit = async (formData: SponsorPayload) => {
     try {
       setSubmitError(null);
-      await mutateAsync({ ...formData });
+      const sponsor = await mutateAsync(formData);
+      if (logoImage) {
+        await uploadLogo({ sponsorId: sponsor.sponsorId, logoImage });
+      }
       toast.success('Sponsor created successfully!');
       handleClose();
     } catch (err: unknown) {
@@ -71,7 +77,7 @@ const CreateSponsorPage = ({ showPage, handleClose }: CreateSponsorPageProps) =>
       title="Add Sponsor"
       component={
         <Box display="flex" flexDirection="column" alignItems="flex-end">
-          <SponsorForm control={control} errors={errors} setValue={setValue} />
+          <SponsorForm control={control} errors={errors} setValue={setValue} onLogoImageChange={setLogoImage} />
           {submitError && (
             <Box color="error.main" mb={2} fontWeight="bold">
               {submitError}

--- a/src/frontend/src/pages/FinancePage/FinanceComponents/CreateSponsorPage.tsx
+++ b/src/frontend/src/pages/FinancePage/FinanceComponents/CreateSponsorPage.tsx
@@ -17,7 +17,7 @@ interface CreateSponsorPageProps {
 
 const CreateSponsorPage = ({ showPage, handleClose }: CreateSponsorPageProps) => {
   const toast = useToast();
-  const { isLoading, mutateAsync } = useCreateSponsor();
+  const { isLoading, mutateAsync: createSponsor } = useCreateSponsor();
   const { mutateAsync: uploadLogo } = useUploadSponsorLogo();
 
   const {
@@ -56,7 +56,7 @@ const CreateSponsorPage = ({ showPage, handleClose }: CreateSponsorPageProps) =>
   const onFormSubmit = async (formData: SponsorPayload) => {
     try {
       setSubmitError(null);
-      const sponsor = await mutateAsync(formData);
+      const sponsor = await createSponsor(formData);
       if (logoImage) {
         await uploadLogo({ sponsorId: sponsor.sponsorId, logoImage });
       }

--- a/src/frontend/src/pages/FinancePage/FinanceComponents/EditSponsorPage.tsx
+++ b/src/frontend/src/pages/FinancePage/FinanceComponents/EditSponsorPage.tsx
@@ -1,6 +1,6 @@
 import { CreateSponsorTask, Sponsor } from 'shared';
 import LoadingIndicator from '../../../components/LoadingIndicator';
-import { SponsorPayload, useEditSponsor } from '../../../hooks/finance.hooks';
+import { SponsorPayload, useEditSponsor, useUploadSponsorLogo } from '../../../hooks/finance.hooks';
 import SidePage from './SidePagePopup';
 import sponsorSchema, { SponsorForm } from './SponsorForm';
 
@@ -21,6 +21,7 @@ interface EditSponsorPageProps {
 const EditSponsorPage = ({ showPage, handleClose, sponsor }: EditSponsorPageProps) => {
   const toast = useToast();
   const { isLoading, mutateAsync } = useEditSponsor();
+  const { mutateAsync: uploadLogo } = useUploadSponsorLogo();
 
   const defaultSponsorTasks: CreateSponsorTask[] = (
     sponsor.sponsorTasks?.map((task) => ({
@@ -61,12 +62,17 @@ const EditSponsorPage = ({ showPage, handleClose, sponsor }: EditSponsorPageProp
     }
   });
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [logoImage, setLogoImage] = useState<File | null>(null);
+
   if (isLoading) return <LoadingIndicator />;
 
   const onSubmit = async (formData: SponsorPayload) => {
     try {
       setSubmitError(null);
       await mutateAsync({ sponsorId: sponsor.sponsorId, ...formData });
+      if (logoImage) {
+        await uploadLogo({ sponsorId: sponsor.sponsorId, logoImage });
+      }
       toast.success('Sponsor updated successfully!');
       handleClose();
     } catch (err: unknown) {
@@ -84,7 +90,7 @@ const EditSponsorPage = ({ showPage, handleClose, sponsor }: EditSponsorPageProp
       title="Edit Sponsor"
       component={
         <Box display="flex" flexDirection="column" alignItems="flex-end">
-          <SponsorForm control={control} errors={errors} setValue={setValue} defaultValues={sponsor}></SponsorForm>
+          <SponsorForm control={control} errors={errors} setValue={setValue} defaultValues={sponsor} onLogoImageChange={setLogoImage} />
           {submitError && (
             <Box color="error.main" mb={2} fontWeight="bold">
               {submitError}

--- a/src/frontend/src/pages/FinancePage/FinanceComponents/EditSponsorPage.tsx
+++ b/src/frontend/src/pages/FinancePage/FinanceComponents/EditSponsorPage.tsx
@@ -90,7 +90,13 @@ const EditSponsorPage = ({ showPage, handleClose, sponsor }: EditSponsorPageProp
       title="Edit Sponsor"
       component={
         <Box display="flex" flexDirection="column" alignItems="flex-end">
-          <SponsorForm control={control} errors={errors} setValue={setValue} defaultValues={sponsor} onLogoImageChange={setLogoImage} />
+          <SponsorForm
+            control={control}
+            errors={errors}
+            setValue={setValue}
+            defaultValues={sponsor}
+            onLogoImageChange={setLogoImage}
+          />
           {submitError && (
             <Box color="error.main" mb={2} fontWeight="bold">
               {submitError}

--- a/src/frontend/src/pages/FinancePage/FinanceComponents/SponsorForm.tsx
+++ b/src/frontend/src/pages/FinancePage/FinanceComponents/SponsorForm.tsx
@@ -1,5 +1,6 @@
 import * as yup from 'yup';
 import { SponsorPayload, useGetAllSponsorTiers } from '../../../hooks/finance.hooks';
+import { useGetImageUrl } from '../../../hooks/onboarding.hook';
 import ErrorPage from '../../ErrorPage';
 import LoadingIndicator from '../../../components/LoadingIndicator';
 import { Control, Controller, FieldErrors, FieldValues, UseFormSetValue, useFieldArray, useWatch } from 'react-hook-form';
@@ -14,13 +15,18 @@ import {
   Checkbox,
   Autocomplete,
   TextField,
-  Chip
+  Chip,
+  Stack
 } from '@mui/material';
+import FileUploadIcon from '@mui/icons-material/FileUpload';
+import ImageIcon from '@mui/icons-material/Image';
 import ReactHookTextField from '../../../components/ReactHookTextField';
 import { DatePicker } from '@mui/x-date-pickers';
 import { useAllMembers } from '../../../hooks/users.hooks';
 import React, { useEffect, useRef, useState } from 'react';
 import { Box } from '@mui/system';
+import { useToast } from '../../../hooks/toasts.hooks';
+import { MAX_FILE_SIZE } from 'shared';
 import { AddCircle } from '@mui/icons-material';
 import AttachMoneyIcon from '@mui/icons-material/AttachMoney';
 import SponsorTaskCard from './SponsorTaskCard';
@@ -31,6 +37,7 @@ interface SponsorFormProps {
   errors: FieldErrors<SponsorPayload>;
   setValue: UseFormSetValue<SponsorPayload>;
   defaultValues?: Sponsor;
+  onLogoImageChange?: (file: File | null) => void;
 }
 
 const getYears = (startYear = 1950) => {
@@ -103,15 +110,25 @@ const sponsorSchema = yup.object().shape(
           done: yup.boolean().optional()
         })
       )
-      .required('Sponsor Tasks are Required')
+      .required('Sponsor Tasks are Required'),
+    logoImageId: yup.string().trim().optional()
   },
   [['contactEmail', 'contactPhone']]
 );
 
-export const SponsorForm: React.FC<SponsorFormProps> = ({ control, errors, setValue, defaultValues }: SponsorFormProps) => {
+export const SponsorForm: React.FC<SponsorFormProps> = ({
+  control,
+  errors,
+  setValue,
+  defaultValues,
+  onLogoImageChange
+}: SponsorFormProps) => {
   const yearsOptions = getYears();
+  const toast = useToast();
 
+  const [logoImage, setLogoImage] = useState<File | null>(null);
   const [datePickerOpenJoin, setDatePickerOpenJoin] = useState(false);
+  const { data: currentLogoUrl } = useGetImageUrl(defaultValues?.logoImageId ?? null);
 
   const { isLoading: membersLoading, isError: membersIsError, error: membersError, data: members } = useAllMembers();
 
@@ -442,6 +459,49 @@ export const SponsorForm: React.FC<SponsorFormProps> = ({ control, errors, setVa
           </Typography>
           <ReactHookTextField name="discountCode" control={control} sx={{ width: 1 }} placeholder="Enter Code" />
           <FormHelperText error> {errors.discountCode?.message}</FormHelperText>
+        </FormControl>
+      </Grid>
+      <Grid item xs={12} sm={6}>
+        <FormControl fullWidth>
+          <Typography variant="h5" color="#EF4345">
+            Sponsor Logo:
+          </Typography>
+          <Box sx={{ display: 'flex', flexDirection: 'row', gap: 1, alignItems: 'center', mt: 1 }}>
+            <Button
+              variant="contained"
+              color="error"
+              component="label"
+              startIcon={<FileUploadIcon />}
+              sx={{ width: 'fit-content', textTransform: 'none', color: 'black' }}
+            >
+              Upload Logo
+              <input
+                onChange={(e) => {
+                  if (e.target.files && e.target.files[0]) {
+                    const [file] = e.target.files;
+                    if (file.size > MAX_FILE_SIZE) {
+                      toast.error(`File "${file.name}" exceeds the maximum size limit of ${MAX_FILE_SIZE / 1024 / 1024} MB`);
+                      return;
+                    }
+                    setLogoImage(file);
+                    onLogoImageChange?.(file);
+                  }
+                }}
+                type="file"
+                accept="image/png, image/jpeg"
+                hidden
+              />
+            </Button>
+            {logoImage && (
+              <Stack direction="row" spacing={1} alignItems="center">
+                <ImageIcon />
+                <Typography>{logoImage.name}</Typography>
+              </Stack>
+            )}
+          </Box>
+          {!logoImage && currentLogoUrl && (
+            <Box component="img" src={currentLogoUrl} alt="Sponsor Logo" sx={{ maxWidth: '200px', mt: 1 }} />
+          )}
         </FormControl>
       </Grid>
       <Grid item xs={12}>

--- a/src/frontend/src/utils/urls.ts
+++ b/src/frontend/src/utils/urls.ts
@@ -297,6 +297,7 @@ const getAllSpendingBarData = (startDate?: Date, endDate?: Date): string => {
 };
 const getAllSponsorTiers = () => `${financeRoutesEndpoints()}/sponsorTiers`;
 const editSponsor = (sponsorId: string) => `${financeRoutesEndpoints()}/sponsor/${sponsorId}/edit`;
+const uploadSponsorLogo = (sponsorId: string) => `${financeRoutesEndpoints()}/sponsor/${sponsorId}/uploadLogo`;
 const financeGetUsersTeamsReimbursementRequests = () => `${financeEndpoints()}/reimbursements/current-user-team`;
 const deleteSponsorTier = (sponsorTierId: string) => `${financeRoutesEndpoints()}/sponsorTier/${sponsorTierId}`;
 const editSponsorTier = (sponsorTierId: string) => `${financeRoutesEndpoints()}/sponsorTier/${sponsorTierId}/edit`;
@@ -692,6 +693,7 @@ export const apiUrls = {
   getAllSpendingBarData,
   getAllSponsorTiers,
   editSponsor,
+  uploadSponsorLogo,
   financeGetUsersTeamsReimbursementRequests,
   deleteSponsorTier,
   editSponsorTier,


### PR DESCRIPTION
## Changes
Created uploadSponsorLogo endpoint + hooks to upload an image to a given sponsor. Added in the upload button to the create/edit sponsor forms. When a sponsor is uploaded it's viewable within the edit tab when you click on the sponsor (not sure if it should somehow be displayed in the table?).

## Screenshots
<img width="718" height="466" alt="Screenshot 2026-04-15 at 11 41 42 PM" src="https://github.com/user-attachments/assets/8b1720bf-c23e-4eab-a4fb-9e23e880f52b" />

<img width="721" height="428" alt="Screenshot 2026-04-15 at 11 41 27 PM" src="https://github.com/user-attachments/assets/fdc09761-8a79-485a-9c0b-01dd988ce473" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #4102 
