### PR TITLE
AutofIll Zoom Link

### DIFF
--- a/src/frontend/src/pages/CalendarPage/Components/EventModal.tsx
+++ b/src/frontend/src/pages/CalendarPage/Components/EventModal.tsx
@@ -35,7 +35,7 @@ import {
   SlackMentionType
 } from 'shared';
 import { useToast } from '../../../hooks/toasts.hooks';
-import { useAllMembers, useCurrentUser } from '../../../hooks/users.hooks';
+import { useAllMembers, useCurrentUser, useUserScheduleSettings } from '../../../hooks/users.hooks';
 import { useAllWorkPackagesPreview } from '../../../hooks/work-packages.hooks';
 import { useAllTeamPreviews } from '../../../hooks/teams.hooks';
 import { userToAutocompleteOption } from '../../../utils/teams.utils';
@@ -231,6 +231,7 @@ const EventModal: React.FC<BaseEventModalProps> = ({
   const theme = useTheme();
   const toast = useToast();
   const user = useCurrentUser();
+  const { data: scheduleSettings } = useUserScheduleSettings(user.userId);
   const [datePickerOpen, setDatePickerOpen] = useState(false);
   const [startTimePickerOpen, setStartTimePickerOpen] = useState(false);
   const [endTimePickerOpen, setEndTimePickerOpen] = useState(false);
@@ -380,6 +381,16 @@ const EventModal: React.FC<BaseEventModalProps> = ({
       setShowRecurringOptions(true);
     }
   }, [initialValues, users, teams]);
+
+  // When creating a new event, autofill the user's personal zoom link from their schedule settings.
+  // Only fills when the field is still empty so we never overwrite a link the user has typed.
+  useEffect(() => {
+    if (!open || isEditMode) return;
+    const personalZoomLink = scheduleSettings?.personalZoomLink;
+    if (personalZoomLink && !watch('zoomLink')) {
+      setValue('zoomLink', personalZoomLink);
+    }
+  }, [open, isEditMode, scheduleSettings, setValue, watch]);
 
   const computedTitle = isEditMode ? 'Edit Event' : 'Add Event';
 

--- a/src/frontend/src/pages/CalendarPage/Components/EventModal.tsx
+++ b/src/frontend/src/pages/CalendarPage/Components/EventModal.tsx
@@ -396,7 +396,7 @@ const EventModal: React.FC<BaseEventModalProps> = ({
     if (scheduleSettings?.personalZoomLink && !getValues('zoomLink')) {
       setValue('zoomLink', scheduleSettings.personalZoomLink);
     }
-  }, [open, isEditMode, scheduleSettings]);
+  }, [open, isEditMode, scheduleSettings, getValues, setValue]);
 
   const computedTitle = isEditMode ? 'Edit Event' : 'Add Event';
 

--- a/src/frontend/src/pages/CalendarPage/Components/EventModal.tsx
+++ b/src/frontend/src/pages/CalendarPage/Components/EventModal.tsx
@@ -60,6 +60,7 @@ import { convertDayToInt, convertIntToDay } from '../../../utils/calendar.utils'
 import EditSeriesConfirmationModal from './EditSeriesConfirmationModal';
 import NotificationsIcon from '@mui/icons-material/Notifications';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import LoadingIndicator from '../../../components/LoadingIndicator';
 
 export interface EventFormValues {
   title: string;
@@ -231,7 +232,12 @@ const EventModal: React.FC<BaseEventModalProps> = ({
   const theme = useTheme();
   const toast = useToast();
   const user = useCurrentUser();
-  const { data: scheduleSettings } = useUserScheduleSettings(user.userId);
+  const {
+    data: scheduleSettings,
+    isError: ssIsError,
+    isLoading: ssIsLoading,
+    error: ssError
+  } = useUserScheduleSettings(user.userId);
   const [datePickerOpen, setDatePickerOpen] = useState(false);
   const [startTimePickerOpen, setStartTimePickerOpen] = useState(false);
   const [endTimePickerOpen, setEndTimePickerOpen] = useState(false);
@@ -315,6 +321,7 @@ const EventModal: React.FC<BaseEventModalProps> = ({
     reset,
     watch,
     setValue,
+    getValues,
     formState: { errors }
   } = useForm<EventFormValues>({
     resolver: yupResolver(schema),
@@ -386,11 +393,10 @@ const EventModal: React.FC<BaseEventModalProps> = ({
   // made it so it only fills when the field is empty, that way doesn't overwrite a link or anythingi me
   useEffect(() => {
     if (!open || isEditMode) return;
-    const personalZoomLink = scheduleSettings?.personalZoomLink;
-    if (personalZoomLink && !watch('zoomLink')) {
-      setValue('zoomLink', personalZoomLink);
+    if (scheduleSettings?.personalZoomLink && !getValues('zoomLink')) {
+      setValue('zoomLink', scheduleSettings.personalZoomLink);
     }
-  }, [open, isEditMode, scheduleSettings, setValue, watch]);
+  }, [open, isEditMode, scheduleSettings]);
 
   const computedTitle = isEditMode ? 'Edit Event' : 'Add Event';
 
@@ -665,6 +671,8 @@ const EventModal: React.FC<BaseEventModalProps> = ({
   if (teamTypesError) return <ErrorPage error={teamTypesErrorMsg} message={teamTypesErrorMsg?.message} />;
   if (shopsError) return <ErrorPage error={shopsErrorMsg} message={shopsErrorMsg?.message} />;
   if (machineryError) return <ErrorPage error={machineryErrorMsg} message={machineryErrorMsg?.message} />;
+  if (ssIsError) return <ErrorPage error={ssError} message={ssError?.message} />;
+  if (ssIsLoading) return <LoadingIndicator />;
 
   const workPackageOptions = workPackagesLoading
     ? [{ id: 'loading', label: 'Loading work packages...' }]

--- a/src/frontend/src/pages/CalendarPage/Components/EventModal.tsx
+++ b/src/frontend/src/pages/CalendarPage/Components/EventModal.tsx
@@ -382,8 +382,8 @@ const EventModal: React.FC<BaseEventModalProps> = ({
     }
   }, [initialValues, users, teams]);
 
-  // When creating a new event, autofill the user's personal zoom link from their schedule settings.
-  // Only fills when the field is still empty so we never overwrite a link the user has typed.
+  // When creating a new event, autofill personal zoom link from the user's schedule settings
+  // made it so it only fills when the field is empty, that way doesn't overwrite a link or anythingi me
   useEffect(() => {
     if (!open || isEditMode) return;
     const personalZoomLink = scheduleSettings?.personalZoomLink;


### PR DESCRIPTION
## Changes

All of the changes went in EventModal.tsx, where I added the 'useUserScheduleSettings' import, called the hook to get the user's schedule settings, and then added a useEffect that autofills the Zoom link with the user's link from settings. Autofills when creating a new event in the calendar section.


## Notes

Made it so the autofill only works when you are creating an event and not editing one.

## Test Cases


## Screenshots
<img width="1630" height="324" alt="Screenshot 2026-06-18 at 10 43 48 PM" src="https://github.com/user-attachments/assets/c8dd3390-8809-4f12-a4bb-8701f09c5916" />
<img width="1792" height="1156" alt="Screenshot 2026-06-18 at 10 43 33 PM" src="https://github.com/user-attachments/assets/2f3f68cd-4b72-4fdc-8516-c3d696de6a0f" />


## Checklist


- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #4252 
