### PR TITLE
#4171 Slack Notification with Diff

### DIFF
--- a/src/backend/src/services/change-requests.services.ts
+++ b/src/backend/src/services/change-requests.services.ts
@@ -997,6 +997,7 @@ export default class ChangeRequestsService {
         wbsNumber: { carNumber, projectNumber, workPackageNumber, organizationId: organization.organizationId }
       },
       include: {
+        links: { where: { dateDeleted: null }, include: { linkType: { select: { name: true } } } },
         project: { select: { budget: true, summary: true } },
         workPackage: { select: { startDate: true, duration: true, stage: true } }
       }

--- a/src/backend/src/services/change-requests.services.ts
+++ b/src/backend/src/services/change-requests.services.ts
@@ -32,6 +32,7 @@ import changeRequestTransformer, {
 } from '../transformers/change-requests.transformer.js';
 import {
   allChangeRequestsReviewed,
+  buildCRDiff,
   validateProposedChangesFields,
   applyProjectProposedChanges,
   applyWorkPackageProposedChanges,
@@ -49,7 +50,8 @@ import {
   addSlackThreadsToChangeRequest,
   sendAndGetSlackCRNotifications,
   sendSlackCRStatusToThread,
-  sendSlackRequestedReviewNotification
+  sendSlackRequestedReviewNotification,
+  sendStandardCRCreatedNotification
 } from '../utils/slack.utils.js';
 import {
   ChangeRequestWithProjectAndWorkPackageQueryArgs,
@@ -993,6 +995,10 @@ export default class ChangeRequestsService {
     const wbsElement = await prisma.wBS_Element.findUnique({
       where: {
         wbsNumber: { carNumber, projectNumber, workPackageNumber, organizationId: organization.organizationId }
+      },
+      include: {
+        project: { select: { budget: true, summary: true } },
+        workPackage: { select: { startDate: true, duration: true, stage: true } }
       }
     });
 
@@ -1199,14 +1205,17 @@ export default class ChangeRequestsService {
     const project = createdCR.wbsElement?.workPackage?.project || createdCR.wbsElement?.project;
     const teams = project?.teams;
     if (teams && teams.length > 0) {
-      const notifications: { channelId: string; ts: string }[] = await sendAndGetSlackCRNotifications(
-        teams,
+      const diffText = buildCRDiff(wbsElement, projectProposedChanges ?? workPackageProposedChanges);
+      await sendStandardCRCreatedNotification(
         createdCR,
+        wbsElement.name,
+        project.wbsElement.name,
         submitter,
-        wbsElement,
-        project.wbsElement.name
+        teams,
+        why,
+        requestedReviewerId,
+        diffText
       );
-      await addSlackThreadsToChangeRequest(createdCR.crId, notifications);
     }
 
     const finishedCR = await prisma.change_Request.findUnique({

--- a/src/backend/src/services/change-requests.services.ts
+++ b/src/backend/src/services/change-requests.services.ts
@@ -1000,7 +1000,11 @@ export default class ChangeRequestsService {
       include: {
         links: { where: { dateDeleted: null }, include: { linkType: { select: { name: true } } } },
         project: { select: { budget: true, summary: true } },
-        workPackage: { select: { startDate: true, duration: true, stage: true } }
+        workPackage: { select: { startDate: true, duration: true, stage: true } },
+        descriptionBullets: {
+          where: { dateDeleted: null },
+          include: { descriptionBulletType: { select: { name: true } } }
+        }
       }
     });
 

--- a/src/backend/src/utils/change-requests.utils.ts
+++ b/src/backend/src/utils/change-requests.utils.ts
@@ -12,7 +12,9 @@ import {
 } from '@prisma/client';
 import {
   DescriptionBulletPreview,
+  formatDateOnly,
   LinkCreateArgs,
+  ProjectProposedChangesCreateArgs,
   WbsNumber,
   wbsPipe,
   WorkPackageProposedChangesCreateArgs,
@@ -380,6 +382,75 @@ export const applyWorkPackageProposedChanges = async (
       organization
     );
   }
+};
+
+/**
+ * Builds a human-readable diff string comparing current WBS state to proposed changes.
+ * Each changed field is shown as two lines: "− Field: old" and "+ Field: new".
+ */
+export const buildCRDiff = (
+  currentWbs: {
+    name: string;
+    leadId: string | null;
+    managerId: string | null;
+    project?: { budget: number; summary: string } | null;
+    workPackage?: { startDate: Date; duration: number; stage: string | null } | null;
+  },
+  proposed: ProjectProposedChangesCreateArgs | WorkPackageProposedChangesCreateArgs | undefined
+): string => {
+  if (!proposed) return '';
+
+  const isWpChange = 'startDate' in proposed;
+  const lines: string[] = [];
+
+  const addDiff = (label: string, before: string | number | null | undefined, after: string | number | null | undefined) => {
+    const b = String(before ?? '(none)');
+    const a = String(after ?? '(none)');
+    if (b !== a) {
+      lines.push(`− ${label}: ${b}`);
+      lines.push(`+ ${label}: ${a}`);
+    }
+  };
+
+  const addNew = (label: string, value: string | number | null | undefined) => {
+    if (value !== null && value !== undefined) lines.push(`+ ${label}: ${value}`);
+  };
+
+  if (isWpChange) {
+    const wpProposed = proposed as WorkPackageProposedChangesCreateArgs;
+    if (!currentWbs.workPackage) {
+      addNew('Name', wpProposed.name);
+      addNew('Lead', wpProposed.leadId);
+      addNew('Manager', wpProposed.managerId);
+      addNew('Start date', wpProposed.startDate);
+      addNew('Duration', wpProposed.duration);
+      addNew('Stage', wpProposed.stage);
+    } else {
+      addDiff('Name', currentWbs.name, wpProposed.name);
+      addDiff('Lead', currentWbs.leadId, wpProposed.leadId);
+      addDiff('Manager', currentWbs.managerId, wpProposed.managerId);
+      addDiff('Start date', formatDateOnly(currentWbs.workPackage.startDate, 'YYYY-MM-DD'), wpProposed.startDate);
+      addDiff('Duration', currentWbs.workPackage.duration, wpProposed.duration);
+      addDiff('Stage', currentWbs.workPackage.stage, wpProposed.stage);
+    }
+  } else {
+    const projProposed = proposed as ProjectProposedChangesCreateArgs;
+    if (!currentWbs.project) {
+      addNew('Name', projProposed.name);
+      addNew('Lead', projProposed.leadId);
+      addNew('Manager', projProposed.managerId);
+      addNew('Budget', projProposed.budget);
+      addNew('Summary', projProposed.summary);
+    } else {
+      addDiff('Name', currentWbs.name, projProposed.name);
+      addDiff('Lead', currentWbs.leadId, projProposed.leadId);
+      addDiff('Manager', currentWbs.managerId, projProposed.managerId);
+      addDiff('Budget', currentWbs.project.budget, projProposed.budget);
+      addDiff('Summary', currentWbs.project.summary, projProposed.summary);
+    }
+  }
+
+  return lines.join('\n');
 };
 
 /**

--- a/src/backend/src/utils/change-requests.utils.ts
+++ b/src/backend/src/utils/change-requests.utils.ts
@@ -396,6 +396,7 @@ export const buildCRDiff = (
     links: { url: string; linkType: { name: string } }[];
     project?: { budget: number; summary: string } | null;
     workPackage?: { startDate: Date; duration: number; stage: string | null } | null;
+    descriptionBullets?: { detail: string; descriptionBulletType: { name: string } }[];
   },
   proposed: ProjectProposedChangesCreateArgs | WorkPackageProposedChangesCreateArgs | undefined
 ): string => {
@@ -433,6 +434,30 @@ export const buildCRDiff = (
     }
   };
 
+  const addBulletDiffs = (
+    currentBullets: { detail: string; descriptionBulletType: { name: string } }[],
+    proposedBullets: DescriptionBulletPreview[]
+  ) => {
+    const allBulletTypeNames = new Set([
+      ...currentBullets.map((b) => b.descriptionBulletType.name),
+      ...proposedBullets.map((b) => b.type)
+    ]);
+    for (const bulletTypeName of allBulletTypeNames) {
+      const currentDetails = new Set(
+        currentBullets.filter((b) => b.descriptionBulletType.name === bulletTypeName).map((b) => b.detail)
+      );
+      const proposedDetails = new Set(proposedBullets.filter((b) => b.type === bulletTypeName).map((b) => b.detail));
+      // add "- Type: detail" for each detail of this type that is in current but not proposed
+      for (const detail of currentDetails) {
+        if (!proposedDetails.has(detail)) lines.push(`− ${bulletTypeName}: ${detail}`);
+      }
+      // add "+ Type: detail" for each detail of this type that is in proposed but not current
+      for (const detail of proposedDetails) {
+        if (!currentDetails.has(detail)) lines.push(`+ ${bulletTypeName}: ${detail}`);
+      }
+    }
+  };
+
   if (isWpChange) {
     const wpProposed = proposed as WorkPackageProposedChangesCreateArgs;
     if (!currentWbs.workPackage) {
@@ -443,6 +468,7 @@ export const buildCRDiff = (
       addNew('Duration', wpProposed.duration);
       addNew('Stage', wpProposed.stage);
       wpProposed.links.forEach((l) => addNew(l.linkTypeName, l.url));
+      wpProposed.descriptionBullets.forEach((b) => addNew(b.type, b.detail));
     } else {
       addDiff('Name', currentWbs.name, wpProposed.name);
       addDiff('Lead', currentWbs.leadId, wpProposed.leadId);
@@ -451,6 +477,7 @@ export const buildCRDiff = (
       addDiff('Duration', currentWbs.workPackage.duration, wpProposed.duration);
       addDiff('Stage', currentWbs.workPackage.stage, wpProposed.stage);
       addLinkDiffs(currentWbs.links, wpProposed.links);
+      addBulletDiffs(currentWbs.descriptionBullets ?? [], wpProposed.descriptionBullets);
     }
   } else {
     const projProposed = proposed as ProjectProposedChangesCreateArgs;
@@ -461,6 +488,7 @@ export const buildCRDiff = (
       addNew('Budget', projProposed.budget);
       addNew('Summary', projProposed.summary);
       projProposed.links.forEach((l) => addNew(l.linkTypeName, l.url));
+      projProposed.descriptionBullets.forEach((b) => addNew(b.type, b.detail));
     } else {
       addDiff('Name', currentWbs.name, projProposed.name);
       addDiff('Lead', currentWbs.leadId, projProposed.leadId);
@@ -468,6 +496,7 @@ export const buildCRDiff = (
       addDiff('Budget', currentWbs.project.budget, projProposed.budget);
       addDiff('Summary', currentWbs.project.summary, projProposed.summary);
       addLinkDiffs(currentWbs.links, projProposed.links);
+      addBulletDiffs(currentWbs.descriptionBullets ?? [], projProposed.descriptionBullets);
     }
   }
 

--- a/src/backend/src/utils/change-requests.utils.ts
+++ b/src/backend/src/utils/change-requests.utils.ts
@@ -393,6 +393,7 @@ export const buildCRDiff = (
     name: string;
     leadId: string | null;
     managerId: string | null;
+    links: { url: string; linkType: { name: string } }[];
     project?: { budget: number; summary: string } | null;
     workPackage?: { startDate: Date; duration: number; stage: string | null } | null;
   },
@@ -416,6 +417,22 @@ export const buildCRDiff = (
     if (value !== null && value !== undefined) lines.push(`+ ${label}: ${value}`);
   };
 
+  const addLinkDiffs = (currentLinks: { url: string; linkType: { name: string } }[], proposedLinks: LinkCreateArgs[]) => {
+    const currentMap = new Map(currentLinks.map((l) => [l.linkType.name, l.url]));
+    const proposedMap = new Map(proposedLinks.map((l) => [l.linkTypeName, l.url]));
+    for (const [name, url] of currentMap) {
+      if (!proposedMap.has(name)) lines.push(`− ${name}: ${url}`);
+    }
+    for (const [name, url] of proposedMap) {
+      if (!currentMap.has(name)) {
+        lines.push(`+ ${name}: ${url}`);
+      } else if (currentMap.get(name) !== url) {
+        lines.push(`− ${name}: ${currentMap.get(name)}`);
+        lines.push(`+ ${name}: ${url}`);
+      }
+    }
+  };
+
   if (isWpChange) {
     const wpProposed = proposed as WorkPackageProposedChangesCreateArgs;
     if (!currentWbs.workPackage) {
@@ -425,6 +442,7 @@ export const buildCRDiff = (
       addNew('Start date', wpProposed.startDate);
       addNew('Duration', wpProposed.duration);
       addNew('Stage', wpProposed.stage);
+      wpProposed.links.forEach((l) => addNew(l.linkTypeName, l.url));
     } else {
       addDiff('Name', currentWbs.name, wpProposed.name);
       addDiff('Lead', currentWbs.leadId, wpProposed.leadId);
@@ -432,6 +450,7 @@ export const buildCRDiff = (
       addDiff('Start date', formatDateOnly(currentWbs.workPackage.startDate, 'YYYY-MM-DD'), wpProposed.startDate);
       addDiff('Duration', currentWbs.workPackage.duration, wpProposed.duration);
       addDiff('Stage', currentWbs.workPackage.stage, wpProposed.stage);
+      addLinkDiffs(currentWbs.links, wpProposed.links);
     }
   } else {
     const projProposed = proposed as ProjectProposedChangesCreateArgs;
@@ -441,12 +460,14 @@ export const buildCRDiff = (
       addNew('Manager', projProposed.managerId);
       addNew('Budget', projProposed.budget);
       addNew('Summary', projProposed.summary);
+      projProposed.links.forEach((l) => addNew(l.linkTypeName, l.url));
     } else {
       addDiff('Name', currentWbs.name, projProposed.name);
       addDiff('Lead', currentWbs.leadId, projProposed.leadId);
       addDiff('Manager', currentWbs.managerId, projProposed.managerId);
       addDiff('Budget', currentWbs.project.budget, projProposed.budget);
       addDiff('Summary', currentWbs.project.summary, projProposed.summary);
+      addLinkDiffs(currentWbs.links, projProposed.links);
     }
   }
 

--- a/src/backend/src/utils/slack.utils.ts
+++ b/src/backend/src/utils/slack.utils.ts
@@ -550,6 +550,66 @@ export const sendSlackCRStatusToThread = async (
 };
 
 /**
+ * Sends Slack notifications for a newly created standard (manual) CR:
+ * 1. Initial message to each project team channel
+ * 2. Thread reply tagging the project head(s) and requested reviewer(s)
+ * 3. Thread reply with the why text and field diff
+ * Also stores Message_Info records linking threads to the CR.
+ */
+export const sendStandardCRCreatedNotification = async (
+  cr: Change_Request,
+  wbsElementName: string,
+  projectWbsName: string,
+  submitter: User,
+  teams: Team[],
+  why: string,
+  requestedReviewerId: string | undefined,
+  diffText: string
+): Promise<void> => {
+  if (process.env.NODE_ENV !== 'production' && !DEV_TESTING_OVERRIDE) return;
+
+  const message =
+    wbsElementName !== projectWbsName
+      ? `${submitter.firstName} ${submitter.lastName} submitted a change request for ${wbsElementName} in ${projectWbsName}`
+      : `${submitter.firstName} ${submitter.lastName} submitted a change request for ${projectWbsName}`;
+  const notifications: { channelId: string; ts: string }[] = [];
+
+  await Promise.all(
+    teams.map(async (team) => {
+      const sent = await sendSlackChangeRequestNotification(team, message, cr.crId, cr.identifier);
+      notifications.push(...sent);
+    })
+  );
+
+  if (notifications.length === 0) return;
+
+  await addSlackThreadsToChangeRequest(cr.crId, notifications);
+
+  // Thread reply 1: why + diff
+  const whyAndDiff = diffText
+    ? `*Change Justification:*\n${why}\n\n*Proposed Changes:*\n${diffText}`
+    : `*Change Justification:*\n${why}`;
+  await Promise.all(notifications.map((n) => replyToMessageInThread(n.channelId, n.ts, whyAndDiff)));
+
+  // Thread reply 2: tag project head(s) + requested reviewer
+  const headSlackIds = (await Promise.all(teams.filter((t) => t.headId).map((t) => getUserSlackId(t.headId!)))).filter(
+    (id): id is string => !!id
+  );
+
+  const reviewerSlackId = requestedReviewerId ? await getUserSlackId(requestedReviewerId) : undefined;
+  const allSlackIds = new Set([...headSlackIds, ...(reviewerSlackId ? [reviewerSlackId] : [])]);
+  const allMentions = [...allSlackIds].map((id) => `<@${id}>`).join(' ');
+
+  if (allMentions) {
+    const reviewMsg = `${allMentions} Your review has been requested on CR #${cr.identifier}!`;
+    const crLink = `https://finishlinebyner.com/cr/${cr.crId}`;
+    await Promise.all(
+      notifications.map((n) => replyToMessageInThread(n.channelId, n.ts, reviewMsg, crLink, `View CR #${cr.identifier}`))
+    );
+  }
+};
+
+/**
  * Adds the relevant slack notifications for a change request to the change request
  *
  * @param crId the change request to add the slack threads to

--- a/src/backend/src/utils/slack.utils.ts
+++ b/src/backend/src/utils/slack.utils.ts
@@ -552,8 +552,8 @@ export const sendSlackCRStatusToThread = async (
 /**
  * Sends Slack notifications for a newly created standard (manual) CR:
  * 1. Initial message to each project team channel
- * 2. Thread reply tagging the project head(s) and requested reviewer(s)
- * 3. Thread reply with the why text and field diff
+ * 2. Thread reply with the why text and field diff
+ * 3. Thread reply tagging the project head(s) and requested reviewer(s)
  * Also stores Message_Info records linking threads to the CR.
  */
 export const sendStandardCRCreatedNotification = async (
@@ -583,15 +583,16 @@ export const sendStandardCRCreatedNotification = async (
 
   if (notifications.length === 0) return;
 
+  // add message_Info records for the sent notifications so we can link the CR to the slack threads for future replies
   await addSlackThreadsToChangeRequest(cr.crId, notifications);
 
-  // Thread reply 1: why + diff
+  // Thread reply: why + diff
   const whyAndDiff = diffText
     ? `*Change Justification:*\n${why}\n\n*Proposed Changes:*\n${diffText}`
     : `*Change Justification:*\n${why}`;
   await Promise.all(notifications.map((n) => replyToMessageInThread(n.channelId, n.ts, whyAndDiff)));
 
-  // Thread reply 2: tag project head(s) + requested reviewer
+  // Thread reply: tag project head(s) + requested reviewer
   const headSlackIds = (await Promise.all(teams.filter((t) => t.headId).map((t) => getUserSlackId(t.headId!)))).filter(
     (id): id is string => !!id
   );


### PR DESCRIPTION
## Changes

New CR slack notif functionality w/ differences +/-

## Test Cases

- new wps don't use diff from project, they only have + (not - and +)
- a head that is also a requested reviewer is not pinged twice
- automatic leadership crs don't notify
- editing project links show in diff changes

## Screenshots

#### wp cr  example (start date formatting issue below was fixed)
<img width="436" height="499" alt="Screenshot 2026-04-26 at 8 53 20 PM" src="https://github.com/user-attachments/assets/0058c864-8f48-4629-a949-a03b1fdb339f" />

#### Project cr diff example
<img width="436" height="492" alt="Screenshot 2026-04-26 at 8 56 21 PM" src="https://github.com/user-attachments/assets/6ffb4afd-e3f7-4876-8da7-1e4c9a86104f" />

#### Removing lead or manager with other changes shows (None)
<img width="441" height="504" alt="Screenshot 2026-04-26 at 8 59 43 PM" src="https://github.com/user-attachments/assets/3966cb51-561e-4be4-85dc-a41a73cab6a5" />


#### New wp only needs + (not - and +)
<img width="440" height="413" alt="Screenshot 2026-04-26 at 8 52 16 PM" src="https://github.com/user-attachments/assets/e60950aa-31b6-4a8e-80e1-84f33f865efa" />

#### Tested adding project links in cr
<img width="437" height="453" alt="Screenshot 2026-04-26 at 9 11 39 PM" src="https://github.com/user-attachments/assets/cdebb10b-96fa-485f-b2d7-daa196b2f052" />

#### CR w/ no changes doesnt include Proposed Changes
<img width="439" height="266" alt="Screenshot 2026-04-26 at 9 25 43 PM" src="https://github.com/user-attachments/assets/4ebd16d9-f8cc-45fc-8c48-3816f18eb7b7" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #4171 
