### PR TITLE
#4217 project changse tab updates

### DIFF
--- a/src/frontend/src/components/ChangesList.tsx
+++ b/src/frontend/src/components/ChangesList.tsx
@@ -8,7 +8,6 @@ import { ImplementedChange } from 'shared';
 import { datePipe, fullNamePipe } from '../utils/pipes';
 import { Link as RouterLink } from 'react-router-dom';
 import { routes } from '../utils/routes';
-import DynamicTooltip from './DynamicTooltip';
 
 interface ChangesListProps {
   changes: ImplementedChange[];
@@ -57,12 +56,16 @@ const ChangesList: React.FC<ChangesListProps> = ({ changes }) => {
           >
             #{ic.changeRequestIdentifier}
           </Link>
-          <DynamicTooltip title={fullNamePipe(ic.implementer)}>
-            <Typography component="span" sx={{ flexGrow: 1, wordBreak: 'break-word' }}>
-              {renderDetailWithLinks(ic.detail)}
+          <Typography component="span" sx={{ wordBreak: 'break-word' }}>
+            {renderDetailWithLinks(ic.detail)}
+            <Typography component="span" sx={{ color: 'text.secondary', ml: 0.75 }}>
+              — {fullNamePipe(ic.implementer)}
             </Typography>
-          </DynamicTooltip>
-          <Typography variant="caption" sx={{ color: 'text.secondary', whiteSpace: 'nowrap', flexShrink: 0 }}>
+          </Typography>
+          <Typography
+            variant="caption"
+            sx={{ color: 'text.secondary', whiteSpace: 'nowrap', flexShrink: 0, ml: 'auto' }}
+          >
             {datePipe(ic.dateImplemented)}
           </Typography>
         </Box>

--- a/src/frontend/src/components/ChangesList.tsx
+++ b/src/frontend/src/components/ChangesList.tsx
@@ -3,10 +3,9 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { Box, Link } from '@mui/material';
-import Typography from '@mui/material/Typography';
+import { Box, Link, Stack, Typography } from '@mui/material';
 import { ImplementedChange } from 'shared';
-import { fullNamePipe, datePipe } from '../utils/pipes';
+import { datePipe, fullNamePipe } from '../utils/pipes';
 import { Link as RouterLink } from 'react-router-dom';
 import { routes } from '../utils/routes';
 import DynamicTooltip from './DynamicTooltip';
@@ -15,28 +14,60 @@ interface ChangesListProps {
   changes: ImplementedChange[];
 }
 
+const URL_REGEX = /(https?:\/\/\S+)/g;
+
+const renderDetailWithLinks = (detail: string) =>
+  detail.split(URL_REGEX).map((segment, idx) => {
+    if (!/^https?:\/\//.test(segment)) return segment;
+    const trailing = segment.match(/[.,;:!?)\]"'`]+$/)?.[0] ?? '';
+    const url = trailing ? segment.slice(0, -trailing.length) : segment;
+    return (
+      <span key={idx}>
+        <Link href={url} target="_blank" rel="noopener noreferrer" underline="hover">
+          {url}
+        </Link>
+        {trailing}
+      </span>
+    );
+  });
+
 const ChangesList: React.FC<ChangesListProps> = ({ changes }) => {
   return (
-    <Box>
-      <ul style={{ paddingLeft: '5px', marginBottom: '0em', listStyleType: 'none' }}>
-        {changes.map((ic, idx) => (
-          <li key={idx}>
-            <Box style={{ display: 'flex', flexDirection: 'row' }}>
-              <div style={{ marginRight: '4px' }}>
-                [
-                <Link component={RouterLink} to={`${routes.CHANGE_REQUESTS}/${ic.changeRequestId}`}>
-                  #{ic.changeRequestIdentifier}
-                </Link>
-                ]
-              </div>
-              <DynamicTooltip title={`${fullNamePipe(ic.implementer)} - ${datePipe(ic.dateImplemented)}`}>
-                <Typography component="span">{ic.detail}</Typography>
-              </DynamicTooltip>
-            </Box>
-          </li>
-        ))}
-      </ul>
-    </Box>
+    <Stack component="ul" spacing={0.75} sx={{ p: 0, m: 0, listStyleType: 'none' }}>
+      {changes.map((ic, idx) => (
+        <Box
+          component="li"
+          key={idx}
+          sx={{
+            display: 'flex',
+            flexDirection: { xs: 'column', sm: 'row' },
+            alignItems: { sm: 'baseline' },
+            gap: 1,
+            px: 1.25,
+            py: 0.75,
+            borderRadius: 1,
+            backgroundColor: (theme) => theme.palette.action.hover
+          }}
+        >
+          <Link
+            component={RouterLink}
+            to={`${routes.CHANGE_REQUESTS}/${ic.changeRequestId}`}
+            underline="hover"
+            sx={{ fontWeight: 600, flexShrink: 0 }}
+          >
+            #{ic.changeRequestIdentifier}
+          </Link>
+          <DynamicTooltip title={fullNamePipe(ic.implementer)}>
+            <Typography component="span" sx={{ flexGrow: 1, wordBreak: 'break-word' }}>
+              {renderDetailWithLinks(ic.detail)}
+            </Typography>
+          </DynamicTooltip>
+          <Typography variant="caption" sx={{ color: 'text.secondary', whiteSpace: 'nowrap', flexShrink: 0 }}>
+            {datePipe(ic.dateImplemented)}
+          </Typography>
+        </Box>
+      ))}
+    </Stack>
   );
 };
 

--- a/src/frontend/src/components/ChangesList.tsx
+++ b/src/frontend/src/components/ChangesList.tsx
@@ -62,10 +62,7 @@ const ChangesList: React.FC<ChangesListProps> = ({ changes }) => {
               — {fullNamePipe(ic.implementer)}
             </Typography>
           </Typography>
-          <Typography
-            variant="caption"
-            sx={{ color: 'text.secondary', whiteSpace: 'nowrap', flexShrink: 0, ml: 'auto' }}
-          >
+          <Typography variant="caption" sx={{ color: 'text.secondary', whiteSpace: 'nowrap', flexShrink: 0, ml: 'auto' }}>
             {datePipe(ic.dateImplemented)}
           </Typography>
         </Box>


### PR DESCRIPTION
## Changes

Updated the project's changes tab to allow hyperlinks, include dates inline, and update design.

## Screenshots
<img width="1470" height="854" alt="Screenshot 2026-05-17 at 9 12 48 PM" src="https://github.com/user-attachments/assets/161861ce-5af6-46e7-bb11-e901a087b897" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #4217 