### PR TITLE
#4114 Duplicate Task Creation

### DIFF
--- a/src/frontend/src/pages/CalendarPage/Components/CalendarCreateTaskModal.tsx
+++ b/src/frontend/src/pages/CalendarPage/Components/CalendarCreateTaskModal.tsx
@@ -44,7 +44,7 @@ interface CalendarCreateTaskModalProps {
 
 const CalendarCreateTaskModal: React.FC<CalendarCreateTaskModalProps> = ({ open, onClose, defaultDeadline }) => {
   const toast = useToast();
-  const { mutateAsync: createTask } = useCreateTask();
+  const { mutateAsync: createTask, isLoading } = useCreateTask();
   const { data: users, isLoading: usersLoading, isError: usersError, error: usersErr } = useAllMembers();
   const { data: projects, isLoading: projectsLoading, isError: projectsError, error: projectsErr } = useAllProjects();
 
@@ -111,6 +111,7 @@ const CalendarCreateTaskModal: React.FC<CalendarCreateTaskModalProps> = ({ open,
       onFormSubmit={onSubmit}
       submitText="Create"
       showCloseButton
+      disabled={isLoading}
     >
       <Grid container spacing={2} sx={{ minWidth: 450 }}>
         <Grid item xs={12}>

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/TaskFormModal.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/TaskFormModal.tsx
@@ -28,9 +28,10 @@ interface TaskFormModalProps {
   onHide: () => void;
   onSubmit: (data: EditTaskFormInput) => Promise<void>;
   onReset?: () => void;
+  isLoading?: boolean;
 }
 
-const TaskFormModal: React.FC<TaskFormModalProps> = ({ task, status, onSubmit, modalShow, onHide, onReset }) => {
+const TaskFormModal: React.FC<TaskFormModalProps> = ({ task, status, onSubmit, modalShow, onHide, onReset, isLoading }) => {
   let schema;
 
   if (status === TaskStatus.IN_PROGRESS) {
@@ -71,7 +72,7 @@ const TaskFormModal: React.FC<TaskFormModalProps> = ({ task, status, onSubmit, m
 
   const user = useCurrentUser();
 
-  const { data: users, isLoading, isError, error } = useAllMembers();
+  const { data: users, isLoading: usersLoading, isError, error } = useAllMembers();
 
   const {
     handleSubmit,
@@ -92,7 +93,7 @@ const TaskFormModal: React.FC<TaskFormModalProps> = ({ task, status, onSubmit, m
   });
 
   if (isError) return <ErrorPage error={error} />;
-  if (isLoading || !users) return <LoadingIndicator />;
+  if (usersLoading || !users) return <LoadingIndicator />;
 
   const options: { label: string; id: string }[] = users.map(taskUserToAutocompleteOption);
 
@@ -111,6 +112,7 @@ const TaskFormModal: React.FC<TaskFormModalProps> = ({ task, status, onSubmit, m
       handleUseFormSubmit={handleSubmit}
       onFormSubmit={onSubmit}
       submitText="Save"
+      disabled={isLoading}
     >
       <form
         onSubmit={(e) => {

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskColumn.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskColumn.tsx
@@ -30,7 +30,7 @@ export const TaskColumn = ({
   onAddTask: (task: Task) => void;
   onHeightChange: (status: TaskStatus, height: number) => void;
 }) => {
-  const { mutateAsync: createTask } = useCreateTask();
+  const { mutateAsync: createTask, isLoading } = useCreateTask();
   const [showCreateTaskModal, setShowCreateTaskModal] = useState(false);
   const toast = useToast();
   const theme = useTheme();
@@ -76,6 +76,7 @@ export const TaskColumn = ({
         onHide={() => setShowCreateTaskModal(false)}
         modalShow={showCreateTaskModal}
         teams={project.teams}
+        isLoading={isLoading}
       />
       <Box
         sx={{


### PR DESCRIPTION
## Changes

Disabled the Save/Create button on task creation modals while a submission is still in progress (prevents multiple clicks).
Use isLoading state from react query's 'useMutation' to disable the button until request resolves.

Made changes to:
**TaskFormModal.tsx** - added 'isLoading' prop, passed as disabled to NERFormModal.
**TaskColumn.tsx** - passes isLoading from useCreateTask() to TaskFormModal.
**CalenderCreateTaskModal.tsx** - passes isLoading from useCreateTask() as disabled to NERFormModal.


## Test Cases



## Screenshots

<img width="970" height="1596" alt="Screenshot 2026-04-16 at 2 40 32 PM" src="https://github.com/user-attachments/assets/5b24de21-b27b-44ca-8dc1-2ecee0763de8" />


## To Do
N/A

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [ ] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #4114 
