### PR TITLE
#4122 Calendar Widget

### DIFF
--- a/src/backend/src/controllers/calendar.controllers.ts
+++ b/src/backend/src/controllers/calendar.controllers.ts
@@ -139,13 +139,14 @@ export default class CalendarController {
 
   static async createCalendar(req: Request, res: Response, next: NextFunction) {
     try {
-      const { name, description, colorHexCode } = req.body;
+      const { name, description, colorHexCode, isNewMemberCalendar } = req.body;
 
       const calendar = await CalendarService.createCalendar(
         req.currentUser,
         name,
         description,
         colorHexCode,
+        isNewMemberCalendar,
         req.organization
       );
 
@@ -158,7 +159,7 @@ export default class CalendarController {
   static async editCalendar(req: Request, res: Response, next: NextFunction) {
     try {
       const { calendarId } = req.params as Record<string, string>;
-      const { name, colorHexCode, description } = req.body;
+      const { name, colorHexCode, description, isNewMemberCalendar } = req.body;
 
       const updatedCalendar = await CalendarService.editCalendar(
         req.currentUser,
@@ -166,10 +167,20 @@ export default class CalendarController {
         name,
         description,
         colorHexCode,
+        isNewMemberCalendar,
         req.organization
       );
 
       res.status(200).json(updatedCalendar);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
+  static async getNewMemberEvents(req: Request, res: Response, next: NextFunction) {
+    try {
+      const events = await CalendarService.getNewMemberEvents(req.organization);
+      res.status(200).json(events);
     } catch (error: unknown) {
       next(error);
     }

--- a/src/backend/src/prisma/migrations/20260522172140_onboarding_improvements/migration.sql
+++ b/src/backend/src/prisma/migrations/20260522172140_onboarding_improvements/migration.sql
@@ -1,6 +1,9 @@
 -- CreateEnum
 CREATE TYPE "Team_Join_Request_Status" AS ENUM ('PENDING', 'APPROVED', 'DENIED');
 
+-- AlterTable
+ALTER TABLE "Calendar" ADD COLUMN     "isNewMemberCalendar" BOOLEAN NOT NULL DEFAULT false;
+
 -- AlterTable: FrequentlyAskedQuestion - add new columns (nullable first for data migration)
 ALTER TABLE "FrequentlyAskedQuestion"
 ADD COLUMN "isOnNewMemberDashboard" BOOLEAN NOT NULL DEFAULT false,

--- a/src/backend/src/prisma/schema.prisma
+++ b/src/backend/src/prisma/schema.prisma
@@ -1177,19 +1177,20 @@ model Event {
 }
 
 model Calendar {
-  calendarId     String       @id @default(uuid())
-  name           String
-  dateCreated    DateTime     @default(now())
-  dateDeleted    DateTime?
-  userCreatedId  String
-  userCreated    User         @relation(name: "calendarCreator", fields: [userCreatedId], references: [userId])
-  userDeletedId  String?
-  userDeleted    User?        @relation(fields: [userDeletedId], references: [userId], name: "calendarDeleter")
-  description    String
-  colorHexCode   String
-  eventTypes     Event_Type[]
-  organizationId String
-  organization   Organization @relation(fields: [organizationId], references: [organizationId])
+  calendarId          String       @id @default(uuid())
+  name                String
+  dateCreated         DateTime     @default(now())
+  dateDeleted         DateTime?
+  userCreatedId       String
+  userCreated         User         @relation(name: "calendarCreator", fields: [userCreatedId], references: [userId])
+  userDeletedId       String?
+  userDeleted         User?        @relation(fields: [userDeletedId], references: [userId], name: "calendarDeleter")
+  description         String
+  colorHexCode        String
+  eventTypes          Event_Type[]
+  organizationId      String
+  organization        Organization @relation(fields: [organizationId], references: [organizationId])
+  isNewMemberCalendar Boolean      @default(false)
 }
 
 model Event_Type {

--- a/src/backend/src/prisma/seed.ts
+++ b/src/backend/src/prisma/seed.ts
@@ -4294,6 +4294,7 @@ const performSeed: () => Promise<void> = async () => {
     'Engineering Team Calendar',
     'Tracks all engineering team events, meetings, and deadlines.',
     '#3498db',
+    false,
     ner
   );
 
@@ -4302,6 +4303,7 @@ const performSeed: () => Promise<void> = async () => {
     'Finishline Projects Calendar',
     'Tracks all ongoing projects currently being developed for Finishline',
     '#911111ff',
+    false,
     ner
   );
 
@@ -4310,6 +4312,16 @@ const performSeed: () => Promise<void> = async () => {
     'Calendar Improvements Calendar',
     'Tracks all current improvements and schedulings for the improvement of the Finishline Calendar',
     '#bf40e6ff',
+    false,
+    ner
+  );
+
+  const newMemberCalendar = await CalendarService.createCalendar(
+    thomasEmrax,
+    'New Member Events',
+    'Tracks all new member onboarding events.',
+    '#5c6bc0',
+    true,
     ner
   );
 
@@ -4403,6 +4415,107 @@ const performSeed: () => Promise<void> = async () => {
     false,
     false,
     false
+  );
+
+  // educational event type, used for new member onboarding events
+  const educationalEventType = await CalendarService.createEventType(
+    thomasEmrax,
+    'Educational',
+    [newMemberCalendar.calendarId],
+    ner,
+    false,
+    true,
+    true,
+    true,
+    true,
+    true,
+    false,
+    false,
+    false,
+    false,
+    true,
+    true,
+    false,
+    false,
+    true
+  );
+
+  await CalendarService.createEvent(
+    thomasEmrax,
+    'New Member Mixer',
+    educationalEventType.eventTypeId,
+    ner,
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [
+      {
+        startTime: new Date(new Date().getTime() + 7 * 24 * 60 * 60 * 1000),
+        endTime: new Date(new Date().getTime() + 7 * 24 * 60 * 60 * 1000 + 60 * 60 * 1000),
+        allDay: false
+      }
+    ],
+    undefined,
+    electrical.teamTypeId,
+    undefined,
+    'Curry Student Center',
+    undefined,
+    'Come meet the team!'
+  );
+
+  await CalendarService.createEvent(
+    thomasEmrax,
+    'New Member Bay Time',
+    educationalEventType.eventTypeId,
+    ner,
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [
+      {
+        startTime: new Date(new Date().getTime() + 14 * 24 * 60 * 60 * 1000),
+        endTime: new Date(new Date().getTime() + 14 * 24 * 60 * 60 * 1000 + 60 * 60 * 1000),
+        allDay: false
+      }
+    ],
+    undefined,
+    mechanical.teamTypeId,
+    undefined,
+    'Richards Hall',
+    undefined,
+    'Hands-on time in the bay with the mechanical team'
+  );
+
+  await CalendarService.createEvent(
+    thomasEmrax,
+    'New Member Software Onboarding',
+    educationalEventType.eventTypeId,
+    ner,
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [
+      {
+        startTime: new Date(new Date().getTime() + 21 * 24 * 60 * 60 * 1000),
+        endTime: new Date(new Date().getTime() + 21 * 24 * 60 * 60 * 1000 + 90 * 60 * 1000),
+        allDay: false
+      }
+    ],
+    undefined,
+    software.teamTypeId,
+    undefined,
+    undefined,
+    'https://zoom.us/j/123456789',
+    'Intro to the FinishLine codebase'
   );
 
   await CalendarService.createEvent(

--- a/src/backend/src/routes/calendar.routes.ts
+++ b/src/backend/src/routes/calendar.routes.ts
@@ -41,6 +41,7 @@ calendarRouter.post(
   nonEmptyString(body('name')),
   nonEmptyString(body('description')),
   nonEmptyString(body('colorHexCode')),
+  body('isNewMemberCalendar').isBoolean(),
   validateInputs,
   CalendarController.createCalendar
 );
@@ -215,6 +216,8 @@ calendarRouter.get('/event/:eventId', CalendarController.getSingleEvent);
 
 calendarRouter.get('/event-members/:eventId', CalendarController.getSingleEventWithMembers);
 
+calendarRouter.get('/events/new-member', CalendarController.getNewMemberEvents);
+
 calendarRouter.get('/events', CalendarController.getAllEvents);
 
 calendarRouter.get('/event-types', CalendarController.getAllEventTypes);
@@ -244,6 +247,7 @@ calendarRouter.post(
   nonEmptyString(body('name')),
   nonEmptyString(body('description')),
   nonEmptyString(body('colorHexCode')),
+  body('isNewMemberCalendar').isBoolean(),
   validateInputs,
   CalendarController.editCalendar
 );

--- a/src/backend/src/services/calendar.services.ts
+++ b/src/backend/src/services/calendar.services.ts
@@ -2104,6 +2104,7 @@ export default class CalendarService {
    * @param name The name of the calendar
    * @param description A summary of what the calendar is used for
    * @param colorHexCode The color of the calendar
+   * @param isNewMemberCalendar Whether this calendar is the org's designated new member calendar
    * @param organization The organization for which the calendar is being created
    *
    * @returns The created calendar
@@ -2115,6 +2116,7 @@ export default class CalendarService {
     name: string,
     description: string,
     colorHexCode: string,
+    isNewMemberCalendar: boolean,
     organization: Organization
   ): Promise<Calendar> {
     if (!(await userHasPermission(submitter.userId, organization.organizationId, isAdmin))) {
@@ -2132,15 +2134,25 @@ export default class CalendarService {
       throw new HttpException(409, "Can't have two calendars with the same name");
     }
 
-    const newCalendar = await prisma.calendar.create({
-      data: {
-        name,
-        description,
-        colorHexCode,
-        userCreatedId: submitter.userId,
-        organizationId: organization.organizationId
-      },
-      ...getCalendarQueryArgs(organization.organizationId)
+    const newCalendar = await prisma.$transaction(async (tx) => {
+      if (isNewMemberCalendar) {
+        await tx.calendar.updateMany({
+          where: { organizationId: organization.organizationId, isNewMemberCalendar: true },
+          data: { isNewMemberCalendar: false }
+        });
+      }
+
+      return tx.calendar.create({
+        data: {
+          name,
+          description,
+          colorHexCode,
+          isNewMemberCalendar,
+          userCreatedId: submitter.userId,
+          organizationId: organization.organizationId
+        },
+        ...getCalendarQueryArgs(organization.organizationId)
+      });
     });
 
     return calendarTransformer(newCalendar);
@@ -2152,6 +2164,7 @@ export default class CalendarService {
    * @param name The name of the calendar.
    * @param description The summary of what the calendar is used for.
    * @param colorHexCode The color of the calendar.
+   * @param isNewMemberCalendar Whether this calendar is the org's designated new member calendar
    * @param organization The organization for which the calendar is being edited.
    *
    * @returns The edited calendar.
@@ -2167,6 +2180,7 @@ export default class CalendarService {
     name: string,
     description: string,
     colorHexCode: string,
+    isNewMemberCalendar: boolean,
     organization: Organization
   ): Promise<Calendar> {
     const calendar = await prisma.calendar.findUnique({
@@ -2196,14 +2210,24 @@ export default class CalendarService {
       throw new HttpException(409, "Can't have two calendars with the same name");
     }
 
-    const newCalendar = await prisma.calendar.update({
-      where: { calendarId },
-      data: {
-        name,
-        description,
-        colorHexCode
-      },
-      ...getCalendarQueryArgs(organization.organizationId)
+    const newCalendar = await prisma.$transaction(async (tx) => {
+      if (isNewMemberCalendar) {
+        await tx.calendar.updateMany({
+          where: { organizationId: organization.organizationId, isNewMemberCalendar: true, NOT: { calendarId } },
+          data: { isNewMemberCalendar: false }
+        });
+      }
+
+      return tx.calendar.update({
+        where: { calendarId },
+        data: {
+          name,
+          description,
+          colorHexCode,
+          isNewMemberCalendar
+        },
+        ...getCalendarQueryArgs(organization.organizationId)
+      });
     });
 
     return calendarTransformer(newCalendar);
@@ -2605,6 +2629,34 @@ export default class CalendarService {
     });
 
     return events.map(eventTransformer);
+  }
+
+  /**
+   * Gets all upcoming events on the organization's designated new member calendar.
+   *
+   * @param organization The organization to get new member events for.
+   *
+   * @returns The upcoming events on the org's new member calendar, or an empty array if no calendar is designated.
+   */
+  static async getNewMemberEvents(organization: Organization): Promise<Event[]> {
+    const newMemberCalendar = await prisma.calendar.findFirst({
+      where: {
+        organizationId: organization.organizationId,
+        isNewMemberCalendar: true,
+        dateDeleted: null
+      }
+    });
+
+    if (!newMemberCalendar) return [];
+
+    return CalendarService.getFilteredEvents(
+      {
+        calendarIds: [newMemberCalendar.calendarId],
+        startPeriod: new Date(),
+        endPeriod: new Date(2099, 11, 31)
+      },
+      organization
+    );
   }
 
   static async getAllShops(organization: Organization): Promise<Shop[]> {

--- a/src/backend/src/transformers/calendar.transformer.ts
+++ b/src/backend/src/transformers/calendar.transformer.ts
@@ -96,7 +96,8 @@ export const calendarTransformer = (calendar: Prisma.CalendarGetPayload<Calendar
     color: calendar.colorHexCode,
     userCreated: userTransformer(calendar.userCreated),
     dateCreated: calendar.dateCreated,
-    eventTypes: calendar.eventTypes.map(eventTypeTransformer)
+    eventTypes: calendar.eventTypes.map(eventTypeTransformer),
+    isNewMemberCalendar: calendar.isNewMemberCalendar
   };
 };
 

--- a/src/backend/tests/unit/calendar.test.ts
+++ b/src/backend/tests/unit/calendar.test.ts
@@ -109,6 +109,7 @@ describe('Calendar Tests', () => {
           'Updated Name',
           'Updated Description',
           '#FF0000',
+          false,
           organization
         )
       ).rejects.toThrow(new AccessDeniedException('Only admins can edit calendars'));
@@ -131,6 +132,7 @@ describe('Calendar Tests', () => {
         'Updated Calendar',
         'Updated Description',
         '#0000FF',
+        false,
         organization
       );
 
@@ -148,6 +150,7 @@ describe('Calendar Tests', () => {
           'Updated Name',
           'Updated Description',
           '#FF0000',
+          false,
           organization
         )
       ).rejects.toThrow(new NotFoundException('Calendar', 'non-existent-id'));
@@ -172,6 +175,7 @@ describe('Calendar Tests', () => {
           'Updated Name',
           'Updated Description',
           '#FF0000',
+          false,
           organization
         )
       ).rejects.toThrow(new DeletedException('Calendar', calendar.calendarId));
@@ -600,6 +604,7 @@ describe('Calendar Tests', () => {
             'Non-Admin Calendar',
             'desc',
             '#3498DB',
+            false,
             organization
           )
         ).rejects.toThrow(new AccessDeniedAdminOnlyException('create calendar'));
@@ -610,6 +615,7 @@ describe('Calendar Tests', () => {
           'Cool Calendar',
           'A very cool calendar',
           '#3498DB',
+          false,
           organization
         );
         expect(result.name).toBe('Cool Calendar');
@@ -618,13 +624,21 @@ describe('Calendar Tests', () => {
         expect(result.userCreated.userId).toBe(adminUser.userId);
       });
       it('fails on duplicate name', async () => {
-        await CalendarService.createCalendar(adminUser, 'Cool Calendar', 'A very cool calendar', '#3498DB', organization);
+        await CalendarService.createCalendar(
+          adminUser,
+          'Cool Calendar',
+          'A very cool calendar',
+          '#3498DB',
+          false,
+          organization
+        );
         await expect(
           CalendarService.createCalendar(
             adminUser,
             'Cool Calendar',
             'A very cool calendar, but not quite as cool',
             '#0062a3ff',
+            false,
             organization
           )
         ).rejects.toBeTruthy();

--- a/src/frontend/src/apis/calendar.api.ts
+++ b/src/frontend/src/apis/calendar.api.ts
@@ -23,7 +23,12 @@ export const getAllCalendars = () => {
   });
 };
 
-export const postCreateCalendar = (payload: { name: string; description: string; colorHexCode: string }) => {
+export const postCreateCalendar = (payload: {
+  name: string;
+  description: string;
+  colorHexCode: string;
+  isNewMemberCalendar: boolean;
+}) => {
   return axios.post<Calendar>(apiUrls.calendarCreateCalendar(), payload, {
     transformResponse: (data) => JSON.parse(data) as Calendar
   });
@@ -31,7 +36,7 @@ export const postCreateCalendar = (payload: { name: string; description: string;
 
 export const postEditCalendar = (
   calendarId: string,
-  payload: { name: string; description: string; colorHexCode: string }
+  payload: { name: string; description: string; colorHexCode: string; isNewMemberCalendar: boolean }
 ) => {
   return axios.post<Calendar>(apiUrls.calendarEditCalendar(calendarId), payload, {
     transformResponse: (data) => JSON.parse(data) as Calendar
@@ -161,6 +166,12 @@ export const postDeleteEventType = async (eventTypeId: string) => {
 
 export const getAllEvents = () => {
   return axios.get(apiUrls.calendarEvents(), {
+    transformResponse: (data) => JSON.parse(data).map(eventTransformer)
+  });
+};
+
+export const getNewMemberEvents = () => {
+  return axios.get(apiUrls.calendarNewMemberEvents(), {
     transformResponse: (data) => JSON.parse(data).map(eventTransformer)
   });
 };

--- a/src/frontend/src/hooks/calendar.hooks.ts
+++ b/src/frontend/src/hooks/calendar.hooks.ts
@@ -35,6 +35,7 @@ import {
   markUserConfirmed,
   getSingleEvent,
   getAllEvents,
+  getNewMemberEvents,
   deleteEvent,
   setEventStatus,
   getAllEventTypes,
@@ -124,7 +125,11 @@ export const useAllCalendars = () =>
 
 export const useCreateCalendar = () => {
   const qc = useQueryClient();
-  return useMutation<Calendar, Error, { name: string; description: string; colorHexCode: string }>(
+  return useMutation<
+    Calendar,
+    Error,
+    { name: string; description: string; colorHexCode: string; isNewMemberCalendar: boolean }
+  >(
     async (payload) => {
       const { data } = await postCreateCalendar(payload);
       return data;
@@ -139,7 +144,11 @@ export const useCreateCalendar = () => {
 
 export const useEditCalendar = (calendarId: string) => {
   const qc = useQueryClient();
-  return useMutation<Calendar, Error, { name: string; description: string; colorHexCode: string }>(
+  return useMutation<
+    Calendar,
+    Error,
+    { name: string; description: string; colorHexCode: string; isNewMemberCalendar: boolean }
+  >(
     async (payload) => {
       const { data } = await postEditCalendar(calendarId, payload);
       return data;
@@ -388,6 +397,13 @@ export const useConflictingEvents = (ids: string[]) => {
 export const useAllEvents = () => {
   return useQuery<Event[], Error>(EVENT_KEY, async () => {
     const { data } = await getAllEvents();
+    return data;
+  });
+};
+
+export const useNewMemberEvents = () => {
+  return useQuery<Event[], Error>(['events', 'new-member'], async () => {
+    const { data } = await getNewMemberEvents();
     return data;
   });
 };

--- a/src/frontend/src/pages/AdminToolsPage/ScheduleConfig/AdminToolsScheduleConfig.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/ScheduleConfig/AdminToolsScheduleConfig.tsx
@@ -20,6 +20,7 @@ import CreateCalendarModal from './Calendar/CreateCalendarModal';
 import EditCalendarModal from './Calendar/EditCalendarModal';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
+import CheckIcon from '@mui/icons-material/Check';
 import CreateMachineryModal from './Machinery/CreateMachineryModal';
 import EditMachineryModal from './Machinery/EditMachineryModal';
 import CreateEventTypeModal from './EventType/CreateEventTypeModal';
@@ -161,13 +162,16 @@ const AdminToolsScheduleConfig: React.FC = () => {
                   <TableCell sx={{ fontWeight: 600 }} align="center">
                     Color
                   </TableCell>
+                  <TableCell sx={{ fontWeight: 600 }} align="center">
+                    New Member
+                  </TableCell>
                   <TableCell sx={{ width: 100 }} />
                 </TableRow>
               </TableHead>
               <TableBody>
                 {!calendars || !Array.isArray(calendars) || calendars.length === 0 ? (
                   <TableRow>
-                    <TableCell colSpan={4} align="center">
+                    <TableCell colSpan={5} align="center">
                       No calendars yet.
                     </TableCell>
                   </TableRow>
@@ -187,6 +191,9 @@ const AdminToolsScheduleConfig: React.FC = () => {
                             backgroundColor: calendar.color ?? '#EF4345'
                           }}
                         />
+                      </TableCell>
+                      <TableCell align="center">
+                        {calendar.isNewMemberCalendar && <CheckIcon fontSize="small" color="success" />}
                       </TableCell>
                       <TableCell align="center">
                         <Box display="flex" gap={1} justifyContent="center">

--- a/src/frontend/src/pages/AdminToolsPage/ScheduleConfig/Calendar/CalendarModal.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/ScheduleConfig/Calendar/CalendarModal.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect } from 'react';
-import { Box, FormControl, FormHelperText, Typography } from '@mui/material';
+import { Box, Checkbox, FormControl, FormControlLabel, FormHelperText, Typography } from '@mui/material';
 import NERFormModal from '../../../../components/NERFormModal';
 import ReactHookTextField from '../../../../components/ReactHookTextField';
 import ColorPickerInput from '../../../../components/ColorPickerInput';
 import { useToast } from '../../../../hooks/toasts.hooks';
-import { useForm } from 'react-hook-form';
+import { useForm, Controller } from 'react-hook-form';
 import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
 import type { Calendar } from 'shared';
@@ -13,12 +13,14 @@ export interface CalendarFormValues {
   name: string;
   description: string;
   colorHexCode: string;
+  isNewMemberCalendar: boolean;
 }
 
 const schema = yup.object({
   name: yup.string().required('Calendar Name is required'),
   description: yup.string().required('Description is required'),
-  colorHexCode: yup.string().required('Color is required')
+  colorHexCode: yup.string().required('Color is required'),
+  isNewMemberCalendar: yup.boolean().required()
 });
 
 export interface BaseCalendarModalProps {
@@ -40,21 +42,27 @@ const CalendarModal: React.FC<BaseCalendarModalProps> = ({ open, onClose, onSubm
     formState: { errors }
   } = useForm<CalendarFormValues>({
     resolver: yupResolver(schema),
-    defaultValues: { name: '', description: '', colorHexCode: '' }
+    defaultValues: { name: '', description: '', colorHexCode: '', isNewMemberCalendar: false }
   });
 
-  const frozenValuesRef = React.useRef<CalendarFormValues>({ name: '', description: '', colorHexCode: '' });
+  const frozenValuesRef = React.useRef<CalendarFormValues>({
+    name: '',
+    description: '',
+    colorHexCode: '',
+    isNewMemberCalendar: false
+  });
 
   useEffect(() => {
     if (open) {
       frozenValuesRef.current = {
         name: initialValues?.name ?? '',
         description: initialValues?.description ?? '',
-        colorHexCode: initialValues?.colorHexCode ?? ''
+        colorHexCode: initialValues?.colorHexCode ?? '',
+        isNewMemberCalendar: initialValues?.isNewMemberCalendar ?? false
       };
       reset(frozenValuesRef.current);
     } else {
-      frozenValuesRef.current = { name: '', description: '', colorHexCode: '' };
+      frozenValuesRef.current = { name: '', description: '', colorHexCode: '', isNewMemberCalendar: false };
       reset(frozenValuesRef.current);
     }
   }, [open, initialValues, reset]);
@@ -65,7 +73,7 @@ const CalendarModal: React.FC<BaseCalendarModalProps> = ({ open, onClose, onSubm
     try {
       await onSubmit(data);
       onClose();
-      reset({ name: '', description: '', colorHexCode: '' });
+      reset({ name: '', description: '', colorHexCode: '', isNewMemberCalendar: false });
     } catch (e: unknown) {
       if (e instanceof Error) toast.error(e.message);
     }
@@ -82,10 +90,10 @@ const CalendarModal: React.FC<BaseCalendarModalProps> = ({ open, onClose, onSubm
       open={open}
       onHide={() => {
         onClose();
-        reset({ name: '', description: '', colorHexCode: '' });
+        reset({ name: '', description: '', colorHexCode: '', isNewMemberCalendar: false });
       }}
       title={computedTitle}
-      reset={() => reset({ name: '', description: '', colorHexCode: '' })}
+      reset={() => reset({ name: '', description: '', colorHexCode: '', isNewMemberCalendar: false })}
       handleUseFormSubmit={handleSubmit}
       onFormSubmit={onFormSubmit}
       formId="calendar-form"
@@ -121,6 +129,16 @@ const CalendarModal: React.FC<BaseCalendarModalProps> = ({ open, onClose, onSubm
           </Typography>
           <ColorPickerInput selectedColor={selectedColor} onColorClick={handleColorClick} />
           <FormHelperText error>{errors.colorHexCode?.message}</FormHelperText>
+        </FormControl>
+
+        <FormControl fullWidth>
+          <Controller
+            control={control}
+            name="isNewMemberCalendar"
+            render={({ field: { onChange, value } }) => (
+              <FormControlLabel control={<Checkbox checked={value} onChange={onChange} />} label="New member calendar" />
+            )}
+          />
         </FormControl>
       </Box>
     </NERFormModal>

--- a/src/frontend/src/pages/AdminToolsPage/ScheduleConfig/Calendar/CreateCalendarModal.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/ScheduleConfig/Calendar/CreateCalendarModal.tsx
@@ -17,7 +17,8 @@ const CreateCalendarModal: React.FC<CreateCalendarModalProps> = ({ open, onClose
       const result = await createCalendar({
         name: data.name,
         description: data.description,
-        colorHexCode: data.colorHexCode
+        colorHexCode: data.colorHexCode,
+        isNewMemberCalendar: data.isNewMemberCalendar
       });
       toast.success('Calendar created successfully');
       return result;

--- a/src/frontend/src/pages/AdminToolsPage/ScheduleConfig/Calendar/EditCalendarModal.tsx
+++ b/src/frontend/src/pages/AdminToolsPage/ScheduleConfig/Calendar/EditCalendarModal.tsx
@@ -17,7 +17,8 @@ const EditCalendarModal: React.FC<EditCalendarModalProps> = ({ open, onClose, ca
   const initialValues: CalendarFormValues = {
     name: calendar.name,
     description: calendar.description ?? '',
-    colorHexCode: calendar.color ?? ''
+    colorHexCode: calendar.color ?? '',
+    isNewMemberCalendar: calendar.isNewMemberCalendar
   };
 
   const onSubmit = async (data: CalendarFormValues) => {
@@ -25,7 +26,8 @@ const EditCalendarModal: React.FC<EditCalendarModalProps> = ({ open, onClose, ca
       const result = await editCalendar({
         name: data.name,
         description: data.description,
-        colorHexCode: data.colorHexCode
+        colorHexCode: data.colorHexCode,
+        isNewMemberCalendar: data.isNewMemberCalendar
       });
       toast.success('Calendar updated successfully');
       return result;

--- a/src/frontend/src/pages/CalendarPage/CalendarDayCard.tsx
+++ b/src/frontend/src/pages/CalendarPage/CalendarDayCard.tsx
@@ -49,6 +49,7 @@ interface CalendarDayCardProps {
   dayOfWeek?: DayOfWeek;
   onCreateEventClick: (date: Date) => void;
   tasks?: CalendarTask[];
+  selectedEventId?: string;
 }
 
 // Constants for dynamic event display calculation
@@ -64,7 +65,8 @@ const CalendarDayCard: React.FC<CalendarDayCardProps> = ({
   calendars = [],
   dayOfWeek = DayOfWeek.MONDAY,
   onCreateEventClick,
-  tasks = []
+  tasks = [],
+  selectedEventId
 }) => {
   const theme = useTheme();
 
@@ -108,6 +110,13 @@ const CalendarDayCard: React.FC<CalendarDayCardProps> = ({
     window.addEventListener('resize', calculateMaxEvents);
     return () => window.removeEventListener('resize', calculateMaxEvents);
   }, []);
+
+  // Open this event's tooltip if it's been deep-linked to via ?eventId=
+  useEffect(() => {
+    if (selectedEventId && events.some((event) => event.eventId === selectedEventId)) {
+      setLockedTooltipEventId(selectedEventId);
+    }
+  }, [selectedEventId, events]);
 
   const { mutateAsync: deleteEvent } = useDeleteEvent(selectedEvent?.eventId ?? '');
   const { mutateAsync: deleteScheduleSlot } = useDeleteScheduleSlot(

--- a/src/frontend/src/pages/CalendarPage/CalendarPage.tsx
+++ b/src/frontend/src/pages/CalendarPage/CalendarPage.tsx
@@ -97,6 +97,7 @@ interface NewCalendarPageProps {
   setDisplayMonthYear: (date: Date) => void;
   displayWeek: Date;
   setDisplayWeek: (date: Date) => void;
+  selectedEventId?: string;
 }
 
 const NewCalendarPage: React.FC<NewCalendarPageProps> = ({
@@ -109,7 +110,8 @@ const NewCalendarPage: React.FC<NewCalendarPageProps> = ({
   displayMonthYear,
   setDisplayMonthYear,
   displayWeek,
-  setDisplayWeek
+  setDisplayWeek,
+  selectedEventId
 }) => {
   const theme = useTheme();
   const history = useHistory();
@@ -609,6 +611,7 @@ const NewCalendarPage: React.FC<NewCalendarPageProps> = ({
                 }}
                 onCreateEventClick={onCreateEventClick}
                 tasks={showTasks && filteredTasks ? filteredTasks : []}
+                selectedEventId={selectedEventId}
               />
             ) : (
               <>
@@ -674,6 +677,7 @@ const NewCalendarPage: React.FC<NewCalendarPageProps> = ({
                                 dayOfWeek={dayDict.get(datePipe(cardDate)) ?? DayOfWeek.SUNDAY}
                                 onCreateEventClick={onCreateEventClick}
                                 tasks={taskDict.get(datePipe(cardDate)) ?? []}
+                                selectedEventId={selectedEventId}
                               />
                             </Box>
                           );

--- a/src/frontend/src/pages/CalendarPage/CalendarTab.tsx
+++ b/src/frontend/src/pages/CalendarPage/CalendarTab.tsx
@@ -3,17 +3,17 @@ import NewCalendarPage from './CalendarPage';
 import PageLayout from '../../components/PageLayout';
 import { Box, ToggleButton, ToggleButtonGroup } from '@mui/material';
 import FullPageTabs from '../../components/FullPageTabs';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useCurrentUser } from '../../hooks/users.hooks';
 import { ConflictStatus, isGuest, isHead, isLead } from 'shared';
-import { useAllCalendars, useAllEventTypes, useFilterEvents } from '../../hooks/calendar.hooks';
+import { useAllCalendars, useAllEventTypes, useFilterEvents, useSingleEvent } from '../../hooks/calendar.hooks';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import ErrorPage from '../ErrorPage';
 import { filterEventTransformer } from '../../apis/transformers/calendar.transformer';
 import EventsTable from './EventsTable';
 import CreateEventModal from './Components/CreateEventModal';
 import CalendarCreateTaskModal from './Components/CalendarCreateTaskModal';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import { NERButton } from '../../components/NERButton';
 import { Add } from '@mui/icons-material';
 import { eventsToEventInstances, getSundayOfWeek } from '../../utils/calendar.utils';
@@ -31,7 +31,20 @@ const CalendarTab: React.FC = () => {
   const [createTaskDefaultDeadline, setCreateTaskDefaultDeadline] = useState<Date | undefined>(undefined);
   const user = useCurrentUser();
   const history = useHistory();
+  const location = useLocation();
   const canViewReviews = isHead(user.role) || isLead(user.role);
+
+  const selectedEventId = new URLSearchParams(location.search).get('eventId') ?? undefined;
+  const { data: selectedEvent } = useSingleEvent(selectedEventId);
+
+  useEffect(() => {
+    if (!selectedEvent) return;
+    const eventDate = selectedEvent.initialDateScheduled ?? selectedEvent.scheduledTimes[0]?.startTime;
+    if (!eventDate) return;
+    const date = new Date(eventDate);
+    setDisplayMonthYear(new Date(date.getFullYear(), date.getMonth(), 1));
+    setDisplayWeek(getSundayOfWeek(date));
+  }, [selectedEvent]);
 
   const handleViewModeToggle = (_: React.MouseEvent, newMode: 'month' | 'week' | null) => {
     if (!newMode || newMode === viewMode) return;
@@ -191,6 +204,7 @@ const CalendarTab: React.FC = () => {
             setDisplayMonthYear={setDisplayMonthYear}
             displayWeek={displayWeek}
             setDisplayWeek={setDisplayWeek}
+            selectedEventId={selectedEventId}
           />
         ) : (
           <EventsTable

--- a/src/frontend/src/pages/CalendarPage/CalendarTab.tsx
+++ b/src/frontend/src/pages/CalendarPage/CalendarTab.tsx
@@ -17,6 +17,7 @@ import { useHistory, useLocation } from 'react-router-dom';
 import { NERButton } from '../../components/NERButton';
 import { Add } from '@mui/icons-material';
 import { eventsToEventInstances, getSundayOfWeek } from '../../utils/calendar.utils';
+import { useToast } from '../../hooks/toasts.hooks';
 
 const CalendarTab: React.FC = () => {
   const [tabIndex, setTabIndex] = useState<number>(0);
@@ -32,19 +33,30 @@ const CalendarTab: React.FC = () => {
   const user = useCurrentUser();
   const history = useHistory();
   const location = useLocation();
+  const toast = useToast();
   const canViewReviews = isHead(user.role) || isLead(user.role);
 
   const selectedEventId = new URLSearchParams(location.search).get('eventId') ?? undefined;
-  const { data: selectedEvent } = useSingleEvent(selectedEventId);
+  const {
+    data: selectedEvent,
+    isLoading: selectedEventIsLoading,
+    isError: selectedEventIsError,
+    error: selectedEventError
+  } = useSingleEvent(selectedEventId);
 
   useEffect(() => {
-    if (!selectedEvent) return;
+    if (selectedEventIsError) {
+      toast.error(selectedEventError?.message ?? 'Failed to load the linked event');
+      return;
+    }
+    if (selectedEventIsLoading || !selectedEvent) return;
     const eventDate = selectedEvent.initialDateScheduled ?? selectedEvent.scheduledTimes[0]?.startTime;
     if (!eventDate) return;
     const date = new Date(eventDate);
     setDisplayMonthYear(new Date(date.getFullYear(), date.getMonth(), 1));
     setDisplayWeek(getSundayOfWeek(date));
-  }, [selectedEvent]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedEvent, selectedEventIsLoading, selectedEventIsError, selectedEventError]);
 
   const handleViewModeToggle = (_: React.MouseEvent, newMode: 'month' | 'week' | null) => {
     if (!newMode || newMode === viewMode) return;
@@ -104,6 +116,14 @@ const CalendarTab: React.FC = () => {
   const yourEvents = untransformedYourEvents?.map(filterEventTransformer);
   const reviewEvents = untransformedReviewEvents?.map(filterEventTransformer);
 
+  if (yourEventsIsError) return <ErrorPage error={yourEventsError} message={yourEventsError?.message} />;
+
+  if (reviewEventsIsError) return <ErrorPage error={reviewEventsError} message={reviewEventsError?.message} />;
+
+  if (allEventTypesIsError) return <ErrorPage error={allEventTypesError} message={allEventTypesError?.message} />;
+
+  if (allCalendarsIsError) return <ErrorPage error={allCalendarsError} message={allCalendarsError?.message} />;
+
   if (
     !yourEvents ||
     yourEventsLoading ||
@@ -115,13 +135,6 @@ const CalendarTab: React.FC = () => {
     allCalendarsLoading
   )
     return <LoadingIndicator />;
-  if (yourEventsIsError) return <ErrorPage error={yourEventsError} message={yourEventsError?.message} />;
-
-  if (reviewEventsIsError) return <ErrorPage error={reviewEventsError} message={reviewEventsError?.message} />;
-
-  if (allEventTypesIsError) return <ErrorPage error={allEventTypesError} message={allEventTypesError?.message} />;
-
-  if (allCalendarsIsError) return <ErrorPage error={allCalendarsError} message={allCalendarsError?.message} />;
 
   if (canViewReviews) tabs.push({ tabUrlValue: 'reviews', tabName: 'Review Bookings' });
 

--- a/src/frontend/src/pages/CalendarPage/CalendarWeekView.tsx
+++ b/src/frontend/src/pages/CalendarPage/CalendarWeekView.tsx
@@ -2,7 +2,7 @@
  * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
  * See the LICENSE file in the repository root folder for details.
  */
-import { useRef, useState, useCallback } from 'react';
+import { useRef, useState, useCallback, useEffect } from 'react';
 import { Box, Card, Stack, Tooltip, Typography, useTheme } from '@mui/material';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
@@ -131,6 +131,7 @@ interface CalendarWeekViewProps {
   onNavigateWeek: (offset: -1 | 1) => void;
   onCreateEventClick: (date: Date, startTime?: Date, endTime?: Date) => void;
   tasks?: CalendarTask[];
+  selectedEventId?: string;
 }
 
 // ─── Drag state ───────────────────────────────────────────────────────────────
@@ -151,7 +152,8 @@ const CalendarWeekView: React.FC<CalendarWeekViewProps> = ({
   displayWeek,
   onNavigateWeek,
   onCreateEventClick,
-  tasks = []
+  tasks = [],
+  selectedEventId
 }) => {
   const theme = useTheme();
   const user = useCurrentUser();
@@ -160,6 +162,15 @@ const CalendarWeekView: React.FC<CalendarWeekViewProps> = ({
 
   const [lockedTooltipEventId, setLockedTooltipEventId] = useState<string | null>(null);
   const [selectedEvent, setSelectedEvent] = useState<EventInstance | null>(null);
+
+  // Open this event's tooltip if it's been deep-linked to via ?eventId=
+  useEffect(() => {
+    if (!selectedEventId) return;
+    const matchingInstance = eventInstances.find((event) => event.eventId === selectedEventId);
+    if (matchingInstance) {
+      setLockedTooltipEventId(matchingInstance.eventId + matchingInstance.scheduleSlotId);
+    }
+  }, [selectedEventId, eventInstances]);
   const [showEditModal, setShowEditModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showSeriesDeleteModal, setShowSeriesDeleteModal] = useState(false);

--- a/src/frontend/src/pages/HomePage/components/NewMemberEventsWidget.tsx
+++ b/src/frontend/src/pages/HomePage/components/NewMemberEventsWidget.tsx
@@ -1,0 +1,151 @@
+import { useMemo, useState } from 'react';
+import { Box, Checkbox, FormControlLabel, FormGroup, Typography, useTheme } from '@mui/material';
+import { useHistory } from 'react-router-dom';
+import { format } from 'date-fns';
+import { Event } from 'shared';
+import ErrorPage from '../../ErrorPage';
+import LoadingIndicator from '../../../components/LoadingIndicator';
+import { useNewMemberEvents } from '../../../hooks/calendar.hooks';
+import { meetingStartTimePipeScheduleSlot } from '../../../utils/pipes';
+import { routes } from '../../../utils/routes';
+
+const getEventDate = (event: Event): Date | undefined => {
+  const firstScheduledDate = event.initialDateScheduled || event.scheduledTimes[0]?.startTime;
+  return firstScheduledDate ? new Date(firstScheduledDate) : undefined;
+};
+
+const EventBlock: React.FC<{ event: Event }> = ({ event }) => {
+  const theme = useTheme();
+  const history = useHistory();
+  const eventDate = getEventDate(event);
+
+  return (
+    <Box
+      onClick={() => history.push(`${routes.CALENDAR}?eventId=${event.eventId}`)}
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1.5,
+        p: 1,
+        borderRadius: '8px',
+        cursor: 'pointer',
+        '&:hover': { backgroundColor: theme.palette.action.hover }
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          minWidth: 48,
+          borderRadius: '6px',
+          border: `1px solid ${theme.palette.divider}`,
+          py: 0.5
+        }}
+      >
+        <Typography variant="caption" sx={{ fontWeight: 'bold', lineHeight: 1 }}>
+          {eventDate ? format(eventDate, 'MMM').toUpperCase() : '—'}
+        </Typography>
+        <Typography variant="body1" sx={{ fontWeight: 'bold', lineHeight: 1 }}>
+          {eventDate ? format(eventDate, 'd') : '—'}
+        </Typography>
+      </Box>
+      <Box sx={{ overflow: 'hidden' }}>
+        <Typography variant="body1" fontWeight="bold" noWrap>
+          {event.title}
+        </Typography>
+        <Typography variant="body2" color="text.secondary" noWrap>
+          {meetingStartTimePipeScheduleSlot(event.scheduledTimes)}
+          {event.location ? ` · ${event.location}` : event.zoomLink ? ` · ${event.zoomLink}` : ''}
+        </Typography>
+      </Box>
+    </Box>
+  );
+};
+
+const NewMemberEventsWidget: React.FC = () => {
+  const theme = useTheme();
+  const { data: events, isLoading, isError, error } = useNewMemberEvents();
+  const [selectedTeamTypeIds, setSelectedTeamTypeIds] = useState<string[]>([]);
+
+  const teamTypeOptions = useMemo(() => {
+    const seen = new Map<string, string>();
+    (events ?? []).forEach((event) => {
+      if (event.teamType) seen.set(event.teamType.teamTypeId, event.teamType.name);
+    });
+    return Array.from(seen, ([teamTypeId, name]) => ({ teamTypeId, name }));
+  }, [events]);
+
+  const sortedEvents = useMemo(() => {
+    return [...(events ?? [])].sort((a, b) => {
+      const aDate = getEventDate(a);
+      const bDate = getEventDate(b);
+      if (!aDate && !bDate) return 0;
+      if (!aDate) return 1;
+      if (!bDate) return -1;
+      return aDate.getTime() - bDate.getTime();
+    });
+  }, [events]);
+
+  const filteredEvents =
+    selectedTeamTypeIds.length === 0
+      ? sortedEvents
+      : sortedEvents.filter((event) => event.teamType && selectedTeamTypeIds.includes(event.teamType.teamTypeId));
+
+  const toggleTeamType = (teamTypeId: string) => {
+    setSelectedTeamTypeIds((prev) =>
+      prev.includes(teamTypeId) ? prev.filter((id) => id !== teamTypeId) : [...prev, teamTypeId]
+    );
+  };
+
+  if (isError) return <ErrorPage message={error?.message} />;
+  if (isLoading || !events) return <LoadingIndicator />;
+
+  return (
+    <Box
+      sx={{
+        backgroundColor: theme.palette.background.paper,
+        borderRadius: '10px',
+        width: '100%',
+        overflow: 'hidden',
+        paddingBottom: 2,
+        minHeight: '150px'
+      }}
+    >
+      <Typography variant="h5" sx={{ mb: 1, px: 2, pt: 2 }}>
+        New Member Events
+      </Typography>
+
+      {teamTypeOptions.length > 1 && (
+        <FormGroup row sx={{ px: 2, mb: 1 }}>
+          {teamTypeOptions.map((teamType) => (
+            <FormControlLabel
+              key={teamType.teamTypeId}
+              control={
+                <Checkbox
+                  size="small"
+                  checked={selectedTeamTypeIds.includes(teamType.teamTypeId)}
+                  onChange={() => toggleTeamType(teamType.teamTypeId)}
+                />
+              }
+              label={<Typography variant="body2">{teamType.name}</Typography>}
+            />
+          ))}
+        </FormGroup>
+      )}
+
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, px: 1 }}>
+        {filteredEvents.length === 0 ? (
+          <Typography variant="body2" color="text.secondary" sx={{ px: 1, py: 2, textAlign: 'center' }}>
+            No upcoming new member events
+          </Typography>
+        ) : (
+          filteredEvents.map((event) => <EventBlock key={event.eventId} event={event} />)
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+export default NewMemberEventsWidget;

--- a/src/frontend/src/pages/HomePage/components/OnboardingInfoSection.tsx
+++ b/src/frontend/src/pages/HomePage/components/OnboardingInfoSection.tsx
@@ -5,6 +5,7 @@ import ErrorPage from '../../ErrorPage';
 import LoadingIndicator from '../../../components/LoadingIndicator';
 import OnboardingBlock from '../../AdminToolsPage/OnboardingConfig/OnboardingBlock';
 import { useAllUsefulLinks } from '../../../hooks/projects.hooks';
+import NewMemberEventsWidget from './NewMemberEventsWidget';
 
 const OnboardingInfoSection: React.FC = () => {
   const theme = useTheme();
@@ -30,6 +31,9 @@ const OnboardingInfoSection: React.FC = () => {
   return (
     <Grid container item sx={{ display: 'flex', flexDirection: 'column', gap: 2.5 }}>
       <OnboardingBlock organization={organization} />
+      <Grid item>
+        <NewMemberEventsWidget />
+      </Grid>
       <Grid item>
         <Box
           sx={{

--- a/src/frontend/src/utils/urls.ts
+++ b/src/frontend/src/utils/urls.ts
@@ -455,6 +455,7 @@ const retrospectiveBudgets = () => `${API_URL}/retrospective/budgets`;
 const calendar = () => `${API_URL}/calendar`;
 const calendarShops = () => `${calendar()}/shops`;
 const calendarEvents = () => `${calendar()}/events`;
+const calendarNewMemberEvents = () => `${calendar()}/events/new-member`;
 const calendarEventsPaginated = () => `${calendar()}/events-paginated`;
 const calendarEventTypes = () => `${calendar()}/event-types`;
 const calendarCreateShop = () => `${calendar()}/shop/create`;
@@ -862,6 +863,7 @@ export const apiUrls = {
   calendarGetSingleEventWithMembers,
   calendarGetConflictingEvent,
   calendarEvents,
+  calendarNewMemberEvents,
   calendarEventsPaginated,
   calendarEventTypes,
   calendarDeleteEvent,

--- a/src/shared/src/types/calendar-types.ts
+++ b/src/shared/src/types/calendar-types.ts
@@ -100,6 +100,7 @@ export interface Calendar {
   userCreated: User;
   dateCreated: Date;
   eventTypes: EventType[];
+  isNewMemberCalendar: boolean;
 }
 
 export interface ScheduleSlot {


### PR DESCRIPTION
## Changes

Adds a "New Member Events" widget to the new member onboarding dashboard

- added `isNewMemberCalendar` boolean to `Calendar`
- new `GET /events/new-member` endpoint that looks up the org's flagged calendar and returns its upcoming events
- "New member calendar" checkbox added to the create/edit calendar modal, and a "New Member" checkmark column added to the calendars table in Admin Tools > Schedule Config
- Widget renders the upcoming new-member events as compact clickable blocks, sorted chronologically by scheduled time
- Clicking an event block auto-opens that event's popup once it's in view
- Added a "New Member Events" calendar, an "Educational" event type, and three sample events (in-person with location, in-person with a different team type, and one using a Zoom link instead of a location) in seed data

## Screenshots

<img width="1470" height="956" alt="Screenshot 2026-07-07 at 5 12 00 PM" src="https://github.com/user-attachments/assets/08fe3ad6-ed02-4596-8c10-da8d7176c757" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #4122 
