### PR TITLE
#4112: reimbursement request timeline fix

### DIFF
--- a/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
+++ b/src/frontend/src/pages/FinancePage/ReimbursementRequestDetailPage/ReimbursementRequestDetailsView.tsx
@@ -617,14 +617,14 @@ const ReimbursementRequestDetailsView: React.FC<ReimbursementRequestDetailsViewP
             width: 'calc(100% - 40px)'
           }}
         />
-        <Box sx={{ display: 'flex', alignItems: 'flex-start' }}>
+        <Box sx={{ display: 'flex', alignItems: 'flex-start', flexDirection: { xs: 'column', md: 'row' } }}>
           <Box sx={{ mt: -3 }}>
             <ReimbursementRequestTimeline
               reimbursementRequestId={reimbursementRequest.reimbursementRequestId}
               reimbursementRequestComments={reimbursementRequest.comments}
             />
           </Box>
-          <Box sx={{ mt: 2, ml: 2, whiteSpace: 'nowrap' }}>
+          <Box sx={{ mt: 2, ml: { xs: 0, md: 2 }, whiteSpace: { xs: 'normal', md: 'nowrap' } }}>
             <ReimbursementProductsView reimbursementRequest={reimbursementRequest} />
             <Box sx={{ mt: 2 }}>
               <ReceiptsView />


### PR DESCRIPTION
## Changes

_Changed the Reimbursement Request Sidebar to be a one column display on smaller screens instead of a two column display_

## Notes

_Any other notes go here_

## Test Cases

- Case A
- Edge case
- ...

## Screenshots

_If you made UI changes you must post a screenshot of the whole page for each change in 1) a normal sized window and 2) the smallest possible window_

<img width="610" height="447" alt="Screenshot 2026-05-22 at 11 54 32 PM" src="https://github.com/user-attachments/assets/cab8750f-ef4d-4328-83c6-2fb3ea023270" />
<img width="1384" height="796" alt="Screenshot 2026-05-22 at 11 53 40 PM" src="https://github.com/user-attachments/assets/5b013792-5414-4622-95fe-e45ee215abf7" />


_If you did any manual testing (e.g., with Postman), put screenshots of the http request and before and after of the db_

_If none of this applies, you can delete this section_

## To Do

_Any remaining things that need to get done_

- [ ] item 1
- [ ] ...

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #4112 
