### PR TITLE
#4176 added dateCompleted to stage gate

### DIFF
--- a/src/backend/src/controllers/change-requests.controllers.ts
+++ b/src/backend/src/controllers/change-requests.controllers.ts
@@ -120,13 +120,14 @@ export default class ChangeRequestsController {
 
   static async createStageGateChangeRequest(req: Request, res: Response, next: NextFunction) {
     try {
-      const { wbsNum, confirmDone } = req.body;
+      const { wbsNum, confirmDone, dateCompleted } = req.body;
       const id = await ChangeRequestsService.createStageGateChangeRequest(
         req.currentUser,
         wbsNum.carNumber,
         wbsNum.projectNumber,
         wbsNum.workPackageNumber,
         confirmDone,
+        new Date(dateCompleted),
         req.organization
       );
       res.status(200).json({ message: `Successfully created stage gate request with id #${id}` });

--- a/src/backend/src/prisma/seed.ts
+++ b/src/backend/src/prisma/seed.ts
@@ -2233,6 +2233,7 @@ const performSeed: () => Promise<void> = async () => {
     workPackageHuskies1WbsNumber.projectNumber,
     workPackageHuskies1WbsNumber.workPackageNumber,
     true,
+    new Date(),
     ner
   );
 

--- a/src/backend/src/routes/change-requests.routes.ts
+++ b/src/backend/src/routes/change-requests.routes.ts
@@ -3,6 +3,7 @@ import { body } from 'express-validator';
 import ChangeRequestsController from '../controllers/change-requests.controllers.js';
 import {
   intMinZero,
+  isDate,
   isDateOnly,
   nonEmptyString,
   projectProposedChangesValidators,
@@ -53,6 +54,7 @@ changeRequestsRouter.post(
   intMinZero(body('wbsNum.projectNumber')),
   intMinZero(body('wbsNum.workPackageNumber')),
   body('confirmDone').isBoolean(),
+  isDate(body('dateCompleted')),
   validateInputs,
   ChangeRequestsController.createStageGateChangeRequest
 );

--- a/src/backend/src/services/change-requests.services.ts
+++ b/src/backend/src/services/change-requests.services.ts
@@ -402,9 +402,8 @@ export default class ChangeRequestsService {
     }
 
     // Calculate new duration from startDate to dateCompleted if provided
-    let newDuration = workPackage.duration;
     const msPerWeek = 7 * 24 * 60 * 60 * 1000;
-    newDuration = Math.max(1, Math.round((dateCompleted.getTime() - workPackage.startDate.getTime()) / msPerWeek));
+    const newDuration = Math.max(1, Math.round((dateCompleted.getTime() - workPackage.startDate.getTime()) / msPerWeek));
 
     if (newDuration !== workPackage.duration) {
       changesList.push({

--- a/src/backend/src/services/change-requests.services.ts
+++ b/src/backend/src/services/change-requests.services.ts
@@ -389,6 +389,10 @@ export default class ChangeRequestsService {
     const shouldChangeStatus = foundCR.wbsElement.status !== WBS_Element_Status.COMPLETE;
     const changesList = [];
 
+    if (dateCompleted < workPackage.startDate) {
+      throw new HttpException(400, 'Date completed cannot be before the work package start date');
+    }
+
     if (shouldChangeStatus) {
       changesList.push({
         changeRequestId: foundCR.crId,
@@ -399,12 +403,8 @@ export default class ChangeRequestsService {
 
     // Calculate new duration from startDate to dateCompleted if provided
     let newDuration = workPackage.duration;
-    const { startDate } = workPackage;
-
-    // Edge case: dateCompleted before startDate
-    const effectiveDate = dateCompleted < startDate ? startDate : dateCompleted;
     const msPerWeek = 7 * 24 * 60 * 60 * 1000;
-    newDuration = Math.max(1, Math.round((effectiveDate.getTime() - startDate.getTime()) / msPerWeek));
+    newDuration = Math.max(1, Math.round((dateCompleted.getTime() - workPackage.startDate.getTime()) / msPerWeek));
 
     if (newDuration !== workPackage.duration) {
       changesList.push({

--- a/src/backend/src/services/change-requests.services.ts
+++ b/src/backend/src/services/change-requests.services.ts
@@ -285,7 +285,7 @@ export default class ChangeRequestsService {
     }
 
     if (accepted && foundCR.type === CR_Type.STAGE_GATE) {
-      await this.reviewStageGateChangeRequest(foundCR, reviewer);
+      await this.reviewStageGateChangeRequest(foundCR, reviewer, new Date());
     } else if (foundCR.type === CR_Type.ACTIVATION && foundCR.activationChangeRequest && accepted) {
       await this.reviewActivationChangeRequest(foundCR, reviewer);
     } else if (foundCR.type === CR_Type.BUDGET && foundCR.budgetChangeRequest && accepted) {
@@ -372,10 +372,12 @@ export default class ChangeRequestsService {
    * Reviews the stage gate change request and automates any changes that are made
    * @param foundCR the change request to be reviewed
    * @param reviewer the user reviewing the change request
+   * @param dateCompleted the date the work package was completed
    */
   static async reviewStageGateChangeRequest(
     foundCR: Prisma.Change_RequestGetPayload<ChangeRequestWithProjectAndWorkPackageQueryArgs>,
-    reviewer: User
+    reviewer: User,
+    dateCompleted: Date
   ): Promise<void> {
     if (!foundCR.wbsElement?.workPackage) {
       throw new HttpException(400, 'Stage gate can only be made on work packages!');
@@ -383,8 +385,10 @@ export default class ChangeRequestsService {
 
     throwIfUncheckedDescriptionBullets(foundCR.wbsElement.descriptionBullets);
 
+    const { workPackage } = foundCR.wbsElement;
     const shouldChangeStatus = foundCR.wbsElement.status !== WBS_Element_Status.COMPLETE;
     const changesList = [];
+
     if (shouldChangeStatus) {
       changesList.push({
         changeRequestId: foundCR.crId,
@@ -393,9 +397,27 @@ export default class ChangeRequestsService {
       });
     }
 
+    // Calculate new duration from startDate to dateCompleted if provided
+    let newDuration = workPackage.duration;
+    const { startDate } = workPackage;
+
+    // Edge case: dateCompleted before startDate
+    const effectiveDate = dateCompleted < startDate ? startDate : dateCompleted;
+    const msPerWeek = 7 * 24 * 60 * 60 * 1000;
+    newDuration = Math.max(1, Math.round((effectiveDate.getTime() - startDate.getTime()) / msPerWeek));
+
+    if (newDuration !== workPackage.duration) {
+      changesList.push({
+        changeRequestId: foundCR.crId,
+        implementerId: reviewer.userId,
+        detail: buildChangeDetail('duration', workPackage.duration.toString(), newDuration.toString())
+      });
+    }
+
     await prisma.work_Package.update({
       where: { wbsElementId: foundCR.wbsElement.wbsElementId },
       data: {
+        duration: newDuration,
         wbsElement: {
           update: {
             status: WBS_Element_Status.COMPLETE,
@@ -640,6 +662,7 @@ export default class ChangeRequestsService {
     projectNumber: number,
     workPackageNumber: number,
     confirmDone: boolean,
+    dateCompleted: Date,
     organization: Organization
   ): Promise<string> {
     if (await userHasPermission(submitter.userId, organization.organizationId, isGuest))
@@ -704,7 +727,7 @@ export default class ChangeRequestsService {
       await addSlackThreadsToChangeRequest(createdChangeRequest.crId, notifications);
     }
 
-    await ChangeRequestsService.reviewStageGateChangeRequest(createdChangeRequest, submitter);
+    await ChangeRequestsService.reviewStageGateChangeRequest(createdChangeRequest, submitter, dateCompleted);
 
     return createdChangeRequest.crId;
   }

--- a/src/backend/tests/unit/change-requests.test.ts
+++ b/src/backend/tests/unit/change-requests.test.ts
@@ -518,14 +518,13 @@ describe('Change Request Tests', () => {
       expect(updatedWp?.duration).toEqual(originalDuration + 2);
     });
 
-    it('duration to 1 when dateCompleted is before startDate', async () => {
+    it('throws an error when dateCompleted is before startDate', async () => {
       const dateCompleted = new Date(startDate);
       dateCompleted.setDate(dateCompleted.getDate() - 7);
 
-      await ChangeRequestsService.createStageGateChangeRequest(user, 2, 1, 1, true, dateCompleted, organization);
-
-      const updatedWp = await prisma.work_Package.findUnique({ where: { workPackageId } });
-      expect(updatedWp?.duration).toEqual(1);
+      await expect(
+        ChangeRequestsService.createStageGateChangeRequest(user, 2, 1, 1, true, dateCompleted, organization)
+      ).rejects.toThrow('Date completed cannot be before the work package start date');
     });
 
     it('leaves duration unchanged when dateCompleted matches existing end date', async () => {

--- a/src/backend/tests/unit/change-requests.test.ts
+++ b/src/backend/tests/unit/change-requests.test.ts
@@ -1,5 +1,12 @@
 import { Organization, User, WBS_Element_Status } from '@prisma/client';
-import { createTestCar, createTestOrganization, createTestProject, createTestUser, resetUsers } from '../test-utils.js';
+import {
+  createTestCar,
+  createTestOrganization,
+  createTestProject,
+  createTestUser,
+  createTestWorkPackage,
+  resetUsers
+} from '../test-utils.js';
 import ChangeRequestsService from '../../src/services/change-requests.services.js';
 import {
   supermanAdmin,
@@ -16,6 +23,9 @@ describe('Change Request Tests', () => {
   let orgId: string;
   let organization: Organization;
   let user: User;
+  let wpWbsElementId: string;
+  let workPackageId: string;
+  let startDate: Date;
 
   beforeEach(async () => {
     organization = await createTestOrganization();
@@ -31,6 +41,12 @@ describe('Change Request Tests', () => {
         status: WBS_Element_Status.INACTIVE
       }
     });
+    const car = await createTestCar(orgId, user.userId, 2);
+    const project = await createTestProject(user, orgId, undefined, car.carId, 2, 1);
+    const wp = await createTestWorkPackage(user, orgId, project.projectId, 2, 1, 1);
+
+    wpWbsElementId = wp.wbsElement.wbsElementId;
+    ({ workPackageId, startDate } = wp);
   });
 
   afterEach(async () => {
@@ -477,6 +493,98 @@ describe('Change Request Tests', () => {
         expect(results).toHaveLength(1);
         expect(results[0].wbsNum?.projectNumber).toBe(1); // car A's project
       }, 15000);
+    });
+  });
+
+  describe('Stage Gate Change Requests', () => {
+    it('sets work package status to COMPLETE on stage gate', async () => {
+      await ChangeRequestsService.createStageGateChangeRequest(user, 2, 1, 1, true, new Date(), organization);
+
+      const updatedWbs = await prisma.wBS_Element.findUnique({ where: { wbsElementId: wpWbsElementId } });
+      expect(updatedWbs?.status).toEqual(WBS_Element_Status.COMPLETE);
+    });
+
+    it('updates work package duration based on dateCompleted', async () => {
+      const wp = await prisma.work_Package.findUnique({ where: { workPackageId } });
+      const originalDuration = wp!.duration;
+
+      // dateCompleted 2 weeks beyond current end date
+      const dateCompleted = new Date(startDate);
+      dateCompleted.setDate(dateCompleted.getDate() + (originalDuration + 2) * 7);
+
+      await ChangeRequestsService.createStageGateChangeRequest(user, 2, 1, 1, true, dateCompleted, organization);
+
+      const updatedWp = await prisma.work_Package.findUnique({ where: { workPackageId } });
+      expect(updatedWp?.duration).toEqual(originalDuration + 2);
+    });
+
+    it('duration to 1 when dateCompleted is before startDate', async () => {
+      const dateCompleted = new Date(startDate);
+      dateCompleted.setDate(dateCompleted.getDate() - 7);
+
+      await ChangeRequestsService.createStageGateChangeRequest(user, 2, 1, 1, true, dateCompleted, organization);
+
+      const updatedWp = await prisma.work_Package.findUnique({ where: { workPackageId } });
+      expect(updatedWp?.duration).toEqual(1);
+    });
+
+    it('leaves duration unchanged when dateCompleted matches existing end date', async () => {
+      const wp = await prisma.work_Package.findUnique({ where: { workPackageId } });
+      const originalDuration = wp!.duration;
+
+      const dateCompleted = new Date(startDate);
+      dateCompleted.setDate(dateCompleted.getDate() + originalDuration * 7);
+
+      await ChangeRequestsService.createStageGateChangeRequest(user, 2, 1, 1, true, dateCompleted, organization);
+
+      const updatedWp = await prisma.work_Package.findUnique({ where: { workPackageId } });
+      expect(updatedWp?.duration).toEqual(originalDuration);
+    });
+
+    it('creates a change record for duration when it changes', async () => {
+      const wp = await prisma.work_Package.findUnique({ where: { workPackageId } });
+      const originalDuration = wp!.duration;
+
+      const dateCompleted = new Date(startDate);
+      dateCompleted.setDate(dateCompleted.getDate() + (originalDuration + 2) * 7);
+
+      const crId = await ChangeRequestsService.createStageGateChangeRequest(
+        user,
+        2,
+        1,
+        1,
+        true,
+        dateCompleted,
+        organization
+      );
+
+      const changes = await prisma.change.findMany({ where: { changeRequestId: crId } });
+      const durationChange = changes.find((c) => c.detail.includes('duration'));
+      expect(durationChange).toBeDefined();
+      expect(durationChange?.detail).toContain(originalDuration.toString());
+      expect(durationChange?.detail).toContain((originalDuration + 2).toString());
+    });
+
+    it('does not create a duration change record when duration is unchanged', async () => {
+      const wp = await prisma.work_Package.findUnique({ where: { workPackageId } });
+      const originalDuration = wp!.duration;
+
+      const dateCompleted = new Date(startDate);
+      dateCompleted.setDate(dateCompleted.getDate() + originalDuration * 7);
+
+      const crId = await ChangeRequestsService.createStageGateChangeRequest(
+        user,
+        2,
+        1,
+        1,
+        true,
+        dateCompleted,
+        organization
+      );
+
+      const changes = await prisma.change.findMany({ where: { changeRequestId: crId } });
+      const durationChange = changes.find((c) => c.detail.includes('duration'));
+      expect(durationChange).toBeUndefined();
     });
   });
 });

--- a/src/frontend/src/apis/change-requests.api.ts
+++ b/src/frontend/src/apis/change-requests.api.ts
@@ -128,13 +128,20 @@ export const createActivationChangeRequest = (
  * @param submitterId The ID of the user creating the change request.
  * @param wbsNumber the wbsNumber of the WBS element the change request is for.
  * @param confirmDone are all details of the WBS element being stage gated fully completed?
+ * @param dateCompleted the date the work package was completed
  */
-export const createStageGateChangeRequest = (submitterId: string, wbsNum: WbsNumber, confirmDone: boolean) => {
+export const createStageGateChangeRequest = (
+  submitterId: string,
+  wbsNum: WbsNumber,
+  confirmDone: boolean,
+  dateCompleted: Date
+) => {
   return axios.post<{ message: string }>(apiUrls.changeRequestsCreateStageGate(), {
     submitterId,
     wbsNum,
     type: ChangeRequestType.StageGate,
-    confirmDone
+    confirmDone,
+    dateCompleted
   });
 };
 

--- a/src/frontend/src/hooks/change-requests.hooks.ts
+++ b/src/frontend/src/hooks/change-requests.hooks.ts
@@ -189,6 +189,7 @@ export interface CreateStageGateChangeRequestPayload {
   wbsNum: WbsNumber;
   confirmDone: boolean;
   type: string;
+  dateCompleted: Date;
 }
 
 export interface CreateBudgetChangeRequestPayload {
@@ -226,7 +227,12 @@ export const useCreateStageGateChangeRequest = () => {
   return useMutation<{ message: string }, Error, CreateStageGateChangeRequestPayload>(
     ['change requests', 'create', 'stage gate'],
     async (payload: CreateStageGateChangeRequestPayload) => {
-      const { data } = await createStageGateChangeRequest(payload.submitterId, payload.wbsNum, payload.confirmDone);
+      const { data } = await createStageGateChangeRequest(
+        payload.submitterId,
+        payload.wbsNum,
+        payload.confirmDone,
+        payload.dateCompleted
+      );
       return data;
     }
   );

--- a/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModal.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModal.tsx
@@ -18,24 +18,33 @@ interface StageGateWorkPackageModalProps {
   modalShow: boolean;
   onHide: () => void;
   onSubmit: (data: FormInput) => Promise<void>;
+  startDate: Date;
 }
 
-const schema = yup.object().shape({
-  confirmDone: yup.boolean().required(),
-  dateCompleted: yup
-    .date()
-    .required('Date completed is required')
-    .max(new Date(new Date().setHours(23, 59, 59, 999)), 'Date completed cannot be in the future')
-});
+const buildSchema = (startDate: Date) =>
+  yup.object().shape({
+    confirmDone: yup.boolean().required(),
+    dateCompleted: yup
+      .date()
+      .required('Date completed is required')
+      .min(startDate, 'Date completed cannot be before the start date')
+      .max(new Date(new Date().setHours(23, 59, 59, 999)), 'Date completed cannot be in the future')
+  });
 
-const StageGateWorkPackageModal: React.FC<StageGateWorkPackageModalProps> = ({ wbsNum, modalShow, onHide, onSubmit }) => {
+const StageGateWorkPackageModal: React.FC<StageGateWorkPackageModalProps> = ({
+  wbsNum,
+  modalShow,
+  onHide,
+  onSubmit,
+  startDate
+}) => {
   const {
     reset,
     handleSubmit,
     control,
     formState: { errors }
   } = useForm<FormInput>({
-    resolver: yupResolver(schema),
+    resolver: yupResolver(buildSchema(startDate)),
     defaultValues: {
       dateCompleted: new Date()
     }
@@ -94,6 +103,7 @@ const StageGateWorkPackageModal: React.FC<StageGateWorkPackageModalProps> = ({ w
             value={value}
             onChange={(newValue) => onChange(newValue ?? new Date())}
             disableFuture
+            minDate={startDate}
             slotProps={{
               textField: {
                 variant: 'outlined',

--- a/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModal.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModal.tsx
@@ -9,8 +9,9 @@ import { Controller, useForm } from 'react-hook-form';
 import { WbsNumber } from 'shared';
 import { FormInput } from './StageGateWorkPackageModalContainer';
 import { wbsPipe } from '../../../utils/pipes';
-import { FormControlLabel, Radio, RadioGroup, Typography } from '@mui/material';
+import { FormControlLabel, FormHelperText, Radio, RadioGroup, Typography } from '@mui/material';
 import NERFormModal from '../../../components/NERFormModal';
+import { DatePicker } from '@mui/x-date-pickers';
 
 interface StageGateWorkPackageModalProps {
   wbsNum: WbsNumber;
@@ -20,12 +21,24 @@ interface StageGateWorkPackageModalProps {
 }
 
 const schema = yup.object().shape({
-  confirmDone: yup.boolean().required()
+  confirmDone: yup.boolean().required(),
+  dateCompleted: yup
+    .date()
+    .required('Date completed is required')
+    .max(new Date(new Date().setHours(23, 59, 59, 999)), 'Date completed cannot be in the future')
 });
 
 const StageGateWorkPackageModal: React.FC<StageGateWorkPackageModalProps> = ({ wbsNum, modalShow, onHide, onSubmit }) => {
-  const { reset, handleSubmit, control } = useForm<FormInput>({
-    resolver: yupResolver(schema)
+  const {
+    reset,
+    handleSubmit,
+    control,
+    formState: { errors }
+  } = useForm<FormInput>({
+    resolver: yupResolver(schema),
+    defaultValues: {
+      dateCompleted: new Date()
+    }
   });
 
   return (
@@ -44,7 +57,6 @@ const StageGateWorkPackageModal: React.FC<StageGateWorkPackageModalProps> = ({ w
         rules={{ required: true }}
         render={({ field: { onChange, value } }) => (
           <>
-            {/* TODO: slide deck changed to confluence in frontend - needs to be updated in the backend */}
             <Typography sx={{ paddingTop: 1 }}>Is everything done?</Typography>
             <ul style={{ marginTop: 0, marginBottom: 2 }}>
               <li>Updated confluence & documentation</li>
@@ -73,6 +85,27 @@ const StageGateWorkPackageModal: React.FC<StageGateWorkPackageModalProps> = ({ w
           </>
         )}
       />
+      <Typography sx={{ mt: 2, mb: 0.5 }}>Date completed</Typography>
+      <Controller
+        name="dateCompleted"
+        control={control}
+        render={({ field: { onChange, value } }) => (
+          <DatePicker
+            value={value}
+            onChange={(newValue) => onChange(newValue ?? new Date())}
+            disableFuture
+            slotProps={{
+              textField: {
+                variant: 'outlined',
+                size: 'small',
+                fullWidth: true,
+                error: !!errors.dateCompleted
+              }
+            }}
+          />
+        )}
+      />
+      {errors.dateCompleted && <FormHelperText error>{errors.dateCompleted.message}</FormHelperText>}
     </NERFormModal>
   );
 };

--- a/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModalContainer.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModalContainer.tsx
@@ -23,6 +23,7 @@ interface StageGateWorkPackageModalContainerProps {
 
 export interface FormInput {
   confirmDone: boolean;
+  dateCompleted: Date;
 }
 
 const StageGateWorkPackageModalContainer: React.FC<StageGateWorkPackageModalContainerProps> = ({
@@ -36,7 +37,7 @@ const StageGateWorkPackageModalContainer: React.FC<StageGateWorkPackageModalCont
   const toast = useToast();
   const { isLoading, isError, error, mutateAsync } = useCreateStageGateChangeRequest();
 
-  const handleConfirm = async ({ confirmDone }: FormInput) => {
+  const handleConfirm = async ({ confirmDone, dateCompleted }: FormInput) => {
     handleClose();
     if (auth.user?.userId === undefined) throw new Error('Cannot create stage gate change request without being logged in');
     try {
@@ -44,7 +45,8 @@ const StageGateWorkPackageModalContainer: React.FC<StageGateWorkPackageModalCont
         submitterId: auth.user?.userId,
         wbsNum,
         type: ChangeRequestType.StageGate,
-        confirmDone
+        confirmDone,
+        dateCompleted
       });
       [0, 0.15, 0.3, 0.45, 0.6, 0.75, 0.9].forEach((xPos) => {
         confetti({

--- a/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModalContainer.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModalContainer.tsx
@@ -69,9 +69,9 @@ const StageGateWorkPackageModalContainer: React.FC<StageGateWorkPackageModalCont
   };
 
   if (!hideStatus) {
-    if (isLoading || wpIsLoading) return <LoadingIndicator />;
     if (isError) return <ErrorPage message={error?.message} />;
     if (wpIsError) return <ErrorPage message={wpError?.message} />;
+    if (isLoading || wpIsLoading) return <LoadingIndicator />;
   }
 
   if (!workPackage) return <LoadingIndicator />;

--- a/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModalContainer.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModalContainer.tsx
@@ -8,6 +8,7 @@ import { useHistory } from 'react-router-dom';
 import { ChangeRequestType, WbsNumber, wbsPipe } from 'shared';
 import { useAuth } from '../../../hooks/auth.hooks';
 import { useCreateStageGateChangeRequest } from '../../../hooks/change-requests.hooks';
+import { useSingleWorkPackage } from '../../../hooks/work-packages.hooks';
 import { routes } from '../../../utils/routes';
 import ErrorPage from '../../ErrorPage';
 import LoadingIndicator from '../../../components/LoadingIndicator';
@@ -36,6 +37,7 @@ const StageGateWorkPackageModalContainer: React.FC<StageGateWorkPackageModalCont
   const history = useHistory();
   const toast = useToast();
   const { isLoading, isError, error, mutateAsync } = useCreateStageGateChangeRequest();
+  const { isLoading: wpIsLoading, isError: wpIsError, error: wpError, data: workPackage } = useSingleWorkPackage(wbsNum);
 
   const handleConfirm = async ({ confirmDone, dateCompleted }: FormInput) => {
     handleClose();
@@ -67,11 +69,22 @@ const StageGateWorkPackageModalContainer: React.FC<StageGateWorkPackageModalCont
   };
 
   if (!hideStatus) {
-    if (isLoading) return <LoadingIndicator />;
+    if (isLoading || wpIsLoading) return <LoadingIndicator />;
     if (isError) return <ErrorPage message={error?.message} />;
+    if (wpIsError) return <ErrorPage message={wpError?.message} />;
   }
 
-  return <StageGateWorkPackageModal wbsNum={wbsNum} modalShow={modalShow} onHide={handleClose} onSubmit={handleConfirm} />;
+  if (!workPackage) return <LoadingIndicator />;
+
+  return (
+    <StageGateWorkPackageModal
+      wbsNum={wbsNum}
+      modalShow={modalShow}
+      onHide={handleClose}
+      onSubmit={handleConfirm}
+      startDate={workPackage.startDate}
+    />
+  );
 };
 
 export default StageGateWorkPackageModalContainer;

--- a/src/frontend/src/tests/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModal.test.tsx
+++ b/src/frontend/src/tests/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModal.test.tsx
@@ -31,6 +31,7 @@ const renderComponent = (modalShow: boolean) => {
           onHide={mockHandleHide}
           onSubmit={mockHandleSubmit}
           wbsNum={exampleWbs1}
+          startDate={new Date('2024-01-01')}
         />
       </ToastProvider>
     </RouterWrapper>

--- a/src/frontend/src/tests/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModalContainer.test.tsx
+++ b/src/frontend/src/tests/pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModalContainer.test.tsx
@@ -3,23 +3,29 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { UseMutationResult } from 'react-query';
+import { UseMutationResult, UseQueryResult } from 'react-query';
 import { render, screen } from '../../../test-support/test-utils';
 import { wbsPipe } from '../../../../utils/pipes';
 import { exampleWbs1 } from '../../../test-support/test-data/wbs-numbers.stub';
 import StageGateWorkPackageModalContainer from '../../../../pages/WorkPackageDetailPage/StageGateWorkPackageModalContainer/StageGateWorkPackageModalContainer';
-import { mockUseMutationResult } from '../../../test-support/test-data/test-utils.stub';
+import { mockUseMutationResult, mockUseQueryResult } from '../../../test-support/test-data/test-utils.stub';
 import { useCreateStageGateChangeRequest } from '../../../../hooks/change-requests.hooks';
+import { useSingleWorkPackage } from '../../../../hooks/work-packages.hooks';
+import { WorkPackage } from 'shared';
+import { exampleWorkPackage5 } from '../../../test-support/test-data/work-packages.stub';
 
 vi.mock('../../../../hooks/change-requests.hooks');
-
+vi.mock('../../../../hooks/work-packages.hooks');
 vi.mock('../../../../hooks/toasts.hooks');
 
-// random shit to make test happy by mocking out this hook
 const mockedUseCreateStageGateCR = useCreateStageGateChangeRequest as jest.Mock<UseMutationResult>;
-
 const mockUseCreateStageGateCRHook = (isLoading: boolean, isError: boolean, error?: Error) => {
   mockedUseCreateStageGateCR.mockReturnValue(mockUseMutationResult<{ in: string }>(isLoading, isError, { in: 'hi' }, error));
+};
+
+const mockedUseSingleWorkPackage = useSingleWorkPackage as jest.Mock<UseQueryResult<WorkPackage>>;
+const mockUseSingleWorkPackageHook = (isLoading: boolean, isError: boolean, data?: WorkPackage, error?: Error) => {
+  mockedUseSingleWorkPackage.mockReturnValue(mockUseQueryResult<WorkPackage>(isLoading, isError, data, error));
 };
 
 const renderComponent = () => {
@@ -29,6 +35,7 @@ const renderComponent = () => {
 describe('stage gate work package modal container test suite', () => {
   it('renders component without crashing', () => {
     mockUseCreateStageGateCRHook(false, false);
+    mockUseSingleWorkPackageHook(false, false, exampleWorkPackage5);
     renderComponent();
 
     expect(screen.getByText(`Stage Gate #${wbsPipe(exampleWbs1)}`)).toBeInTheDocument();


### PR DESCRIPTION
## Changes

Added dateCompleted to stage gate backend endpoint and to the frontend modal, hooks and api.

## Test Cases

- sets work package to complete on stage gate
- updates work package duration based on dateCompleted
- creates a change record for duration when it changes
- does not create a duration change record when duration is unchanged 

## Screenshots
<img width="1470" height="956" alt="Screenshot 2026-04-29 at 9 44 01 PM" src="https://github.com/user-attachments/assets/ce9bc3e8-2a38-4458-ad0c-11a33319a4b7" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #4176 
