### PR TITLE
#4172 started cr approve slack button

### DIFF
--- a/src/backend/src/controllers/slack.controllers.ts
+++ b/src/backend/src/controllers/slack.controllers.ts
@@ -87,7 +87,15 @@ export default class SlackController {
     }
   }
 
-  static async handleApproveCRAction(body: SlackBlockActionBody, respond: any) {
+  static async handleApproveCRAction(
+    body: SlackBlockActionBody,
+    respond: (msg: {
+      response_type?: 'ephemeral';
+      text?: string;
+      replace_original?: boolean;
+      delete_original?: boolean;
+    }) => Promise<unknown>
+  ) {
     const { user, container, actions } = body;
     const channelId = container.channel_id;
     const threadTs = container.thread_ts || container.message_ts;

--- a/src/backend/src/controllers/slack.controllers.ts
+++ b/src/backend/src/controllers/slack.controllers.ts
@@ -1,6 +1,10 @@
 import { getWorkspaceId, replyToMessageInThread } from '../integrations/slack.js';
 import OrganizationsService from '../services/organizations.services.js';
-import SlackServices, { SlackBlockActionBody, SaboSubmissionActionValue } from '../services/slack.services.js';
+import SlackServices, {
+  SlackBlockActionBody,
+  SaboSubmissionActionValue,
+  CrApprovalActionValue
+} from '../services/slack.services.js';
 
 export default class SlackController {
   static async processMessageEvent(event: any) {
@@ -72,6 +76,66 @@ export default class SlackController {
 
       // Pass the extracted fields to the service layer for business logic
       await SlackServices.handleSaboSubmittedAction(userSlackId, reimbursementRequestId);
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      await replyToMessageInThread(
+        channelId,
+        threadTs,
+        `❌ An unexpected error occurred while processing your request.\n\n*Error message:* ${errorMessage}\n\nPlease contact the software team and provide them with this information.`
+      );
+      throw error;
+    }
+  }
+
+  static async handleApproveCRAction(body: SlackBlockActionBody, respond: any) {
+    const { user, container, actions } = body;
+    const channelId = container.channel_id;
+    const threadTs = container.thread_ts || container.message_ts;
+    const [firstAction] = actions;
+
+    try {
+      // Action-specific validation: verify action_id
+      if (firstAction.action_id !== 'approve_cr') {
+        console.error('Unexpected action_id:', firstAction.action_id);
+        await replyToMessageInThread(
+          channelId,
+          threadTs,
+          `❌ An error occurred: Unexpected action type "${firstAction.action_id}". Please contact the software team.`
+        );
+        return;
+      }
+
+      // Action-specific validation: verify value format
+      let actionValue: CrApprovalActionValue;
+      try {
+        actionValue = JSON.parse(firstAction.value);
+      } catch (parseError) {
+        const parseErrorMsg = parseError instanceof Error ? parseError.message : 'Unknown parse error';
+        await replyToMessageInThread(
+          channelId,
+          threadTs,
+          `❌ An error occurred: Invalid action data format.\n\n*Error:* ${parseErrorMsg}\n*Value:* \`${firstAction.value}\`\n\nPlease contact the software team.`
+        );
+        return;
+      }
+
+      // Validate that changeRequestId exists in the parsed value
+      if (!actionValue.crId || typeof actionValue.crId !== 'string') {
+        const actionValueStr = JSON.stringify(actionValue, null, 2);
+        await replyToMessageInThread(
+          channelId,
+          threadTs,
+          `❌ An error occurred: Missing or invalid reimbursement request ID.\n\n*Parsed value:*\n\`\`\`${actionValueStr}\`\`\`\n\nPlease contact the software team.`
+        );
+        return;
+      }
+
+      // Extract validated fields
+      const userSlackId = user.id;
+      const { crId } = actionValue;
+
+      // Pass the extracted fields to the service layer for business logic
+      await SlackServices.handleApproveCRAction(userSlackId, crId, respond);
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       await replyToMessageInThread(

--- a/src/backend/src/routes/slack.routes.ts
+++ b/src/backend/src/routes/slack.routes.ts
@@ -129,6 +129,22 @@ if (slackApp) {
     }
   });
 
+  // Register interactive action handler for CR approval
+  slackApp.action('approve_cr', async ({ ack, body, logger, respond }: any) => {
+    await ack();
+
+    try {
+      if (!validateSlackActionBody(body)) {
+        logger.error('Invalid Slack action body structure');
+        return;
+      }
+
+      await SlackController.handleApproveCRAction(body, respond);
+    } catch (error) {
+      logger.error('Error handling approve_cr action:', error);
+    }
+  });
+
   // Error handler
   slackApp.error(async (error: Error) => {
     console.error('Slack app error:', error);

--- a/src/backend/src/services/slack.services.ts
+++ b/src/backend/src/services/slack.services.ts
@@ -13,6 +13,7 @@ import ReimbursementRequestService from './reimbursement-requests.services.js';
 import ChangeRequestsService from './change-requests.services.js';
 import { userTransformer } from '../transformers/user.transformer.js';
 import { getUserQueryArgs } from '../prisma-query-args/user.query-args.js';
+import { User } from 'shared';
 
 /**
  * Represents a slack event for a message in a channel.
@@ -266,8 +267,10 @@ export default class SlackServices {
       throw new NotFoundException('Organization', cr.organizationId);
     }
 
+    const reviewerShared: User = userTransformer(reviewer);
+
     try {
-      await ChangeRequestsService.reviewChangeRequest(userTransformer(reviewer), crId, '', true, org);
+      await ChangeRequestsService.reviewChangeRequest(reviewerShared, crId, '', true, org);
       await respond({
         replace_original: true,
         text: `✅ CR #${cr.identifier} approved by ${reviewer.firstName} ${reviewer.lastName}.`

--- a/src/backend/src/services/slack.services.ts
+++ b/src/backend/src/services/slack.services.ts
@@ -2,9 +2,15 @@ import { getChannelName, getUserName } from '../integrations/slack.js';
 import AnnouncementService from './announcement.services.js';
 import { Announcement, ReimbursementStatusType } from 'shared';
 import prisma from '../prisma/prisma.js';
-import { blockToMentionedUsers, blockToString } from '../utils/slack.utils.js';
-import { InvalidOrganizationException, NotFoundException } from '../utils/errors.utils.js';
+import { blockToMentionedUsers, blockToString, getUserIdFromSlackId } from '../utils/slack.utils.js';
+import {
+  AccessDeniedException,
+  HttpException,
+  InvalidOrganizationException,
+  NotFoundException
+} from '../utils/errors.utils.js';
 import ReimbursementRequestService from './reimbursement-requests.services.js';
+import ChangeRequestsService from './change-requests.services.js';
 
 /**
  * Represents a slack event for a message in a channel.
@@ -125,6 +131,13 @@ export interface SaboSubmissionActionValue {
   reimbursementRequestId: string;
 }
 
+/**
+ * Represents the parsed value from a CR approval action
+ */
+export interface CrApprovalActionValue {
+  crId: string;
+}
+
 export default class SlackServices {
   /**
    * Handles the Slack button click for marking a reimbursement request as SABO submitted.
@@ -197,6 +210,90 @@ export default class SlackServices {
       user,
       reimbursementRequest.organization
     );
+  }
+
+  /**
+   * Approves a change request from a Slack interactive button click.
+   * Auth (admin/head/requested-reviewer) is enforced inside reviewChangeRequest.
+   *
+   * @param userSlackId Slack id of the user who clicked the button
+   * @param crId the change request to approve
+   * @param respond Bolt response callback bound to this interaction's response_url
+   */
+  static async handleApproveCRAction(
+    userSlackId: string,
+    crId: string,
+    respond: (msg: {
+      response_type?: 'ephemeral';
+      text?: string;
+      replace_original?: boolean;
+      delete_original?: boolean;
+    }) => Promise<unknown>
+  ): Promise<void> {
+    const reviewer = await prisma.user.findFirst({
+      where: {
+        userSettings: {
+          slackId: userSlackId
+        }
+      }
+    });
+
+    if (!reviewer) {
+      console.error('User not found for slack ID:', userSlackId);
+      throw new NotFoundException('User', userSlackId);
+    }
+
+    const cr = await prisma.change_Request.findUnique({
+      where: {
+        crId
+      }
+    });
+
+    if (!cr) {
+      throw new NotFoundException('Change Request', crId);
+    }
+
+    const org = await prisma.organization.findUnique({
+      where: {
+        organizationId: cr.organizationId
+      }
+    });
+
+    if (!org) {
+      throw new NotFoundException('Organization', cr.organizationId);
+    }
+
+    try {
+      await ChangeRequestsService.reviewChangeRequest(reviewer, crId, '', true, org);
+      await respond({
+        replace_original: true,
+        text: `✅ CR #${cr.identifier} approved by ${reviewer.firstName} ${reviewer.lastName}.`
+      });
+    } catch (error) {
+      if (error instanceof AccessDeniedException) {
+        await respond({
+          response_type: 'ephemeral',
+          text: `❌ You're not authorized to approve this CR. Only admins, team heads, or requested reviewers can approve.`
+        });
+      } else if (error instanceof NotFoundException) {
+        await respond({
+          response_type: 'ephemeral',
+          text: `❌ ${error.message}`
+        });
+      } else if (error instanceof HttpException) {
+        await respond({
+          response_type: 'ephemeral',
+          text: `❌ ${error.message}`
+        });
+      } else {
+        const msg = error instanceof Error ? error.message : 'Unknown error';
+        console.error('Error approving CR via Slack:', error);
+        await respond({
+          response_type: 'ephemeral',
+          text: `❌ An unexpected error occurred while approving this CR.\n\n*Error:* ${msg}`
+        });
+      }
+    }
   }
 
   /**

--- a/src/backend/src/services/slack.services.ts
+++ b/src/backend/src/services/slack.services.ts
@@ -233,20 +233,6 @@ export default class SlackServices {
       delete_original?: boolean;
     }) => Promise<unknown>
   ): Promise<void> {
-    const reviewer = await prisma.user.findFirst({
-      where: {
-        userSettings: {
-          slackId: userSlackId
-        }
-      },
-      ...getUserQueryArgs()
-    });
-
-    if (!reviewer) {
-      console.error('User not found for slack ID:', userSlackId);
-      throw new NotFoundException('User', userSlackId);
-    }
-
     const cr = await prisma.change_Request.findUnique({
       where: {
         crId
@@ -255,6 +241,20 @@ export default class SlackServices {
 
     if (!cr) {
       throw new NotFoundException('Change Request', crId);
+    }
+
+    const reviewer = await prisma.user.findFirst({
+      where: {
+        userSettings: {
+          slackId: userSlackId
+        }
+      },
+      ...getUserQueryArgs(cr.organizationId)
+    });
+
+    if (!reviewer) {
+      console.error('User not found for slack ID:', userSlackId);
+      throw new NotFoundException('User', userSlackId);
     }
 
     const org = await prisma.organization.findUnique({

--- a/src/backend/src/services/slack.services.ts
+++ b/src/backend/src/services/slack.services.ts
@@ -2,7 +2,7 @@ import { getChannelName, getUserName } from '../integrations/slack.js';
 import AnnouncementService from './announcement.services.js';
 import { Announcement, ReimbursementStatusType } from 'shared';
 import prisma from '../prisma/prisma.js';
-import { blockToMentionedUsers, blockToString, getUserIdFromSlackId } from '../utils/slack.utils.js';
+import { blockToMentionedUsers, blockToString } from '../utils/slack.utils.js';
 import {
   AccessDeniedException,
   HttpException,

--- a/src/backend/src/services/slack.services.ts
+++ b/src/backend/src/services/slack.services.ts
@@ -11,6 +11,8 @@ import {
 } from '../utils/errors.utils.js';
 import ReimbursementRequestService from './reimbursement-requests.services.js';
 import ChangeRequestsService from './change-requests.services.js';
+import { userTransformer } from '../transformers/user.transformer.js';
+import { getUserQueryArgs } from '../prisma-query-args/user.query-args.js';
 
 /**
  * Represents a slack event for a message in a channel.
@@ -235,7 +237,8 @@ export default class SlackServices {
         userSettings: {
           slackId: userSlackId
         }
-      }
+      },
+      ...getUserQueryArgs()
     });
 
     if (!reviewer) {
@@ -264,7 +267,7 @@ export default class SlackServices {
     }
 
     try {
-      await ChangeRequestsService.reviewChangeRequest(reviewer, crId, '', true, org);
+      await ChangeRequestsService.reviewChangeRequest(userTransformer(reviewer), crId, '', true, org);
       await respond({
         replace_original: true,
         text: `✅ CR #${cr.identifier} approved by ${reviewer.firstName} ${reviewer.lastName}.`

--- a/src/backend/src/services/slack.services.ts
+++ b/src/backend/src/services/slack.services.ts
@@ -270,7 +270,7 @@ export default class SlackServices {
     const reviewerShared: User = userTransformer(reviewer);
 
     try {
-      await ChangeRequestsService.reviewChangeRequest(reviewerShared, crId, '', true, org);
+      await ChangeRequestsService.reviewChangeRequest(reviewerShared, crId, true, org);
       await respond({
         replace_original: true,
         text: `✅ CR #${cr.identifier} approved by ${reviewer.firstName} ${reviewer.lastName}.`

--- a/src/backend/src/utils/slack.utils.ts
+++ b/src/backend/src/utils/slack.utils.ts
@@ -608,6 +608,35 @@ export const sendStandardCRCreatedNotification = async (
       notifications.map((n) => replyToMessageInThread(n.channelId, n.ts, reviewMsg, crLink, `View CR #${cr.identifier}`))
     );
   }
+
+  // Send the approve button as an ephemeral message to each head and requested reviewer,
+  // so only authorized approvers see it. reviewChangeRequest still enforces auth on click.
+  const approveBlocks = [
+    {
+      type: 'section',
+      text: { type: 'mrkdwn', text: `Approve CR #${cr.identifier}?` }
+    },
+    {
+      type: 'actions',
+      elements: [
+        {
+          type: 'button',
+          text: { type: 'plain_text', text: 'Approve Change Request' },
+          style: 'primary',
+          action_id: 'approve_cr',
+          value: JSON.stringify({ crId: cr.crId, organizationId: cr.organizationId })
+        }
+      ]
+    }
+  ];
+
+  await Promise.all(
+    notifications.flatMap((n) =>
+      [...allSlackIds].map((slackId) =>
+        sendEphemeralMessage(n.channelId, n.ts, slackId, `Approve CR #${cr.identifier}?`, approveBlocks)
+      )
+    )
+  );
 };
 
 /**


### PR DESCRIPTION
## Changes

Added the ability for user's to approve change requests via slack. Tested using Finishling Testing slack app and ngrok to redirect url.

## Screenshots
When the cr is submitted:
<img width="612" height="314" alt="Screenshot 2026-05-11 at 9 35 18 PM" src="https://github.com/user-attachments/assets/7f07c9f0-8b19-4975-9b98-d95a4cf4ec2d" />
After the cr has been approved in slack:
<img width="620" height="372" alt="Screenshot 2026-05-11 at 9 35 36 PM" src="https://github.com/user-attachments/assets/89388147-6463-4c7c-b0ba-5aab4dfc5c58" />


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [ ] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #4172
