### PR TITLE
ics calendar integration

### DIFF
--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -29,6 +29,7 @@ import financeRouter from './src/routes/finance.routes.js';
 import calendarRouter from './src/routes/calendar.routes.js';
 import prospectiveSponsorRouter from './src/routes/prospective-sponsor.routes.js';
 import attendanceRouter from './src/routes/attendance.routes.js';
+import icsRouter from './src/routes/ics.routes.js';
 
 const app = express();
 
@@ -84,6 +85,9 @@ app.use(express.json());
 
 // cors settings
 app.use(cors(options));
+
+// Public ICS feed routes — mounted before JWT middleware so calendar apps can subscribe without auth
+app.use('/ics', icsRouter);
 
 // ensure each request is authorized using JWT
 app.use(isProd ? requireJwtProd : requireJwtDev);

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -30,6 +30,7 @@
     "express-validator": "^6.14.2",
     "google-auth-library": "^8.1.1",
     "googleapis": "^118.0.0",
+    "ical-generator": "^10.2.0",
     "jsonwebtoken": "^8.5.1",
     "multer": "^1.4.5-lts.1",
     "nodemailer": "^6.9.1",

--- a/src/backend/src/controllers/calendar.controllers.ts
+++ b/src/backend/src/controllers/calendar.controllers.ts
@@ -1,6 +1,7 @@
 import { NextFunction, Request, Response } from 'express';
 import CalendarService from '../services/calendar.services.js';
 import { getCurrentUserWithUserSettings } from '../utils/auth.utils.js';
+import { generateIcsFeed } from '../utils/ics.utils.js';
 
 export default class CalendarController {
   static async createEventType(req: Request, res: Response, next: NextFunction) {
@@ -606,6 +607,33 @@ export default class CalendarController {
         pastCursor ? new Date(pastCursor) : undefined
       );
       res.status(200).json(paginatedEvents);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
+  static async getOrCreateIcsToken(req: Request, res: Response, next: NextFunction) {
+    try {
+      const icsToken = await CalendarService.getOrCreateIcsToken(req.currentUser.userId);
+      res.status(200).json({ icsToken, organizationId: req.organization.organizationId });
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
+  static async getIcsFeed(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { token } = req.params as Record<string, string>;
+      const { org, calendars } = req.query as Record<string, string | undefined>;
+      const organizationId = org ?? '';
+      const calendarIds = calendars ? calendars.split(',').filter(Boolean) : [];
+
+      const events = await CalendarService.getIcsFeedEvents(token, organizationId, calendarIds);
+      const icsContent = generateIcsFeed(events);
+
+      res.setHeader('Content-Type', 'text/calendar; charset=utf-8');
+      res.setHeader('Content-Disposition', 'attachment; filename="finishline.ics"');
+      res.send(icsContent);
     } catch (error: unknown) {
       next(error);
     }

--- a/src/backend/src/prisma/migrations/20260505000000_add_ics_token_to_user/migration.sql
+++ b/src/backend/src/prisma/migrations/20260505000000_add_ics_token_to_user/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "icsToken" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_icsToken_key" ON "User"("icsToken");

--- a/src/backend/src/prisma/schema.prisma
+++ b/src/backend/src/prisma/schema.prisma
@@ -191,6 +191,7 @@ model User {
   additionalPermissions String[]
   userSettings          User_Settings?
   userSecureSettings    User_Secure_Settings?
+  icsToken              String?               @unique
 
   // Relation references
   submittedChangeRequests                 Change_Request[]                     @relation(name: "submittedChangeRequests")

--- a/src/backend/src/routes/calendar.routes.ts
+++ b/src/backend/src/routes/calendar.routes.ts
@@ -298,5 +298,6 @@ calendarRouter.post(
 
 calendarRouter.get('/calendars', CalendarController.getAllCalendars);
 calendarRouter.post('/events-paginated', CalendarController.getAllEventsPaginated);
+calendarRouter.get('/ics/token', CalendarController.getOrCreateIcsToken);
 
 export default calendarRouter;

--- a/src/backend/src/routes/ics.routes.ts
+++ b/src/backend/src/routes/ics.routes.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+import CalendarController from '../controllers/calendar.controllers.js';
+
+const icsRouter = express.Router();
+
+icsRouter.get('/:token', CalendarController.getIcsFeed);
+
+export default icsRouter;

--- a/src/backend/src/services/calendar.services.ts
+++ b/src/backend/src/services/calendar.services.ts
@@ -2813,4 +2813,55 @@ export default class CalendarService {
       nextPastCursor: pastSlots.length === 25 ? pastSlots[pastSlots.length - 1].startTime : null
     };
   }
+
+  static async getOrCreateIcsToken(userId: string): Promise<string> {
+    const user = await prisma.user.findUnique({ where: { userId } });
+    if (!user) throw new NotFoundException('User', userId);
+    if (user.icsToken) return user.icsToken;
+
+    const token = crypto.randomUUID();
+    await prisma.user.update({ where: { userId }, data: { icsToken: token } });
+    return token;
+  }
+
+  static async getIcsFeedEvents(icsToken: string, organizationId: string, calendarIds: string[]) {
+    const user = await prisma.user.findUnique({
+      where: { icsToken },
+      include: {
+        teamsAsMember: { select: { teamId: true } },
+        teamsAsLead: { select: { teamId: true } },
+        teamsAsHead: { select: { teamId: true } }
+      }
+    });
+
+    if (!user) throw new NotFoundException('User', 'icsToken');
+
+    const userTeamIds = [
+      ...user.teamsAsMember.map((t) => t.teamId),
+      ...user.teamsAsLead.map((t) => t.teamId),
+      ...user.teamsAsHead.map((t) => t.teamId)
+    ];
+
+    const calendarFilter =
+      calendarIds.length > 0
+        ? [{ eventType: { calendars: { some: { calendarId: { in: calendarIds }, organizationId } } } }]
+        : [];
+
+    const events = await prisma.event.findMany({
+      where: {
+        dateDeleted: null,
+        status: { in: [Event_Status.CONFIRMED, Event_Status.SCHEDULED, Event_Status.DONE] },
+        scheduledTimes: { some: {} },
+        OR: [
+          { requiredMembers: { some: { userId: user.userId } } },
+          { optionalMembers: { some: { userId: user.userId } } },
+          ...(userTeamIds.length > 0 ? [{ teams: { some: { teamId: { in: userTeamIds } } } }] : []),
+          ...calendarFilter
+        ]
+      },
+      ...getEventQueryArgs(organizationId)
+    });
+
+    return events.map(eventTransformer);
+  }
 }

--- a/src/backend/src/utils/ics.utils.ts
+++ b/src/backend/src/utils/ics.utils.ts
@@ -1,0 +1,43 @@
+import ical, { ICalEventStatus } from 'ical-generator';
+import { Event, wbsPipe } from 'shared';
+
+export const generateIcsFeed = (events: Event[]): string => {
+  const cal = ical({ name: 'Northeastern Electric Racing' });
+
+  for (const event of events) {
+    for (const slot of event.scheduledTimes) {
+      const descriptionParts: string[] = [];
+      if (event.description) descriptionParts.push(event.description);
+
+      const memberName = (m: { firstName: string; lastName: string }) => `${m.firstName} ${m.lastName}`;
+      if (event.requiredMembers.length > 0)
+        descriptionParts.push(`Required: ${event.requiredMembers.map(memberName).join(', ')}`);
+      if (event.optionalMembers.length > 0)
+        descriptionParts.push(`Optional: ${event.optionalMembers.map(memberName).join(', ')}`);
+
+      if (event.zoomLink) descriptionParts.push(`Zoom: ${event.zoomLink}`);
+      if (event.teams.length > 0) descriptionParts.push(`Teams: ${event.teams.map((team) => team.teamName).join(', ')}`);
+      if (event.shops.length > 0) descriptionParts.push(`Shops: ${event.shops.map((shop) => shop.name).join(', ')}`);
+      if (event.machinery.length > 0)
+        descriptionParts.push(`Machinery: ${event.machinery.map((machine) => machine.name).join(', ')}`);
+      if (event.workPackages.length > 0)
+        descriptionParts.push(
+          `Work Package: ${event.workPackages.map((wp) => `${wp.wbsElement.name} (${wbsPipe(wp.wbsElement)})`).join(', ')}`
+        );
+
+      cal.createEvent({
+        id: `${event.eventId}-${slot.scheduleSlotId}@finishlinebyner.com`,
+        summary: event.title,
+        start: slot.startTime,
+        end: slot.endTime,
+        allDay: slot.allDay,
+        description: descriptionParts.length > 0 ? descriptionParts.join('\n\n') : undefined,
+        location: event.location ?? event.zoomLink ?? undefined,
+        status: ICalEventStatus.CONFIRMED,
+        organizer: { name: event.userCreated.firstName + ' ' + event.userCreated.lastName, email: event.userCreated.email }
+      });
+    }
+  }
+
+  return cal.toString();
+};

--- a/src/frontend/src/apis/calendar.api.ts
+++ b/src/frontend/src/apis/calendar.api.ts
@@ -290,3 +290,9 @@ export const getAllEventsPaginated = (futureCursor?: Date, pastCursor?: Date) =>
     }
   );
 };
+
+export const getIcsToken = () => {
+  return axios.get<{ icsToken: string; organizationId: string }>(apiUrls.calendarIcsToken(), {
+    transformResponse: (data) => JSON.parse(data)
+  });
+};

--- a/src/frontend/src/hooks/calendar.hooks.ts
+++ b/src/frontend/src/hooks/calendar.hooks.ts
@@ -50,7 +50,8 @@ import {
   previewScheduleSlotRecurringEdits,
   postDeleteScheduleSlot,
   scheduleEvent,
-  getAllEventsPaginated
+  getAllEventsPaginated,
+  getIcsToken
 } from '../apis/calendar.api';
 import { useCurrentUser } from './users.hooks';
 import { PDFDocument } from 'pdf-lib';
@@ -688,3 +689,9 @@ export const usePastEventsPaginated = () => {
     { getNextPageParam: (lastPage) => lastPage.nextPastCursor ?? undefined }
   );
 };
+
+export const useGetIcsToken = () =>
+  useQuery<{ icsToken: string; organizationId: string }, Error>(['icsToken'], async () => {
+    const { data } = await getIcsToken();
+    return data;
+  });

--- a/src/frontend/src/pages/CalendarPage/CalendarPage.tsx
+++ b/src/frontend/src/pages/CalendarPage/CalendarPage.tsx
@@ -27,6 +27,7 @@ import { datePipe } from '../../utils/pipes';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import { useAllTeamTypes } from '../../hooks/team-types.hooks';
 import FilterModal from './FilterModal';
+import IcsSubscribeModal from './IcsSubscribeModal';
 import { DateCalendar } from '@mui/x-date-pickers';
 import { useCurrentUser } from '../../hooks/users.hooks';
 import { useGetUsersTeams } from '../../hooks/teams.hooks';
@@ -129,6 +130,7 @@ const NewCalendarPage: React.FC<NewCalendarPageProps> = ({
   const [showInvitedEvents, setShowInvitedEvents] = useState<boolean>(savedFilters.showInvitedEvents ?? true);
   const [showTeamEvents, setShowTeamEvents] = useState<boolean>(savedFilters.showTeamEvents ?? true);
   const [openFilterModal, setOpenFilterModal] = useState(false);
+  const [openSubscribeModal, setOpenSubscribeModal] = useState(false);
   const [additionalMemberIds, setAdditionalMemberIds] = useState<string[]>([user.userId]);
   const [additionalTeamIds, setAdditionalTeamIds] = useState<string[]>([]);
   const [allEventsMode, setAllEventsMode] = useState<boolean>(savedFilters.allEventsMode ?? true);
@@ -907,6 +909,27 @@ const NewCalendarPage: React.FC<NewCalendarPageProps> = ({
                     label={<Typography sx={{ fontSize: 12, color: 'white', whiteSpace: 'nowrap' }}>Tasks</Typography>}
                     sx={{ mr: 0 }}
                   />
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    onClick={() => setOpenSubscribeModal(true)}
+                    sx={{
+                      px: 1,
+                      py: 0,
+                      color: 'white',
+                      borderColor: 'white',
+                      backgroundColor: 'transparent',
+                      textTransform: 'none',
+                      fontSize: 12,
+                      fontFamily: (t) => t.typography.h4.fontFamily,
+                      '&:hover': {
+                        borderColor: 'white',
+                        backgroundColor: 'rgba(255, 255, 255, 0.1)'
+                      }
+                    }}
+                  >
+                    Connect With Your Calendar
+                  </Button>
                 </Stack>
               </Stack>
             </Box>
@@ -922,6 +945,7 @@ const NewCalendarPage: React.FC<NewCalendarPageProps> = ({
           setShowInvited={(changed: boolean) => updateAdditionalMemberIds(changed)}
           setShowTeam={(changed: boolean) => updateAdditionalTeamIds(changed)}
         />
+        <IcsSubscribeModal open={openSubscribeModal} onClose={() => setOpenSubscribeModal(false)} />
       </PageLayout>
     </>
   );

--- a/src/frontend/src/pages/CalendarPage/IcsSubscribeModal.tsx
+++ b/src/frontend/src/pages/CalendarPage/IcsSubscribeModal.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+import { Checkbox, FormControlLabel, FormGroup, Stack, Typography } from '@mui/material';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import CheckIcon from '@mui/icons-material/Check';
+import NERModal from '../../components/NERModal';
+import { NERButton } from '../../components/NERButton';
+import LoadingIndicator from '../../components/LoadingIndicator';
+import ErrorPage from '../ErrorPage';
+import { useGetIcsToken, useAllCalendars } from '../../hooks/calendar.hooks';
+import { apiUrls } from '../../utils/urls';
+import { Calendar } from 'shared';
+
+interface IcsSubscribeModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const IcsSubscribeModal: React.FC<IcsSubscribeModalProps> = ({ open, onClose }) => {
+  const [selectedCalendarIds, setSelectedCalendarIds] = useState<string[]>([]);
+  const [copied, setCopied] = useState(false);
+
+  const { data: tokenData, isLoading: tokenLoading, isError: tokenError, error: tokenErr } = useGetIcsToken();
+  const {
+    data: allCalendars,
+    isLoading: calendarsLoading,
+    isError: calendarsError,
+    error: calendarsErr
+  } = useAllCalendars();
+
+  if (tokenError) return <ErrorPage message={tokenErr?.message} />;
+  if (calendarsError) return <ErrorPage message={calendarsErr?.message} />;
+
+  const isLoading = tokenLoading || calendarsLoading;
+  const allSelected = !!allCalendars && selectedCalendarIds.length === allCalendars.length;
+  const someSelected = selectedCalendarIds.length > 0 && !allSelected;
+
+  const toggleCalendar = (calendarId: string) => {
+    setSelectedCalendarIds((prev) =>
+      prev.includes(calendarId) ? prev.filter((id) => id !== calendarId) : [...prev, calendarId]
+    );
+  };
+
+  const toggleAll = () => {
+    setSelectedCalendarIds(allSelected ? [] : (allCalendars ?? []).map((c) => c.calendarId));
+  };
+
+  const handleCopy = async () => {
+    if (!tokenData) return;
+    const feedUrl = apiUrls.icsFeed(tokenData.icsToken, tokenData.organizationId, selectedCalendarIds);
+    await navigator.clipboard.writeText(feedUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <NERModal open={open} onHide={onClose} title="Connect With Your Calendar" hideFormButtons showCloseButton>
+      {isLoading ? (
+        <LoadingIndicator />
+      ) : (
+        <Stack spacing={2}>
+          <Typography variant="body2">
+            Your feed includes events you're invited to and events for your teams. Optionally include additional calendars
+            below.
+          </Typography>
+
+          {allCalendars && allCalendars.length > 0 && (
+            <FormGroup>
+              <FormControlLabel
+                control={<Checkbox size="small" checked={allSelected} indeterminate={someSelected} onChange={toggleAll} />}
+                label="Select All"
+              />
+              {allCalendars.map((cal: Calendar) => (
+                <FormControlLabel
+                  key={cal.calendarId}
+                  control={
+                    <Checkbox
+                      size="small"
+                      checked={selectedCalendarIds.includes(cal.calendarId)}
+                      onChange={() => toggleCalendar(cal.calendarId)}
+                    />
+                  }
+                  label={cal.name}
+                  sx={{ pl: 2 }}
+                />
+              ))}
+            </FormGroup>
+          )}
+
+          <NERButton
+            variant="contained"
+            startIcon={copied ? <CheckIcon /> : <ContentCopyIcon />}
+            onClick={handleCopy}
+            disabled={!tokenData}
+          >
+            {copied ? 'Copied!' : 'Copy Feed URL'}
+          </NERButton>
+
+          <Typography variant="caption" color="text.secondary">
+            In Google Calendar: click <strong>+ Other calendars</strong> → <strong>From URL</strong> → paste this link.
+          </Typography>
+        </Stack>
+      )}
+    </NERModal>
+  );
+};
+
+export default IcsSubscribeModal;

--- a/src/frontend/src/utils/urls.ts
+++ b/src/frontend/src/utils/urls.ts
@@ -486,6 +486,13 @@ const calendarDeleteScheduleSlot = (eventId: string, scheduleSlotId: string) =>
 const calendarUploadDocument = (eventId: string) => `${calendar()}/event/${eventId}/upload-document`;
 const calendarPDFById = (fileId: string) => `${calendar()}/document/${fileId}`;
 const calendarScheduleEvent = (eventId: string) => `${calendar()}/event/${eventId}/schedule`;
+const calendarIcsToken = () => `${calendar()}/ics/token`;
+
+// Generates ICS URL to be given to calendars for integration, not directly hit by FL frontend
+const icsFeed = (token: string, organizationId: string, calendarIds: string[]) => {
+  const base = `${API_URL}/ics/${token}?org=${organizationId}`;
+  return calendarIds.length > 0 ? `${base}&calendars=${calendarIds.join(',')}` : base;
+};
 
 /**************** Attendance Endpoints ****************/
 const attendance = () => `${API_URL}/attendance`;
@@ -848,6 +855,8 @@ export const apiUrls = {
   calendarCreateCalendar,
   calendarEditCalendar,
   calendarCalendars,
+  calendarIcsToken,
+  icsFeed,
   calendarCreateEventType,
   calendarEditEventType,
   calendarCreateEvent,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9270,6 +9270,7 @@ __metadata:
     express-validator: ^6.14.2
     google-auth-library: ^8.1.1
     googleapis: ^118.0.0
+    ical-generator: ^10.2.0
     jsonwebtoken: ^8.5.1
     multer: ^1.4.5-lts.1
     nodemailer: ^6.9.1
@@ -15288,6 +15289,41 @@ __metadata:
   version: 1.2.0
   resolution: "hyperdyperid@npm:1.2.0"
   checksum: 210029d1c86926f09109f6317d143f8b056fc38e8dd11b0c3e3205fc6c6ff8429fb55b4b9c2bce065462719ed9d34366eced387aaa0035d93eb76b306a8547ef
+  languageName: node
+  linkType: hard
+
+"ical-generator@npm:^10.2.0":
+  version: 10.2.0
+  resolution: "ical-generator@npm:10.2.0"
+  peerDependencies:
+    "@touch4it/ical-timezones": ">=1.6.0"
+    "@types/luxon": ">= 1.26.0"
+    "@types/mocha": ">= 8.2.1"
+    dayjs: ">= 1.10.0"
+    luxon: ">= 1.26.0"
+    moment: ">= 2.29.0"
+    moment-timezone: ">= 0.5.33"
+    rrule: ">= 2.6.8"
+  peerDependenciesMeta:
+    "@touch4it/ical-timezones":
+      optional: true
+    "@types/luxon":
+      optional: true
+    "@types/mocha":
+      optional: true
+    "@types/node":
+      optional: true
+    dayjs:
+      optional: true
+    luxon:
+      optional: true
+    moment:
+      optional: true
+    moment-timezone:
+      optional: true
+    rrule:
+      optional: true
+  checksum: 93d7e4a872f19eb0fa271f327eab12768718db96974007c9e3581c13e3b68048c2cb088746b0b88a3c7ae9847a01134673443af9542141b20fc8b64b5be6056f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Changes

Ics url integration with calendar events. Lets users generate ics link to sync calendar events with other calendars by exposing read only url. Identify user via generated ical uuid. Allows users to specify calendars to include via url parameters. 

[Video Demo](https://northeastern.sharepoint.com/:v:/r/sites/northeasternelectricracing/Shared%20Documents/Software/FinishLine/[gcalIntegrationDemo.mov](https://northeastern.sharepoint.com/:v:/r/sites/northeasternelectricracing/Shared%20Documents/Software/FinishLine/gcalIntegrationDemo.mov?csf=1&web=1&e=7xdcHu&nav=eyJyZWZlcnJhbEluZm8iOnsicmVmZXJyYWxBcHAiOiJTdHJlYW1XZWJBcHAiLCJyZWZlcnJhbFZpZXciOiJTaGFyZURpYWxvZy1MaW5rIiwicmVmZXJyYWxBcHBQbGF0Zm9ybSI6IldlYiIsInJlZmVycmFsTW9kZSI6InZpZXcifX0%3D)?csf=1&web=1&e=7xdcHu&nav=eyJyZWZlcnJhbEluZm8iOnsicmVmZXJyYWxBcHAiOiJTdHJlYW1XZWJBcHAiLCJyZWZlcnJhbFZpZXciOiJTaGFyZURpYWxvZy1MaW5rIiwicmVmZXJyYWxBcHBQbGF0Zm9ybSI6IldlYiIsInJlZmVycmFsTW9kZSI6InZpZXcifX0%3D)

### Notes
- must bypass auth middleware bc you cannot specify headers in ical request, instead authenticates with user ical token + org id
- read only, users cannot edit / create events from gcal (this would require significantly more work)
- seperate ical uuid to decouple from user id in case we wanted to secure this later, but atm security is not an issue as all calendar events are publicaly accessible (considered putting in secure settings but that would mean forcing users to fill out secure settings in order to integrate)
- Ical util uses lightweight npm package. Called from controller not service bc this is packaging for request after data retrieval
- Demo above uses ngrok to expose localhost url for gcal to hit, deployed site would not have issues

I don't think cors would be an issue bc theres no scripting but only one way to find out #testinprod

