### PR TITLE
4262-onboarding-admin-tools fix subtask background color and add markdown support in admin onboarding

### DIFF
--- a/src/frontend/src/pages/AdminToolsPage/OnboardingConfig/Checklists/AdminSubtaskSection.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/OnboardingConfig/Checklists/AdminSubtaskSection.tsx
@@ -115,21 +115,19 @@ const AdminSubtaskSection: React.FC<AdminSubtaskSectionProps> = ({ parentTask })
                               borderRadius: 3,
                               mb: 2,
                               backgroundColor:
-                                item.itemType === ChecklistItemType.TASK ? theme.palette.background.paper : 'transparent',
+                                item.itemType === ChecklistItemType.TASK ? theme.palette.grey[100] : 'transparent',
                               padding: item.itemType === ChecklistItemType.TASK ? 2 : 0
                             }}
                           >
                             {item.itemType === ChecklistItemType.TASK ? (
                               <>
-                                <Box display="flex" alignItems="center" gap={1} sx={{ flex: 1 }}>
+                                <Box display="flex" alignItems="center" gap={1} sx={{ flex: 1, color: 'black' }}>
                                   <Box {...provided.dragHandleProps}>
                                     <IconButton>
                                       <GridDragIcon sx={{ color: 'black' }} />
                                     </IconButton>
                                   </Box>
-                                  <Typography color="black" fontWeight="bold">
-                                    {item.content} {item.isOptional && '(Optional)'}
-                                  </Typography>
+                                  <NERMarkdown markdown={`${item.content}${item.isOptional ? ' (Optional)' : ''}`} />
                                 </Box>
                                 <Box sx={{ display: 'flex' }}>
                                   <IconButton onClick={() => setItemToDelete(item)}>


### PR DESCRIPTION
## Changes
- Fix subtask background color in admin onboarding from dark (background.paper) to light (grey[100])
- Replace Typography with NERMarkdown for subtask content to support markdown rendering
- Set color: 'black' on subtask content container so text is legible on the light background

## Screenshots
Before:
<img width="956" height="872" alt="image" src="https://github.com/user-attachments/assets/30cd8c22-5c83-4f25-9c3d-65ab78ac2e03" />


After:
<img width="961" height="888" alt="image" src="https://github.com/user-attachments/assets/8b42d47d-3663-46f0-b004-19e645345020" />

Closes #4262
