### PR TITLE
#4272 filter past events

### DIFF
--- a/src/frontend/src/pages/CalendarPage/EventsTable.tsx
+++ b/src/frontend/src/pages/CalendarPage/EventsTable.tsx
@@ -28,6 +28,8 @@ import EditEventModal from './Components/EditEventModal';
 import { useToast } from '../../hooks/toasts.hooks';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
+import FilterListIcon from '@mui/icons-material/FilterList';
+import FilterListOffIcon from '@mui/icons-material/FilterListOff';
 import NERDeleteModal from '../../components/NERDeleteModal';
 
 interface YourEventsHeadCells {
@@ -122,6 +124,7 @@ const EventsTable: React.FC<EventTableArgs> = ({ tab, yourEvents, reviewEvents, 
   const [showEditModal, setShowEditModal] = useState(false);
 
   const [eventToDelete, setEventToDelete] = useState<Event | undefined>(undefined);
+  const [hidePastEvents, setHidePastEvents] = useState(true);
 
   const handleOpenClickPopup = (event: Event) => {
     setClickedEvent(event);
@@ -226,7 +229,12 @@ const EventsTable: React.FC<EventTableArgs> = ({ tab, yourEvents, reviewEvents, 
       : [])
   ];
 
-  const events = sortEvents(tab === 1 ? yourEvents : reviewEvents);
+  const now = new Date();
+  const baseEvents = tab === 1 ? yourEvents : reviewEvents;
+  const filteredEvents = hidePastEvents
+    ? baseEvents.filter((event) => getNextMeetingTime(event).getTime() >= now.getTime())
+    : baseEvents;
+  const events = sortEvents(filteredEvents);
 
   return (
     <Box sx={{ width: '100%', borderRadius: '8px 8px 0 0' }}>
@@ -245,9 +253,29 @@ const EventsTable: React.FC<EventTableArgs> = ({ tab, yourEvents, reviewEvents, 
         <Table stickyHeader>
           <TableHead>
             <TableRow>
-              {headCells.map((headCell) => (
-                <TableCellHuge title={headCell.label} />
-              ))}
+              {headCells.map((headCell) =>
+                headCell.id === 'date' ? (
+                  <TableCell key={headCell.id} sx={{ backgroundColor: '#dd514c' }}>
+                    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0.5 }}>
+                      <Typography variant="h4" fontSize={25}>
+                        {headCell.label}
+                      </Typography>
+                      <Tooltip
+                        title={
+                          hidePastEvents ? 'Showing upcoming only; click to show all' : 'Showing all; click to hide past'
+                        }
+                        arrow
+                      >
+                        <IconButton size="small" onClick={() => setHidePastEvents((prev) => !prev)} sx={{ color: 'white' }}>
+                          {hidePastEvents ? <FilterListIcon fontSize="small" /> : <FilterListOffIcon fontSize="small" />}
+                        </IconButton>
+                      </Tooltip>
+                    </Box>
+                  </TableCell>
+                ) : (
+                  <TableCellHuge key={headCell.id} title={headCell.label} />
+                )
+              )}
               {tab === 1 && <TableCellHuge title={''} />}
             </TableRow>
           </TableHead>


### PR DESCRIPTION
## Changes

Added a button on the your events page to filter in/out past events in the table.


## Screenshots
<img width="247" height="130" alt="Screenshot 2026-06-20 at 8 24 53 PM" src="https://github.com/user-attachments/assets/399c07f9-78cb-48ce-aafc-4958d396bc34" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #4272 
