### PR TITLE
#4253 Made events 1 hour

### DIFF
--- a/src/frontend/src/pages/CalendarPage/Components/EventModal.tsx
+++ b/src/frontend/src/pages/CalendarPage/Components/EventModal.tsx
@@ -897,7 +897,14 @@ const EventModal: React.FC<BaseEventModalProps> = ({
                               open={startTimePickerOpen}
                               onClose={() => setStartTimePickerOpen(false)}
                               onOpen={() => setStartTimePickerOpen(true)}
-                              onChange={(newValue) => onChange(newValue)}
+                              onChange={(newValue) => {
+                                onChange(newValue);
+                                if (newValue) {
+                                  const newEndTime = new Date(newValue);
+                                  newEndTime.setHours(newEndTime.getHours() + 1);
+                                  setValue('endTime', newEndTime);
+                                }
+                              }}
                               slotProps={{
                                 textField: {
                                   variant: 'standard',


### PR DESCRIPTION
## Changes

Made it so end hour now automatically updates to be 1 hour after the starting hour

## Screenshots

<img width="1470" height="717" alt="Screenshot 2026-06-12 at 3 14 16 PM" src="https://github.com/user-attachments/assets/344be458-6ea6-450f-8c3b-60687d7c58d7" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #4253 
