### PR TITLE
highlight cell if all required members are available

### DIFF
--- a/src/frontend/src/pages/CalendarPage/AvailabilityScheduleView.tsx
+++ b/src/frontend/src/pages/CalendarPage/AvailabilityScheduleView.tsx
@@ -45,6 +45,17 @@ const AvailabilityScheduleView: React.FC<AvailabilityScheduleViewProps> = ({
     }
   };
 
+  // Boolean check to see if all required users can attend at the time.
+  const allRequiredUsersAvailable = (index: number) => {
+    const currUnavailableUsers: User[] = unavailableUsers.get(index) ?? [];
+    for (const user of currUnavailableUsers) {
+      if (event && event.requiredMembers.some((m) => m.userId === user.userId)) {
+        return false; // there is a required member unavailable
+      }
+    }
+    return true;
+  };
+
   // Handle mouse leave - clears the hover state and shows selected slot's users if any
   const handleMouseLeave = () => {
     if (setCurrentHoveredSlot) {
@@ -160,10 +171,16 @@ const AvailabilityScheduleView: React.FC<AvailabilityScheduleViewProps> = ({
               {potentialDays.map((day, dayIndex) => {
                 const index = dayIndex * enumToArray(REVIEW_TIMES).length + timeIndex;
                 return (
-                  <TableCell key={index} sx={{ p: 0 }}>
+                  <TableCell
+                    key={index}
+                    sx={{
+                      p: 0
+                    }}
+                  >
                     <EventTimeSlot
                       backgroundColor={getBackgroundColor(availableUsers.get(index)?.length, totalUsers)}
                       selected={selectedTimeslot === index}
+                      allRequiredAvailable={allRequiredUsersAvailable(index)}
                       onClick={() => handleTimeslotClick(index, day, timeIndex)}
                       onMouseEnter={() => handleTimeslotHover(index, day, timeIndex)}
                     />

--- a/src/frontend/src/pages/CalendarPage/Components/EventTimeSlot.tsx
+++ b/src/frontend/src/pages/CalendarPage/Components/EventTimeSlot.tsx
@@ -4,6 +4,7 @@ interface EventTimeSlotProps {
   backgroundColor?: string;
   onClick?: () => void;
   selected?: boolean;
+  allRequiredAvailable?: boolean;
   onMouseDown?: (e: React.MouseEvent) => void;
   onMouseEnter?: (e: React.MouseEvent) => void;
   onMouseUp?: () => void;
@@ -13,17 +14,19 @@ const EventTimeSlot: React.FC<EventTimeSlotProps> = ({
   backgroundColor,
   onClick,
   selected = false,
+  allRequiredAvailable = false,
   onMouseDown,
   onMouseEnter,
   onMouseUp
 }) => {
   const getBorderColor = () => {
     if (selected) return '#ffff8c';
+    if (allRequiredAvailable) return '#216799';
     return 'gray';
   };
 
   const getBorderWidth = () => {
-    if (selected) return '3px';
+    if (selected || allRequiredAvailable) return '3px';
     return '0.1px';
   };
 


### PR DESCRIPTION
## Changes

All timeslots for an event where all the required users are available are highlighted with a blue outline 

## Notes



## Test Cases

- When all required users are available, the highlight on the time slot is shown accordingly/

## Screenshots
The timeslots that all required users are available are highlighted with a blue outline.
<img width="2061" height="1527" alt="image" src="https://github.com/user-attachments/assets/53c53945-5d08-4387-91e5-af818e4aaa0f" />


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #4228 
