### PR TITLE
ui fixes

### DIFF
--- a/src/frontend/src/pages/CalendarPage/Components/EventAvailabilityPage.tsx
+++ b/src/frontend/src/pages/CalendarPage/Components/EventAvailabilityPage.tsx
@@ -148,6 +148,20 @@ export const EventAvailabilityPage: React.FC = () => {
     return event.confirmedMembers.some((m) => m.userId === currentUser.userId);
   }, [event, currentUser]);
 
+  // Reorders users by alphabetical order.
+  const reorderAlphabetically = (users: User[]) => {
+    return users.sort((a, b) => (a.lastName + a.firstName).localeCompare(b.lastName + b.firstName));
+  };
+
+  // Reorders users by confirmation or not. All confirmed users are above the unconfirmed users
+  const reorderByConfirmation = (users: User[]) => {
+    return [...reorderAlphabetically(users)].sort((a, b) => {
+      const aConfirmation = event && event.confirmedMembers.some((m) => m.userId === a.userId) ? 1 : 0;
+      const bConfirmation = event && event.confirmedMembers.some((m) => m.userId === b.userId) ? 1 : 0;
+      return bConfirmation - aConfirmation;
+    });
+  };
+
   useEffect(() => {
     if (userScheduleSettings && userScheduleSettings.availabilities.length > 0) {
       const confirmed = getMostRecentAvailabilities(userScheduleSettings.availabilities, displayDate);
@@ -318,11 +332,15 @@ export const EventAvailabilityPage: React.FC = () => {
               </Typography>
               <Box sx={{ maxHeight: 300, overflowY: 'auto' }}>
                 {currentAvailableUsers.length > 0 ? (
-                  currentAvailableUsers.map((user) => {
+                  reorderByConfirmation(currentAvailableUsers).map((user) => {
                     const isConfirmed = event.confirmedMembers.some((cm) => cm.userId === user.userId);
-                    const displayName = fullNamePipe(user) + (isConfirmed ? '' : ' *');
+                    const displayName = fullNamePipe(user);
                     return (
-                      <Typography key={user.userId} variant="body2" sx={{ py: 0.25 }}>
+                      <Typography
+                        key={user.userId}
+                        variant="body2"
+                        sx={{ py: 0.25, color: isConfirmed ? 'inherit' : '#ef4345' }}
+                      >
                         {displayName}
                       </Typography>
                     );
@@ -341,11 +359,15 @@ export const EventAvailabilityPage: React.FC = () => {
               </Typography>
               <Box sx={{ maxHeight: 300, overflowY: 'auto' }}>
                 {currentUnavailableUsers.length > 0 ? (
-                  currentUnavailableUsers.map((user) => {
+                  reorderByConfirmation(currentUnavailableUsers).map((user) => {
                     const isConfirmed = event.confirmedMembers.some((cm) => cm.userId === user.userId);
-                    const displayName = fullNamePipe(user) + (isConfirmed ? '' : ' *');
+                    const displayName = fullNamePipe(user);
                     return (
-                      <Typography key={user.userId} variant="body2" sx={{ py: 0.25 }}>
+                      <Typography
+                        key={user.userId}
+                        variant="body2"
+                        sx={{ py: 0.25, color: isConfirmed ? 'inherit' : '#ef4345' }}
+                      >
                         {displayName}
                       </Typography>
                     );
@@ -361,7 +383,7 @@ export const EventAvailabilityPage: React.FC = () => {
 
           {(currentAvailableUsers.length > 0 || currentUnavailableUsers.length > 0) && (
             <Typography variant="caption" color="text.secondary" sx={{ mt: 2, display: 'block' }}>
-              * has not confirmed availability
+              <span style={{ color: '#ef4345' }}>Red</span> means has not confirmed availability
             </Typography>
           )}
 


### PR DESCRIPTION
## Changes

Made visual changes to the list of available/unavailable people in availability. 
- People with unconfirmed schedules are now colored red instead of being marked with an asterisk.
- All people with unconfirmed schedules are now below the people with confirmed schedules.
- All names are now sorted by alphabetical order before being sorted by schedule confirmation.

## Test Cases

- Confirmed names are always above the unconfirmed names. 
- All the names in both groups are sorted in alphabetical order.

## Screenshots

Normal Sized Window:
<img width="2865" height="1537" alt="image" src="https://github.com/user-attachments/assets/7678898f-db46-418f-be37-0c0eeb9cb6d9" />

Phone Sized Window:
<img width="837" height="1357" alt="image" src="https://github.com/user-attachments/assets/c7805a2e-94b7-482a-8a92-4941e0ee0a36" />


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #4200
