### PR TITLE
#4303 fix team assign flip team general tabs

### DIFF
--- a/src/backend/src/controllers/rules.controllers.ts
+++ b/src/backend/src/controllers/rules.controllers.ts
@@ -254,7 +254,7 @@ export default class RulesController {
     }
   }
 
-  static async getUnassignedRulesForRuleset(req: Request, res: Response, next: NextFunction) {
+  static async getUnassignedRulesForProjectRuleset(req: Request, res: Response, next: NextFunction) {
     try {
       const { rulesetId, projectId } = req.params as Record<string, string>;
 

--- a/src/backend/src/controllers/rules.controllers.ts
+++ b/src/backend/src/controllers/rules.controllers.ts
@@ -256,14 +256,11 @@ export default class RulesController {
 
   static async getUnassignedRulesForRuleset(req: Request, res: Response, next: NextFunction) {
     try {
-      const { rulesetId, teamId } = req.params as Record<string, string>;
-      const { projectId } = req.query;
-      const projectIdString = typeof projectId === 'string' ? projectId : undefined;
+      const { rulesetId, projectId } = req.params as Record<string, string>;
 
-      const rules = await RulesService.getUnassignedRulesForRuleset(
+      const rules = await RulesService.getUnassignedRulesForProjectRuleset(
         rulesetId,
-        teamId,
-        projectIdString,
+        projectId,
         req.organization.organizationId
       );
       res.status(200).json(rules);

--- a/src/backend/src/prisma-query-args/rules.query-args.ts
+++ b/src/backend/src/prisma-query-args/rules.query-args.ts
@@ -28,6 +28,26 @@ export const getRulePreviewQueryArgs = () =>
           teamName: true
         }
       },
+      projects: {
+        where: { dateDeleted: null },
+        select: {
+          project: {
+            select: {
+              projectId: true,
+              wbsElement: {
+                select: {
+                  name: true
+                }
+              },
+              teams: {
+                select: {
+                  teamId: true
+                }
+              }
+            }
+          }
+        }
+      },
       completedBy: {
         select: {
           firstName: true,

--- a/src/backend/src/prisma/seed-data/rules.seed.ts
+++ b/src/backend/src/prisma/seed-data/rules.seed.ts
@@ -699,11 +699,12 @@ export const seedFsaeRules = async (
     }
   });
 
-  // Add the rule to the husky team, then the bodywork project, and mark it complete.
+  // Assign the leaf rule T.1.1.2.a to the husky team along with its full chain of
+  // ancestors (T -> T.1 -> T.1.1 -> T.1.1.2). Simulates how the assign-rules page automatically completes this full chain.
   for (const rule of [topLevelTechnical, T1Rule, T11Rule, T112Rule, T112ARule]) {
     await RulesService.toggleRuleTeam(rule.ruleId, huskyTeamId, batman, organization);
   }
-  // TODO: the above logic should be in the service function, not handled in the assign team frontend
+  // Add the leaf rule to the bodywork project and mark it complete.
   await RulesService.createProjectRule(batman, organization, T112ARule.ruleId, projectId);
   await RulesService.setRuleCompletion(batman, organization, T112ARule.ruleId, true, projectId);
 };

--- a/src/backend/src/prisma/seed.ts
+++ b/src/backend/src/prisma/seed.ts
@@ -912,7 +912,7 @@ const performSeed: () => Promise<void> = async () => {
     0,
     'Create the invisible jet.',
     'Develop a prototype of the invisible jet that wonder woman uses.',
-    [justiceLeague.teamId],
+    [justiceLeague.teamId, penguinTeam.teamId],
     wonderwoman,
     500,
     [

--- a/src/backend/src/routes/rules.routes.ts
+++ b/src/backend/src/routes/rules.routes.ts
@@ -86,7 +86,10 @@ rulesRouter.post(
   validateInputs,
   RulesController.updateRuleset
 );
-rulesRouter.get('/ruleset/:rulesetId/project/:projectId/rules/unassigned', RulesController.getUnassignedRulesForRuleset);
+rulesRouter.get(
+  '/ruleset/:rulesetId/project/:projectId/rules/unassigned',
+  RulesController.getUnassignedRulesForProjectRuleset
+);
 
 rulesRouter.get('/ruleset/:rulesetId/project/:projectId/rules', RulesController.getProjectRules);
 

--- a/src/backend/src/routes/rules.routes.ts
+++ b/src/backend/src/routes/rules.routes.ts
@@ -86,7 +86,7 @@ rulesRouter.post(
   validateInputs,
   RulesController.updateRuleset
 );
-rulesRouter.get('/ruleset/:rulesetId/team/:teamId/rules/unassigned', RulesController.getUnassignedRulesForRuleset);
+rulesRouter.get('/ruleset/:rulesetId/project/:projectId/rules/unassigned', RulesController.getUnassignedRulesForRuleset);
 
 rulesRouter.get('/ruleset/:rulesetId/project/:projectId/rules', RulesController.getProjectRules);
 

--- a/src/backend/src/services/rules.services.ts
+++ b/src/backend/src/services/rules.services.ts
@@ -1254,9 +1254,10 @@ export default class RulesService {
           }
         },
         // a rule can belong to many projects within a team
-        // only hide it from a project that already has it assigned
+        // only hide it from a project that already has it actively assigned
+        // (ignore soft-deleted assignments so a removed rule can be re-added)
         projects: {
-          none: { projectId }
+          none: { projectId, dateDeleted: null }
         },
         deletedByUserId: null
       },

--- a/src/backend/src/services/rules.services.ts
+++ b/src/backend/src/services/rules.services.ts
@@ -821,6 +821,20 @@ export default class RulesService {
           }
         }
       });
+
+      // Unassigning a rule from a team also soft deletes its project rules for
+      // that team's projects, since a rule can only be in a project whose team it is on
+      await prisma.project_Rule.updateMany({
+        where: {
+          ruleId: rule.ruleId,
+          dateDeleted: null,
+          project: { teams: { some: { teamId } } }
+        },
+        data: {
+          dateDeleted: new Date(),
+          deletedByUserId: user.userId
+        }
+      });
     }
 
     // retrieve and return the updated rule

--- a/src/backend/src/services/rules.services.ts
+++ b/src/backend/src/services/rules.services.ts
@@ -376,9 +376,10 @@ export default class RulesService {
 
     if (project.wbsElement.dateDeleted) throw new DeletedException('Project', projectId);
 
-    // Checks if this rule was already assigned to this project
-    const existingProjectRule = await prisma.project_Rule.findUnique({
-      where: { ruleId_projectId: { ruleId, projectId } }
+    // Checks if this rule is already actively assigned to this project.
+    // A soft-deleted project rule from previous unassignment would be revived instead of creating a new one
+    const existingProjectRule = await prisma.project_Rule.findFirst({
+      where: { ruleId, projectId, dateDeleted: null }
     });
 
     if (existingProjectRule) {
@@ -412,25 +413,25 @@ export default class RulesService {
     const existingAncestorIds = new Set(existingAncestors.map((projectRule) => projectRule.ruleId));
     const ancestorsToCreate = ancestorIds.filter((id) => !existingAncestorIds.has(id));
 
-    // create all project rules
-    await prisma.$transaction([
-      ...ancestorsToCreate.map((ancestorId) =>
-        prisma.project_Rule.create({
-          data: {
-            ruleId: ancestorId,
-            projectId,
-            createdByUserId: submitter.userId
-          }
-        })
-      ),
-      prisma.project_Rule.create({
-        data: {
-          ruleId,
+    // create (or revive) all project rules. (ruleId, projectId) is unique so
+    // soft deleted rules from previous team unassignment would be revived instead of colliding on insert
+    const reviveOrCreate = (targetRuleId: string) =>
+      // upsert - updates existing record, or inserts if it doesn't exist
+      prisma.project_Rule.upsert({
+        where: { ruleId_projectId: { ruleId: targetRuleId, projectId } },
+        create: {
+          ruleId: targetRuleId,
           projectId,
           createdByUserId: submitter.userId
+        },
+        update: {
+          dateDeleted: null,
+          deletedByUserId: null,
+          createdByUserId: submitter.userId
         }
-      })
-    ]);
+      });
+
+    await prisma.$transaction([...ancestorsToCreate.map(reviveOrCreate), reviveOrCreate(ruleId)]);
 
     // return only original project rule being assigned (leaf rule)
     const projectRule = await prisma.project_Rule.findUnique({
@@ -811,32 +812,34 @@ export default class RulesService {
         }
       });
     } else {
-      await prisma.rule.update({
-        where: { ruleId: rule.ruleId },
-        data: {
-          teams: {
-            disconnect: {
-              teamId
+      // Disconnect the team and soft delete its project rules, ensure we never leave
+      // the rule unassigned from the team while its project rules stay active
+      await prisma.$transaction(async (tx) => {
+        await tx.rule.update({
+          where: { ruleId: rule.ruleId },
+          data: {
+            teams: {
+              disconnect: {
+                teamId
+              }
             }
           }
-        }
-      });
-
-      // Unassigning a rule from a team also soft deletes its project rules for
-      // that team's projects, since a rule can only be in a project whose team it is on
-      await prisma.project_Rule.updateMany({
-        where: {
-          ruleId: rule.ruleId,
-          dateDeleted: null,
-          project: { teams: { some: { teamId } } }
-        },
-        data: {
-          dateDeleted: new Date(),
-          deletedByUserId: user.userId
-        }
+        });
+        // Unassigning a rule also soft deletes its project rules for that team's projects,
+        // since a rule can only be in a project whose team it is assigned to
+        await tx.project_Rule.updateMany({
+          where: {
+            ruleId: rule.ruleId,
+            dateDeleted: null,
+            project: { teams: { some: { teamId } } }
+          },
+          data: {
+            dateDeleted: new Date(),
+            deletedByUserId: user.userId
+          }
+        });
       });
     }
-
     // retrieve and return the updated rule
     const newRule = await prisma.rule.findUnique({
       where: { ruleId },

--- a/src/backend/src/services/rules.services.ts
+++ b/src/backend/src/services/rules.services.ts
@@ -1195,9 +1195,8 @@ export default class RulesService {
   }
 
   /**
-   * Gets rules assignable to a project, on any of the project's teams, that are not
-   * already assigned to it. A project can belong to multiple teams, so rules from all
-   * of its teams are shown.
+   * Gets rules assignable to a project that are not already assigned to it.
+   * A project can belong to multiple teams, so rules from all of its teams are shown.
    * @param rulesetId ruleset the rules are in
    * @param projectId the project the rules would be assigned to
    * @param organizationId the organization id

--- a/src/backend/src/services/rules.services.ts
+++ b/src/backend/src/services/rules.services.ts
@@ -349,6 +349,7 @@ export default class RulesService {
       where: { ruleId },
       include: {
         subRules: true,
+        teams: { select: { teamId: true } },
         ruleset: { select: { car: { include: { wbsElement: { select: { organizationId: true } } } } } }
       }
     });
@@ -364,7 +365,7 @@ export default class RulesService {
 
     const project = await prisma.project.findUnique({
       where: { projectId },
-      include: { wbsElement: true }
+      include: { wbsElement: true, teams: { select: { teamId: true } } }
     });
 
     if (!project) {
@@ -375,6 +376,13 @@ export default class RulesService {
     }
 
     if (project.wbsElement.dateDeleted) throw new DeletedException('Project', projectId);
+
+    // A rule can only be assigned to a project if the rule is on one of that project's teams.
+    // This should never be reached since the frontend only shows unassigned rules that are assigned to the project's teams
+    const projectTeamIds = new Set(project.teams.map((team) => team.teamId));
+    if (!rule.teams.some((team) => projectTeamIds.has(team.teamId))) {
+      throw new HttpException(400, "Rule must be on one of the project's teams to be assigned to it");
+    }
 
     // Checks if this rule is already actively assigned to this project.
     // A soft-deleted project rule from previous unassignment would be revived instead of creating a new one
@@ -812,6 +820,11 @@ export default class RulesService {
         }
       });
     } else {
+      // teams the rule still belongs to once this team assignment is removed
+      const remainingTeamIds = rule.teams
+        .filter((currTeam) => currTeam.teamId !== teamId)
+        .map((currTeam) => currTeam.teamId);
+
       // Disconnect the team and soft delete its project rules, ensure we never leave
       // the rule unassigned from the team while its project rules stay active
       await prisma.$transaction(async (tx) => {
@@ -825,13 +838,18 @@ export default class RulesService {
             }
           }
         });
-        // Unassigning a rule also soft deletes its project rules for that team's projects,
-        // since a rule can only be in a project whose team it is assigned to
+        // Since a project can belong to multiple teams, only soft delete the project rule
+        // when the project shares no remaining team with the rule.
         await tx.project_Rule.updateMany({
           where: {
             ruleId: rule.ruleId,
             dateDeleted: null,
-            project: { teams: { some: { teamId } } }
+            project: {
+              teams: {
+                some: { teamId }, // project has the team where the assignment is being removed
+                none: { teamId: { in: remainingTeamIds } } // project has no remaining teams that the rule is still assigned to
+              }
+            }
           },
           data: {
             dateDeleted: new Date(),
@@ -1177,21 +1195,15 @@ export default class RulesService {
   }
 
   /**
-   * Gets team rules that are unassigned to a project
+   * Gets rules assignable to a project, on any of the project's teams, that are not
+   * already assigned to it. A project can belong to multiple teams, so rules from all
+   * of its teams are shown.
    * @param rulesetId ruleset the rules are in
-   * @param teamId team that rules are assigned to
+   * @param projectId the project the rules would be assigned to
    * @param organizationId the organization id
-   * @returns the rules in this team that do not have an associated project rule
+   * @returns the rules on one of the project's teams that are not already actively assigned to this project
    */
-  static async getUnassignedRulesForRuleset(
-    rulesetId: string,
-    teamId: string,
-    projectId: string | undefined,
-    organizationId: string
-  ) {
-    if (!projectId) {
-      throw new HttpException(400, 'Query parameter projectId is required');
-    }
+  static async getUnassignedRulesForProjectRuleset(rulesetId: string, projectId: string, organizationId: string) {
     const ruleset = await prisma.ruleset.findUnique({
       where: { rulesetId },
       select: {
@@ -1216,24 +1228,12 @@ export default class RulesService {
       throw new InvalidOrganizationException('Ruleset');
     }
 
-    const team = await prisma.team.findUnique({
-      where: { teamId },
-      select: {
-        organizationId: true
-      }
-    });
-
-    if (!team) {
-      throw new NotFoundException('Team', teamId);
-    }
-
-    if (team.organizationId !== organizationId) {
-      throw new InvalidOrganizationException('Team');
-    }
-
     const project = await prisma.project.findUnique({
       where: { projectId },
-      select: { wbsElement: { select: { organizationId: true } } }
+      select: {
+        wbsElement: { select: { organizationId: true } },
+        teams: { select: { teamId: true } }
+      }
     });
 
     if (!project) {
@@ -1244,18 +1244,19 @@ export default class RulesService {
       throw new InvalidOrganizationException('Project');
     }
 
+    const projectTeamIds = project.teams.map((team) => team.teamId);
+
     const rules = await prisma.rule.findMany({
       where: {
         rulesetId,
+        // rule is on at least one of the project's teams
         teams: {
           some: {
-            teamId,
+            teamId: { in: projectTeamIds },
             organizationId
           }
         },
-        // a rule can belong to many projects within a team
         // only hide it from a project that already has it actively assigned
-        // (ignore soft-deleted assignments so a removed rule can be re-added)
         projects: {
           none: { projectId, dateDeleted: null }
         },

--- a/src/backend/src/services/rules.services.ts
+++ b/src/backend/src/services/rules.services.ts
@@ -403,12 +403,16 @@ export default class RulesService {
       visited.add(currentParentId);
       const parent = await prisma.rule.findUnique({
         where: { ruleId: currentParentId },
-        select: { parentRuleId: true, dateDeleted: true }
+        select: { parentRuleId: true, dateDeleted: true, teams: { select: { teamId: true } } }
       });
       // rule only displays if the full chain to a top-level rule exists, so a missing or deleted
       // ancestor means this rule would not display - do not assign it OR its ancestors to the project
       if (!parent) throw new NotFoundException('Rule', currentParentId);
       if (parent.dateDeleted) throw new DeletedException('Rule', currentParentId);
+      // ancestors must also be on one of the project's teams otherwise the chain to the top-level rule would break
+      if (!parent.teams.some((team) => projectTeamIds.has(team.teamId))) {
+        throw new HttpException(400, "Parent rules must be on one of the project's teams to be assigned to it");
+      }
       ancestorIds.push(currentParentId);
       currentParentId = parent.parentRuleId;
     }

--- a/src/backend/src/transformers/rules.transformer.ts
+++ b/src/backend/src/transformers/rules.transformer.ts
@@ -20,6 +20,11 @@ export const ruleTransformer = (rule: Prisma.RuleGetPayload<RulePreviewQueryArgs
       teamId: team.teamId,
       teamName: team.teamName
     })),
+    projects: rule.projects?.map((projectRule) => ({
+      projectId: projectRule.project.projectId,
+      projectName: projectRule.project.wbsElement.name,
+      teamIds: projectRule.project.teams.map((team) => team.teamId)
+    })),
     isComplete: rule.isComplete,
     completedBy: rule.completedBy
       ? {

--- a/src/backend/tests/unit/rule.test.ts
+++ b/src/backend/tests/unit/rule.test.ts
@@ -28,6 +28,7 @@ import {
   InvalidOrganizationException
 } from '../../src/utils/errors.utils';
 import TeamsService from '../../src/services/teams.services';
+import ProjectsService from '../../src/services/projects.services';
 
 describe('Create Rules Tests', () => {
   let orgId: string;
@@ -380,7 +381,11 @@ describe('Create Rules Tests', () => {
       );
       const grandchild = await RulesService.createRule(batman, 'T.1.1.1', 'Wheels', rulesetId, organization, child.ruleId);
 
-      const project = await createTestProject(aquaman, orgId, undefined, carId);
+      const teamType = await createTestTeamType('technical', orgId);
+      const team = await createTestTeam(batman.userId, teamType.teamTypeId, orgId);
+      await RulesService.toggleRuleTeam(grandchild.ruleId, team.teamId, batman, organization);
+
+      const project = await createTestProject(aquaman, orgId, team.teamId, carId);
 
       await RulesService.createProjectRule(aquaman, organization, grandchild.ruleId, project.projectId);
 
@@ -403,7 +408,13 @@ describe('Create Rules Tests', () => {
       const grandchild1 = await RulesService.createRule(batman, 'T.1.1.1', 'Wheels', rulesetId, organization, child.ruleId);
       const grandchild2 = await RulesService.createRule(batman, 'T.1.1.2', 'Brakes', rulesetId, organization, child.ruleId);
 
-      const project = await createTestProject(aquaman, orgId, undefined, carId);
+      const teamType = await createTestTeamType('technical', orgId);
+      const team = await createTestTeam(batman.userId, teamType.teamTypeId, orgId);
+
+      await RulesService.toggleRuleTeam(grandchild1.ruleId, team.teamId, batman, organization);
+      await RulesService.toggleRuleTeam(grandchild2.ruleId, team.teamId, batman, organization);
+
+      const project = await createTestProject(aquaman, orgId, team.teamId, carId);
 
       await RulesService.createProjectRule(aquaman, organization, grandchild1.ruleId, project.projectId);
       // adding sibling must not error or duplicate the already-present parent/root rules
@@ -429,7 +440,11 @@ describe('Create Rules Tests', () => {
       );
       await RulesService.createRule(batman, 'T.1.1.1', 'Wheels', rulesetId, organization, child.ruleId);
 
-      const project = await createTestProject(aquaman, orgId, undefined, carId);
+      const teamType = await createTestTeamType('technical', orgId);
+      const team = await createTestTeam(batman.userId, teamType.teamTypeId, orgId);
+      await RulesService.toggleRuleTeam(child.ruleId, team.teamId, batman, organization);
+
+      const project = await createTestProject(aquaman, orgId, team.teamId, carId);
 
       await RulesService.createProjectRule(aquaman, organization, child.ruleId, project.projectId);
 
@@ -451,13 +466,17 @@ describe('Create Rules Tests', () => {
       );
       const grandchild = await RulesService.createRule(batman, 'T.1.1.1', 'Wheels', rulesetId, organization, child.ruleId);
 
+      const teamType = await createTestTeamType('technical', orgId);
+      const team = await createTestTeam(batman.userId, teamType.teamTypeId, orgId);
+      await RulesService.toggleRuleTeam(grandchild.ruleId, team.teamId, batman, organization);
+
       // soft-delete an ancestor so the chain to the top-level rule is broken
       await prisma.rule.update({
         where: { ruleId: child.ruleId },
         data: { dateDeleted: new Date(), deletedBy: { connect: { userId: batman.userId } } }
       });
 
-      const project = await createTestProject(aquaman, orgId, undefined, carId);
+      const project = await createTestProject(aquaman, orgId, team.teamId, carId);
 
       // a broken chain means the grandchild could never display, so no rules are assigned to the project and an error is thrown
       await expect(
@@ -476,7 +495,12 @@ describe('Create Rules Tests', () => {
 
     it('throws when the rule is already associated with the project', async () => {
       const rule = await RulesService.createRule(batman, 'T.1', 'Technical Rules', rulesetId, organization);
-      const project = await createTestProject(aquaman, orgId, undefined, carId);
+
+      const teamType = await createTestTeamType('technical', orgId);
+      const team = await createTestTeam(batman.userId, teamType.teamTypeId, orgId);
+      await RulesService.toggleRuleTeam(rule.ruleId, team.teamId, batman, organization);
+
+      const project = await createTestProject(aquaman, orgId, team.teamId, carId);
 
       await RulesService.createProjectRule(aquaman, organization, rule.ruleId, project.projectId);
 
@@ -508,6 +532,19 @@ describe('Create Rules Tests', () => {
       await expect(
         async () => await RulesService.createProjectRule(aquaman, organization, rule.ruleId, 'fake-project-id')
       ).rejects.toThrow(new NotFoundException('Project', 'fake-project-id'));
+    });
+
+    it('throws when the rule is not on any of the project`s teams', async () => {
+      // rule has no team, but the project belongs to a team, so they share no team
+      const rule = await RulesService.createRule(batman, 'T.1', 'Technical Rules', rulesetId, organization);
+
+      const teamType = await createTestTeamType('technical', orgId);
+      const team = await createTestTeam(batman.userId, teamType.teamTypeId, orgId);
+      const project = await createTestProject(aquaman, orgId, team.teamId, carId);
+
+      await expect(
+        async () => await RulesService.createProjectRule(aquaman, organization, rule.ruleId, project.projectId)
+      ).rejects.toThrow(new HttpException(400, "Rule must be on one of the project's teams to be assigned to it"));
     });
   });
 
@@ -939,6 +976,9 @@ describe('Rule Tests', () => {
     it('Creates a project rule successfully', async () => {
       const car = await createUniqueCar(orgId);
       const { topLevelRule } = await setupRules(car);
+      // rule and project must share a team for the rule to be assignable
+      const project = await createTestProject(admin, orgId, testTeam.teamId, car.carId, car.wbsElement.carNumber);
+      await RulesService.toggleRuleTeam(topLevelRule.ruleId, testTeam.teamId, admin, organization);
       const projectRule = await RulesService.createProjectRule(admin, organization, topLevelRule.ruleId, project.projectId);
 
       expect(projectRule.projectRuleId).toBeDefined();
@@ -951,6 +991,9 @@ describe('Rule Tests', () => {
     it('Creates a project rule successfully for a leaf rule', async () => {
       const car = await createUniqueCar(orgId);
       const { leafRule1 } = await setupRules(car);
+      // rule and project must share a team for the rule to be assignable
+      const project = await createTestProject(admin, orgId, testTeam.teamId, car.carId, car.wbsElement.carNumber);
+      await RulesService.toggleRuleTeam(leafRule1.ruleId, testTeam.teamId, admin, organization);
       const projectRule = await RulesService.createProjectRule(admin, organization, leafRule1.ruleId, project.projectId);
 
       expect(projectRule.projectRuleId).toBeDefined();
@@ -1009,6 +1052,9 @@ describe('Rule Tests', () => {
     it('Create project rule fails if project rule assignment already exists', async () => {
       const car = await createUniqueCar(orgId);
       const { leafRule1 } = await setupRules(car);
+      // rule and project must share a team so the first assignment succeeds
+      const project = await createTestProject(admin, orgId, testTeam.teamId, car.carId, car.wbsElement.carNumber);
+      await RulesService.toggleRuleTeam(leafRule1.ruleId, testTeam.teamId, admin, organization);
       await RulesService.createProjectRule(admin, organization, leafRule1.ruleId, project.projectId);
       await expect(RulesService.createProjectRule(admin, organization, leafRule1.ruleId, project.projectId)).rejects.toThrow(
         new HttpException(400, 'This rule is already associated with the project')
@@ -1374,6 +1420,8 @@ describe('Rule Tests', () => {
     it('Deletes a project rule successfully and returns the correct information', async () => {
       const car = await createUniqueCar(orgId);
       const { leafRule1 } = await setupRules(car);
+      const project = await createTestProject(admin, orgId, testTeam.teamId, car.carId, car.wbsElement.carNumber);
+      await RulesService.toggleRuleTeam(leafRule1.ruleId, testTeam.teamId, admin, organization);
       const projectRule = await RulesService.createProjectRule(admin, organization, leafRule1.ruleId, project.projectId);
 
       const deletedProjectRule = await RulesService.deleteProjectRule(projectRule.projectRuleId, admin, organization);
@@ -1387,6 +1435,8 @@ describe('Rule Tests', () => {
     it('Delete project rule fails if user does not have permission', async () => {
       const car = await createUniqueCar(orgId);
       const { leafRule1 } = await setupRules(car);
+      const project = await createTestProject(admin, orgId, testTeam.teamId, car.carId, car.wbsElement.carNumber);
+      await RulesService.toggleRuleTeam(leafRule1.ruleId, testTeam.teamId, admin, organization);
       const projectRule = await RulesService.createProjectRule(admin, organization, leafRule1.ruleId, project.projectId);
 
       await expect(
@@ -1396,6 +1446,8 @@ describe('Rule Tests', () => {
     it('Delete project rule fails if project rule was already deleted', async () => {
       const car = await createUniqueCar(orgId);
       const { leafRule1 } = await setupRules(car);
+      const project = await createTestProject(admin, orgId, testTeam.teamId, car.carId, car.wbsElement.carNumber);
+      await RulesService.toggleRuleTeam(leafRule1.ruleId, testTeam.teamId, admin, organization);
       const projectRule = await RulesService.createProjectRule(admin, organization, leafRule1.ruleId, project.projectId);
 
       await RulesService.deleteProjectRule(projectRule.projectRuleId, admin, organization);
@@ -1674,89 +1726,60 @@ describe('Rule Tests', () => {
         }
       });
       await expect(
-        RulesService.getUnassignedRulesForRuleset(
+        RulesService.getUnassignedRulesForProjectRuleset(
           otherRuleset.rulesetId,
-          testTeam.teamId,
           project.projectId,
           organization.organizationId
         )
       ).rejects.toThrow(InvalidOrganizationException);
     });
-    it('fails if team is in the wrong org', async () => {
+    it('fails if project is in the wrong org', async () => {
       const car = await createUniqueCar(orgId);
-      const otherTeam = await prisma.team.create({
-        data: {
-          teamName: 'Other Team',
-          slackId: 'other-slack',
-          headId: admin.userId,
-          organizationId: otherOrg.organizationId
-        }
-      });
       const { ruleset1 } = await setupRules(car);
+      const otherOrgProject = await createTestProject(admin, otherOrg.organizationId);
       await expect(
-        RulesService.getUnassignedRulesForRuleset(
+        RulesService.getUnassignedRulesForProjectRuleset(
           ruleset1.rulesetId,
-          otherTeam.teamId,
-          project.projectId,
+          otherOrgProject.projectId,
           organization.organizationId
         )
       ).rejects.toThrow(InvalidOrganizationException);
     });
     it('fails if ruleset does not exist', async () => {
       await expect(
-        RulesService.getUnassignedRulesForRuleset(
+        RulesService.getUnassignedRulesForProjectRuleset(
           'nonexistent-ruleset-id',
-          testTeam.teamId,
           project.projectId,
           organization.organizationId
         )
       ).rejects.toThrow(new NotFoundException('Ruleset', 'nonexistent-ruleset-id'));
     });
-    it('fails if team does not exist', async () => {
+    it('fails if project does not exist', async () => {
       const car = await createUniqueCar(orgId);
       const { ruleset1 } = await setupRules(car);
       await expect(
-        RulesService.getUnassignedRulesForRuleset(
-          ruleset1.rulesetId,
-          'fake-team-id',
-          project.projectId,
-          organization.organizationId
-        )
-      ).rejects.toThrow(new NotFoundException('Team', 'fake-team-id'));
+        RulesService.getUnassignedRulesForProjectRuleset(ruleset1.rulesetId, 'fake-project-id', organization.organizationId)
+      ).rejects.toThrow(new NotFoundException('Project', 'fake-project-id'));
     });
-    it('successfully returns rules in the team that have no projects', async () => {
+    it("successfully returns rules on the project's teams that are not already assigned to the project", async () => {
       const car = await createUniqueCar(orgId);
       const { ruleset1, topLevelRule, leafRule1, leafRule2 } = await setupRules(car);
-      // add rules to the team
-      await prisma.rule.update({
-        where: { ruleId: topLevelRule.ruleId },
-        data: {
-          teams: {
-            connect: { teamId: testTeam.teamId }
-          }
-        }
-      });
-      await prisma.rule.update({
-        where: { ruleId: leafRule1.ruleId },
-        data: {
-          teams: {
-            connect: { teamId: testTeam.teamId }
-          }
-        }
-      });
-      // rule in the team that has a project
+      // the project belongs to the team, so rules on that team are candidates
+      const project = await createTestProject(admin, orgId, testTeam.teamId, car.carId, car.wbsElement.carNumber);
+      // add rules to the project's team
+      await RulesService.toggleRuleTeam(topLevelRule.ruleId, testTeam.teamId, admin, organization);
+      await RulesService.toggleRuleTeam(leafRule1.ruleId, testTeam.teamId, admin, organization);
+      // rule on the project's team that is already assigned to the project
       const ruleWithProject = await prisma.rule.create({
         data: {
           ruleCode: 'T.1.3',
           ruleContent: 'Rule with project',
           imageFileIds: [],
           rulesetId: ruleset1.rulesetId,
-          createdByUserId: admin.userId,
-          teams: {
-            connect: { teamId: testTeam.teamId }
-          }
+          createdByUserId: admin.userId
         }
       });
+      await RulesService.toggleRuleTeam(ruleWithProject.ruleId, testTeam.teamId, admin, organization);
       await prisma.project_Rule.create({
         data: {
           projectId: project.projectId,
@@ -1764,26 +1787,56 @@ describe('Rule Tests', () => {
           createdByUserId: admin.userId
         }
       });
-      const rules = await RulesService.getUnassignedRulesForRuleset(
+      const rules = await RulesService.getUnassignedRulesForProjectRuleset(
         ruleset1.rulesetId,
-        testTeam.teamId,
         project.projectId,
         organization.organizationId
       );
       expect(rules.length).toEqual(2);
       expect(rules[0].ruleCode).toEqual('T');
       expect(rules[1].ruleCode).toEqual('T2');
-      // leafRule2 is not in the team so should not be returned
+      // leafRule2 is not on any of the project's teams so should not be returned
       expect(rules.find((r) => r.ruleCode === leafRule2.ruleCode)).toBeUndefined();
-      // ruleWithProject has a project so should not be returned
+      // ruleWithProject is already assigned to the project so should not be returned
       expect(rules.find((r) => r.ruleCode === ruleWithProject.ruleCode)).toBeUndefined();
     });
-    it('successfully returns empty if team has no assigned rules', async () => {
+    it('returns rules from any of the project`s teams when it belongs to multiple', async () => {
+      const car = await createUniqueCar(orgId);
+      const { ruleset1, topLevelRule, leafRule1, leafRule2 } = await setupRules(car);
+
+      // a second team the project also belongs to
+      const teamType = await createTestTeamType('secondTeamType', orgId);
+      const secondTeam = await createTestTeam(admin.userId, teamType.teamTypeId, orgId);
+
+      // project belongs to both testTeam and secondTeam
+      const project = await createTestProject(admin, orgId, testTeam.teamId, car.carId, car.wbsElement.carNumber);
+      await ProjectsService.setProjectTeam(
+        admin,
+        { carNumber: car.wbsElement.carNumber, projectNumber: 1, workPackageNumber: 0 },
+        secondTeam.teamId,
+        organization
+      );
+
+      // topLevelRule on the first team, leafRule1 on the second team - both should be returned
+      await RulesService.toggleRuleTeam(topLevelRule.ruleId, testTeam.teamId, admin, organization);
+      await RulesService.toggleRuleTeam(leafRule1.ruleId, secondTeam.teamId, admin, organization);
+
+      const rules = await RulesService.getUnassignedRulesForProjectRuleset(
+        ruleset1.rulesetId,
+        project.projectId,
+        organization.organizationId
+      );
+      expect(rules.map((r) => r.ruleId)).toContain(topLevelRule.ruleId);
+      expect(rules.map((r) => r.ruleId)).toContain(leafRule1.ruleId);
+      // leafRule2 has no team so it should not be returned
+      expect(rules.map((r) => r.ruleId)).not.toContain(leafRule2.ruleId);
+    });
+    it("successfully returns empty if the project's teams have no assignable rules", async () => {
       const car = await createUniqueCar(orgId);
       const { ruleset1 } = await setupRules(car);
-      const rules = await RulesService.getUnassignedRulesForRuleset(
+      const project = await createTestProject(admin, orgId, testTeam.teamId, car.carId, car.wbsElement.carNumber);
+      const rules = await RulesService.getUnassignedRulesForProjectRuleset(
         ruleset1.rulesetId,
-        testTeam.teamId,
         project.projectId,
         organization.organizationId
       );
@@ -1795,6 +1848,8 @@ describe('Rule Tests', () => {
     it('Successfully gets all project rules for a project', async () => {
       const car = await createUniqueCar(orgId);
       const { topLevelRule } = await setupRules(car);
+      const project = await createTestProject(admin, orgId, testTeam.teamId, car.carId, car.wbsElement.carNumber);
+      await RulesService.toggleRuleTeam(topLevelRule.ruleId, testTeam.teamId, admin, organization);
       const projectRule = await RulesService.createProjectRule(admin, organization, topLevelRule.ruleId, project.projectId);
 
       const projectRules = await RulesService.getProjectRules(topLevelRule.rulesetId, projectRule.projectId, organization);

--- a/src/backend/tests/unit/rule.test.ts
+++ b/src/backend/tests/unit/rule.test.ts
@@ -383,6 +383,10 @@ describe('Create Rules Tests', () => {
 
       const teamType = await createTestTeamType('technical', orgId);
       const team = await createTestTeam(batman.userId, teamType.teamTypeId, orgId);
+      // every rule in the ancestor chain must be on the project's team for the leaf to be assignable
+      await RulesService.toggleRuleTeam(topLevelRule.ruleId, team.teamId, batman, organization);
+      await RulesService.toggleRuleTeam(child.ruleId, team.teamId, batman, organization);
+
       await RulesService.toggleRuleTeam(grandchild.ruleId, team.teamId, batman, organization);
 
       const project = await createTestProject(aquaman, orgId, team.teamId, carId);
@@ -410,6 +414,10 @@ describe('Create Rules Tests', () => {
 
       const teamType = await createTestTeamType('technical', orgId);
       const team = await createTestTeam(batman.userId, teamType.teamTypeId, orgId);
+
+      // every rule in the ancestor chain must be on the project's team for the leaves to be assignable
+      await RulesService.toggleRuleTeam(topLevelRule.ruleId, team.teamId, batman, organization);
+      await RulesService.toggleRuleTeam(child.ruleId, team.teamId, batman, organization);
 
       await RulesService.toggleRuleTeam(grandchild1.ruleId, team.teamId, batman, organization);
       await RulesService.toggleRuleTeam(grandchild2.ruleId, team.teamId, batman, organization);
@@ -442,6 +450,8 @@ describe('Create Rules Tests', () => {
 
       const teamType = await createTestTeamType('technical', orgId);
       const team = await createTestTeam(batman.userId, teamType.teamTypeId, orgId);
+
+      await RulesService.toggleRuleTeam(topLevelRule.ruleId, team.teamId, batman, organization);
       await RulesService.toggleRuleTeam(child.ruleId, team.teamId, batman, organization);
 
       const project = await createTestProject(aquaman, orgId, team.teamId, carId);
@@ -990,9 +1000,10 @@ describe('Rule Tests', () => {
     });
     it('Creates a project rule successfully for a leaf rule', async () => {
       const car = await createUniqueCar(orgId);
-      const { leafRule1 } = await setupRules(car);
-      // rule and project must share a team for the rule to be assignable
+      const { leafRule1, topLevelRule } = await setupRules(car);
+      // every rule in the ancestor chain must be on the project's team for the leaf to be assignable
       const project = await createTestProject(admin, orgId, testTeam.teamId, car.carId, car.wbsElement.carNumber);
+      await RulesService.toggleRuleTeam(topLevelRule.ruleId, testTeam.teamId, admin, organization);
       await RulesService.toggleRuleTeam(leafRule1.ruleId, testTeam.teamId, admin, organization);
       const projectRule = await RulesService.createProjectRule(admin, organization, leafRule1.ruleId, project.projectId);
 
@@ -1051,9 +1062,10 @@ describe('Rule Tests', () => {
     });
     it('Create project rule fails if project rule assignment already exists', async () => {
       const car = await createUniqueCar(orgId);
-      const { leafRule1 } = await setupRules(car);
-      // rule and project must share a team so the first assignment succeeds
+      const { leafRule1, topLevelRule } = await setupRules(car);
+      // every rule in the chain must be on the project's team
       const project = await createTestProject(admin, orgId, testTeam.teamId, car.carId, car.wbsElement.carNumber);
+      await RulesService.toggleRuleTeam(topLevelRule.ruleId, testTeam.teamId, admin, organization);
       await RulesService.toggleRuleTeam(leafRule1.ruleId, testTeam.teamId, admin, organization);
       await RulesService.createProjectRule(admin, organization, leafRule1.ruleId, project.projectId);
       await expect(RulesService.createProjectRule(admin, organization, leafRule1.ruleId, project.projectId)).rejects.toThrow(
@@ -1419,8 +1431,10 @@ describe('Rule Tests', () => {
   describe('Delete Project Rule', () => {
     it('Deletes a project rule successfully and returns the correct information', async () => {
       const car = await createUniqueCar(orgId);
-      const { leafRule1 } = await setupRules(car);
+      const { leafRule1, topLevelRule } = await setupRules(car);
       const project = await createTestProject(admin, orgId, testTeam.teamId, car.carId, car.wbsElement.carNumber);
+      // every rule in the chain must be on the project's team for the leaf to be assignable
+      await RulesService.toggleRuleTeam(topLevelRule.ruleId, testTeam.teamId, admin, organization);
       await RulesService.toggleRuleTeam(leafRule1.ruleId, testTeam.teamId, admin, organization);
       const projectRule = await RulesService.createProjectRule(admin, organization, leafRule1.ruleId, project.projectId);
 
@@ -1434,8 +1448,9 @@ describe('Rule Tests', () => {
     });
     it('Delete project rule fails if user does not have permission', async () => {
       const car = await createUniqueCar(orgId);
-      const { leafRule1 } = await setupRules(car);
+      const { leafRule1, topLevelRule } = await setupRules(car);
       const project = await createTestProject(admin, orgId, testTeam.teamId, car.carId, car.wbsElement.carNumber);
+      await RulesService.toggleRuleTeam(topLevelRule.ruleId, testTeam.teamId, admin, organization);
       await RulesService.toggleRuleTeam(leafRule1.ruleId, testTeam.teamId, admin, organization);
       const projectRule = await RulesService.createProjectRule(admin, organization, leafRule1.ruleId, project.projectId);
 
@@ -1445,8 +1460,9 @@ describe('Rule Tests', () => {
     });
     it('Delete project rule fails if project rule was already deleted', async () => {
       const car = await createUniqueCar(orgId);
-      const { leafRule1 } = await setupRules(car);
+      const { leafRule1, topLevelRule } = await setupRules(car);
       const project = await createTestProject(admin, orgId, testTeam.teamId, car.carId, car.wbsElement.carNumber);
+      await RulesService.toggleRuleTeam(topLevelRule.ruleId, testTeam.teamId, admin, organization);
       await RulesService.toggleRuleTeam(leafRule1.ruleId, testTeam.teamId, admin, organization);
       const projectRule = await RulesService.createProjectRule(admin, organization, leafRule1.ruleId, project.projectId);
 

--- a/src/frontend/src/apis/rules.api.ts
+++ b/src/frontend/src/apis/rules.api.ts
@@ -93,10 +93,10 @@ export const getProjectRules = (rulesetId: string, projectId: string) => {
 };
 
 /**
- * Gets unassigned rules for a ruleset and team.
+ * Gets rules assignable to a project, across all of its teams, that aren't already assigned
  */
-export const getUnassignedRulesForRuleset = (rulesetId: string, teamId: string, projectId: string) => {
-  return axios.get<SharedRule[]>(apiUrls.rulesGetUnassignedRulesForRuleset(rulesetId, teamId, projectId), {
+export const getUnassignedRulesForRuleset = (rulesetId: string, projectId: string) => {
+  return axios.get<SharedRule[]>(apiUrls.rulesGetUnassignedRulesForRuleset(rulesetId, projectId), {
     transformResponse: (data) => JSON.parse(data).map(ruleTransformer)
   });
 };

--- a/src/frontend/src/hooks/rules.hooks.ts
+++ b/src/frontend/src/hooks/rules.hooks.ts
@@ -78,16 +78,16 @@ export const useProjectRules = (rulesetId: string, projectId: string) => {
 };
 
 /**
- * Hook to get unassigned rules for a ruleset and team.
+ * Hook to get rules assignable to a project, across all of its teams, that aren't already assigned.
  */
-export const useUnassignedRulesForRuleset = (rulesetId: string, teamId: string, projectId: string) => {
+export const useUnassignedRulesForRuleset = (rulesetId: string, projectId: string) => {
   return useQuery<SharedRule[], Error>(
-    ['rules', 'unassigned', rulesetId, teamId, projectId],
+    ['rules', 'unassigned', rulesetId, projectId],
     async () => {
-      const { data } = await getUnassignedRulesForRuleset(rulesetId, teamId, projectId);
+      const { data } = await getUnassignedRulesForRuleset(rulesetId, projectId);
       return data;
     },
-    { enabled: !!rulesetId && !!teamId && !!projectId }
+    { enabled: !!rulesetId && !!projectId }
   );
 };
 

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectRules/AddProjectRuleModal.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectRules/AddProjectRuleModal.tsx
@@ -26,17 +26,16 @@ interface AddRuleModalProps {
   open: boolean;
   onHide: () => void;
   rulesetId: string;
-  teamId: string;
-  teamName: string;
   projectId: string;
+  teamNames: string[];
   onSubmit: (ruleIds: string[]) => void;
 }
 
-const AddRuleModal = ({ open, onHide, rulesetId, teamId, teamName, projectId, onSubmit }: AddRuleModalProps) => {
+const AddRuleModal = ({ open, onHide, rulesetId, projectId, teamNames, onSubmit }: AddRuleModalProps) => {
   const theme = useTheme();
   const [selectedRuleIds, setSelectedRuleIds] = useState<string[]>([]);
 
-  const { data: unassignedRules, isLoading, isError } = useUnassignedRulesForRuleset(rulesetId, teamId, projectId);
+  const { data: unassignedRules, isLoading, isError } = useUnassignedRulesForRuleset(rulesetId, projectId);
 
   type ParentInfo = { ruleId: string; ruleCode: string };
 
@@ -150,7 +149,9 @@ const AddRuleModal = ({ open, onHide, rulesetId, teamId, teamName, projectId, on
           </Box>
         ) : !unassignedRules || unassignedRules.length === 0 ? (
           <Typography variant="body1" color="text.secondary" sx={{ textAlign: 'center', py: 4 }}>
-            No unassigned rules available for the {teamName} team.
+            {teamNames.length > 0
+              ? `No unassigned rules available for the ${teamNames.join(', ')} team${teamNames.length === 1 ? '' : 's'}.`
+              : 'No unassigned rules available for this project.'}
           </Typography>
         ) : (
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectRules/AddProjectRuleModal.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectRules/AddProjectRuleModal.tsx
@@ -17,7 +17,6 @@ import {
   useTheme
 } from '@mui/material';
 import RemoveCircleOutlineIcon from '@mui/icons-material/RemoveCircleOutline';
-import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import { Rule } from 'shared';
 import NERModal from '../../../../components/NERModal';
 import { useUnassignedRulesForRuleset } from '../../../../hooks/rules.hooks';
@@ -33,39 +32,79 @@ interface AddRuleModalProps {
 
 const AddRuleModal = ({ open, onHide, rulesetId, projectId, teamNames, onSubmit }: AddRuleModalProps) => {
   const theme = useTheme();
-  const [selectedRuleIds, setSelectedRuleIds] = useState<string[]>([]);
 
+  const [selectedRuleIds, setSelectedRuleIds] = useState<string[]>([]); // Leaf-rule selections that will be submitted
+  const [path, setPath] = useState<string[]>([]); // In-progress path (rule ids from top level down); only holds non-leaf rules
   const { data: unassignedRules, isLoading, isError } = useUnassignedRulesForRuleset(rulesetId, projectId);
 
-  type ParentInfo = { ruleId: string; ruleCode: string };
+  const addableRules = useMemo(() => unassignedRules ?? [], [unassignedRules]); // rules that can still be added
+  const rulesById = useMemo(
+    () => new Map(addableRules.map((rule: Rule) => [rule.ruleId, rule] as [string, Rule])),
+    [addableRules]
+  );
+  const addableRuleIds = useMemo(() => new Set(addableRules.map((rule: Rule) => rule.ruleId)), [addableRules]);
 
-  const uniqueParents = useMemo(() => {
-    if (!unassignedRules) return [];
-    const parentMap = new Map<string, ParentInfo>();
-    unassignedRules.forEach((rule: Rule) => {
-      if (rule.parentRule) {
-        parentMap.set(rule.parentRule.ruleId, rule.parentRule);
-      }
-    });
-    return Array.from(parentMap.values()).sort((a, b) => a.ruleCode.localeCompare(b.ruleCode));
-  }, [unassignedRules]);
+  // only leaves can be submitted
+  const isLeaf = (rule: Rule) => rule.subRuleIds.length === 0;
+  // used to sort rules in the dropdowns by their rule code
+  const byRuleCode = (a: Rule, b: Rule) => a.ruleCode.localeCompare(b.ruleCode, undefined, { numeric: true });
 
-  const [selectedParentId, setSelectedParentId] = useState<string>('');
-
-  const availableRules = useMemo(() => {
-    if (!unassignedRules || !selectedParentId) return [];
-    return unassignedRules.filter((rule: Rule) => rule.parentRule?.ruleId === selectedParentId);
-  }, [unassignedRules, selectedParentId]);
-
-  const handleParentChange = (event: SelectChangeEvent<string>) => {
-    setSelectedParentId(event.target.value);
-    setSelectedRuleIds([]);
+  // Recursively checks if a rule has any unselected leaf descendants.
+  const hasUnselectedLeaf = (ruleId: string, selected: string[]): boolean => {
+    const rule = rulesById.get(ruleId);
+    if (!rule) return false;
+    if (isLeaf(rule)) return !selected.includes(ruleId);
+    return addableRules.some(
+      (child: Rule) => child.parentRule?.ruleId === ruleId && hasUnselectedLeaf(child.ruleId, selected)
+    );
   };
 
-  const handleRuleSelect = (event: SelectChangeEvent<string>) => {
+  // Finds children of the given parent that still have a leaf left to assign
+  // Or if parentId is null finds the top-level rules of each addable branch (has some unassigned leaf rule)
+  const optionsForParent = (parentId: string | null, selected: string[] = selectedRuleIds): Rule[] =>
+    addableRules
+      .filter((rule: Rule) =>
+        parentId === null
+          ? !rule.parentRule || !addableRuleIds.has(rule.parentRule.ruleId)
+          : rule.parentRule?.ruleId === parentId
+      )
+      .filter((rule: Rule) => hasUnselectedLeaf(rule.ruleId, selected))
+      .sort(byRuleCode);
+
+  // One dropdown per level: the top-level rules, then the children of each chosen rule, recursively.
+  // The first dropdown will always be the top level options, each selection adds a dropdown for its children, until a leaf is chosen.
+  const levels = useMemo(() => {
+    // Tracks the dropdowns to show, starting with the top-level rules and adding a level for each selected rule in the path.
+    const result: { options: Rule[]; value: string }[] = [{ options: optionsForParent(null), value: path[0] ?? '' }];
+    // Each rule already chosen in the path adds one more dropdown beneath it, listing that rule's children.
+    path.forEach((ruleId, index) => {
+      result.push({ options: optionsForParent(ruleId), value: path[index + 1] ?? '' });
+    });
+    return result;
+    // Recompute when the path changes, the addable pool loads/changes, or a selection is made/removed
+  }, [path, addableRules, selectedRuleIds]);
+
+  // If an addable leaf exists anywhere
+  const hasAddableRules = optionsForParent(null).length > 0;
+
+  const handleLevelChange = (levelIndex: number, event: SelectChangeEvent<string>) => {
     const ruleId = event.target.value;
-    if (ruleId && !selectedRuleIds.includes(ruleId)) {
-      setSelectedRuleIds((prev) => [...prev, ruleId]);
+    const rule = rulesById.get(ruleId);
+    if (!rule) return;
+
+    if (isLeaf(rule)) {
+      // Add the leaf to the selected list if it isn't already there
+      const updatedSelected = selectedRuleIds.includes(ruleId) ? selectedRuleIds : [...selectedRuleIds, ruleId];
+      setSelectedRuleIds(updatedSelected);
+      // Keep the path up to the parent of the leaf so siblings can be added if any exist
+      // Collapse levels whose options are now exhausted (no unselected leaves left)
+      let newPath = path.slice(0, levelIndex);
+      while (newPath.length > 0 && optionsForParent(newPath[newPath.length - 1], updatedSelected).length === 0) {
+        newPath = newPath.slice(0, -1);
+      }
+      setPath(newPath);
+    } else {
+      setPath([...path.slice(0, levelIndex), ruleId]);
     }
   };
 
@@ -86,14 +125,11 @@ const AddRuleModal = ({ open, onHide, rulesetId, projectId, teamNames, onSubmit 
 
   const resetForm = () => {
     setSelectedRuleIds([]);
-    setSelectedParentId('');
+    setPath([]); // reset dropdowns
   };
 
   // Get rule display name
-  const getRuleName = (ruleId: string): string => {
-    const rule = unassignedRules?.find((r: Rule) => r.ruleId === ruleId);
-    return rule ? rule.ruleCode : ruleId;
-  };
+  const getRuleName = (ruleId: string): string => rulesById.get(ruleId)?.ruleCode ?? ruleId;
 
   // Dropdown styling
   const selectStyles = {
@@ -147,7 +183,8 @@ const AddRuleModal = ({ open, onHide, rulesetId, projectId, teamNames, onSubmit 
           <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
             <CircularProgress />
           </Box>
-        ) : !unassignedRules || unassignedRules.length === 0 ? (
+        ) : // Empty state when there are no rules assigned or nothing addable is left
+        addableRules.length === 0 || (!hasAddableRules && selectedRuleIds.length === 0) ? (
           <Typography variant="body1" color="text.secondary" sx={{ textAlign: 'center', py: 4 }}>
             {teamNames.length > 0
               ? `No unassigned rules available for the ${teamNames.join(', ')} team${teamNames.length === 1 ? '' : 's'}.`
@@ -155,93 +192,89 @@ const AddRuleModal = ({ open, onHide, rulesetId, projectId, teamNames, onSubmit 
           </Typography>
         ) : (
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-            {/* Select Section */}
-            <Box>
-              <Typography variant="h4" sx={labelStyles}>
-                Select Section
-              </Typography>
-              <FormControl fullWidth>
-                <Select
-                  value={selectedParentId}
-                  onChange={handleParentChange}
-                  displayEmpty
-                  disabled={uniqueParents.length === 0}
-                  sx={selectStyles}
-                  MenuProps={{
-                    PaperProps: {
-                      sx: { backgroundColor: theme.palette.background.paper }
-                    }
-                  }}
-                >
-                  <MenuItem value="" disabled>
-                    <Typography sx={{ color: theme.palette.text.secondary }}>Select Section</Typography>
-                  </MenuItem>
-                  {uniqueParents.map((parent) => (
-                    <MenuItem key={parent.ruleId} value={parent.ruleId}>
-                      {parent.ruleCode}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
-            </Box>
-
-            {/* Select Rules */}
-            <Box>
-              <Typography variant="h4" sx={labelStyles}>
-                Select Rules
-              </Typography>
-
-              {/* Selected Rules */}
-              {selectedRuleIds.map((ruleId) => (
-                <Box key={ruleId} sx={selectedRuleStyles}>
-                  <Box sx={{ display: 'flex', alignItems: 'center', flex: 1 }}>
-                    <IconButton
-                      size="small"
-                      onClick={() => handleRemoveRule(ruleId)}
-                      sx={{ color: theme.palette.text.primary, p: 0.5, mr: 1 }}
-                    >
-                      <RemoveCircleOutlineIcon fontSize="small" />
-                    </IconButton>
-                    <Typography sx={{ color: theme.palette.text.primary }}>{getRuleName(ruleId)}</Typography>
+            {/* Selected Rules */}
+            {selectedRuleIds.length > 0 && (
+              <Box>
+                <Typography variant="h4" sx={labelStyles}>
+                  Selected Rules
+                </Typography>
+                {selectedRuleIds.map((ruleId) => (
+                  <Box key={ruleId} sx={selectedRuleStyles}>
+                    <Box sx={{ display: 'flex', alignItems: 'center', flex: 1 }}>
+                      <IconButton
+                        size="small"
+                        onClick={() => handleRemoveRule(ruleId)}
+                        sx={{ color: theme.palette.text.primary, p: 0.5, mr: 1 }}
+                      >
+                        <RemoveCircleOutlineIcon fontSize="small" />
+                      </IconButton>
+                      <Typography sx={{ color: theme.palette.text.primary }}>{getRuleName(ruleId)}</Typography>
+                    </Box>
                   </Box>
-                  <KeyboardArrowDownIcon sx={{ color: theme.palette.text.primary }} />
-                </Box>
-              ))}
+                ))}
+              </Box>
+            )}
 
-              {/* Add Subtask dropdown */}
-              <FormControl fullWidth>
-                <Select
-                  value=""
-                  onChange={handleRuleSelect}
-                  displayEmpty
-                  disabled={!selectedParentId}
-                  sx={selectStyles}
-                  MenuProps={{
-                    PaperProps: {
-                      sx: { backgroundColor: '#3a3a3a', maxHeight: 300 }
-                    }
-                  }}
-                >
-                  <MenuItem value="" disabled>
-                    <Typography sx={{ color: theme.palette.text.secondary }}>Add Subtask</Typography>
-                  </MenuItem>
-                  {availableRules
-                    .filter((rule: Rule) => !selectedRuleIds.includes(rule.ruleId))
-                    .map((rule: Rule) => (
-                      <MenuItem key={rule.ruleId} value={rule.ruleId}>
-                        <Box>
-                          <Typography fontWeight="bold">{rule.ruleCode}</Typography>
-                          {rule.ruleContent && (
-                            <Typography variant="body2" sx={{ color: theme.palette.text.secondary, maxWidth: 350 }} noWrap>
-                              {rule.ruleContent}
-                            </Typography>
-                          )}
-                        </Box>
-                      </MenuItem>
-                    ))}
-                </Select>
-              </FormControl>
-            </Box>
+            {/* Continuous dropdowns: start at a top-level rule and pick sub-rules until reaching a leaf */}
+            {hasAddableRules ? (
+              <Box>
+                <Typography variant="h4" sx={labelStyles}>
+                  Select Rule
+                </Typography>
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+                  {/* Non-leaf options are flagged with a › to show the ability to continue selecting */}
+                  {levels.map((level, levelIndex) => (
+                    <FormControl fullWidth key={levelIndex}>
+                      <Select
+                        value={level.value}
+                        onChange={(event) => handleLevelChange(levelIndex, event)}
+                        displayEmpty
+                        disabled={level.options.length === 0}
+                        sx={selectStyles}
+                        MenuProps={{
+                          PaperProps: {
+                            sx: { backgroundColor: theme.palette.background.paper, maxHeight: 300 }
+                          }
+                        }}
+                      >
+                        <MenuItem value="" disabled>
+                          <Typography sx={{ color: theme.palette.text.secondary }}>
+                            {levelIndex === 0 ? 'Select Rule' : 'Select Sub-Rule'}
+                          </Typography>
+                        </MenuItem>
+                        {level.options.map((rule: Rule) => (
+                          <MenuItem key={rule.ruleId} value={rule.ruleId}>
+                            <Box>
+                              <Typography fontWeight="bold">
+                                {rule.ruleCode}
+                                {isLeaf(rule) ? '' : ' ›'}
+                              </Typography>
+                              {rule.ruleContent && (
+                                <Typography
+                                  variant="body2"
+                                  sx={{ color: theme.palette.text.secondary, maxWidth: 350 }}
+                                  noWrap
+                                >
+                                  {rule.ruleContent}
+                                </Typography>
+                              )}
+                            </Box>
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                  ))}
+                </Box>
+              </Box>
+            ) : (
+              // Every addable leaf has been selected this session, but the Selected Rules list
+              // above stays visible with save enabled so the user can submit what they picked
+              <Typography variant="body2" color="text.secondary">
+                {teamNames.length > 0
+                  ? `No more unassigned rules available for the ${teamNames.join(', ')} team${teamNames.length === 1 ? '' : 's'}.`
+                  : 'No more unassigned rules available for this project.'}
+              </Typography>
+            )}
           </Box>
         )}
       </Box>

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectRules/AddProjectRuleModal.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectRules/AddProjectRuleModal.tsx
@@ -73,7 +73,7 @@ const AddRuleModal = ({ open, onHide, rulesetId, projectId, teamNames, onSubmit 
 
   // One dropdown per level: the top-level rules, then the children of each chosen rule, recursively.
   // The first dropdown will always be the top level options, each selection adds a dropdown for its children, until a leaf is chosen.
-  const levels = useMemo(() => {
+  const buildLevels = (): { options: Rule[]; value: string }[] => {
     // Tracks the dropdowns to show, starting with the top-level rules and adding a level for each selected rule in the path.
     const result: { options: Rule[]; value: string }[] = [{ options: optionsForParent(null), value: path[0] ?? '' }];
     // Each rule already chosen in the path adds one more dropdown beneath it, listing that rule's children.
@@ -81,8 +81,8 @@ const AddRuleModal = ({ open, onHide, rulesetId, projectId, teamNames, onSubmit 
       result.push({ options: optionsForParent(ruleId), value: path[index + 1] ?? '' });
     });
     return result;
-    // Recompute when the path changes, the addable pool loads/changes, or a selection is made/removed
-  }, [path, addableRules, selectedRuleIds]);
+  };
+  const levels = buildLevels();
 
   // If an addable leaf exists anywhere
   const hasAddableRules = optionsForParent(null).length > 0;

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectRules/AddProjectRuleModal.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectRules/AddProjectRuleModal.tsx
@@ -44,8 +44,10 @@ const AddRuleModal = ({ open, onHide, rulesetId, projectId, teamNames, onSubmit 
   );
   const addableRuleIds = useMemo(() => new Set(addableRules.map((rule: Rule) => rule.ruleId)), [addableRules]);
 
-  // only leaves can be submitted
-  const isLeaf = (rule: Rule) => rule.subRuleIds.length === 0;
+  // Children of a rule that are still addable
+  const addableChildrenOf = (ruleId: string) => addableRules.filter((rule: Rule) => rule.parentRule?.ruleId === ruleId);
+  // A rule is a selectable leaf when it has no addable children to drill into
+  const isLeaf = (rule: Rule) => addableChildrenOf(rule.ruleId).length === 0;
   // used to sort rules in the dropdowns by their rule code
   const byRuleCode = (a: Rule, b: Rule) => a.ruleCode.localeCompare(b.ruleCode, undefined, { numeric: true });
 
@@ -53,10 +55,9 @@ const AddRuleModal = ({ open, onHide, rulesetId, projectId, teamNames, onSubmit 
   const hasUnselectedLeaf = (ruleId: string, selected: string[]): boolean => {
     const rule = rulesById.get(ruleId);
     if (!rule) return false;
-    if (isLeaf(rule)) return !selected.includes(ruleId);
-    return addableRules.some(
-      (child: Rule) => child.parentRule?.ruleId === ruleId && hasUnselectedLeaf(child.ruleId, selected)
-    );
+    const addableChildren = addableChildrenOf(ruleId);
+    if (addableChildren.length === 0) return !selected.includes(ruleId);
+    return addableChildren.some((child: Rule) => hasUnselectedLeaf(child.ruleId, selected));
   };
 
   // Finds children of the given parent that still have a leaf left to assign

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectRules/ProjectRulesTab.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectRules/ProjectRulesTab.tsx
@@ -438,14 +438,13 @@ export const ProjectRulesTab = ({ project }: ProjectRulesTabProps) => {
       )}
 
       {/* Add Rule Modal */}
-      {activeRuleset && teamId && (
+      {activeRuleset && (
         <AddRuleModal
           open={addRuleModalOpen}
           onHide={() => setAddRuleModalOpen(false)}
           rulesetId={activeRuleset.rulesetId}
-          teamId={teamId}
-          teamName={project.teams[0]?.teamName ?? ''}
           projectId={project.id}
+          teamNames={project.teams.map((team) => team.teamName)}
           onSubmit={handleAddRules}
         />
       )}

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectRules/ProjectRulesTab.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectRules/ProjectRulesTab.tsx
@@ -82,6 +82,7 @@ export const ProjectRulesTab = ({ project }: ProjectRulesTabProps) => {
 
   // Get the first team's ID for fetching unassigned rules
   const teamId = project.teams[0]?.teamId || '';
+  const teamNames = project.teams.map((team) => team.teamName);
 
   // Convert project rules to rules
   const allRules = useMemo(() => {
@@ -214,7 +215,13 @@ export const ProjectRulesTab = ({ project }: ProjectRulesTabProps) => {
         </MuiTabs>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
           <Tooltip
-            title={`Assign rules to ${project.teams[0]?.teamName ?? ''} team to add them to this project`}
+            title={
+              teamNames.length > 0
+                ? `Assign rules to the ${teamNames.join(', ')} team${
+                    teamNames.length === 1 ? '' : 's'
+                  } to add them to this project`
+                : 'Add a team to this project to assign rules'
+            }
             arrow
             slotProps={{ tooltip: { sx: { textAlign: 'center' } } }}
           >
@@ -230,7 +237,7 @@ export const ProjectRulesTab = ({ project }: ProjectRulesTabProps) => {
             </IconButton>
           </Tooltip>
           <Button
-            disabled={!activeRuleset}
+            disabled={!activeRuleset || teamNames.length === 0}
             onClick={() =>
               activeRuleset &&
               history.push(

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectRules/ProjectRulesTab.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectRules/ProjectRulesTab.tsx
@@ -80,7 +80,7 @@ export const ProjectRulesTab = ({ project }: ProjectRulesTabProps) => {
 
   const { mutateAsync: createProjectRuleMutation, isLoading: isCreating } = useCreateProjectRule();
 
-  // Get the first team's ID for fetching unassigned rules
+  // First team's ID, used only to pre-select a team tab on the assign-rules deep link
   const teamId = project.teams[0]?.teamId || '';
   const teamNames = project.teams.map((team) => team.teamName);
 
@@ -238,6 +238,7 @@ export const ProjectRulesTab = ({ project }: ProjectRulesTabProps) => {
           </Tooltip>
           <Button
             disabled={!activeRuleset || teamNames.length === 0}
+            // Assign rule page only supports highlighting a single team at a time
             onClick={() =>
               activeRuleset &&
               history.push(
@@ -332,7 +333,7 @@ export const ProjectRulesTab = ({ project }: ProjectRulesTabProps) => {
           <Button
             variant="contained"
             onClick={() => setAddRuleModalOpen(true)}
-            disabled={!teamId || hasNoActiveRuleset}
+            disabled={teamNames.length === 0 || hasNoActiveRuleset}
             sx={{
               borderRadius: '8px',
               backgroundColor: '#ef4345',

--- a/src/frontend/src/pages/RulesPage/AssignRulesTab.tsx
+++ b/src/frontend/src/pages/RulesPage/AssignRulesTab.tsx
@@ -34,17 +34,19 @@ interface AssignRulesTabProps {
   rules: Rule[];
 }
 
-const getLeafRuleIds = (ruleId: string, allRules: Rule[]): string[] => {
+/**
+ * Collects a rule and all of its descendants
+ * Assignment applies to the clicked rule and everything beneath it, so each of
+ * those rules gets its own team relation — a parent is only assigned when it is
+ * clicked directly.
+ */
+const getRuleAndDescendantIds = (ruleId: string, allRules: Rule[]): string[] => {
   const rule = allRules.find((r) => r.ruleId === ruleId);
   if (!rule) {
     return [];
   }
 
-  if (rule.subRuleIds.length === 0) {
-    return [ruleId];
-  }
-
-  return rule.subRuleIds.flatMap((subId) => getLeafRuleIds(subId, allRules));
+  return [ruleId, ...rule.subRuleIds.flatMap((subId) => getRuleAndDescendantIds(subId, allRules))];
 };
 
 /*
@@ -168,21 +170,23 @@ const AssignRulesTab: React.FC<AssignRulesTabProps> = ({ rules }) => {
       return;
     }
 
-    const leafIds = getLeafRuleIds(ruleId, rules);
-    if (leafIds.length === 0) {
+    // Assign the clicked rule and all of its descendants, not just leaves, so
+    // every rule in the subtree gets its own team relation
+    const subtreeIds = getRuleAndDescendantIds(ruleId, rules);
+    if (subtreeIds.length === 0) {
       return;
     }
 
     const newAssignments = new Set(assignments);
     let allSelected = true;
-    for (const id of leafIds) {
+    for (const id of subtreeIds) {
       if (!newAssignments.has(`${selectedTeamId}:${id}`)) {
         allSelected = false;
         break;
       }
     }
 
-    for (const id of leafIds) {
+    for (const id of subtreeIds) {
       const key = `${selectedTeamId}:${id}`;
       if (allSelected) {
         newAssignments.delete(key);
@@ -287,16 +291,8 @@ const AssignRulesTab: React.FC<AssignRulesTabProps> = ({ rules }) => {
                     key={rule.ruleId}
                     rule={rule}
                     allRules={rules}
-                    backgroundColor={(r) => {
-                      const leafIds = getLeafRuleIds(r.ruleId, rules);
-                      const isSelected = leafIds.length > 0 && leafIds.every((id) => isRuleAssigned(id));
-                      return isSelected ? '#b36b6b' : '#CECECE';
-                    }}
-                    hoverColor={(r) => {
-                      const leafIds = getLeafRuleIds(r.ruleId, rules);
-                      const isSelected = leafIds.length > 0 && leafIds.every((id) => isRuleAssigned(id));
-                      return isSelected ? '#a05858' : '#5e5e5e';
-                    }}
+                    backgroundColor={(r) => (isRuleAssigned(r.ruleId) ? '#b36b6b' : '#CECECE')}
+                    hoverColor={(r) => (isRuleAssigned(r.ruleId) ? '#a05858' : '#5e5e5e')}
                     textColor="#000000"
                     onRowClick={(r) => handleRuleToggle(r.ruleId)}
                     middleContent={() => null}

--- a/src/frontend/src/pages/RulesPage/AssignRulesTab.tsx
+++ b/src/frontend/src/pages/RulesPage/AssignRulesTab.tsx
@@ -230,6 +230,9 @@ const AssignRulesTab: React.FC<AssignRulesTabProps> = ({ rules }) => {
     bulkToggle(toggles, {
       onSuccess: () => {
         history.push(routes.RULESET_EDIT.replace(':rulesetId', rulesetId));
+      },
+      onSettled: () => {
+        setPendingToggles(null);
       }
     });
   };
@@ -264,7 +267,6 @@ const AssignRulesTab: React.FC<AssignRulesTabProps> = ({ rules }) => {
     if (pendingToggles) {
       executeToggles(pendingToggles);
     }
-    setPendingToggles(null);
   };
 
   if (teamsError) {
@@ -388,6 +390,7 @@ const AssignRulesTab: React.FC<AssignRulesTabProps> = ({ rules }) => {
         cancelText="Cancel"
         submitText="Save"
         onSubmit={handleConfirmSave}
+        disabled={isSaving}
       >
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
           <WarningIcon sx={{ color: '#ef4345', fontSize: 30 }} />

--- a/src/frontend/src/pages/RulesPage/AssignRulesTab.tsx
+++ b/src/frontend/src/pages/RulesPage/AssignRulesTab.tsx
@@ -215,8 +215,17 @@ const AssignRulesTab: React.FC<AssignRulesTabProps> = ({ rules }) => {
     removedKeys.forEach((key) => {
       const [teamId, ruleId] = key.split(':');
       const rule = rules.find((r) => r.ruleId === ruleId);
+      // teams the rule will remain on after this save
+      const remainingTeamIds = [...assignments]
+        .filter((assignmentKey) => assignmentKey.endsWith(`:${ruleId}`))
+        .map((assignmentKey) => assignmentKey.split(':')[0]);
+
       rule?.projects?.forEach((project) => {
-        if (project.teamIds.includes(teamId)) {
+        if (!project.teamIds.includes(teamId)) return;
+        // A project can belong to multiple teams
+        // Therefore a project only loses the rule if the rule no longer shares ANY team with it
+        const sharesRemainingTeam = project.teamIds.some((id) => remainingTeamIds.includes(id));
+        if (!sharesRemainingTeam) {
           affectedRuleIds.add(ruleId);
           affectedProjectIds.add(project.projectId);
         }

--- a/src/frontend/src/pages/RulesPage/AssignRulesTab.tsx
+++ b/src/frontend/src/pages/RulesPage/AssignRulesTab.tsx
@@ -24,6 +24,8 @@ import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { routes } from '../../utils/routes';
 import { useToast } from '../../hooks/toasts.hooks';
 import { NERButton } from '../../components/NERButton';
+import NERModal from '../../components/NERModal';
+import WarningIcon from '@mui/icons-material/Warning';
 import RuleRow from './RuleRow';
 import { useBulkToggleRuleTeam } from '../../hooks/rules.hooks';
 
@@ -102,6 +104,12 @@ const AssignRulesTab: React.FC<AssignRulesTabProps> = ({ rules }) => {
   const [assignments, setAssignments] = useState<Set<string>>(new Set());
   const [originalAssignments, setOriginalAssignments] = useState<Set<string>>(new Set());
   const [isInitialized, setIsInitialized] = useState(false);
+  // unassign impact for the amount of project rules that would be deleted by this action, used to warn the user before saving
+  const [pendingToggles, setPendingToggles] = useState<Array<{ ruleId: string; teamId: string }> | null>(null);
+  const [unassignImpact, setUnassignImpact] = useState<{ ruleCount: number; projectCount: number }>({
+    ruleCount: 0,
+    projectCount: 0
+  });
 
   const { data: teams, isLoading: teamsLoading, isError: teamsError, error: teamsErrorData } = useAllTeams();
   const { mutate: bulkToggle, isLoading: isSaving } = useBulkToggleRuleTeam();
@@ -198,6 +206,34 @@ const AssignRulesTab: React.FC<AssignRulesTabProps> = ({ rules }) => {
     setAssignments(newAssignments);
   };
 
+  // Counts the amount of rules and projects that would lose their project rule
+  // assignments when the given team-unassignments are saved
+  const getUnassignImpact = (removedKeys: string[]): { ruleCount: number; projectCount: number } => {
+    const affectedRuleIds = new Set<string>();
+    const affectedProjectIds = new Set<string>();
+
+    removedKeys.forEach((key) => {
+      const [teamId, ruleId] = key.split(':');
+      const rule = rules.find((r) => r.ruleId === ruleId);
+      rule?.projects?.forEach((project) => {
+        if (project.teamIds.includes(teamId)) {
+          affectedRuleIds.add(ruleId);
+          affectedProjectIds.add(project.projectId);
+        }
+      });
+    });
+
+    return { ruleCount: affectedRuleIds.size, projectCount: affectedProjectIds.size };
+  };
+
+  const executeToggles = (toggles: Array<{ ruleId: string; teamId: string }>) => {
+    bulkToggle(toggles, {
+      onSuccess: () => {
+        history.push(routes.RULESET_EDIT.replace(':rulesetId', rulesetId));
+      }
+    });
+  };
+
   const handleSaveAndExit = () => {
     const toAdd = [...assignments].filter((key) => !originalAssignments.has(key));
     const toRemove = [...originalAssignments].filter((key) => !assignments.has(key));
@@ -208,24 +244,27 @@ const AssignRulesTab: React.FC<AssignRulesTabProps> = ({ rules }) => {
     }
 
     // Build array of toggles to execute
-    const toggles: Array<{ ruleId: string; teamId: string }> = [];
-
-    toAdd.forEach((key) => {
+    const toggles = [...toAdd, ...toRemove].map((key) => {
       const [teamId, ruleId] = key.split(':');
-      toggles.push({ ruleId, teamId });
+      return { ruleId, teamId };
     });
 
-    toRemove.forEach((key) => {
-      const [teamId, ruleId] = key.split(':');
-      toggles.push({ ruleId, teamId });
-    });
+    // Warn before saving if unassignments would remove existing project assignments
+    const impact = getUnassignImpact(toRemove);
+    if (impact.ruleCount > 0) {
+      setUnassignImpact(impact);
+      setPendingToggles(toggles);
+      return;
+    }
 
-    // Execute bulk toggle and navigate on success
-    bulkToggle(toggles, {
-      onSuccess: () => {
-        history.push(routes.RULESET_EDIT.replace(':rulesetId', rulesetId));
-      }
-    });
+    executeToggles(toggles);
+  };
+
+  const handleConfirmSave = () => {
+    if (pendingToggles) {
+      executeToggles(pendingToggles);
+    }
+    setPendingToggles(null);
   };
 
   if (teamsError) {
@@ -341,6 +380,23 @@ const AssignRulesTab: React.FC<AssignRulesTabProps> = ({ rules }) => {
           </NERButton>
         </Box>
       </Box>
+
+      <NERModal
+        open={pendingToggles !== null}
+        onHide={() => setPendingToggles(null)}
+        title="Confirm Unassignment"
+        cancelText="Cancel"
+        submitText="Save"
+        onSubmit={handleConfirmSave}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <WarningIcon sx={{ color: '#ef4345', fontSize: 30 }} />
+          <Typography sx={{ fontSize: '1rem' }}>
+            This will remove {unassignImpact.ruleCount} rule{unassignImpact.ruleCount === 1 ? '' : 's'} from{' '}
+            {unassignImpact.projectCount} project{unassignImpact.projectCount === 1 ? '' : 's'}.
+          </Typography>
+        </Box>
+      </NERModal>
     </Box>
   );
 };

--- a/src/frontend/src/pages/RulesPage/AssignRulesTab.tsx
+++ b/src/frontend/src/pages/RulesPage/AssignRulesTab.tsx
@@ -28,6 +28,7 @@ import NERModal from '../../components/NERModal';
 import WarningIcon from '@mui/icons-material/Warning';
 import RuleRow from './RuleRow';
 import { useBulkToggleRuleTeam } from '../../hooks/rules.hooks';
+import { getAncestorIds, getRuleAndDescendantIds } from '../../utils/rules.utils';
 
 /*
  * Props for the assign rules tab.
@@ -35,21 +36,6 @@ import { useBulkToggleRuleTeam } from '../../hooks/rules.hooks';
 interface AssignRulesTabProps {
   rules: Rule[];
 }
-
-/**
- * Collects a rule and all of its descendants
- * Assignment applies to the clicked rule and everything beneath it, so each of
- * those rules gets its own team relation — a parent is only assigned when it is
- * clicked directly.
- */
-const getRuleAndDescendantIds = (ruleId: string, allRules: Rule[]): string[] => {
-  const rule = allRules.find((r) => r.ruleId === ruleId);
-  if (!rule) {
-    return [];
-  }
-
-  return [ruleId, ...rule.subRuleIds.flatMap((subId) => getRuleAndDescendantIds(subId, allRules))];
-};
 
 /*
  * Props for the team row.
@@ -186,21 +172,30 @@ const AssignRulesTab: React.FC<AssignRulesTabProps> = ({ rules }) => {
     }
 
     const newAssignments = new Set(assignments);
-    let allSelected = true;
-    for (const id of subtreeIds) {
-      if (!newAssignments.has(`${selectedTeamId}:${id}`)) {
-        allSelected = false;
-        break;
-      }
-    }
+    const teamAssignmentKey = (id: string) => `${selectedTeamId}:${id}`; // needed since the same rule can be assigned to multiple teams
+    const allSelected = subtreeIds.every((id) => newAssignments.has(teamAssignmentKey(id)));
 
-    for (const id of subtreeIds) {
-      const key = `${selectedTeamId}:${id}`;
-      if (allSelected) {
-        newAssignments.delete(key);
-      } else {
-        newAssignments.add(key);
+    if (allSelected) {
+      // Unassign the rule and its descendants
+      subtreeIds.forEach((id) => newAssignments.delete(teamAssignmentKey(id)));
+
+      // Drop each parent that no longer has ANY assigned descendant.
+      for (const ancestorId of getAncestorIds(ruleId, rules)) {
+        const hasAssignedDescendant = getRuleAndDescendantIds(ancestorId, rules).some(
+          (id) => id !== ancestorId && newAssignments.has(teamAssignmentKey(id))
+        );
+        // Stop at the first ancestor still holding an assigned leaf rule, since every
+        // higher ancestor shares that descendant and must remain assigned.
+        if (hasAssignedDescendant) {
+          break;
+        }
+        newAssignments.delete(teamAssignmentKey(ancestorId));
       }
+    } else {
+      // Assign the rule, its descendants, and all of its ancestors so there is
+      // always a path to the top-level rule
+      subtreeIds.forEach((id) => newAssignments.add(teamAssignmentKey(id)));
+      getAncestorIds(ruleId, rules).forEach((id) => newAssignments.add(teamAssignmentKey(id)));
     }
 
     setAssignments(newAssignments);

--- a/src/frontend/src/pages/RulesPage/RulesetViewPage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetViewPage.tsx
@@ -7,53 +7,14 @@ import { useParams } from 'react-router-dom';
 import ErrorPage from '../ErrorPage';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import RulesetGeneralView from './components/RulesetGeneralView';
-import { Rule } from 'shared';
-import RulesetTeamView, { TeamRules } from './components/RulesetTeamView';
+import RulesetTeamView from './components/RulesetTeamView';
 import { useSingleRuleset, useAllRulesForRuleset } from '../../hooks/rules.hooks';
-
-/**
- * Organizes rules by team and project assignments.
- * Rules without team assignments are shown in the unassigned section.
- */
-const getTeamOrganization = (allRules: Rule[]): { teamRules: TeamRules[]; unassignedToTeam: Rule[] } => {
-  const teamMap = new Map<string, TeamRules>();
-  const unassignedToTeam: Rule[] = [];
-
-  // Iterate through all rules and organize by team
-  allRules.forEach((rule) => {
-    if (!rule.teams || rule.teams.length === 0) {
-      // Only add to unassigned if it's a top-level rule (no parent)
-      if (!rule.parentRule) {
-        unassignedToTeam.push(rule);
-      }
-    } else {
-      // Add rule to each assigned team (includes both parents and children)
-      rule.teams.forEach((team) => {
-        if (!teamMap.has(team.teamId)) {
-          teamMap.set(team.teamId, {
-            teamId: team.teamId,
-            teamName: team.teamName,
-            projects: [],
-            unassignedRules: []
-          });
-        }
-
-        const teamRules = teamMap.get(team.teamId)!;
-        if (!rule.parentRule) {
-          teamRules.unassignedRules.push(rule);
-        }
-      });
-    }
-  });
-
-  return { teamRules: Array.from(teamMap.values()), unassignedToTeam };
-};
 
 const RulesetViewPage = () => {
   const [tabIndex, setTabIndex] = useState<number>(0);
   const tabs = [
-    { tabUrlValue: 'teamView', tabName: 'Team View' },
-    { tabUrlValue: 'generalView', tabName: 'General View' }
+    { tabUrlValue: 'generalView', tabName: 'General View' },
+    { tabUrlValue: 'teamView', tabName: 'Team View' }
   ];
 
   const { rulesetId } = useParams<{ rulesetId: string }>();
@@ -88,8 +49,6 @@ const RulesetViewPage = () => {
     return <LoadingIndicator />;
   }
 
-  const { teamRules, unassignedToTeam } = getTeamOrganization(allRules);
-
   return (
     <Box>
       <PageLayout
@@ -108,18 +67,14 @@ const RulesetViewPage = () => {
               setTab={setTabIndex}
               tabsLabels={tabs}
               baseUrl={routes.RULESET_VIEW.replace(':rulesetId', rulesetId!)}
-              defaultTab={'teamView'}
+              defaultTab={'generalView'}
               id="rules-view-tabs"
             />
           </Box>
         }
       >
         <Box sx={{ width: '100%', borderRadius: '8px 8px 0 0' }}>
-          {tabIndex === 0 ? (
-            <RulesetTeamView allRules={allRules} teamRules={teamRules} unassignedToTeam={unassignedToTeam} />
-          ) : (
-            <RulesetGeneralView allRules={allRules} />
-          )}
+          {tabIndex === 0 ? <RulesetGeneralView allRules={allRules} /> : <RulesetTeamView allRules={allRules} />}
         </Box>
       </PageLayout>
     </Box>

--- a/src/frontend/src/pages/RulesPage/components/RulesetTeamView.tsx
+++ b/src/frontend/src/pages/RulesPage/components/RulesetTeamView.tsx
@@ -21,27 +21,27 @@ interface RulesetTeamViewProps {
 }
 
 /**
- * Groups ruleset's rules by team and project for team view.
- *   team → project → rules assigned to that project, or unassigned to any project
- *   "unassigned to team" → rules on no team at all
- * Note that rules can be on more than one team and in more than one project.
+ * Groups ruleset's rules by team and project for team view. First groups by team
+ * assigned to, then by projects assign to within that team, or unassigned to any
+ * project. Finally groups by rules not assigned to any team.
+ * Note that rules can be on more than one team and in more than one project for that team.
  */
 const getTeamOrganization = (allRules: Rule[]): { teamRules: TeamRules[]; unassignedToTeam: Rule[] } => {
   const teamMap = new Map<string, TeamRules>();
-  // per team, projects keyed by projectId so rules sharing a project merge into one bucket
   const teamProjectMaps = new Map<string, Map<string, TeamProject>>();
   const unassignedToTeam: Rule[] = [];
 
+  // iterate through all rules and organize by team and project
   allRules.forEach((rule) => {
-    // A rule with no team belongs to the top-level "unassigned to team" bucket.
+    // rule with no team belongs to the top-level "unassigned to team" bucket.
     if (!rule.teams || rule.teams.length === 0) {
       unassignedToTeam.push(rule);
       return;
     }
 
-    // otherwise place the rule under each team it belongs to.
+    // otherwise place the rule under each team it belongs to
     rule.teams.forEach((team) => {
-      // create the team's buckets the first time we see it.
+      // create the team's buckets the first time we see it
       if (!teamMap.has(team.teamId)) {
         teamMap.set(team.teamId, {
           teamId: team.teamId,
@@ -85,29 +85,24 @@ const getTeamOrganization = (allRules: Rule[]): { teamRules: TeamRules[]; unassi
 };
 
 /**
- * Turns one bucket's rules into rows that RuleRow can render.
- *
- * Returns the prepared rows plus the ids of the bucket's roots (rules whose
- * parent isn't in the bucket) and those become the section header row's children
+ * Prepares one bucket's rules for the shared RuleRow tree.
+ * Ids are prefixed with their bucket since the same rule can live in multiple teams or projects
  */
 const scopeRulesToBucket = (bucketId: string, rules: Rule[]): { rows: Rule[]; rootIds: string[] } => {
   const idsInBucket = new Set(rules.map((rule) => rule.ruleId));
-  const scopedId = (ruleId: string) => `${bucketId}::${ruleId}`;
+  const bucketPrefixId = (ruleId: string) => `${bucketId}::${ruleId}`;
 
+  // add bucket prefix id to each rule, filtering out subRuleIds that are not in this bucket
   const rows: Rule[] = rules.map((rule) => ({
     ...rule,
-    // Bucket-prefixed id so copies of the same rule in different buckets don't collide
-    ruleId: scopedId(rule.ruleId),
-    // only keeps parent link if parent is in this bucket
-    parentRule:
-      rule.parentRule && idsInBucket.has(rule.parentRule.ruleId)
-        ? { ruleId: scopedId(rule.parentRule.ruleId), ruleCode: rule.parentRule.ruleCode }
-        : undefined,
-    // only keep child links if children are in this bucket
-    subRuleIds: rule.subRuleIds.filter((id) => idsInBucket.has(id)).map(scopedId)
+    ruleId: bucketPrefixId(rule.ruleId),
+    subRuleIds: rule.subRuleIds.filter((id) => idsInBucket.has(id)).map(bucketPrefixId)
   }));
-  // rules with no in-bucket parent
-  const rootIds = rows.filter((row) => !row.parentRule).map((row) => row.ruleId);
+
+  // find top level rules in this bucket where parentRule is either not set or not in this bucket
+  const rootIds = rules
+    .filter((rule) => !rule.parentRule || !idsInBucket.has(rule.parentRule.ruleId))
+    .map((rule) => bucketPrefixId(rule.ruleId));
 
   return { rows, rootIds };
 };

--- a/src/frontend/src/pages/RulesPage/components/RulesetTeamView.tsx
+++ b/src/frontend/src/pages/RulesPage/components/RulesetTeamView.tsx
@@ -18,15 +18,53 @@ interface TeamRules {
 
 interface RulesetTeamViewProps {
   allRules: Rule[];
-  teamRules: TeamRules[];
-  unassignedToTeam: Rule[];
 }
+
+/**
+ * Organizes rules by team and project assignments.
+ * Rules without team assignments are shown in the unassigned section.
+ */
+const getTeamOrganization = (allRules: Rule[]): { teamRules: TeamRules[]; unassignedToTeam: Rule[] } => {
+  const teamMap = new Map<string, TeamRules>();
+  const unassignedToTeam: Rule[] = [];
+
+  // Iterate through all rules and organize by team
+  allRules.forEach((rule) => {
+    if (!rule.teams || rule.teams.length === 0) {
+      // Only add to unassigned if it's a top-level rule (no parent)
+      if (!rule.parentRule) {
+        unassignedToTeam.push(rule);
+      }
+    } else {
+      // Add rule to each assigned team (includes both parents and children)
+      rule.teams.forEach((team) => {
+        if (!teamMap.has(team.teamId)) {
+          teamMap.set(team.teamId, {
+            teamId: team.teamId,
+            teamName: team.teamName,
+            projects: [],
+            unassignedRules: []
+          });
+        }
+
+        const teamRules = teamMap.get(team.teamId)!;
+        if (!rule.parentRule) {
+          teamRules.unassignedRules.push(rule);
+        }
+      });
+    }
+  });
+
+  return { teamRules: Array.from(teamMap.values()), unassignedToTeam };
+};
 
 /**
  * Displays rules organized by team and project
  * Teams and projects are rendered as RuleRows for consistent formatting
  */
-const RulesetTeamView: React.FC<RulesetTeamViewProps> = ({ allRules, teamRules, unassignedToTeam }) => {
+const RulesetTeamView: React.FC<RulesetTeamViewProps> = ({ allRules }) => {
+  const { teamRules, unassignedToTeam } = getTeamOrganization(allRules);
+
   // Convert teams to mock rules for rendering with RuleRow
   const teamRulesAsRules: Rule[] = teamRules.map((team) => ({
     ruleId: `team-${team.teamId}`,

--- a/src/frontend/src/pages/RulesPage/components/RulesetTeamView.tsx
+++ b/src/frontend/src/pages/RulesPage/components/RulesetTeamView.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Box, Paper, Table, TableBody, TableContainer } from '@mui/material';
 import { Rule } from 'shared';
 import RuleRow from '../RuleRow';
@@ -21,125 +21,166 @@ interface RulesetTeamViewProps {
 }
 
 /**
- * Organizes rules by team and project assignments.
- * Rules without team assignments are shown in the unassigned section.
+ * Groups ruleset's rules by team and project for team view.
+ *   team → project → rules assigned to that project, or unassigned to any project
+ *   "unassigned to team" → rules on no team at all
+ * Note that rules can be on more than one team and in more than one project.
  */
 const getTeamOrganization = (allRules: Rule[]): { teamRules: TeamRules[]; unassignedToTeam: Rule[] } => {
   const teamMap = new Map<string, TeamRules>();
+  // per team, projects keyed by projectId so rules sharing a project merge into one bucket
+  const teamProjectMaps = new Map<string, Map<string, TeamProject>>();
   const unassignedToTeam: Rule[] = [];
 
-  // Iterate through all rules and organize by team
   allRules.forEach((rule) => {
+    // A rule with no team belongs to the top-level "unassigned to team" bucket.
     if (!rule.teams || rule.teams.length === 0) {
-      // Only add to unassigned if it's a top-level rule (no parent)
-      if (!rule.parentRule) {
-        unassignedToTeam.push(rule);
-      }
-    } else {
-      // Add rule to each assigned team (includes both parents and children)
-      rule.teams.forEach((team) => {
-        if (!teamMap.has(team.teamId)) {
-          teamMap.set(team.teamId, {
-            teamId: team.teamId,
-            teamName: team.teamName,
-            projects: [],
-            unassignedRules: []
-          });
-        }
-
-        const teamRules = teamMap.get(team.teamId)!;
-        if (!rule.parentRule) {
-          teamRules.unassignedRules.push(rule);
-        }
-      });
+      unassignedToTeam.push(rule);
+      return;
     }
+
+    // otherwise place the rule under each team it belongs to.
+    rule.teams.forEach((team) => {
+      // create the team's buckets the first time we see it.
+      if (!teamMap.has(team.teamId)) {
+        teamMap.set(team.teamId, {
+          teamId: team.teamId,
+          teamName: team.teamName,
+          projects: [],
+          unassignedRules: []
+        });
+        teamProjectMaps.set(team.teamId, new Map());
+      }
+
+      const teamRules = teamMap.get(team.teamId)!;
+      const projectMap = teamProjectMaps.get(team.teamId)!;
+
+      // Keep only the rule's projects that belong to this team. Since rules can be on multiple teams,
+      // this ensures projects don't show up under teams they are not a part of
+      const projectsForTeam = rule.projects?.filter((project) => project.teamIds.includes(team.teamId)) ?? [];
+
+      // Add the rule under each of its projects, or unassigned to project, for this team
+      if (projectsForTeam.length > 0) {
+        projectsForTeam.forEach((project) => {
+          if (!projectMap.has(project.projectId)) {
+            projectMap.set(project.projectId, {
+              projectId: project.projectId,
+              projectName: project.projectName,
+              rules: []
+            });
+          }
+          projectMap.get(project.projectId)!.rules.push(rule);
+        });
+      } else {
+        teamRules.unassignedRules.push(rule);
+      }
+    });
+  });
+
+  teamMap.forEach((teamRules, teamId) => {
+    teamRules.projects = Array.from(teamProjectMaps.get(teamId)!.values());
   });
 
   return { teamRules: Array.from(teamMap.values()), unassignedToTeam };
 };
 
 /**
- * Displays rules organized by team and project
- * Teams and projects are rendered as RuleRows for consistent formatting
+ * Turns one bucket's rules into rows that RuleRow can render.
+ *
+ * Returns the prepared rows plus the ids of the bucket's roots (rules whose
+ * parent isn't in the bucket) and those become the section header row's children
+ */
+const scopeRulesToBucket = (bucketId: string, rules: Rule[]): { rows: Rule[]; rootIds: string[] } => {
+  const idsInBucket = new Set(rules.map((rule) => rule.ruleId));
+  const scopedId = (ruleId: string) => `${bucketId}::${ruleId}`;
+
+  const rows: Rule[] = rules.map((rule) => ({
+    ...rule,
+    // Bucket-prefixed id so copies of the same rule in different buckets don't collide
+    ruleId: scopedId(rule.ruleId),
+    // only keeps parent link if parent is in this bucket
+    parentRule:
+      rule.parentRule && idsInBucket.has(rule.parentRule.ruleId)
+        ? { ruleId: scopedId(rule.parentRule.ruleId), ruleCode: rule.parentRule.ruleCode }
+        : undefined,
+    // only keep child links if children are in this bucket
+    subRuleIds: rule.subRuleIds.filter((id) => idsInBucket.has(id)).map(scopedId)
+  }));
+  // rules with no in-bucket parent
+  const rootIds = rows.filter((row) => !row.parentRule).map((row) => row.ruleId);
+
+  return { rows, rootIds };
+};
+
+/**
+ * Builds a structural header row (team, project, or "unassigned" section), not a real rule
+ */
+const makeSectionRow = (ruleId: string, ruleCode: string, subRuleIds: string[]): Rule => ({
+  ruleId,
+  ruleCode,
+  ruleContent: '',
+  imageFileIds: [],
+  parentRule: undefined,
+  subRuleIds,
+  referencedRuleIds: [],
+  isComplete: false
+});
+
+/**
+ * Displays rules organized by team and project.
+ * Teams, projects, and unassigned sections are all rendered as RuleRows for consistent formatting.
  */
 const RulesetTeamView: React.FC<RulesetTeamViewProps> = ({ allRules }) => {
-  const { teamRules, unassignedToTeam } = getTeamOrganization(allRules);
+  // recompute row tree only when the rules change
+  const { topLevelItems, rowsById } = useMemo(() => {
+    const { teamRules, unassignedToTeam } = getTeamOrganization(allRules);
 
-  // Convert teams to mock rules for rendering with RuleRow
-  const teamRulesAsRules: Rule[] = teamRules.map((team) => ({
-    ruleId: `team-${team.teamId}`,
-    ruleCode: `${team.teamName}`,
-    ruleContent: '',
-    imageFileIds: [],
-    parentRule: undefined,
-    subRuleIds: [
-      ...team.projects.map((p) => `project-${p.projectId}`),
-      ...(team.unassignedRules.length > 0 ? [`team-${team.teamId}-unassigned`] : [])
-    ],
-    referencedRuleIds: [],
-    isComplete: false
-  }));
+    // real-rule rows (bucket-scoped)
+    const ruleRows: Rule[] = [];
+    // header rows: teams, projects, and unassigned sections
+    const sectionRows: Rule[] = [];
+    // top level - one header row per team, plus "unassigned to team"
+    const topLevelItems: Rule[] = [];
 
-  // Convert projects to mock rules for rendering with RuleRow
-  const projectRulesAsRules: Rule[] = teamRules.flatMap((team) =>
-    team.projects.map((project) => ({
-      ruleId: `project-${project.projectId}`,
-      ruleCode: `${project.projectName}`,
-      ruleContent: '',
-      imageFileIds: [],
-      parentRule: {
-        ruleId: `team-${team.teamId}`,
-        ruleCode: `${team.teamName}`
-      },
-      subRuleIds: project.rules.map((r) => r.ruleId),
-      referencedRuleIds: [],
-      isComplete: false
-    }))
-  );
+    teamRules.forEach((team) => {
+      const teamRowId = `team-${team.teamId}`;
+      const teamChildIds: string[] = [];
 
-  // Convert unassigned to project sections to mock rules
-  const unassignedToProjectRules: Rule[] = teamRules
-    .filter((team) => team.unassignedRules.length > 0)
-    .map((team) => ({
-      ruleId: `team-${team.teamId}-unassigned`,
-      ruleCode: 'Unassigned Rules - Unassigned to Project',
-      ruleContent: '',
-      imageFileIds: [],
-      parentRule: {
-        ruleId: `team-${team.teamId}`,
-        ruleCode: `${team.teamName}`
-      },
-      subRuleIds: team.unassignedRules.map((r) => r.ruleId),
-      referencedRuleIds: [],
-      isComplete: false
-    }));
+      // one section per project, holding that project's assigned rules
+      team.projects.forEach((project) => {
+        const projectRowId = `project-${team.teamId}-${project.projectId}`;
+        const { rows, rootIds } = scopeRulesToBucket(projectRowId, project.rules);
+        ruleRows.push(...rows);
+        sectionRows.push(makeSectionRow(projectRowId, project.projectName, rootIds));
+        teamChildIds.push(projectRowId);
+      });
 
-  // Create unassigned to team mock rule
-  const unassignedToTeamRule: Rule | null =
-    unassignedToTeam.length > 0
-      ? {
-          ruleId: 'unassigned-to-team',
-          ruleCode: 'Unassigned Rules - Unassigned to Team',
-          ruleContent: '',
-          imageFileIds: [],
-          parentRule: undefined,
-          subRuleIds: unassignedToTeam.map((r) => r.ruleId),
-          referencedRuleIds: [],
-          isComplete: false
-        }
-      : null;
+      // one section for rules on the team but assigned to no project
+      if (team.unassignedRules.length > 0) {
+        const unassignedRowId = `team-${team.teamId}-unassigned`;
+        const { rows, rootIds } = scopeRulesToBucket(unassignedRowId, team.unassignedRules);
+        ruleRows.push(...rows);
+        sectionRows.push(makeSectionRow(unassignedRowId, 'Unassigned Rules - Unassigned to Project', rootIds));
+        teamChildIds.push(unassignedRowId);
+      }
 
-  // mock team/project rules + actual rules
-  const allRulesIncludingMock = [
-    ...teamRulesAsRules,
-    ...projectRulesAsRules,
-    ...unassignedToProjectRules,
-    ...(unassignedToTeamRule ? [unassignedToTeamRule] : []),
-    ...allRules
-  ];
+      const teamRow = makeSectionRow(teamRowId, team.teamName, teamChildIds);
+      sectionRows.push(teamRow);
+      topLevelItems.push(teamRow);
+    });
 
-  // Top level items are teams and unassigned to team
-  const topLevelItems = [...teamRulesAsRules, ...(unassignedToTeamRule ? [unassignedToTeamRule] : [])];
+    // top-level for rules unassigned to any team
+    if (unassignedToTeam.length > 0) {
+      const unassignedToTeamRowId = 'unassigned-to-team';
+      const { rows, rootIds } = scopeRulesToBucket(unassignedToTeamRowId, unassignedToTeam);
+      ruleRows.push(...rows);
+      const unassignedToTeamRow = makeSectionRow(unassignedToTeamRowId, 'Unassigned Rules - Unassigned to Team', rootIds);
+      sectionRows.push(unassignedToTeamRow);
+      topLevelItems.push(unassignedToTeamRow);
+    }
+
+    return { topLevelItems, rowsById: [...sectionRows, ...ruleRows] };
+  }, [allRules]);
 
   return (
     <Box>
@@ -150,7 +191,7 @@ const RulesetTeamView: React.FC<RulesetTeamViewProps> = ({ allRules }) => {
               <RuleRow
                 key={item.ruleId}
                 rule={item}
-                allRules={allRulesIncludingMock}
+                allRules={rowsById}
                 rightContent={() => null}
                 backgroundColor="#9d9d9d"
                 textColor="#000000"

--- a/src/frontend/src/utils/rules.utils.ts
+++ b/src/frontend/src/utils/rules.utils.ts
@@ -55,3 +55,31 @@ export const isRuleComplete = (rule: Rule, allRules: Rule[]): boolean => {
 export const getRuleStatusConfig = (isComplete: boolean): { label: string; color: string } => {
   return isComplete ? { label: 'Complete', color: '#4caf50' } : { label: 'Incomplete', color: '#f44336' };
 };
+
+/**
+ * Collects a rule and all of its descendants, down to the leaf rules.
+ */
+export const getRuleAndDescendantIds = (ruleId: string, allRules: Rule[]): string[] => {
+  const rule = allRules.find((r) => r.ruleId === ruleId);
+  if (!rule) {
+    return [];
+  }
+
+  return [ruleId, ...rule.subRuleIds.flatMap((subId) => getRuleAndDescendantIds(subId, allRules))];
+};
+
+/**
+ * Collects the ancestors of a rule, from its immediate parent up to the top-level rule.
+ */
+export const getAncestorIds = (ruleId: string, allRules: Rule[]): string[] => {
+  const ancestorIds: string[] = [];
+  let current = allRules.find((r) => r.ruleId === ruleId);
+
+  while (current?.parentRule) {
+    const parentId = current.parentRule.ruleId;
+    ancestorIds.push(parentId);
+    current = allRules.find((r) => r.ruleId === parentId);
+  }
+
+  return ancestorIds;
+};

--- a/src/frontend/src/utils/urls.ts
+++ b/src/frontend/src/utils/urls.ts
@@ -465,8 +465,8 @@ const uploadRulesetFile = () => `${rules()}/upload/file`;
 const rulesGetActiveRuleset = (rulesetTypeId: string) => `${rules()}/rulesetType/${rulesetTypeId}/active`;
 const rulesGetProjectRules = (rulesetId: string, projectId: string) =>
   `${rules()}/ruleset/${rulesetId}/project/${projectId}/rules`;
-const rulesGetUnassignedRulesForRuleset = (rulesetId: string, teamId: string, projectId: string) =>
-  `${rules()}/ruleset/${rulesetId}/team/${teamId}/rules/unassigned?projectId=${projectId}`;
+const rulesGetUnassignedRulesForRuleset = (rulesetId: string, projectId: string) =>
+  `${rules()}/ruleset/${rulesetId}/project/${projectId}/rules/unassigned`;
 const rulesCreateProjectRule = () => `${rules()}/projectRule/create`;
 const rulesDeleteProjectRule = (projectRuleId: string) => `${rules()}/projectRule/${projectRuleId}/delete`;
 const rulesSetRuleCompletion = (ruleId: string) => `${rules()}/rule/${ruleId}/setCompletion`;

--- a/src/shared/src/types/rules-types.ts
+++ b/src/shared/src/types/rules-types.ts
@@ -40,6 +40,11 @@ export interface Rule {
     teamId: string;
     teamName: string;
   }>;
+  projects?: Array<{
+    projectId: string;
+    projectName: string;
+    teamIds: string[];
+  }>;
   isComplete: boolean;
   completedBy?: {
     firstName: string;


### PR DESCRIPTION
## Changes

- Switched general view and team view tab ordering, defaults now to general view
- Added by-project assignment to the team view
- Fixed issues with assigning parent rules to teams
- Unassigning rules from a team removes corresponding project rules (added warning modal before saving unassignment)

## Notes

- fixed issue with existing project rules being unassigned and deleted, and then erroring when trying to reassign and re-add them to the project because of duplicate keys

- updated project rules to support projects w/ multiple teams

## Screenshots

<img width="1204" height="859" alt="Screenshot 2026-07-05 at 1 26 59 PM" src="https://github.com/user-attachments/assets/7c93cb35-599c-444f-91db-a44eaf5512a3" />

https://github.com/user-attachments/assets/5dd150b7-7a49-451c-91df-555d69859435


<img width="1426" height="778" alt="Screenshot 2026-07-06 at 10 01 01 AM" src="https://github.com/user-attachments/assets/6ad46701-4f8e-4cdb-8802-40a08f9b0841" />
<img width="850" height="443" alt="Screenshot 2026-07-07 at 9 36 31 PM" src="https://github.com/user-attachments/assets/e0fb8f6e-612a-4021-8ec7-6125f304abcd" />
<img width="791" height="437" alt="Screenshot 2026-07-07 at 9 37 04 PM" src="https://github.com/user-attachments/assets/248d03aa-b1f7-48c7-9f7e-d7581afa1d5b" />
<img width="370" height="585" alt="Screenshot 2026-07-07 at 10 24 47 PM" src="https://github.com/user-attachments/assets/0b947659-adaf-4d0e-9d12-e5cd3ac73bfb" />

---
<img width="647" height="719" alt="Screenshot 2026-07-08 at 2 16 14 PM" src="https://github.com/user-attachments/assets/2a202343-e036-4491-9394-20b8290e4cdd" />
<img width="602" height="402" alt="Screenshot 2026-07-08 at 2 18 16 PM" src="https://github.com/user-attachments/assets/35f43002-e852-4af5-a869-d1d45e0eec55" />
<img width="684" height="833" alt="Screenshot 2026-07-08 at 2 15 08 PM" src="https://github.com/user-attachments/assets/291b12ae-2e9a-4ec4-a8f1-60fc737c5831" />

## To Do

- [x] unassigning rules from a team should warn and then delete corresponding project rules

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #4303