### PR TITLE
3953-save-gantt-changes-modal-misplaced center draggable modal on open using positionOffset

### DIFF
--- a/src/frontend/src/components/NERDraggableFormModal.tsx
+++ b/src/frontend/src/components/NERDraggableFormModal.tsx
@@ -39,20 +39,20 @@ export const NERDraggableFormModal = ({
   return (
     <>
       {open && (
-        <Draggable handle=".draggable-handle" nodeRef={nodeRef}>
-          <Box
-            ref={nodeRef}
-            sx={{
-              position: 'fixed',
-              top: '50%',
-              right: '5%',
-              backgroundColor: theme.palette.background.paper,
-              boxShadow: 24,
-              zIndex: 6,
-              width: '40%',
-              borderRadius: '8px'
-            }}
-          >
+          <Draggable handle=".draggable-handle" nodeRef={nodeRef} positionOffset={{ x: '-50%', y: '-50%' }}>
+            <Box
+              ref={nodeRef}
+              sx={{
+                position: 'fixed',
+                top: '50%',
+                left: '50%',
+                backgroundColor: theme.palette.background.paper,
+                boxShadow: 24,
+                zIndex: 6,
+                width: '40%',
+                borderRadius: '8px'
+              }}
+            >
             {showCloseButton && (
               <IconButton
                 aria-label="close"
@@ -81,8 +81,8 @@ export const NERDraggableFormModal = ({
                 </NERSuccessButton>
               </Box>
             )}
-          </Box>
-        </Draggable>
+            </Box>
+          </Draggable>
       )}
     </>
   );

--- a/src/frontend/src/components/NERDraggableFormModal.tsx
+++ b/src/frontend/src/components/NERDraggableFormModal.tsx
@@ -39,20 +39,20 @@ export const NERDraggableFormModal = ({
   return (
     <>
       {open && (
-          <Draggable handle=".draggable-handle" nodeRef={nodeRef} positionOffset={{ x: '-50%', y: '-50%' }}>
-            <Box
-              ref={nodeRef}
-              sx={{
-                position: 'fixed',
-                top: '50%',
-                left: '50%',
-                backgroundColor: theme.palette.background.paper,
-                boxShadow: 24,
-                zIndex: 6,
-                width: '40%',
-                borderRadius: '8px'
-              }}
-            >
+        <Draggable handle=".draggable-handle" nodeRef={nodeRef} positionOffset={{ x: '-50%', y: '-50%' }}>
+          <Box
+            ref={nodeRef}
+            sx={{
+              position: 'fixed',
+              top: '50%',
+              left: '50%',
+              backgroundColor: theme.palette.background.paper,
+              boxShadow: 24,
+              zIndex: 6,
+              width: '40%',
+              borderRadius: '8px'
+            }}
+          >
             {showCloseButton && (
               <IconButton
                 aria-label="close"
@@ -81,8 +81,8 @@ export const NERDraggableFormModal = ({
                 </NERSuccessButton>
               </Box>
             )}
-            </Box>
-          </Draggable>
+          </Box>
+        </Draggable>
       )}
     </>
   );


### PR DESCRIPTION
## Changes                                                                                                                                                                              
Centered the draggable modal on open by replacing the hardcoded `top: 50%, right: 5%` position with `top: 50%, left: 50%` combined with react-draggable's `positionOffset={{ x: '-50%', y: '-50%' }}`, which offsets the modal by half its own dimensions to land it in the center of the viewport. Dragging still works normally from that starting position.

## Notes
The Gantt chart's timeline line rendering above the modal was investigated but turned out to not be an issue, so no changes were made to address it.

## Test Cases
- Modal opens centered on screen on popup
- Modal is draggable from the centered position  

## Screenshots
Before: 
<img width="1712" height="904" alt="image" src="https://github.com/user-attachments/assets/48600b9c-9b31-424a-843d-87a9c03d9a96" />

After:
<img width="1711" height="901" alt="image" src="https://github.com/user-attachments/assets/71b4f79c-39c2-42e0-9293-58e2f92a0299" />

Closes #3953
