### PR TITLE
#4088 Individual subteam page

### DIFF
--- a/src/frontend/src/pages/GuestTeamsPage/GuestTeamSpecificPage.tsx
+++ b/src/frontend/src/pages/GuestTeamsPage/GuestTeamSpecificPage.tsx
@@ -1,0 +1,107 @@
+import { Box, Grid, Stack, Typography } from '@mui/material';
+import { useSingleTeam } from '../../hooks/teams.hooks';
+import { useParams } from 'react-router-dom';
+import LoadingIndicator from '../../components/LoadingIndicator';
+import ErrorPage from '../ErrorPage';
+import PageLayout from '../../components/PageLayout';
+import { WbsElementStatus } from 'shared';
+import { routes } from '../../utils/routes';
+import PersonOutlineOutlinedIcon from '@mui/icons-material/PersonOutlineOutlined';
+import GroupOutlinedIcon from '@mui/icons-material/GroupOutlined';
+import GroupsOutlinedIcon from '@mui/icons-material/GroupsOutlined';
+import GuestProjectsCard from '../GuestProjectsPage/GuestProjectsCard';
+
+interface ParamTypes {
+  teamId: string;
+}
+
+const GuestTeamSpecificPage: React.FC = () => {
+  const { teamId } = useParams<ParamTypes>();
+  const { isLoading, isError, data, error } = useSingleTeam(teamId);
+
+  if (isError) return <ErrorPage message={error?.message} />;
+  if (isLoading || !data) return <LoadingIndicator />;
+
+  const activeProjects = data.projects.filter((project) => project.status === WbsElementStatus.Active);
+
+  const formatNames = (members: { firstName: string; lastName: string }[]) =>
+    members.map((m) => `${m.firstName} ${m.lastName}`).join(', ');
+
+  return (
+    <PageLayout
+      title={`${data.teamName}`}
+      previousPages={
+        data.teamType
+          ? [
+              { name: 'Divisions', route: routes.TEAMS },
+              { name: data.teamType.name, route: `${routes.TEAMS}/${data.teamType.teamTypeId}` }
+            ]
+          : [{ name: 'Divisions', route: routes.TEAMS }]
+      }
+    >
+      <Box sx={{ mb: 3 }}>
+        <Typography variant="body2" sx={{ color: 'text.secondary', lineHeight: 1.7 }}>
+          {data.description}
+        </Typography>
+      </Box>
+      <Box sx={{ mb: 3 }}>
+        <Typography variant="h5" fontWeight={700} sx={{ mb: 2 }}>
+          People
+        </Typography>
+        <Stack spacing={3}>
+          <Box display="flex" alignItems="flex-start" gap={1.5}>
+            <PersonOutlineOutlinedIcon sx={{ color: 'text.secondary', mt: 0.25 }} />
+            <Box>
+              <Typography variant="subtitle1" fontWeight={700}>
+                Head
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {data.head.firstName} {data.head.lastName}
+              </Typography>
+            </Box>
+          </Box>
+          {data.leads && data.leads.length > 0 && (
+            <Box display="flex" alignItems="flex-start" gap={1.5}>
+              <GroupOutlinedIcon sx={{ color: 'text.secondary', mt: 0.25 }} />
+              <Box>
+                <Typography variant="subtitle1" fontWeight={700}>
+                  Leads
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {formatNames(data.leads)}
+                </Typography>
+              </Box>
+            </Box>
+          )}
+          {data.members && data.members.length > 0 && (
+            <Box display="flex" alignItems="flex-start" gap={1.5}>
+              <GroupsOutlinedIcon sx={{ color: 'text.secondary', mt: 0.25 }} />
+              <Box>
+                <Typography variant="subtitle1" fontWeight={700}>
+                  Members
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {formatNames(data.members)}
+                </Typography>
+              </Box>
+            </Box>
+          )}
+        </Stack>
+      </Box>
+      <Box sx={{ mb: 3 }}>
+        <Typography variant="h5" fontWeight={700} sx={{ mb: 2 }}>
+          Active Projects
+        </Typography>
+        <Grid container spacing={2}>
+          {activeProjects.map((project) => (
+            <Grid item xs={12} sm={6} md={4} key={project.id}>
+              <GuestProjectsCard project={{ ...project, teamTypes: [] }} />
+            </Grid>
+          ))}
+        </Grid>
+      </Box>
+    </PageLayout>
+  );
+};
+
+export default GuestTeamSpecificPage;

--- a/src/frontend/src/pages/GuestTeamsPage/GuestTeamSpecificPage.tsx
+++ b/src/frontend/src/pages/GuestTeamsPage/GuestTeamSpecificPage.tsx
@@ -1,4 +1,5 @@
-import { Box, Grid, Stack, Typography } from '@mui/material';
+import { Box, Stack, Typography } from '@mui/material';
+import { useMediaQuery } from '@mui/system';
 import { useSingleTeam } from '../../hooks/teams.hooks';
 import { useParams } from 'react-router-dom';
 import LoadingIndicator from '../../components/LoadingIndicator';
@@ -10,6 +11,7 @@ import PersonOutlineOutlinedIcon from '@mui/icons-material/PersonOutlineOutlined
 import GroupOutlinedIcon from '@mui/icons-material/GroupOutlined';
 import GroupsOutlinedIcon from '@mui/icons-material/GroupsOutlined';
 import GuestProjectsCard from '../GuestProjectsPage/GuestProjectsCard';
+import NERMarkdown from '../../components/NERMarkdown';
 
 interface ParamTypes {
   teamId: string;
@@ -18,6 +20,7 @@ interface ParamTypes {
 const GuestTeamSpecificPage: React.FC = () => {
   const { teamId } = useParams<ParamTypes>();
   const { isLoading, isError, data, error } = useSingleTeam(teamId);
+  const isMobilePortrait = useMediaQuery('(max-width:480px)');
 
   if (isError) return <ErrorPage message={error?.message} />;
   if (isLoading || !data) return <LoadingIndicator />;
@@ -40,9 +43,7 @@ const GuestTeamSpecificPage: React.FC = () => {
       }
     >
       <Box sx={{ mb: 3 }}>
-        <Typography variant="body2" sx={{ color: 'text.secondary', lineHeight: 1.7 }}>
-          {data.description}
-        </Typography>
+        <NERMarkdown markdown={data.description} />
       </Box>
       <Box sx={{ mb: 3 }}>
         <Typography variant="h5" fontWeight={700} sx={{ mb: 2 }}>
@@ -92,13 +93,19 @@ const GuestTeamSpecificPage: React.FC = () => {
         <Typography variant="h5" fontWeight={700} sx={{ mb: 2 }}>
           Active Projects
         </Typography>
-        <Grid container spacing={2}>
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: isMobilePortrait ? '1fr' : 'repeat(3, 1fr)',
+            gap: isMobilePortrait ? 2 : 3,
+            width: '100%',
+            px: isMobilePortrait ? 1 : 0
+          }}
+        >
           {activeProjects.map((project) => (
-            <Grid item xs={12} sm={6} md={4} key={project.id}>
-              <GuestProjectsCard project={{ ...project, teamTypes: [] }} />
-            </Grid>
+            <GuestProjectsCard key={project.id} project={{ ...project, teamTypes: [] }} />
           ))}
-        </Grid>
+        </Box>
       </Box>
     </PageLayout>
   );

--- a/src/frontend/src/pages/TeamsPage/Teams.tsx
+++ b/src/frontend/src/pages/TeamsPage/Teams.tsx
@@ -13,6 +13,7 @@ import { isGuest } from 'shared';
 import { useAllTeamTypes } from '../../hooks/team-types.hooks';
 import GuestTeamPage from '../GuestTeamsPage/GuestTeamPage';
 import GuestDivisionPage from '../GuestDivisionsPage/GuestDivisionPage';
+import GuestTeamSpecificPage from '../GuestTeamsPage/GuestTeamSpecificPage';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import ErrorPage from '../ErrorPage';
 
@@ -24,8 +25,11 @@ const TeamOrDivisionPage: React.FC = () => {
   if (isTeamsError) return <ErrorPage message={teamsError.message} />;
   if (teamsLoading || !teamTypes) return <LoadingIndicator />;
 
-  if (isGuest(user.role) && teamTypes?.some((t) => t.teamTypeId === teamId)) {
-    return <GuestTeamPage teamTypeId={teamId} />;
+  if (isGuest(user.role)) {
+    if (teamTypes?.some((t) => t.teamTypeId === teamId)) {
+      return <GuestTeamPage teamTypeId={teamId} />;
+    }
+    return <GuestTeamSpecificPage />;
   }
   return <TeamSpecificPage />;
 };


### PR DESCRIPTION
## Changes

Added an individual information page for subteams that displays relevant information (description, heads/leads/members, active projects) in a similar fashion to the provided mock. Ensured the page is responsive for mobile use.

## Screenshots

<img width="2555" height="1360" alt="Screenshot 2026-04-16 130720" src="https://github.com/user-attachments/assets/33c3fa90-98ae-4124-8737-480ee964c692" />
<img width="850" height="1261" alt="Screenshot 2026-04-16 130741" src="https://github.com/user-attachments/assets/3a6ef020-3bb4-4c55-b0a6-903344cf5a1c" />
<img width="748" height="1280" alt="Screenshot 2026-04-16 130755" src="https://github.com/user-attachments/assets/6781d3a3-7843-4504-9a9c-8fa949909891" />
<img width="2559" height="1363" alt="Screenshot 2026-04-16 130811" src="https://github.com/user-attachments/assets/a90ecbea-0a63-4dc4-90d2-22a65dd30baf" />
<img width="933" height="1269" alt="Screenshot 2026-04-16 130822" src="https://github.com/user-attachments/assets/bf912e76-b558-48ee-9557-5cdfd4884d56" />
<img width="693" height="1259" alt="Screenshot 2026-04-16 130830" src="https://github.com/user-attachments/assets/7d649199-8952-4dd0-bfe5-c2a5b5756698" />


## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #4088 
