### PR TITLE
#4173 simplified making a CR

### DIFF
--- a/src/frontend/src/hooks/change-requests.hooks.ts
+++ b/src/frontend/src/hooks/change-requests.hooks.ts
@@ -151,6 +151,7 @@ export const useDeleteChangeRequest = () => {
 export type CreateStandardChangeRequestPayload = {
   wbsNum: WbsNumber;
   why: string;
+  requestedReviewerId?: string;
   projectProposedChanges?: ProjectProposedChangesCreateArgs;
   workPackageProposedChanges?: WorkPackageProposedChangesCreateArgs;
 };

--- a/src/frontend/src/pages/CreateChangeRequestPage/CreateChangeRequest.tsx
+++ b/src/frontend/src/pages/CreateChangeRequestPage/CreateChangeRequest.tsx
@@ -26,30 +26,23 @@ const CreateChangeRequest: React.FC<CreateChangeRequestProps> = () => {
   const [wbsNum, setWbsNum] = useState(query.get('wbsNum') || '');
   const toast = useToast();
   const changeRequestSchema = yup.object().shape({
-    why: yup.string().required('Why Explain is required')
+    why: yup.string().required('Why Explain is required'),
+    requestedReviewerId: yup.string().optional()
   });
 
   const { reset: resetChangeRequestForm, ...changeRequestFormMethods } = useForm<FormInput>({
     resolver: yupResolver(changeRequestSchema),
     defaultValues: query.get('budgetChange')
-      ? {
-          why: 'The cost of materials ended up exceeding the initial budget'
-        }
+      ? { why: 'The cost of materials ended up exceeding the initial budget' }
       : query.get('timelineDelay')
-        ? {
-            why: 'Decided to extend timeline after design review'
-          }
+        ? { why: 'Decided to extend timeline after design review' }
         : query.get('createWP')
-          ? {
-              why: 'Creating a Work Package on this Project'
-            }
-          : {
-              why: ''
-            }
+          ? { why: 'Creating a Work Package on this Project' }
+          : { why: '' }
   });
 
-  if (isLoading) return <LoadingIndicator />;
   if (isError) return <ErrorPage message={error?.message} />;
+  if (isLoading) return <LoadingIndicator />;
 
   const handleConfirm = async (data: FormInput) => {
     try {

--- a/src/frontend/src/pages/CreateChangeRequestPage/CreateChangeRequestView.tsx
+++ b/src/frontend/src/pages/CreateChangeRequestPage/CreateChangeRequestView.tsx
@@ -10,6 +10,8 @@ import { FormControl, FormLabel } from '@mui/material';
 import ReactHookTextField from '../../components/ReactHookTextField';
 import NERAutocomplete from '../../components/NERAutocomplete';
 import { useAllProjects } from '../../hooks/projects.hooks';
+import { useAllMembers } from '../../hooks/users.hooks';
+import { userToAutocompleteOption } from '../../utils/teams.utils';
 import ErrorPage from '../ErrorPage';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import NERFailButton from '../../components/NERFailButton';
@@ -56,9 +58,13 @@ const CreateChangeRequestsView: React.FC<CreateChangeRequestViewProps> = ({
   } = changeRequestFormReturn;
 
   const { isLoading, isError, error, data: projects } = useAllProjects();
+  const { isLoading: membersIsLoading, isError: membersIsError, error: membersError, data: members } = useAllMembers();
 
-  if (isLoading || !projects) return <LoadingIndicator />;
   if (isError) return <ErrorPage message={error?.message} />;
+  if (membersIsError) return <ErrorPage message={membersError?.message} />;
+  if (isLoading || !projects || membersIsLoading || !members) return <LoadingIndicator />;
+
+  const memberOptions = members.map(userToAutocompleteOption);
 
   const wbsDropdownOptions: { label: string; id: string }[] = [];
 
@@ -115,8 +121,8 @@ const CreateChangeRequestsView: React.FC<CreateChangeRequestViewProps> = ({
                 Cancel
               </NERFailButton>
             )}
-            <NERSuccessButton variant="contained" type="submit" sx={{ mx: 1, width: 90, mt: { xs: 1, md: 0 } }}>
-              Submit
+            <NERSuccessButton variant="contained" type="submit" sx={{ mx: 1, mt: { xs: 1, md: 0 } }}>
+              {'Submit'}
             </NERSuccessButton>
           </Box>
         }
@@ -151,15 +157,17 @@ const CreateChangeRequestsView: React.FC<CreateChangeRequestViewProps> = ({
               </FormControl>
             </Grid>
             <Grid item xs={12}>
-              <FormControl fullWidth>
-                <FormLabel>Requested Reviewer (optional)</FormLabel>
-                <ReactHookTextField
-                  name="requestedReviewerId"
-                  control={control}
-                  errorMessage={errors.requestedReviewerId}
-                  placeholder="Reviewer user ID"
-                />
-              </FormControl>
+              <FormLabel>Requested Reviewer (optional)</FormLabel>
+              <NERAutocomplete
+                id="requested-reviewer-autocomplete"
+                onChange={(_event, value) => {
+                  changeRequestFormReturn.setValue('requestedReviewerId', value?.id ?? undefined);
+                }}
+                options={memberOptions}
+                size="small"
+                placeholder="Select a reviewer"
+                value={memberOptions.find((m) => m.id === changeRequestFormReturn.watch('requestedReviewerId')) ?? null}
+              />
             </Grid>
           </Grid>
         </Grid>

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectForm/ProjectCreateContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectForm/ProjectCreateContainer.tsx
@@ -131,6 +131,7 @@ const ProjectCreateContainer: React.FC = () => {
       const changeRequestPayload: CreateStandardChangeRequestPayload = {
         wbsNum: { carNumber, projectNumber: 0, workPackageNumber: 0 },
         why,
+        requestedReviewerId: data.requestedReviewerId,
         projectProposedChanges: projectPayload
       };
       await mutateCRAsync(changeRequestPayload);

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectForm/ProjectEditContainer.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectForm/ProjectEditContainer.tsx
@@ -183,6 +183,7 @@ const ProjectEditContainer: React.FC<ProjectEditContainerProps> = ({ project, ex
       const changeRequestPayload: CreateStandardChangeRequestPayload = {
         wbsNum: project.wbsNum,
         why,
+        requestedReviewerId: data.requestedReviewerId,
         projectProposedChanges: projectPayload
       };
       await mutateCRAsync(changeRequestPayload);


### PR DESCRIPTION
## Changes

Fixed the create CR modal and page to just have the why box and optional reviewer. I changed the reviewer to be an autocomplete because asking for the ID felt nonsensical. Made the reviewer link up to the CR correctly. 

## Screenshots

<img width="1470" height="956" alt="Screenshot 2026-04-27 at 5 30 28 PM" src="https://github.com/user-attachments/assets/e09562c3-f6ff-4f2c-960e-c5eeb9daad33" />

the modal picture would not load in here but it has the same stuff

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #4173 
