### PR TITLE
#4182 sidebar fixes

### DIFF
--- a/src/frontend/src/layouts/Sidebar/Sidebar.tsx
+++ b/src/frontend/src/layouts/Sidebar/Sidebar.tsx
@@ -6,7 +6,7 @@
 import { routes } from '../../utils/routes';
 import { LinkItem } from '../../utils/types';
 import styles from '../../stylesheets/layouts/sidebar/sidebar.module.css';
-import { Typography, Box, IconButton, Divider } from '@mui/material';
+import { Typography, Box, IconButton, Divider, Drawer, useMediaQuery, useTheme as useMuiTheme } from '@mui/material';
 import HomeIcon from '@mui/icons-material/Home';
 import AlignHorizontalLeftIcon from '@mui/icons-material/AlignHorizontalLeft';
 import DashboardIcon from '@mui/icons-material/Dashboard';
@@ -46,6 +46,8 @@ interface SidebarProps {
 
 const Sidebar = ({ drawerOpen, setDrawerOpen, moveContent, setMoveContent }: SidebarProps) => {
   const [openSubmenu, setOpenSubmenu] = useState<string | null>(null);
+  const muiTheme = useMuiTheme();
+  const isMobile = useMediaQuery(muiTheme.breakpoints.down('sm'));
   const { onPNMHomePage, onOnboardingHomePage } = useHomePageContext();
   const user = useCurrentUser();
   const { onGuestHomePage } = useHomePageContext();
@@ -192,6 +194,10 @@ const Sidebar = ({ drawerOpen, setDrawerOpen, moveContent, setMoveContent }: Sid
   const linkItems = onPNMHomePage || onOnboardingHomePage ? onboardingLinkItems : memberLinkItems;
 
   const handleMoveContent = () => {
+    if (isMobile) {
+      setDrawerOpen(false);
+      return;
+    }
     if (moveContent) {
       setDrawerOpen(false);
     }
@@ -206,14 +212,8 @@ const Sidebar = ({ drawerOpen, setDrawerOpen, moveContent, setMoveContent }: Sid
     setOpenSubmenu(null);
   };
 
-  return (
-    <NERDrawer
-      open={drawerOpen}
-      variant="permanent"
-      onMouseLeave={() => {
-        if (!moveContent) setDrawerOpen(false);
-      }}
-    >
+  const drawerContent = (
+    <>
       <DrawerHeader>
         <Box sx={{ flex: 1, minWidth: 0 }}>
           <Box sx={{ display: 'flex', alignItems: 'center' }}>
@@ -255,6 +255,31 @@ const Sidebar = ({ drawerOpen, setDrawerOpen, moveContent, setMoveContent }: Sid
           <Typography className={styles.versionNumber}>v5.0.0</Typography>
         </Box>
       </Box>
+    </>
+  );
+
+  if (isMobile) {
+    return (
+      <Drawer
+        variant="temporary"
+        open={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        slotProps={{ paper: { sx: { width: '100vw', backgroundColor: '#ef4345' } } }}
+      >
+        {drawerContent}
+      </Drawer>
+    );
+  }
+
+  return (
+    <NERDrawer
+      open={drawerOpen}
+      variant="permanent"
+      onMouseLeave={() => {
+        if (!moveContent) setDrawerOpen(false);
+      }}
+    >
+      {drawerContent}
     </NERDrawer>
   );
 };

--- a/src/frontend/src/layouts/Sidebar/Sidebar.tsx
+++ b/src/frontend/src/layouts/Sidebar/Sidebar.tsx
@@ -50,7 +50,7 @@ const Sidebar = ({ drawerOpen, setDrawerOpen, moveContent, setMoveContent }: Sid
   const isMobile = useMediaQuery(muiTheme.breakpoints.down('sm'));
   const { onPNMHomePage, onOnboardingHomePage } = useHomePageContext();
   const user = useCurrentUser();
-  const { onGuestHomePage } = useHomePageContext();
+  const onGuestHomePage = isGuest(user.role);
   const { isError: teamsError, error: teamsErrorMsg, data: teams } = useAllTeamTypes();
 
   const allTeams: LinkItem[] = (teams ?? []).map((team: TeamType) => {

--- a/src/frontend/src/layouts/SidebarLayout.tsx
+++ b/src/frontend/src/layouts/SidebarLayout.tsx
@@ -9,14 +9,16 @@ import { useState } from 'react';
 import ArrowCircleRightTwoToneIcon from '@mui/icons-material/ArrowCircleRightTwoTone';
 import Sidebar from './Sidebar/Sidebar';
 import HiddenContentMargin from '../components/HiddenContentMargin';
-import { useHomePageContext } from '../app/HomePageContext';
+import { useCurrentUser } from '../hooks/users.hooks';
+import { isGuest } from 'shared';
 
 const SidebarLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [moveContent, setMoveContent] = useState(false);
-  const { onGuestHomePage } = useHomePageContext();
+  const user = useCurrentUser();
+  const onGuestHomePage = isGuest(user.role);
 
   return (
     <>

--- a/src/frontend/src/layouts/SidebarLayout.tsx
+++ b/src/frontend/src/layouts/SidebarLayout.tsx
@@ -4,7 +4,7 @@
  */
 
 import { Box } from '@mui/system';
-import { Container, IconButton, useTheme } from '@mui/material';
+import { Container, IconButton, useMediaQuery, useTheme } from '@mui/material';
 import { useState } from 'react';
 import ArrowCircleRightTwoToneIcon from '@mui/icons-material/ArrowCircleRightTwoTone';
 import Sidebar from './Sidebar/Sidebar';
@@ -13,6 +13,7 @@ import { useHomePageContext } from '../app/HomePageContext';
 
 const SidebarLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [moveContent, setMoveContent] = useState(false);
   const { onGuestHomePage } = useHomePageContext();
@@ -34,7 +35,7 @@ const SidebarLayout: React.FC<{ children: React.ReactNode }> = ({ children }) =>
       <IconButton
         onClick={() => {
           setDrawerOpen(true);
-          setMoveContent(true);
+          if (!isMobile) setMoveContent(true);
         }}
         sx={{ position: 'fixed', left: -8, top: '3%' }}
         id="sidebar-button"


### PR DESCRIPTION
## Changes

Updated the sidebar to fill up the whole screen on mobile. Fixed bug that was causing all tabs be shown to a guest upon reload.

## Screenshots

<img width="608" height="558" alt="Screenshot 2026-04-26 at 4 36 44 PM" src="https://github.com/user-attachments/assets/6245c40e-70ef-44b3-a398-15b92d2ba95a" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #4182 
