### PR TITLE
#4152 Changed gantt chart tooltip location

### DIFF
--- a/src/frontend/src/pages/GanttPage/GanttChart/GanttChartComponents/GanttToolTip.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChart/GanttChartComponents/GanttToolTip.tsx
@@ -4,6 +4,7 @@ import { emDashPipe } from '../../../../utils/pipes';
 import { formatDateOnly } from 'shared';
 
 interface GanttToolTipProps {
+  xCoordinate: number;
   yCoordinate: number;
   title: string;
   startDate?: Date;
@@ -14,6 +15,7 @@ interface GanttToolTipProps {
 }
 
 const GanttToolTip: React.FC<GanttToolTipProps> = ({
+  xCoordinate,
   yCoordinate,
   title,
   startDate,
@@ -22,15 +24,18 @@ const GanttToolTip: React.FC<GanttToolTipProps> = ({
   lowerRightDisplay
 }) => {
   const theme = useTheme();
-  const xCoordinate = window.innerWidth - 375 - 35;
+  const tooltipWidth = 375;
+  const horizontalPadding = 16;
+  const left = Math.min(Math.max(horizontalPadding, xCoordinate + 12), window.innerWidth - tooltipWidth - horizontalPadding);
+
   return (
     <Box
       style={{
         position: 'fixed',
-        left: `${xCoordinate}px`,
+        left: `${left}px`,
         top: `${yCoordinate + 20}px`,
         zIndex: 4,
-        width: 375
+        width: tooltipWidth
       }}
     >
       <Box color={'white'}>

--- a/src/frontend/src/pages/GanttPage/GanttChart/GanttChartSection.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChart/GanttChartSection.tsx
@@ -30,15 +30,17 @@ interface GanttChartSectionProps<T> {
 }
 
 interface GanttTooltipLayerProps {
-  updateRef: MutableRefObject<(options: OnMouseOverOptions | undefined, y?: number) => void>;
+  updateRef: MutableRefObject<(options: OnMouseOverOptions | undefined, x?: number, y?: number) => void>;
 }
 
 const GanttTooltipLayer: React.FC<GanttTooltipLayerProps> = ({ updateRef }) => {
   const [tooltipOptions, setTooltipOptions] = useState<OnMouseOverOptions | undefined>(undefined);
+  const [cursorX, setCursorX] = useState(0);
   const [cursorY, setCursorY] = useState(0);
 
-  updateRef.current = (options, y = 0) => {
+  updateRef.current = (options, x = 0, y = 0) => {
     setTooltipOptions(options);
+    if (options && x !== undefined && x !== null) setCursorX(x);
     if (options && y !== undefined && y !== null) setCursorY(y);
   };
 
@@ -46,6 +48,7 @@ const GanttTooltipLayer: React.FC<GanttTooltipLayerProps> = ({ updateRef }) => {
 
   return (
     <GanttToolTip
+      xCoordinate={cursorX}
       yCoordinate={cursorY}
       title={tooltipOptions.name}
       startDate={tooltipOptions.start}
@@ -73,11 +76,11 @@ const GanttChartSection = <T,>({
   const archerRef = useRef<ArcherContainerRef>(null);
   const handleToggle = useCallback(() => archerRef.current?.refreshScreen(), []);
 
-  const updateTooltip = useRef<(options: OnMouseOverOptions | undefined, y?: number) => void>(() => {});
+  const updateTooltip = useRef<(options: OnMouseOverOptions | undefined, x?: number, y?: number) => void>(() => {});
 
   const handleOnMouseOver = useCallback(
     (e: React.MouseEvent, task: OnMouseOverOptions) => {
-      if (!isEditMode) updateTooltip.current(task, e.clientY);
+      if (!isEditMode) updateTooltip.current(task, e.clientX, e.clientY);
     },
     [isEditMode]
   );


### PR DESCRIPTION
## Changes

Updated tooltip positioning on the Gantt chart so it follows where the user hovers instead of appearing in a fixed spot.

It now uses the mouse coordinates from the hover event and places the tooltip near the cursor.

## Notes

I added an x coordinate prop into GanttTooltipProps such that the tooltip now is close to the user's cursor when they hover over a gantt chart element. I also changed the y coordinate calculation and variable declarations for better code readability and visibility.

Also, it seems that gantt elements which have subelements have the tooltip positions where the start of the sub element which is being hovered over is, but this is not a huge difference than what may be expected in my opinion.

## Screenshots

https://github.com/user-attachments/assets/9b7cefc4-8e1c-44be-8ba5-39cb9a513982

## To Do

Change positioning of tooltip if needed.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #4152  
