### PR TITLE
#4089 Limit tabs shown on projects page for guests

### DIFF
--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
@@ -179,6 +179,39 @@ const ProjectViewContainer: React.FC<ProjectViewContainerProps> = ({ project, en
 
   const wbsNum = wbsPipe(project.wbsNum);
 
+  if (user.role === RoleEnum.GUEST) return (
+    <PageLayout
+      title={pageTitle}
+      headerRight={headerRight}
+      tabs={
+        <FullPageTabs
+          setTab={setTab}
+          tabsLabels={[
+            { tabUrlValue: 'overview', tabName: 'Overview' },
+            { tabUrlValue: 'tasks', tabName: 'Tasks' },
+            { tabUrlValue: 'changes', tabName: 'Changes' },
+            { tabUrlValue: 'gantt', tabName: 'Gantt' }
+          ]}
+          baseUrl={`${routes.PROJECTS}/${wbsNum}`}
+          defaultTab='overview'
+          id='project-detail-tabs'
+        />
+      }
+      previousPages={[{ name: 'Projects', route: routes.PROJECTS }]}
+    >
+      {tab === 0 ? (
+        <ProjectDetails project={project} />
+      ) : tab === 1 ? (
+        <TaskList project={project} isGuest={user.role === RoleEnum.GUEST} />
+      ) : tab === 2 ? (
+        <ChangesList changes={project.changes} />
+      ) : (
+        <ProjectGantt workPackages={project.workPackages} />
+      ) 
+      }
+    </PageLayout>
+  )
+
   return (
     <PageLayout
       title={pageTitle}

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectViewContainer.tsx
@@ -4,7 +4,7 @@
  */
 
 import { Link, useHistory } from 'react-router-dom';
-import { Project, isGuest, isAdmin, isLeadership, RoleEnum } from 'shared';
+import { Project, isGuest, isAdmin, isLeadership } from 'shared';
 import { projectWbsPipe, wbsPipe } from '../../../utils/pipes';
 import ProjectDetails from './ProjectDetails';
 import { routes } from '../../../utils/routes';
@@ -179,38 +179,38 @@ const ProjectViewContainer: React.FC<ProjectViewContainerProps> = ({ project, en
 
   const wbsNum = wbsPipe(project.wbsNum);
 
-  if (user.role === RoleEnum.GUEST) return (
-    <PageLayout
-      title={pageTitle}
-      headerRight={headerRight}
-      tabs={
-        <FullPageTabs
-          setTab={setTab}
-          tabsLabels={[
-            { tabUrlValue: 'overview', tabName: 'Overview' },
-            { tabUrlValue: 'tasks', tabName: 'Tasks' },
-            { tabUrlValue: 'changes', tabName: 'Changes' },
-            { tabUrlValue: 'gantt', tabName: 'Gantt' }
-          ]}
-          baseUrl={`${routes.PROJECTS}/${wbsNum}`}
-          defaultTab='overview'
-          id='project-detail-tabs'
-        />
-      }
-      previousPages={[{ name: 'Projects', route: routes.PROJECTS }]}
-    >
-      {tab === 0 ? (
-        <ProjectDetails project={project} />
-      ) : tab === 1 ? (
-        <TaskList project={project} isGuest={user.role === RoleEnum.GUEST} />
-      ) : tab === 2 ? (
-        <ChangesList changes={project.changes} />
-      ) : (
-        <ProjectGantt workPackages={project.workPackages} />
-      ) 
-      }
-    </PageLayout>
-  )
+  if (isGuest(user.role))
+    return (
+      <PageLayout
+        title={pageTitle}
+        headerRight={headerRight}
+        tabs={
+          <FullPageTabs
+            setTab={setTab}
+            tabsLabels={[
+              { tabUrlValue: 'overview', tabName: 'Overview' },
+              { tabUrlValue: 'tasks', tabName: 'Tasks' },
+              { tabUrlValue: 'changes', tabName: 'Changes' },
+              { tabUrlValue: 'gantt', tabName: 'Gantt' }
+            ]}
+            baseUrl={`${routes.PROJECTS}/${wbsNum}`}
+            defaultTab="overview"
+            id="project-detail-tabs"
+          />
+        }
+        previousPages={[{ name: 'Projects', route: routes.PROJECTS }]}
+      >
+        {tab === 0 ? (
+          <ProjectDetails project={project} />
+        ) : tab === 1 ? (
+          <TaskList project={project} isGuest={true} />
+        ) : tab === 2 ? (
+          <ChangesList changes={project.changes} />
+        ) : (
+          <ProjectGantt workPackages={project.workPackages} />
+        )}
+      </PageLayout>
+    );
 
   return (
     <PageLayout
@@ -240,7 +240,7 @@ const ProjectViewContainer: React.FC<ProjectViewContainerProps> = ({ project, en
       {tab === 0 ? (
         <ProjectDetails project={project} />
       ) : tab === 1 ? (
-        <TaskList project={project} isGuest={user.role === RoleEnum.GUEST} />
+        <TaskList project={project} isGuest={false} />
       ) : tab === 2 ? (
         <BOMTab project={project} />
       ) : tab === 3 ? (


### PR DESCRIPTION
## Changes

_Added code to the ProjectViewContainer.tsx which includes an if statement that checks if the user is guest. If they are, the tabs that are returned are limited._

## Screenshots

_If you made UI changes you must post a screenshot of the whole page for each change in 1) a normal sized window and 2) the smallest possible window_

Project Page as a Guest:

<img width="1919" height="1066" alt="Screenshot 2026-04-16 162435" src="https://github.com/user-attachments/assets/67dcebfc-50ba-4f14-bab3-eb2e8c97e259" />

<img width="1919" height="1057" alt="Screenshot 2026-04-16 162510" src="https://github.com/user-attachments/assets/c75db3bd-15e8-4180-8cec-57265e25db00" />

<img width="752" height="1069" alt="Screenshot 2026-04-16 162616" src="https://github.com/user-attachments/assets/9d5a0229-bc5f-43df-9acd-e53870293614" />


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #4089  (issue #4089)
