### PR TITLE
#4183 future events on events page

### DIFF
--- a/src/backend/src/controllers/calendar.controllers.ts
+++ b/src/backend/src/controllers/calendar.controllers.ts
@@ -599,11 +599,11 @@ export default class CalendarController {
 
   static async getAllEventsPaginated(req: Request, res: Response, next: NextFunction) {
     try {
-      const { cursor, pageSize } = req.body;
+      const { futureCursor, pastCursor } = req.body;
       const paginatedEvents = await CalendarService.getAllEventsPaginated(
         req.organization,
-        cursor ? new Date(cursor) : undefined,
-        pageSize ? parseInt(pageSize) : undefined
+        futureCursor ? new Date(futureCursor) : undefined,
+        pastCursor ? new Date(pastCursor) : undefined
       );
       res.status(200).json(paginatedEvents);
     } catch (error: unknown) {

--- a/src/backend/src/services/calendar.services.ts
+++ b/src/backend/src/services/calendar.services.ts
@@ -2752,42 +2752,48 @@ export default class CalendarService {
   }
 
   /**
-   * Gets all the events paginated, ordered by start time and grouped by date
+   * Gets the 25 events on each side of a reference point (defaults to now).
+   * futureCursor paginates forward; pastCursor paginates backward.
    * @param organization the org the user is currently in
-   * @param cursor the start time of the last event on the prev page
-   * @param pageSize the number of events to return per page
-   * @returns
+   * @param futureCursor the startTime of the last future event from the previous page
+   * @param pastCursor the startTime of the last past event from the previous page
    */
   static async getAllEventsPaginated(
     organization: Organization,
-    cursor?: Date,
-    pageSize: number = 25
-  ): Promise<{ instances: EventInstance[]; nextCursor: Date | null }> {
+    futureCursor?: Date,
+    pastCursor?: Date
+  ): Promise<{
+    futureInstances: EventInstance[];
+    pastInstances: EventInstance[];
+    nextFutureCursor: Date | null;
+    nextPastCursor: Date | null;
+  }> {
     const now = new Date();
 
-    const slots = await prisma.schedule_Slot.findMany({
-      where: {
-        startTime: {
-          lt: cursor ?? now
-        },
-        event: {
-          dateDeleted: null,
-          status: Event_Status.SCHEDULED,
-          eventType: {
-            organizationId: organization.organizationId
-          }
-        }
-      },
-      include: {
-        event: getEventQueryArgs(organization.organizationId)
-      },
-      orderBy: { startTime: 'desc' },
-      take: pageSize
-    });
+    const eventFilter = {
+      dateDeleted: null,
+      status: Event_Status.SCHEDULED,
+      eventType: {
+        organizationId: organization.organizationId
+      }
+    };
 
-    const nextCursor = slots.length === pageSize ? slots[slots.length - 1].startTime : null;
+    const [futureSlots, pastSlots] = await Promise.all([
+      prisma.schedule_Slot.findMany({
+        where: { startTime: { gte: futureCursor ?? now }, event: eventFilter },
+        include: { event: getEventQueryArgs(organization.organizationId) },
+        orderBy: { startTime: 'asc' },
+        take: 25
+      }),
+      prisma.schedule_Slot.findMany({
+        where: { startTime: { lt: pastCursor ?? now }, event: eventFilter },
+        include: { event: getEventQueryArgs(organization.organizationId) },
+        orderBy: { startTime: 'desc' },
+        take: 25
+      })
+    ]);
 
-    const instances: EventInstance[] = slots.map((slot) => {
+    const toInstance = (slot: (typeof futureSlots)[0]): EventInstance => {
       const { scheduledTimes, ...eventWithoutSlots } = eventTransformer(slot.event);
       return {
         ...eventWithoutSlots,
@@ -2798,8 +2804,13 @@ export default class CalendarService {
         recurring: slot.event.scheduledTimes.length > 1,
         totalScheduledSlots: slot.event.scheduledTimes.length
       };
-    });
+    };
 
-    return { instances, nextCursor };
+    return {
+      futureInstances: futureSlots.map(toInstance),
+      pastInstances: pastSlots.map(toInstance),
+      nextFutureCursor: futureSlots.length === 25 ? futureSlots[futureSlots.length - 1].startTime : null,
+      nextPastCursor: pastSlots.length === 25 ? pastSlots[pastSlots.length - 1].startTime : null
+    };
   }
 }

--- a/src/frontend/src/apis/calendar.api.ts
+++ b/src/frontend/src/apis/calendar.api.ts
@@ -268,18 +268,21 @@ export const scheduleEvent = async (eventId: string, payload: { startTime: Date;
   });
 };
 
-export const getAllEventsPaginated = (cursor?: Date, pageSize?: number) => {
-  return axios.post<{ instances: EventInstance[]; nextCursor: Date | null }>(
-    apiUrls.calendarEventsPaginated(),
-    { cursor, pageSize },
-    {
-      transformResponse: (data) => {
-        const parsed = JSON.parse(data);
-        return {
-          instances: parsed.instances,
-          nextCursor: parsed.nextCursor ? new Date(parsed.nextCursor) : null
-        };
-      }
+export const getAllEventsPaginated = (futureCursor?: Date, pastCursor?: Date) => {
+  return axios.post<{
+    futureInstances: EventInstance[];
+    pastInstances: EventInstance[];
+    nextFutureCursor: Date | null;
+    nextPastCursor: Date | null;
+  }>(apiUrls.calendarEventsPaginated(), { futureCursor, pastCursor }, {
+    transformResponse: (data) => {
+      const parsed = JSON.parse(data);
+      return {
+        futureInstances: parsed.futureInstances,
+        pastInstances: parsed.pastInstances,
+        nextFutureCursor: parsed.nextFutureCursor ? new Date(parsed.nextFutureCursor) : null,
+        nextPastCursor: parsed.nextPastCursor ? new Date(parsed.nextPastCursor) : null
+      };
     }
-  );
+  });
 };

--- a/src/frontend/src/apis/calendar.api.ts
+++ b/src/frontend/src/apis/calendar.api.ts
@@ -274,15 +274,19 @@ export const getAllEventsPaginated = (futureCursor?: Date, pastCursor?: Date) =>
     pastInstances: EventInstance[];
     nextFutureCursor: Date | null;
     nextPastCursor: Date | null;
-  }>(apiUrls.calendarEventsPaginated(), { futureCursor, pastCursor }, {
-    transformResponse: (data) => {
-      const parsed = JSON.parse(data);
-      return {
-        futureInstances: parsed.futureInstances,
-        pastInstances: parsed.pastInstances,
-        nextFutureCursor: parsed.nextFutureCursor ? new Date(parsed.nextFutureCursor) : null,
-        nextPastCursor: parsed.nextPastCursor ? new Date(parsed.nextPastCursor) : null
-      };
+  }>(
+    apiUrls.calendarEventsPaginated(),
+    { futureCursor, pastCursor },
+    {
+      transformResponse: (data) => {
+        const parsed = JSON.parse(data);
+        return {
+          futureInstances: parsed.futureInstances,
+          pastInstances: parsed.pastInstances,
+          nextFutureCursor: parsed.nextFutureCursor ? new Date(parsed.nextFutureCursor) : null,
+          nextPastCursor: parsed.nextPastCursor ? new Date(parsed.nextPastCursor) : null
+        };
+      }
     }
-  });
+  );
 };

--- a/src/frontend/src/hooks/calendar.hooks.ts
+++ b/src/frontend/src/hooks/calendar.hooks.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from 'react-query';
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from 'react-query';
 import {
   Shop,
   Machinery,
@@ -667,17 +667,24 @@ export const combinePdfsAndDownload = async (blobData: Blob[], filename: string)
   saveAs(pdfBlob, filename);
 };
 
-export const useAllEventsPaginated = (futureCursor?: Date, pastCursor?: Date) => {
-  return useQuery<
-    {
-      futureInstances: EventInstance[];
-      pastInstances: EventInstance[];
-      nextFutureCursor: Date | null;
-      nextPastCursor: Date | null;
+export const useFutureEventsPaginated = () => {
+  return useInfiniteQuery<{ futureInstances: EventInstance[]; nextFutureCursor: Date | null }, Error>(
+    ['events', 'future', 'paginated'],
+    async ({ pageParam }: { pageParam?: Date }) => {
+      const { data } = await getAllEventsPaginated(pageParam, undefined);
+      return { futureInstances: data.futureInstances, nextFutureCursor: data.nextFutureCursor };
     },
-    Error
-  >(['events', 'paginated', futureCursor, pastCursor], async () => {
-    const { data } = await getAllEventsPaginated(futureCursor, pastCursor);
-    return data;
-  });
+    { getNextPageParam: (lastPage) => lastPage.nextFutureCursor ?? undefined }
+  );
+};
+
+export const usePastEventsPaginated = () => {
+  return useInfiniteQuery<{ pastInstances: EventInstance[]; nextPastCursor: Date | null }, Error>(
+    ['events', 'past', 'paginated'],
+    async ({ pageParam }: { pageParam?: Date }) => {
+      const { data } = await getAllEventsPaginated(undefined, pageParam);
+      return { pastInstances: data.pastInstances, nextPastCursor: data.nextPastCursor };
+    },
+    { getNextPageParam: (lastPage) => lastPage.nextPastCursor ?? undefined }
+  );
 };

--- a/src/frontend/src/hooks/calendar.hooks.ts
+++ b/src/frontend/src/hooks/calendar.hooks.ts
@@ -667,15 +667,17 @@ export const combinePdfsAndDownload = async (blobData: Blob[], filename: string)
   saveAs(pdfBlob, filename);
 };
 
-/**
- * Custom hook to get all events in a paginated manner, sorted by scheduled date ascending.
- */
-export const useAllEventsPaginated = (cursor?: Date, pageSize?: number) => {
-  return useQuery<{ instances: EventInstance[]; nextCursor: Date | null }, Error>(
-    ['events', 'paginated', cursor, pageSize],
-    async () => {
-      const { data } = await getAllEventsPaginated(cursor, pageSize);
-      return data;
-    }
-  );
+export const useAllEventsPaginated = (futureCursor?: Date, pastCursor?: Date) => {
+  return useQuery<
+    {
+      futureInstances: EventInstance[];
+      pastInstances: EventInstance[];
+      nextFutureCursor: Date | null;
+      nextPastCursor: Date | null;
+    },
+    Error
+  >(['events', 'paginated', futureCursor, pastCursor], async () => {
+    const { data } = await getAllEventsPaginated(futureCursor, pastCursor);
+    return data;
+  });
 };

--- a/src/frontend/src/pages/GuestEventPage/GuestEventPage.tsx
+++ b/src/frontend/src/pages/GuestEventPage/GuestEventPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, forwardRef } from 'react';
+import { useEffect, useMemo, useRef, useState, forwardRef } from 'react';
 import { Box, Button } from '@mui/material';
 import { Collapse, IconButton, Stack, Typography, useTheme } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
@@ -8,7 +8,7 @@ import LoadingIndicator from '../../components/LoadingIndicator';
 import ErrorPage from '../ErrorPage';
 import GuestEventCard from './GuestEventCard';
 import { EventInstance, formatEventDate } from 'shared';
-import { useAllEventsPaginated } from '../../hooks/calendar.hooks';
+import { useFutureEventsPaginated, usePastEventsPaginated } from '../../hooks/calendar.hooks';
 
 const groupInstancesByDate = (instances: EventInstance[]): [string, EventInstance[]][] => {
   const groups = new Map<string, { date: Date; instances: EventInstance[] }>();
@@ -61,30 +61,31 @@ const DateGroup = forwardRef<HTMLDivElement, DateGroupProps>(({ date, instances 
 });
 
 const GuestEventPage: React.FC = () => {
-  const [futureCursor, setFutureCursor] = useState<Date | undefined>(undefined);
-  const [pastCursor, setPastCursor] = useState<Date | undefined>(undefined);
-  const [futureInstances, setFutureInstances] = useState<EventInstance[]>([]);
-  const [pastInstances, setPastInstances] = useState<EventInstance[]>([]);
   const [hasScrolled, setHasScrolled] = useState(false);
   const todayRef = useRef<HTMLDivElement>(null);
-  const { data, isLoading, isError, error } = useAllEventsPaginated(futureCursor, pastCursor);
 
-  useEffect(() => {
-    if (data?.futureInstances) {
-      setFutureInstances((prev) => {
-        const existingKeys = new Set(prev.map((i) => `${i.eventId}-${i.scheduleSlotId}`));
-        const next = data.futureInstances.filter((i) => !existingKeys.has(`${i.eventId}-${i.scheduleSlotId}`));
-        return next.length > 0 ? [...prev, ...next] : prev;
-      });
-    }
-    if (data?.pastInstances) {
-      setPastInstances((prev) => {
-        const existingKeys = new Set(prev.map((i) => `${i.eventId}-${i.scheduleSlotId}`));
-        const next = data.pastInstances.filter((i) => !existingKeys.has(`${i.eventId}-${i.scheduleSlotId}`));
-        return next.length > 0 ? [...prev, ...next] : prev;
-      });
-    }
-  }, [data]);
+  const {
+    data: futureData,
+    isLoading: futureLoading,
+    isError: futureIsError,
+    error: futureError,
+    fetchNextPage: fetchNextFuture,
+    hasNextPage: hasNextFuture,
+    isFetchingNextPage: isFetchingNextFuture
+  } = useFutureEventsPaginated();
+
+  const {
+    data: pastData,
+    isLoading: pastLoading,
+    isError: pastIsError,
+    error: pastError,
+    fetchNextPage: fetchNextPast,
+    hasNextPage: hasNextPast,
+    isFetchingNextPage: isFetchingNextPast
+  } = usePastEventsPaginated();
+
+  const futureInstances = useMemo(() => futureData?.pages.flatMap((p) => p.futureInstances) ?? [], [futureData]);
+  const pastInstances = useMemo(() => pastData?.pages.flatMap((p) => p.pastInstances) ?? [], [pastData]);
 
   useEffect(() => {
     if (!hasScrolled && (futureInstances.length > 0 || pastInstances.length > 0)) {
@@ -93,12 +94,13 @@ const GuestEventPage: React.FC = () => {
     }
   }, [futureInstances, pastInstances, hasScrolled]);
 
-  if (isLoading && futureInstances.length === 0 && pastInstances.length === 0) return <LoadingIndicator />;
-  if (isError) return <ErrorPage message={error.message} />;
+  const isInitialLoading = (futureLoading || pastLoading) && futureInstances.length === 0 && pastInstances.length === 0;
+  if (futureIsError) return <ErrorPage message={futureError!.message} />;
+  if (pastIsError) return <ErrorPage message={pastError!.message} />;
+  if (isInitialLoading) return <LoadingIndicator />;
 
   const pastGroups = groupInstancesByDate(pastInstances);
   const futureGroups = groupInstancesByDate(futureInstances);
-  const todayKey = formatEventDate(new Date());
 
   return (
     <Box sx={{ position: 'relative' }}>
@@ -122,20 +124,21 @@ const GuestEventPage: React.FC = () => {
         Jump to Today
       </Button>
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, p: 2 }}>
-        {data?.nextPastCursor && (
-          <Button variant="outlined" onClick={() => setPastCursor(data.nextPastCursor!)} disabled={isLoading}>
-            {isLoading ? <LoadingIndicator /> : 'Load More Past Events'}
+        {hasNextPast && (
+          <Button variant="outlined" onClick={() => fetchNextPast()} disabled={isFetchingNextPast}>
+            {isFetchingNextPast ? <LoadingIndicator /> : 'Load More Past Events'}
           </Button>
         )}
         {pastGroups.map(([date, instances]) => (
-          <DateGroup key={date} ref={date === todayKey ? todayRef : null} date={date} instances={instances} />
+          <DateGroup key={date} date={date} instances={instances} />
         ))}
+        <div ref={todayRef} />
         {futureGroups.map(([date, instances]) => (
-          <DateGroup key={date} ref={date === todayKey ? todayRef : null} date={date} instances={instances} />
+          <DateGroup key={date} date={date} instances={instances} />
         ))}
-        {data?.nextFutureCursor && (
-          <Button variant="outlined" onClick={() => setFutureCursor(data.nextFutureCursor!)} disabled={isLoading}>
-            {isLoading ? <LoadingIndicator /> : 'Load More Future Events'}
+        {hasNextFuture && (
+          <Button variant="outlined" onClick={() => fetchNextFuture()} disabled={isFetchingNextFuture}>
+            {isFetchingNextFuture ? <LoadingIndicator /> : 'Load More Future Events'}
           </Button>
         )}
       </Box>

--- a/src/frontend/src/pages/GuestEventPage/GuestEventPage.tsx
+++ b/src/frontend/src/pages/GuestEventPage/GuestEventPage.tsx
@@ -105,30 +105,40 @@ const GuestEventPage: React.FC = () => {
       <Button
         onClick={() => todayRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })}
         startIcon={<TodayIcon />}
-        sx={{ position: 'fixed', bottom: 24, right: 24, bgcolor: 'rgba(255,255,255,0.2)', backdropFilter: 'blur(6px)', boxShadow: 3, zIndex: 1, color: '#fff', border: '1px solid rgba(255,255,255,0.35)' }}
+        sx={{
+          position: 'fixed',
+          bottom: 24,
+          right: 24,
+          bgcolor: 'rgba(255,255,255,0.2)',
+          backdropFilter: 'blur(6px)',
+          boxShadow: 3,
+          zIndex: 1,
+          color: '#fff',
+          border: '1px solid rgba(255,255,255,0.35)'
+        }}
         variant="contained"
         disableElevation
       >
         Jump to Today
       </Button>
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, p: 2 }}>
-      {data?.nextPastCursor && (
-        <Button variant="outlined" onClick={() => setPastCursor(data.nextPastCursor!)} disabled={isLoading}>
-          {isLoading ? <LoadingIndicator /> : 'Load More Past Events'}
-        </Button>
-      )}
-      {pastGroups.map(([date, instances]) => (
-        <DateGroup key={date} ref={date === todayKey ? todayRef : null} date={date} instances={instances} />
-      ))}
-      {futureGroups.map(([date, instances]) => (
-        <DateGroup key={date} ref={date === todayKey ? todayRef : null} date={date} instances={instances} />
-      ))}
-      {data?.nextFutureCursor && (
-        <Button variant="outlined" onClick={() => setFutureCursor(data.nextFutureCursor!)} disabled={isLoading}>
-          {isLoading ? <LoadingIndicator /> : 'Load More Future Events'}
-        </Button>
-      )}
-    </Box>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, p: 2 }}>
+        {data?.nextPastCursor && (
+          <Button variant="outlined" onClick={() => setPastCursor(data.nextPastCursor!)} disabled={isLoading}>
+            {isLoading ? <LoadingIndicator /> : 'Load More Past Events'}
+          </Button>
+        )}
+        {pastGroups.map(([date, instances]) => (
+          <DateGroup key={date} ref={date === todayKey ? todayRef : null} date={date} instances={instances} />
+        ))}
+        {futureGroups.map(([date, instances]) => (
+          <DateGroup key={date} ref={date === todayKey ? todayRef : null} date={date} instances={instances} />
+        ))}
+        {data?.nextFutureCursor && (
+          <Button variant="outlined" onClick={() => setFutureCursor(data.nextFutureCursor!)} disabled={isLoading}>
+            {isLoading ? <LoadingIndicator /> : 'Load More Future Events'}
+          </Button>
+        )}
+      </Box>
     </Box>
   );
 };

--- a/src/frontend/src/pages/GuestEventPage/GuestEventPage.tsx
+++ b/src/frontend/src/pages/GuestEventPage/GuestEventPage.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState, forwardRef } from 'react';
 import { Box, Button } from '@mui/material';
 import { Collapse, IconButton, Stack, Typography, useTheme } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import TodayIcon from '@mui/icons-material/Today';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import ErrorPage from '../ErrorPage';
 import GuestEventCard from './GuestEventCard';
@@ -18,7 +19,7 @@ const groupInstancesByDate = (instances: EventInstance[]): [string, EventInstanc
     groups.get(key)!.instances.push(instance);
   }
   return Array.from(groups.entries())
-    .sort(([, a], [, b]) => b.date.getTime() - a.date.getTime())
+    .sort(([, a], [, b]) => a.date.getTime() - b.date.getTime())
     .map(([key, { instances }]) => [key, instances]);
 };
 
@@ -27,12 +28,15 @@ interface DateGroupProps {
   instances: EventInstance[];
 }
 
-const DateGroup: React.FC<DateGroupProps> = ({ date, instances }) => {
+const DateGroup = forwardRef<HTMLDivElement, DateGroupProps>(({ date, instances }, ref) => {
   const theme = useTheme();
   const [open, setOpen] = useState(true);
 
+  const todayKey = formatEventDate(new Date());
+  const label = date === todayKey ? `Today: ${date}` : date;
+
   return (
-    <Box>
+    <Box ref={ref}>
       <Stack
         direction="row"
         alignItems="center"
@@ -41,7 +45,7 @@ const DateGroup: React.FC<DateGroupProps> = ({ date, instances }) => {
         onClick={() => setOpen((prev) => !prev)}
       >
         <Typography variant="h6" fontWeight="bold">
-          {date}
+          {label}
         </Typography>
         <IconButton size="small">{open ? <ExpandLessIcon /> : <ExpandMoreIcon />}</IconButton>
       </Stack>
@@ -54,38 +58,77 @@ const DateGroup: React.FC<DateGroupProps> = ({ date, instances }) => {
       </Collapse>
     </Box>
   );
-};
+});
 
 const GuestEventPage: React.FC = () => {
-  const [cursor, setCursor] = useState<Date | undefined>(undefined);
-  const [allInstances, setAllInstances] = useState<EventInstance[]>([]);
-  const { data, isLoading, isError, error } = useAllEventsPaginated(cursor);
+  const [futureCursor, setFutureCursor] = useState<Date | undefined>(undefined);
+  const [pastCursor, setPastCursor] = useState<Date | undefined>(undefined);
+  const [futureInstances, setFutureInstances] = useState<EventInstance[]>([]);
+  const [pastInstances, setPastInstances] = useState<EventInstance[]>([]);
+  const [hasScrolled, setHasScrolled] = useState(false);
+  const todayRef = useRef<HTMLDivElement>(null);
+  const { data, isLoading, isError, error } = useAllEventsPaginated(futureCursor, pastCursor);
 
   useEffect(() => {
-    if (data?.instances) {
-      setAllInstances((prev) => {
+    if (data?.futureInstances) {
+      setFutureInstances((prev) => {
         const existingKeys = new Set(prev.map((i) => `${i.eventId}-${i.scheduleSlotId}`));
-        const newInstances = data.instances.filter((i) => !existingKeys.has(`${i.eventId}-${i.scheduleSlotId}`));
-        return newInstances.length > 0 ? [...prev, ...newInstances] : prev;
+        const next = data.futureInstances.filter((i) => !existingKeys.has(`${i.eventId}-${i.scheduleSlotId}`));
+        return next.length > 0 ? [...prev, ...next] : prev;
+      });
+    }
+    if (data?.pastInstances) {
+      setPastInstances((prev) => {
+        const existingKeys = new Set(prev.map((i) => `${i.eventId}-${i.scheduleSlotId}`));
+        const next = data.pastInstances.filter((i) => !existingKeys.has(`${i.eventId}-${i.scheduleSlotId}`));
+        return next.length > 0 ? [...prev, ...next] : prev;
       });
     }
   }, [data]);
 
-  if (isLoading && allInstances.length === 0) return <LoadingIndicator />;
+  useEffect(() => {
+    if (!hasScrolled && (futureInstances.length > 0 || pastInstances.length > 0)) {
+      todayRef.current?.scrollIntoView({ block: 'start' });
+      setHasScrolled(true);
+    }
+  }, [futureInstances, pastInstances, hasScrolled]);
+
+  if (isLoading && futureInstances.length === 0 && pastInstances.length === 0) return <LoadingIndicator />;
   if (isError) return <ErrorPage message={error.message} />;
 
-  const groups = groupInstancesByDate(allInstances);
+  const pastGroups = groupInstancesByDate(pastInstances);
+  const futureGroups = groupInstancesByDate(futureInstances);
+  const todayKey = formatEventDate(new Date());
 
   return (
+    <Box sx={{ position: 'relative' }}>
+      <Button
+        onClick={() => todayRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })}
+        startIcon={<TodayIcon />}
+        sx={{ position: 'fixed', bottom: 24, right: 24, bgcolor: 'rgba(255,255,255,0.2)', backdropFilter: 'blur(6px)', boxShadow: 3, zIndex: 1, color: '#fff', border: '1px solid rgba(255,255,255,0.35)' }}
+        variant="contained"
+        disableElevation
+      >
+        Jump to Today
+      </Button>
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, p: 2 }}>
-      {groups.map(([date, instances]) => (
-        <DateGroup key={date} date={date} instances={instances} />
-      ))}
-      {data?.nextCursor && (
-        <Button variant="outlined" onClick={() => setCursor(data.nextCursor!)} disabled={isLoading}>
-          {isLoading ? <LoadingIndicator /> : 'Load More'}
+      {data?.nextPastCursor && (
+        <Button variant="outlined" onClick={() => setPastCursor(data.nextPastCursor!)} disabled={isLoading}>
+          {isLoading ? <LoadingIndicator /> : 'Load More Past Events'}
         </Button>
       )}
+      {pastGroups.map(([date, instances]) => (
+        <DateGroup key={date} ref={date === todayKey ? todayRef : null} date={date} instances={instances} />
+      ))}
+      {futureGroups.map(([date, instances]) => (
+        <DateGroup key={date} ref={date === todayKey ? todayRef : null} date={date} instances={instances} />
+      ))}
+      {data?.nextFutureCursor && (
+        <Button variant="outlined" onClick={() => setFutureCursor(data.nextFutureCursor!)} disabled={isLoading}>
+          {isLoading ? <LoadingIndicator /> : 'Load More Future Events'}
+        </Button>
+      )}
+    </Box>
     </Box>
   );
 };

--- a/src/frontend/src/pages/GuestEventPage/GuestEventPage.tsx
+++ b/src/frontend/src/pages/GuestEventPage/GuestEventPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, forwardRef } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { Box, Button } from '@mui/material';
 import { Collapse, IconButton, Stack, Typography, useTheme } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
@@ -28,7 +28,7 @@ interface DateGroupProps {
   instances: EventInstance[];
 }
 
-const DateGroup = forwardRef<HTMLDivElement, DateGroupProps>(({ date, instances }, ref) => {
+const DateGroup: React.FC<DateGroupProps> = ({ date, instances }) => {
   const theme = useTheme();
   const [open, setOpen] = useState(true);
 
@@ -36,7 +36,7 @@ const DateGroup = forwardRef<HTMLDivElement, DateGroupProps>(({ date, instances 
   const label = date === todayKey ? `Today: ${date}` : date;
 
   return (
-    <Box ref={ref}>
+    <Box>
       <Stack
         direction="row"
         alignItems="center"
@@ -58,10 +58,9 @@ const DateGroup = forwardRef<HTMLDivElement, DateGroupProps>(({ date, instances 
       </Collapse>
     </Box>
   );
-});
+};
 
 const GuestEventPage: React.FC = () => {
-  const [hasScrolled, setHasScrolled] = useState(false);
   const todayRef = useRef<HTMLDivElement>(null);
 
   const {
@@ -87,16 +86,9 @@ const GuestEventPage: React.FC = () => {
   const futureInstances = useMemo(() => futureData?.pages.flatMap((p) => p.futureInstances) ?? [], [futureData]);
   const pastInstances = useMemo(() => pastData?.pages.flatMap((p) => p.pastInstances) ?? [], [pastData]);
 
-  useEffect(() => {
-    if (!hasScrolled && (futureInstances.length > 0 || pastInstances.length > 0)) {
-      todayRef.current?.scrollIntoView({ block: 'start' });
-      setHasScrolled(true);
-    }
-  }, [futureInstances, pastInstances, hasScrolled]);
-
-  const isInitialLoading = (futureLoading || pastLoading) && futureInstances.length === 0 && pastInstances.length === 0;
   if (futureIsError) return <ErrorPage message={futureError!.message} />;
   if (pastIsError) return <ErrorPage message={pastError!.message} />;
+  const isInitialLoading = (futureLoading || pastLoading) && futureInstances.length === 0 && pastInstances.length === 0;
   if (isInitialLoading) return <LoadingIndicator />;
 
   const pastGroups = groupInstancesByDate(pastInstances);


### PR DESCRIPTION
## Changes

Added future events onto the guest events page. Scroll down to see future events, scroll up for past events. Added future events into the events pagination endpoint.

## Screenshots
<img width="266" height="509" alt="Screenshot 2026-04-24 at 10 56 33 AM" src="https://github.com/user-attachments/assets/d77274f2-8c8d-4de7-865f-364349621953" />
<img width="1470" height="850" alt="Screenshot 2026-04-24 at 10 56 23 AM" src="https://github.com/user-attachments/assets/a67a36df-1b99-4ab9-8d3b-e3c5f51e8f41" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #4183
