### PR TITLE
#4310-deselect-all-BOM-bug

### DIFF
--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/CopyBOM/CopyBOMProjectSection.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/CopyBOM/CopyBOMProjectSection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Typography } from '@mui/material';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
 import { useState } from 'react';
@@ -36,14 +36,12 @@ const CopyBOMProjectSection: React.FC<CopyBOMProjectSectionProps> = ({ selectedP
     error: assembliesError
   } = useGetAssembliesForWbsElement(selectedProject.wbsNum);
 
-  useEffect(() => {
-    if (materials && !isInitialized) {
-      setInitialization(true);
-      const allIds = materials.map((m) => m.materialId);
-      setSelectedMaterialIds(allIds);
-      onSelectionChange(allIds);
-    }
-  }, [materials, onSelectionChange, isInitialized]);
+  if (materials && !isInitialized) {
+    setInitialization(true);
+    const allIds = materials.map((m) => m.materialId);
+    setSelectedMaterialIds(allIds);
+    onSelectionChange(allIds);
+  }
 
   if (isErrorMaterials) return <ErrorPage message={materialsError?.message} />;
   if (isErrorAssemblies) return <ErrorPage message={assembliesError?.message} />;

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/CopyBOM/CopyBOMProjectSection.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/BOM/CopyBOM/CopyBOMProjectSection.tsx
@@ -21,6 +21,7 @@ const columns: GridColDef[] = [
 
 const CopyBOMProjectSection: React.FC<CopyBOMProjectSectionProps> = ({ selectedProject, onSelectionChange }) => {
   const [selectedMaterialIds, setSelectedMaterialIds] = useState<string[]>([]);
+  const [isInitialized, setInitialization] = useState<boolean>(false);
   const {
     data: materials,
     isLoading: isLoadingMaterials,
@@ -36,12 +37,13 @@ const CopyBOMProjectSection: React.FC<CopyBOMProjectSectionProps> = ({ selectedP
   } = useGetAssembliesForWbsElement(selectedProject.wbsNum);
 
   useEffect(() => {
-    if (materials) {
+    if (materials && !isInitialized) {
+      setInitialization(true);
       const allIds = materials.map((m) => m.materialId);
       setSelectedMaterialIds(allIds);
       onSelectionChange(allIds);
     }
-  }, [materials, onSelectionChange]);
+  }, [materials, onSelectionChange, isInitialized]);
 
   if (isErrorMaterials) return <ErrorPage message={materialsError?.message} />;
   if (isErrorAssemblies) return <ErrorPage message={assembliesError?.message} />;


### PR DESCRIPTION
## Changes

The select all checkbox no longer chooses everything when every material is already selected

## Test Cases

- When every material is selected, clicking the checkbox deselects everything
- When there is at least one material unselected, clicking the checkbox deselects all materials
- When all materials are deselected, clicking on the checkbox selects them all.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #4310 
