### PR TITLE
#4204 responsive availability filler outer

### DIFF
--- a/src/frontend/src/pages/CalendarPage/Components/EventAvailabilityPage.tsx
+++ b/src/frontend/src/pages/CalendarPage/Components/EventAvailabilityPage.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState, useEffect, useMemo } from 'react';
 import { useQuery as useQueryParam } from '../../../hooks/utils.hooks';
-import { Box, Grid, Typography, useTheme } from '@mui/material';
+import { Box, Grid, Typography, useMediaQuery, useTheme } from '@mui/material';
 import {
   Availability,
   getMostRecentAvailabilities,
@@ -157,13 +157,15 @@ export const EventAvailabilityPage: React.FC = () => {
     }
   }, [userScheduleSettings, displayDate]);
 
+  const isMobile = useMediaQuery('(max-width:480px)');
+
   // Auto-open modal for users who haven't confirmed (runs once when event loads)
   useEffect(() => {
-    if (!hasAutoOpened && event && !hasConfirmed) {
+    if (!hasAutoOpened && event && !hasConfirmed && !isMobile) {
       setEditAvailabilityOpen(true);
       setHasAutoOpened(true);
     }
-  }, [event, hasAutoOpened, hasConfirmed]);
+  }, [event, hasAutoOpened, hasConfirmed, isMobile]);
 
   if (eventLoading || !event) return <LoadingIndicator />;
   if (eventError) return <ErrorPage error={eventErrorMsg} message={eventErrorMsg?.message} />;
@@ -225,7 +227,24 @@ export const EventAvailabilityPage: React.FC = () => {
     return `${hour}:00 AM`;
   };
 
-  // RENDER
+  // MOBILE EDIT OPEN RENDER
+  if (isMobile && editAvailabilityOpen) {
+    return (
+      <AvailabilityEditModal
+        open={editAvailabilityOpen}
+        onHide={() => setEditAvailabilityOpen(false)}
+        header={editModalTitle}
+        confirmedAvailabilities={confirmedAvailabilities}
+        setConfirmedAvailabilities={setConfirmedAvailabilities}
+        totalAvailabilities={deeplyCopy(userScheduleSettings.availabilities, availabilityTransformer) as Availability[]}
+        initialDate={displayDate}
+        onSubmit={handleConfirm}
+        canChangeDateRange={false}
+      />
+    );
+  }
+
+  // RENDER NORMALLY
   return (
     <PageLayout
       title={workPackageNames}
@@ -356,7 +375,6 @@ export const EventAvailabilityPage: React.FC = () => {
           )}
         </Box>
       </Box>
-
       <SingleAvailabilityModal
         open={viewAvailabilityOpen}
         onHide={() => setViewAvailabilityOpen(false)}
@@ -364,7 +382,6 @@ export const EventAvailabilityPage: React.FC = () => {
         availabilites={userScheduleSettings.availabilities}
         initialDate={displayDate}
       />
-
       <AvailabilityEditModal
         open={editAvailabilityOpen}
         onHide={() => setEditAvailabilityOpen(false)}
@@ -376,7 +393,6 @@ export const EventAvailabilityPage: React.FC = () => {
         onSubmit={handleConfirm}
         canChangeDateRange={false}
       />
-
       {selectedSlot && (
         <ScheduleEventModal
           open={scheduleModalOpen}

--- a/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/AvailabilityEditModal.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/AvailabilityEditModal.tsx
@@ -37,24 +37,10 @@ const AvailabilityEditModal: React.FC<DRCEditModalProps> = ({
 
   const isMobile = useMediaQuery('(max-width:480px)');
 
-  if (isMobile && !open) return null; // do not want mobile to fall to computer version
+  if (isMobile && !open) return null;
   if (isMobile && open) {
     return (
-      <PageLayout
-        title={header}
-        headerRight={
-          <Box sx={{ display: 'flex', gap: 2, width: '100%' }}>
-            <NERFailButton variant="contained" onClick={onCancel}>
-              {' '}
-              CANCEL{' '}
-            </NERFailButton>
-            <NERSuccessButton variant="contained" onClick={onSubmit}>
-              {' '}
-              SAVE{' '}
-            </NERSuccessButton>
-          </Box>
-        }
-      >
+      <PageLayout title={header}>
         <EditAvailability
           editedAvailabilities={confirmedAvailabilities}
           setEditedAvailabilities={setConfirmedAvailabilities}
@@ -62,6 +48,26 @@ const AvailabilityEditModal: React.FC<DRCEditModalProps> = ({
           canChangeDateRange={canChangeDateRange}
           initialDate={initialDate}
         />
+
+        <Box
+          sx={{
+            position: 'fixed',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            p: 2,
+            display: 'flex',
+            gap: 2,
+            backgroundColor: 'background.paper'
+          }}
+        >
+          <NERFailButton sx={{ flex: 1 }} onClick={onCancel}>
+            CANCEL
+          </NERFailButton>
+          <NERSuccessButton sx={{ flex: 1 }} onClick={onSubmit}>
+            SAVE
+          </NERSuccessButton>
+        </Box>
       </PageLayout>
     );
   }

--- a/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/AvailabilityEditModal.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/AvailabilityEditModal.tsx
@@ -5,7 +5,7 @@ import { Box, useMediaQuery } from '@mui/system';
 import PageLayout from '../../../../components/PageLayout';
 import NERFailButton from '../../../../components/NERFailButton';
 import NERSuccessButton from '../../../../components/NERSuccessButton';
-import { useHistory } from 'react-router-dom';
+
 
 interface DRCEditModalProps {
   open: boolean;

--- a/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/AvailabilityEditModal.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/AvailabilityEditModal.tsx
@@ -6,7 +6,6 @@ import PageLayout from '../../../../components/PageLayout';
 import NERFailButton from '../../../../components/NERFailButton';
 import NERSuccessButton from '../../../../components/NERSuccessButton';
 
-
 interface DRCEditModalProps {
   open: boolean;
   header: string;

--- a/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/AvailabilityEditModal.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/AvailabilityEditModal.tsx
@@ -36,7 +36,6 @@ const AvailabilityEditModal: React.FC<DRCEditModalProps> = ({
 
   const isMobile = useMediaQuery('(max-width:480px)');
 
-  if (isMobile && !open) return null;
   if (isMobile && open) {
     return (
       <PageLayout title={header}>

--- a/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/AvailabilityEditModal.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/AvailabilityEditModal.tsx
@@ -1,6 +1,11 @@
 import { Availability } from 'shared';
 import NERModal from '../../../../components/NERModal';
 import EditAvailability from './EditAvailability';
+import { Box, useMediaQuery } from '@mui/system';
+import PageLayout from '../../../../components/PageLayout';
+import NERFailButton from '../../../../components/NERFailButton';
+import NERSuccessButton from '../../../../components/NERSuccessButton';
+import { useHistory } from 'react-router-dom';
 
 interface DRCEditModalProps {
   open: boolean;
@@ -30,6 +35,36 @@ const AvailabilityEditModal: React.FC<DRCEditModalProps> = ({
     onHide();
   };
 
+  const isMobile = useMediaQuery('(max-width:480px)');
+
+  if (isMobile && !open) return null; // do not want mobile to fall to computer version
+  if (isMobile && open) {
+    return (
+      <PageLayout
+        title={header}
+        headerRight={
+          <Box sx={{ display: 'flex', gap: 2, width: '100%' }}>
+            <NERFailButton variant="contained" onClick={onCancel}>
+              {' '}
+              CANCEL{' '}
+            </NERFailButton>
+            <NERSuccessButton variant="contained" onClick={onSubmit}>
+              {' '}
+              SAVE{' '}
+            </NERSuccessButton>
+          </Box>
+        }
+      >
+        <EditAvailability
+          editedAvailabilities={confirmedAvailabilities}
+          setEditedAvailabilities={setConfirmedAvailabilities}
+          totalAvailabilities={totalAvailabilities}
+          canChangeDateRange={canChangeDateRange}
+          initialDate={initialDate}
+        />
+      </PageLayout>
+    );
+  }
   return (
     <NERModal
       open={open}
@@ -49,5 +84,4 @@ const AvailabilityEditModal: React.FC<DRCEditModalProps> = ({
     </NERModal>
   );
 };
-
 export default AvailabilityEditModal;

--- a/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/EditAvailability.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/EditAvailability.tsx
@@ -128,8 +128,10 @@ const EditAvailability: React.FC<EditAvailabilityProps> = ({
       <TableContainer
         sx={{
           overflowX: 'auto',
-          overflowY: 'hidden',
+          overflowY: 'auto',
           maxWidth: '100%',
+          maxHeight: '100%',
+          scrollSnapType: 'x mandatory',
           flex: 1
         }}
       >
@@ -158,9 +160,9 @@ const EditAvailability: React.FC<EditAvailabilityProps> = ({
         >
           <TableHead>
             <TableRow>
-              <TableCell sx={stickyLeft}></TableCell>
+              <TableCell sx={{ ...stickyLeft, scrollSnapAlign: 'start' }}></TableCell>
               {currentlyDisplayedAvailabilities.map((availability, idx) => (
-                <TableCell key={idx}>
+                <TableCell key={idx} sx={{ scrollSnapAlign: 'start' }}>
                   <Typography variant="body1" align="center" fontWeight="bold" sx={{ fontSize: 15 }}>
                     {getDayOfWeek(availability.dateSet)}
                     <br />
@@ -173,7 +175,7 @@ const EditAvailability: React.FC<EditAvailabilityProps> = ({
           <TableBody>
             {enumToArray(REVIEW_TIMES).map((time, timeIndex) => (
               <TableRow key={time}>
-                <TableCell sx={{ ...stickyLeft, zIndex: 1 }}>
+                <TableCell sx={{ ...stickyLeft, zIndex: 1, scrollSnapAlign: 'start' }}>
                   <Typography variant="body1" align="center" sx={{ fontSize: 15 }}>
                     {time}
                   </Typography>
@@ -181,7 +183,7 @@ const EditAvailability: React.FC<EditAvailabilityProps> = ({
                 {currentlyDisplayedAvailabilities.map((availability, dayIndex) => {
                   const isAvailable = availability.availability.includes(timeIndex);
                   return (
-                    <TableCell key={dayIndex} sx={{ p: 0 }}>
+                    <TableCell key={dayIndex} sx={{ p: 0, scrollSnapAlign: 'start' }}>
                       <EventTimeSlot
                         backgroundColor={isAvailable ? HeatmapColors[3] : HeatmapColors[0]}
                         selected={false}

--- a/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/EditAvailability.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/EditAvailability.tsx
@@ -126,6 +126,8 @@ const EditAvailability: React.FC<EditAvailabilityProps> = ({
     bgcolor: 'background.paper'
   };
 
+  const isMobile = useMediaQuery('(max-width:480px)');
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
       <Box display="flex" justifyContent="space-between" mb={1}>
@@ -174,9 +176,11 @@ const EditAvailability: React.FC<EditAvailabilityProps> = ({
               {currentlyDisplayedAvailabilities.map((availability, idx) => (
                 <TableCell key={idx} sx={{ scrollSnapAlign: 'start' }}>
                   <Typography variant="body1" align="center" fontWeight="bold" sx={{ fontSize: 15 }}>
-                    {getDayOfWeek(availability.dateSet)}
+                    {!isMobile && getDayOfWeek(availability.dateSet)}
+                    {isMobile && getDayOfWeek(availability.dateSet).slice(0, 3)}
                     <br />
-                    {datePipe(availability.dateSet)}
+                    {!isMobile && datePipe(availability.dateSet)}
+                    {isMobile && datePipe(availability.dateSet, false)}
                   </Typography>
                 </TableCell>
               ))}

--- a/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/EditAvailability.tsx
+++ b/src/frontend/src/pages/SettingsPage/UserScheduleSettings/Availability/EditAvailability.tsx
@@ -1,4 +1,14 @@
-import { Box, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typography } from '@mui/material';
+import {
+  Box,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+  useMediaQuery
+} from '@mui/material';
 import { useEffect, useState } from 'react';
 import { HeatmapColors, enumToArray, REVIEW_TIMES } from '../../../../utils/design-review.utils';
 import { addDaysToDate, Availability, getDayOfWeek, getMostRecentAvailabilities } from 'shared';
@@ -208,5 +218,4 @@ const EditAvailability: React.FC<EditAvailabilityProps> = ({
     </Box>
   );
 };
-
 export default EditAvailability;


### PR DESCRIPTION
## Changes

The edit screen for availability is now significantly improved for mobile compared to before.
A page is presented compared to a popup like before.

## Test Cases

- Closing and editing works
- Invert Availability works
- Edit availability looks the same as before on computer.

## Screenshots

<img width="898" height="1420" alt="image" src="https://github.com/user-attachments/assets/e3c20fbd-b124-4cf1-bdeb-e1af8dca0150" />



## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #4204
