### PR TITLE
4218-uploads-not-displaying-on-parts-review-page clear stale files state when part form modals close

### DIFF
--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/PartReview/PartReviewComponents/PartFormModels/ReviewFormModal.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/PartReview/PartReviewComponents/PartFormModels/ReviewFormModal.tsx
@@ -3,7 +3,7 @@ import { useToast } from '../../../../../../hooks/toasts.hooks';
 import * as yup from 'yup';
 import { Controller, useFieldArray, useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import NERFormModal from '../../../../../../components/NERFormModal';
 import { Autocomplete, Button, Grid, IconButton, List, ListItem, Typography } from '@mui/material';
 import { FormControl, FormHelperText, FormLabel, TextField } from '@mui/material';
@@ -23,14 +23,14 @@ const ReviewFormModal = ({ open, handleClose, defaultValues, onSubmit, partsInPr
   const toast = useToast();
   const [files, setFiles] = useState<File[]>([]);
   const [uploading, setUploading] = useState(false);
+  const [selectedPartIndex, setSelectedPartIndex] = useState<number>();
   const { mutateAsync: uploadFile } = useUploadFile();
 
-  useEffect(() => {
-    if (!open) {
-      setFiles([]);
-      setSelectedPartIndex(undefined);
-    }
-  }, [open]);
+  const handleCloseAndReset = () => {
+    setFiles([]);
+    setSelectedPartIndex(undefined);
+    handleClose();
+  };
 
   const schema = yup.object().shape({
     submissionId: yup.string().required(),
@@ -61,8 +61,6 @@ const ReviewFormModal = ({ open, handleClose, defaultValues, onSubmit, partsInPr
     control,
     name: 'fileIds'
   });
-
-  const [selectedPartIndex, setSelectedPartIndex] = useState<number>();
 
   const onFormSubmit = async (data: { submissionId: string; status: Review_Status; notes?: string; fileIds: string[] }) => {
     try {
@@ -95,7 +93,7 @@ const ReviewFormModal = ({ open, handleClose, defaultValues, onSubmit, partsInPr
   return (
     <NERFormModal
       open={open}
-      onHide={handleClose}
+      onHide={handleCloseAndReset}
       title={!!defaultValues ? 'Edit Review' : 'New Review'}
       reset={() => reset()}
       handleUseFormSubmit={handleSubmit}

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/PartReview/PartReviewComponents/PartFormModels/ReviewFormModal.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/PartReview/PartReviewComponents/PartFormModels/ReviewFormModal.tsx
@@ -3,7 +3,7 @@ import { useToast } from '../../../../../../hooks/toasts.hooks';
 import * as yup from 'yup';
 import { Controller, useFieldArray, useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import NERFormModal from '../../../../../../components/NERFormModal';
 import { Autocomplete, Button, Grid, IconButton, List, ListItem, Typography } from '@mui/material';
 import { FormControl, FormHelperText, FormLabel, TextField } from '@mui/material';
@@ -24,6 +24,13 @@ const ReviewFormModal = ({ open, handleClose, defaultValues, onSubmit, partsInPr
   const [files, setFiles] = useState<File[]>([]);
   const [uploading, setUploading] = useState(false);
   const { mutateAsync: uploadFile } = useUploadFile();
+
+  useEffect(() => {
+    if (!open) {
+      setFiles([]);
+      setSelectedPartIndex(undefined);
+    }
+  }, [open]);
 
   const schema = yup.object().shape({
     submissionId: yup.string().required(),

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/PartReview/PartReviewComponents/PartFormModels/SubmissionFormModal.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/PartReview/PartReviewComponents/PartFormModels/SubmissionFormModal.tsx
@@ -39,11 +39,10 @@ const SubmissionFormModal = ({
   const [uploading, setUploading] = useState(false);
   const { mutateAsync: uploadFile } = useUploadFile();
 
-  useEffect(() => {
-    if (!open) {
-      setFiles([]);
-    }
-  }, [open]);
+  const handleCloseAndReset = () => {
+    setFiles([]);
+    handleClose();
+  };
 
   const schema = yup.object().shape({
     partId: yup.string().required(),
@@ -108,7 +107,7 @@ const SubmissionFormModal = ({
   return (
     <NERFormModal
       open={open}
-      onHide={handleClose}
+      onHide={handleCloseAndReset}
       title={!!defaultValues ? 'Edit Submission Details' : 'New Submission'}
       reset={() => reset()}
       handleUseFormSubmit={handleSubmit}

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/PartReview/PartReviewComponents/PartFormModels/SubmissionFormModal.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/PartReview/PartReviewComponents/PartFormModels/SubmissionFormModal.tsx
@@ -39,6 +39,12 @@ const SubmissionFormModal = ({
   const [uploading, setUploading] = useState(false);
   const { mutateAsync: uploadFile } = useUploadFile();
 
+  useEffect(() => {
+    if (!open) {
+      setFiles([]);
+    }
+  }, [open]);
+
   const schema = yup.object().shape({
     partId: yup.string().required(),
     name: yup.string().required(),


### PR DESCRIPTION
## Changes
Fixed a bug in `SubmissionFormModal` and `ReviewFormModal` where uploaded file names would not appear after form submission. `NERFormModal` resets the RHF `fileIds`field array on every close, but the parallel local `files: File[]` state was never cleared. On re-open, the length mismatch caused the file list to not render. Added a `useEffect` in both modals that resets `files` (and `selectedPartIndex` in `ReviewFormModal`) whenever `open` becomes `false`. 

## Test Cases
- Repeat several times to ensure the fix works
  - Upload files in New Submission modal (`Projects` -> Specific Project -> `Part Review` -> `New` -> `New Submission`) — file names appear in the list                                                                                                   
  - Submit the form, re-open New Submission — file list is empty with no stale entries                                                                                     
  - Upload a new file on re-open — correct file name appears                                                                                                               
  
## Screenshots
### Before
**Note: This sometimes happens, not always**
A file is uploaded, but it doesn't show file name
<img width="584" height="403" alt="New Submission" src="https://github.com/user-attachments/assets/238c1882-f2df-4feb-a1e3-a779f937be49" />
<img width="1709" height="898" alt="All Parts for Impact Attessatel" src="https://github.com/user-attachments/assets/df2fb069-8a64-484d-b5e2-891235513fa5" />

### After
A file is uploaded, but it **always** shows file name:
<img width="611" height="433" alt="New Submission" src="https://github.com/user-attachments/assets/460eb9eb-0d7d-488c-8d86-a245d690d368" />
<img width="1717" height="902" alt="All Parts for legact Altengate" src="https://github.com/user-attachments/assets/032af042-c5ce-4a93-bd42-e86814e11b66" />


Closes #4218 
