### PR TITLE
the creator of a meeting is now shown as required

### DIFF
--- a/src/backend/src/services/calendar.services.ts
+++ b/src/backend/src/services/calendar.services.ts
@@ -421,13 +421,10 @@ export default class CalendarService {
     // Check for conflicts using expanded slots
     const { hasConflict, conflictingEvent } = await checkEventConflicts(scheduleSlots, organization, location, undefined);
 
-    // Returns whether the event creator is part of the list of required members
-    const creatorInRequiredMembers = () => {
-      for (const member of requiredMemberIds) {
-        if (member === submitter.userId) return true;
-      }
-      return false;
-    };
+    const allRequiredMembers = [
+      ...requiredMemberIds,
+      ...(requiredMemberIds.includes(submitter.userId) ? [] : [submitter.userId])
+    ];
 
     const newEvent = await prisma.event.create({
       data: {
@@ -436,9 +433,7 @@ export default class CalendarService {
         title,
         eventTypeId,
         requiredMembers: {
-          connect: requiredMemberIds
-            .concat(creatorInRequiredMembers() ? [] : [submitter.userId])
-            .map((userId) => ({ userId }))
+          connect: allRequiredMembers.map((userId) => ({ userId }))
         },
         optionalMembers: {
           connect: optionalMemberIds.map((userId) => ({ userId }))
@@ -480,11 +475,7 @@ export default class CalendarService {
     let calendarEventIds: string[] = [];
     if (process.env.NODE_ENV === 'production') {
       try {
-        const allMemberIds = [
-          ...requiredMemberIds,
-          ...(creatorInRequiredMembers() ? [] : [submitter.userId]),
-          ...optionalMemberIds
-        ];
+        const allMemberIds = [...allRequiredMembers, ...optionalMemberIds];
         const isInPerson = !!location;
 
         calendarEventIds = await createCalendarEvent(
@@ -511,7 +502,7 @@ export default class CalendarService {
       const members = await prisma.user.findMany({
         where: {
           userId: {
-            in: optionalMemberIds.concat(requiredMemberIds).concat(creatorInRequiredMembers() ? [] : submitter.userId)
+            in: optionalMemberIds.concat(allRequiredMembers)
           }
         }
       });
@@ -756,19 +747,13 @@ export default class CalendarService {
       }
     }
 
-    // Returns whether the event creator is part of the list of required members
-    const creatorInRequiredMembers = () => {
-      for (const member of requiredMemberIds) {
-        if (member === submitter.userId) return true;
-      }
-      return false;
-    };
+    const allRequiredMembers = [
+      ...requiredMemberIds,
+      ...(requiredMemberIds.includes(submitter.userId) ? [] : [submitter.userId])
+    ];
 
     // throw if a user isn't found, then build prisma queries for connecting userIds
-    const updatedRequiredMembers = [
-      ...getPrismaQueryUserIds(await getUsers(requiredMemberIds)),
-      ...(creatorInRequiredMembers() ? [] : [{ userId: submitter.userId }])
-    ];
+    const updatedRequiredMembers = [...getPrismaQueryUserIds(await getUsers(allRequiredMembers))];
     const updatedOptionalMembers = getPrismaQueryUserIds(await getUsers(optionalMemberIds));
 
     // Update the event with new data (excluding schedule slots)

--- a/src/backend/src/services/calendar.services.ts
+++ b/src/backend/src/services/calendar.services.ts
@@ -311,17 +311,16 @@ export default class CalendarService {
     });
 
     // Validate required memberIds
-    if (requiredMemberIds.length > 0) {
-      const foundMembers = await prisma.user.findMany({
-        where: {
-          userId: { in: requiredMemberIds },
-          organizations: { some: { organizationId: organization.organizationId } }
-        }
-      });
-      if (foundMembers.length !== requiredMemberIds.length) {
-        const missingIds = requiredMemberIds.filter((id) => !foundMembers.some((user) => user.userId === id));
-        throw new NotFoundException('User', missingIds.join(', '));
+
+    const foundMembers = await prisma.user.findMany({
+      where: {
+        userId: { in: requiredMemberIds || submitter.userId },
+        organizations: { some: { organizationId: organization.organizationId } }
       }
+    });
+    if (foundMembers.length !== requiredMemberIds.length) {
+      const missingIds = requiredMemberIds.filter((id) => !foundMembers.some((user) => user.userId === id));
+      throw new NotFoundException('User', missingIds.join(', '));
     }
 
     // Validate optionals memberIds
@@ -422,6 +421,14 @@ export default class CalendarService {
     // Check for conflicts using expanded slots
     const { hasConflict, conflictingEvent } = await checkEventConflicts(scheduleSlots, organization, location, undefined);
 
+    // Returns whether the event creator is part of the list of required members
+    const creatorInRequiredMembers = () => {
+      for (const member of requiredMemberIds) {
+        if (member === submitter.userId) return true;
+      }
+      return false;
+    };
+
     const newEvent = await prisma.event.create({
       data: {
         userCreatedId: submitter.userId,
@@ -429,7 +436,9 @@ export default class CalendarService {
         title,
         eventTypeId,
         requiredMembers: {
-          connect: requiredMemberIds.map((userId) => ({ userId }))
+          connect: requiredMemberIds
+            .concat(creatorInRequiredMembers() ? [] : [submitter.userId])
+            .map((userId) => ({ userId }))
         },
         optionalMembers: {
           connect: optionalMemberIds.map((userId) => ({ userId }))
@@ -471,7 +480,11 @@ export default class CalendarService {
     let calendarEventIds: string[] = [];
     if (process.env.NODE_ENV === 'production') {
       try {
-        const allMemberIds = [...requiredMemberIds, ...optionalMemberIds];
+        const allMemberIds = [
+          ...requiredMemberIds,
+          ...(creatorInRequiredMembers() ? [] : [submitter.userId]),
+          ...optionalMemberIds
+        ];
         const isInPerson = !!location;
 
         calendarEventIds = await createCalendarEvent(
@@ -496,7 +509,11 @@ export default class CalendarService {
 
     if (foundEventType.sendSlackNotifications) {
       const members = await prisma.user.findMany({
-        where: { userId: { in: optionalMemberIds.concat(requiredMemberIds) } }
+        where: {
+          userId: {
+            in: optionalMemberIds.concat(requiredMemberIds).concat(creatorInRequiredMembers() ? [] : submitter.userId)
+          }
+        }
       });
 
       // get the user settings for all the members invited, who are leaderingship
@@ -633,17 +650,15 @@ export default class CalendarService {
     }
 
     // Validate required memberIds
-    if (requiredMemberIds.length > 0) {
-      const foundMembers = await prisma.user.findMany({
-        where: {
-          userId: { in: requiredMemberIds },
-          organizations: { some: { organizationId: organization.organizationId } }
-        }
-      });
-      if (foundMembers.length !== requiredMemberIds.length) {
-        const missingIds = requiredMemberIds.filter((id) => !foundMembers.some((user) => user.userId === id));
-        throw new NotFoundException('User', missingIds.join(', '));
+    const foundMembers = await prisma.user.findMany({
+      where: {
+        userId: { in: requiredMemberIds || submitter.userId },
+        organizations: { some: { organizationId: organization.organizationId } }
       }
+    });
+    if (foundMembers.length !== requiredMemberIds.length) {
+      const missingIds = requiredMemberIds.filter((id) => !foundMembers.some((user) => user.userId === id));
+      throw new NotFoundException('User', missingIds.join(', '));
     }
 
     // Validate optional memberIds
@@ -741,8 +756,19 @@ export default class CalendarService {
       }
     }
 
+    // Returns whether the event creator is part of the list of required members
+    const creatorInRequiredMembers = () => {
+      for (const member of requiredMemberIds) {
+        if (member === submitter.userId) return true;
+      }
+      return false;
+    };
+
     // throw if a user isn't found, then build prisma queries for connecting userIds
-    const updatedRequiredMembers = getPrismaQueryUserIds(await getUsers(requiredMemberIds));
+    const updatedRequiredMembers = [
+      ...getPrismaQueryUserIds(await getUsers(requiredMemberIds)),
+      ...(creatorInRequiredMembers() ? [] : [{ userId: submitter.userId }])
+    ];
     const updatedOptionalMembers = getPrismaQueryUserIds(await getUsers(optionalMemberIds));
 
     // Update the event with new data (excluding schedule slots)

--- a/src/backend/tests/unit/calendar.test.ts
+++ b/src/backend/tests/unit/calendar.test.ts
@@ -902,7 +902,7 @@ describe('Calendar Tests', () => {
       expect(result.title).toBe('Team Sync');
       expect(result.eventTypeId).toBe(eventType.eventTypeId);
       expect(result.requiredMembers).toHaveLength(2);
-      expect(result.requiredMembers[0].userId).toBe(member.userId);
+      expect(result.requiredMembers[1].userId).toBe(member.userId);
       expect(result.optionalMembers).toHaveLength(1);
       expect(result.optionalMembers[0].userId).toBe(adminUser.userId);
       expect(result.shops).toHaveLength(1);
@@ -1008,7 +1008,7 @@ describe('Calendar Tests', () => {
       expect(result.title).toBe('Minimal Event');
       expect(result.eventTypeId).toBe(eventType.eventTypeId);
       expect(result.requiredMembers).toHaveLength(2);
-      expect(result.requiredMembers[0].userId).toBe(member.userId);
+      expect(result.requiredMembers[1].userId).toBe(member.userId);
       expect(result.optionalMembers).toHaveLength(1);
       expect(result.optionalMembers[0].userId).toBe(adminUser.userId);
       expect(result.shops).toHaveLength(1);
@@ -1888,7 +1888,7 @@ describe('Calendar Tests', () => {
       expect(result.eventId).toBe(event.eventId);
       expect(result.title).toBe('Updated Event Title');
       expect(result.requiredMembers).toHaveLength(2);
-      expect(result.requiredMembers[0].userId).toBe(newMember.userId);
+      expect(result.requiredMembers[1].userId).toBe(newMember.userId);
       expect(result.optionalMembers).toHaveLength(1);
       expect(result.optionalMembers[0].userId).toBe(adminUser.userId);
       expect(result.documents).toEqual([]);

--- a/src/backend/tests/unit/calendar.test.ts
+++ b/src/backend/tests/unit/calendar.test.ts
@@ -901,7 +901,7 @@ describe('Calendar Tests', () => {
 
       expect(result.title).toBe('Team Sync');
       expect(result.eventTypeId).toBe(eventType.eventTypeId);
-      expect(result.requiredMembers).toHaveLength(1);
+      expect(result.requiredMembers).toHaveLength(2);
       expect(result.requiredMembers[0].userId).toBe(member.userId);
       expect(result.optionalMembers).toHaveLength(1);
       expect(result.optionalMembers[0].userId).toBe(adminUser.userId);
@@ -1007,7 +1007,7 @@ describe('Calendar Tests', () => {
 
       expect(result.title).toBe('Minimal Event');
       expect(result.eventTypeId).toBe(eventType.eventTypeId);
-      expect(result.requiredMembers).toHaveLength(1);
+      expect(result.requiredMembers).toHaveLength(2);
       expect(result.requiredMembers[0].userId).toBe(member.userId);
       expect(result.optionalMembers).toHaveLength(1);
       expect(result.optionalMembers[0].userId).toBe(adminUser.userId);
@@ -1887,7 +1887,7 @@ describe('Calendar Tests', () => {
 
       expect(result.eventId).toBe(event.eventId);
       expect(result.title).toBe('Updated Event Title');
-      expect(result.requiredMembers).toHaveLength(1);
+      expect(result.requiredMembers).toHaveLength(2);
       expect(result.requiredMembers[0].userId).toBe(newMember.userId);
       expect(result.optionalMembers).toHaveLength(1);
       expect(result.optionalMembers[0].userId).toBe(adminUser.userId);

--- a/src/frontend/src/pages/CalendarPage/Components/EventAvailabilityPage.tsx
+++ b/src/frontend/src/pages/CalendarPage/Components/EventAvailabilityPage.tsx
@@ -334,12 +334,17 @@ export const EventAvailabilityPage: React.FC = () => {
                 {currentAvailableUsers.length > 0 ? (
                   reorderByConfirmation(currentAvailableUsers).map((user) => {
                     const isConfirmed = event.confirmedMembers.some((cm) => cm.userId === user.userId);
+                    const isRequired = event.requiredMembers.some((cm) => cm.userId === user.userId);
                     const displayName = fullNamePipe(user);
                     return (
                       <Typography
                         key={user.userId}
                         variant="body2"
-                        sx={{ py: 0.25, color: isConfirmed ? 'inherit' : '#ef4345' }}
+                        sx={{
+                          py: 0.25,
+                          color: isConfirmed ? 'inherit' : '#ef4345',
+                          textDecoration: isRequired ? 'underline' : 'none'
+                        }}
                       >
                         {displayName}
                       </Typography>
@@ -361,12 +366,17 @@ export const EventAvailabilityPage: React.FC = () => {
                 {currentUnavailableUsers.length > 0 ? (
                   reorderByConfirmation(currentUnavailableUsers).map((user) => {
                     const isConfirmed = event.confirmedMembers.some((cm) => cm.userId === user.userId);
+                    const isRequired = event.requiredMembers.some((cm) => cm.userId === user.userId);
                     const displayName = fullNamePipe(user);
                     return (
                       <Typography
                         key={user.userId}
                         variant="body2"
-                        sx={{ py: 0.25, color: isConfirmed ? 'inherit' : '#ef4345' }}
+                        sx={{
+                          py: 0.25,
+                          color: isConfirmed ? 'inherit' : '#ef4345',
+                          textDecoration: isRequired ? 'underline' : 'none'
+                        }}
                       >
                         {displayName}
                       </Typography>
@@ -383,7 +393,10 @@ export const EventAvailabilityPage: React.FC = () => {
 
           {(currentAvailableUsers.length > 0 || currentUnavailableUsers.length > 0) && (
             <Typography variant="caption" color="text.secondary" sx={{ mt: 2, display: 'block' }}>
-              <span style={{ color: '#ef4345' }}>Red</span> means has not confirmed availability
+              <span style={{ color: '#ef4345' }}>Red</span> means that member has not confirmed availability
+              <Typography variant="caption" color="text.secondary" sx={{ mt: 2, display: 'block' }}>
+                <span style={{ textDecoration: 'underline' }}>Underline</span> means that member is required for the meeting
+              </Typography>
             </Typography>
           )}
 


### PR DESCRIPTION
## Changes

- the creator of a meeting is now shown as a required attendee for a meeting.

Additional Change: the list of members in availability now underlines required members. 

## Notes


## UI Changes
The updated availability:
<img width="2854" height="1542" alt="image" src="https://github.com/user-attachments/assets/c256893d-bab8-4b8f-aadf-4f4b7d379afd" />


## Test Cases

- Having the creator not marked as a required member will still be shown as a required member. 
- Having the creator marked as a required member will make the creator show up once as a required member 

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #4233
