### PR TITLE
#4282 rules add referenced rules

### DIFF
--- a/src/backend/src/controllers/rules.controllers.ts
+++ b/src/backend/src/controllers/rules.controllers.ts
@@ -101,6 +101,30 @@ export default class RulesController {
     }
   }
 
+  static async addRuleReferences(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { ruleId } = req.params as Record<string, string>;
+      const { referencedRuleId } = req.body;
+
+      const rule = await RulesService.addRuleReferences(req.currentUser, ruleId, referencedRuleId, req.organization);
+      res.status(200).json(rule);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
+  static async removeRuleReferences(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { ruleId } = req.params as Record<string, string>;
+      const { referencedRuleId } = req.body;
+
+      const rule = await RulesService.removeRuleReferences(req.currentUser, ruleId, referencedRuleId, req.organization);
+      res.status(200).json(rule);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
   static async getAllRulesetTypes(req: Request, res: Response, next: NextFunction) {
     try {
       const rulesets = await RulesService.getAllRulesetTypes(req.organization);

--- a/src/backend/src/prisma-query-args/rules.query-args.ts
+++ b/src/backend/src/prisma-query-args/rules.query-args.ts
@@ -19,7 +19,8 @@ export const getRulePreviewQueryArgs = () =>
       },
       referencedRule: {
         select: {
-          ruleId: true
+          ruleId: true,
+          ruleCode: true
         }
       },
       teams: {

--- a/src/backend/src/prisma/seed-data/rules.seed.ts
+++ b/src/backend/src/prisma/seed-data/rules.seed.ts
@@ -153,6 +153,38 @@ export const seedFsaeRules = async (
     }
   });
 
+  const F6Rule = await prisma.rule.create({
+    data: {
+      ruleCode: 'F.6',
+      ruleContent: 'TUBE FRAMES',
+      rulesetId: fsaeRulesetId,
+      createdByUserId: joeShmoe.userId
+    }
+  });
+
+  // referenced by T.1.1.2
+  const F64Rule = await prisma.rule.create({
+    data: {
+      ruleCode: 'F.6.4',
+      ruleContent: 'Side Impact Structure',
+      rulesetId: fsaeRulesetId,
+      parentRuleId: F6Rule.ruleId,
+      createdByUserId: joeShmoe.userId
+    }
+  });
+
+  // referenced by T.1.1.2
+  const F751Rule = await prisma.rule.create({
+    data: {
+      ruleCode: 'F.7.5.1',
+      ruleContent:
+        'Side Impact Zone - the region longitudinally forward of the Main Hoop and aft of the Front Hoop consisting of the combination of a vertical section minimum 290 mm in height from the bottom surface of the floor of the monocoque and half the horizontal floor',
+      rulesetId: fsaeRulesetId,
+      createdByUserId: joeShmoe.userId
+      // add image
+    }
+  });
+
   const T112Rule = await prisma.rule.create({
     data: {
       ruleCode: 'T.1.1.2',
@@ -160,7 +192,10 @@ export const seedFsaeRules = async (
         'The template will be held horizontally, parallel to the ground, and inserted vertically from a height above any Primary Structure or bodywork that is between the Front Hoop and the Main Hoop until it meets the two of: ( refer to F.6.4 and F.7.5.1 )',
       rulesetId: fsaeRulesetId,
       parentRuleId: T11Rule.ruleId,
-      createdByUserId: joeShmoe.userId
+      createdByUserId: joeShmoe.userId,
+      referencedRule: {
+        connect: [{ ruleId: F64Rule.ruleId }, { ruleId: F751Rule.ruleId }]
+      }
     }
   });
 
@@ -292,6 +327,16 @@ export const seedFsaeRules = async (
       ruleContent: 'All fuel vent lines must exit outside the bodywork',
       rulesetId: fsaeRulesetId,
       parentRuleId: IC56Rule.ruleId,
+      createdByUserId: thomasEmrax.userId
+    }
+  });
+
+  const IC81Rule = await prisma.rule.create({
+    data: {
+      ruleCode: 'IC.8.1',
+      ruleContent: 'Starter Each vehicle must start the engine using an onboard starter at all times',
+      rulesetId: fsaeRulesetId,
+      parentRuleId: ICRule.ruleId,
       createdByUserId: thomasEmrax.userId
     }
   });
@@ -473,6 +518,20 @@ export const seedFsaeRules = async (
       rulesetId: fsaeRulesetId,
       parentRuleId: D3Rule.ruleId,
       createdByUserId: superman.userId
+    }
+  });
+
+  const D36Rule = await prisma.rule.create({
+    data: {
+      ruleCode: 'D.3.6',
+      ruleContent:
+        'Starting Auxiliary batteries must not be used once a vehicle has moved to the starting line of any event. See IC.8.1',
+      rulesetId: fsaeRulesetId,
+      parentRuleId: D3Rule.ruleId,
+      createdByUserId: batman.userId,
+      referencedRule: {
+        connect: [{ ruleId: IC81Rule.ruleId }]
+      }
     }
   });
 
@@ -704,6 +763,19 @@ export const seedFsaeRules = async (
   for (const rule of [topLevelTechnical, T1Rule, T11Rule, T112Rule, T112ARule]) {
     await RulesService.toggleRuleTeam(rule.ruleId, huskyTeamId, batman, organization);
   }
+
+  // Assign D.3.6 to Husky along with ancestors (D -> D.3 -> D.3.6)
+  for (const rule of [DRule, D3Rule, D36Rule]) {
+    await RulesService.toggleRuleTeam(rule.ruleId, huskyTeamId, batman, organization);
+  }
+  await RulesService.createProjectRule(batman, organization, D36Rule.ruleId, projectId);
+
+  // Assign IC.8.1 to Husky (IC -> IC.8.1)
+  // IC.8.1 referenced by D.3.6 above to test in-project referenced rule
+  await RulesService.toggleRuleTeam(ICRule.ruleId, huskyTeamId, batman, organization);
+  await RulesService.toggleRuleTeam(IC81Rule.ruleId, huskyTeamId, batman, organization);
+  await RulesService.createProjectRule(batman, organization, IC81Rule.ruleId, projectId);
+
   // Add the leaf rule to the bodywork project and mark it complete.
   await RulesService.createProjectRule(batman, organization, T112ARule.ruleId, projectId);
   await RulesService.setRuleCompletion(batman, organization, T112ARule.ruleId, true, projectId);

--- a/src/backend/src/routes/rules.routes.ts
+++ b/src/backend/src/routes/rules.routes.ts
@@ -35,6 +35,19 @@ rulesRouter.post(
 );
 rulesRouter.post('/rule/:ruleId/delete', RulesController.deleteRule);
 
+rulesRouter.post(
+  '/rule/:ruleId/references/add',
+  nonEmptyString(body('referencedRuleId')),
+  validateInputs,
+  RulesController.addRuleReferences
+);
+rulesRouter.post(
+  '/rule/:ruleId/references/delete',
+  nonEmptyString(body('referencedRuleId')),
+  validateInputs,
+  RulesController.removeRuleReferences
+);
+
 rulesRouter.post('/rulesetType/create', nonEmptyString(body('name')), validateInputs, RulesController.createRulesetType);
 
 rulesRouter.post(

--- a/src/backend/src/services/rules.services.ts
+++ b/src/backend/src/services/rules.services.ts
@@ -575,8 +575,9 @@ export default class RulesService {
       throw new HttpException(400, 'A rule cannot reference itself');
     }
 
+    // Referenced rules must be in the same ruleset, which guarantees same org
     const referencedRule = await prisma.rule.findUnique({
-      where: { ruleId: referencedRuleId }
+      where: { ruleId: referencedRuleId, rulesetId: rule.rulesetId }
     });
 
     if (!referencedRule) throw new NotFoundException('Referenced Rule', referencedRuleId);

--- a/src/backend/src/services/rules.services.ts
+++ b/src/backend/src/services/rules.services.ts
@@ -540,6 +540,111 @@ export default class RulesService {
   }
 
   /**
+   * Adds a referenced rule to an existing rule
+   * @param submitter the user making the request
+   * @param ruleId the rule receiving the reference
+   * @param referencedRuleId the rule ID to add as a reference
+   * @param organization the organization the rule belongs to
+   * @returns the updated rule
+   */
+  static async addRuleReferences(submitter: User, ruleId: string, referencedRuleId: string, organization: Organization) {
+    if (!(await userHasPermission(submitter.userId, organization.organizationId, isAdmin)))
+      throw new AccessDeniedAdminOnlyException('edit a rule');
+
+    const rule = await prisma.rule.findUnique({
+      where: { ruleId },
+      include: {
+        ruleset: {
+          include: {
+            car: {
+              include: {
+                wbsElement: true
+              }
+            }
+          }
+        }
+      }
+    });
+
+    if (!rule) throw new NotFoundException('Rule', ruleId);
+    if (rule.dateDeleted) throw new DeletedException('Rule', ruleId);
+    if (rule.ruleset?.car?.wbsElement?.organizationId !== organization.organizationId)
+      throw new InvalidOrganizationException('Rule');
+
+    if (referencedRuleId === ruleId) {
+      throw new HttpException(400, 'A rule cannot reference itself');
+    }
+
+    const referencedRule = await prisma.rule.findUnique({
+      where: { ruleId: referencedRuleId }
+    });
+
+    if (!referencedRule) throw new NotFoundException('Referenced Rule', referencedRuleId);
+    if (referencedRule.dateDeleted) throw new DeletedException('Referenced Rule', referencedRuleId);
+
+    const updatedRule = await prisma.rule.update({
+      where: { ruleId },
+      data: {
+        referencedRule: {
+          connect: { ruleId: referencedRuleId }
+        },
+        dateUpdated: new Date(),
+        updatedByUserId: submitter.userId
+      },
+      ...getRulePreviewQueryArgs()
+    });
+
+    return ruleTransformer(updatedRule);
+  }
+
+  /**
+   * Removes a referenced rule from an existing rule
+   * @param submitter the user making the request
+   * @param ruleId the rule losing the reference
+   * @param referencedRuleId the rule ID to remove from the references
+   * @param organization the organization the rule belongs to
+   * @returns the updated rule
+   */
+  static async removeRuleReferences(submitter: User, ruleId: string, referencedRuleId: string, organization: Organization) {
+    if (!(await userHasPermission(submitter.userId, organization.organizationId, isAdmin)))
+      throw new AccessDeniedAdminOnlyException('edit a rule');
+
+    const rule = await prisma.rule.findUnique({
+      where: { ruleId },
+      include: {
+        ruleset: {
+          include: {
+            car: {
+              include: {
+                wbsElement: true
+              }
+            }
+          }
+        }
+      }
+    });
+
+    if (!rule) throw new NotFoundException('Rule', ruleId);
+    if (rule.dateDeleted) throw new DeletedException('Rule', ruleId);
+    if (rule.ruleset?.car?.wbsElement?.organizationId !== organization.organizationId)
+      throw new InvalidOrganizationException('Rule');
+
+    const updatedRule = await prisma.rule.update({
+      where: { ruleId },
+      data: {
+        referencedRule: {
+          disconnect: { ruleId: referencedRuleId }
+        },
+        dateUpdated: new Date(),
+        updatedByUserId: submitter.userId
+      },
+      ...getRulePreviewQueryArgs()
+    });
+
+    return ruleTransformer(updatedRule);
+  }
+
+  /**
    * Given a ruleset id, retrieves the ruleset and throws errors if
    * it does not exist or is already deleted
    * @param rulesetId the id of the ruleset

--- a/src/backend/src/services/rules.services.ts
+++ b/src/backend/src/services/rules.services.ts
@@ -630,6 +630,13 @@ export default class RulesService {
     if (rule.ruleset?.car?.wbsElement?.organizationId !== organization.organizationId)
       throw new InvalidOrganizationException('Rule');
 
+    const referencedRule = await prisma.rule.findUnique({
+      where: { ruleId: referencedRuleId }
+    });
+
+    if (!referencedRule) throw new NotFoundException('Referenced Rule', referencedRuleId);
+    if (referencedRule.dateDeleted) throw new DeletedException('Referenced Rule', referencedRuleId);
+
     const updatedRule = await prisma.rule.update({
       where: { ruleId },
       data: {

--- a/src/backend/src/transformers/rules.transformer.ts
+++ b/src/backend/src/transformers/rules.transformer.ts
@@ -15,7 +15,7 @@ export const ruleTransformer = (rule: Prisma.RuleGetPayload<RulePreviewQueryArgs
         }
       : undefined,
     subRuleIds: rule.subRules.map((subRule) => subRule.ruleId),
-    referencedRuleIds: rule.referencedRule.map((ref) => ref.ruleId),
+    referencedRules: rule.referencedRule.map((ref) => ({ ruleId: ref.ruleId, ruleCode: ref.ruleCode })),
     teams: rule.teams?.map((team) => ({
       teamId: team.teamId,
       teamName: team.teamName

--- a/src/backend/tests/unit/rule.test.ts
+++ b/src/backend/tests/unit/rule.test.ts
@@ -966,7 +966,30 @@ describe('Rule Tests', () => {
       }
     });
 
-    return { ruleset1, ruleset2, topLevelRule, leafRule1, leafRule2 };
+    const referencedRule = await prisma.rule.create({
+      data: {
+        ruleCode: 'B2',
+        ruleContent: 'Rule content for B2',
+        imageFileIds: [],
+        dateCreated: new Date(),
+        ruleset: { connect: { rulesetId: ruleset1.rulesetId } },
+        createdBy: { connect: { userId: admin.userId } }
+      }
+    });
+
+    const referencingRule = await prisma.rule.create({
+      data: {
+        ruleCode: 'A2',
+        ruleContent: 'This rule references B2',
+        imageFileIds: [],
+        dateCreated: new Date(),
+        ruleset: { connect: { rulesetId: ruleset1.rulesetId } },
+        createdBy: { connect: { userId: admin.userId } },
+        referencedRule: { connect: { ruleId: referencedRule.ruleId } }
+      }
+    });
+
+    return { ruleset1, ruleset2, topLevelRule, leafRule1, leafRule2, referencedRule, referencingRule };
   };
 
   describe('Create Ruleset Type', () => {
@@ -2170,6 +2193,164 @@ describe('Rule Tests', () => {
       expect(rulesetType).toBeDefined();
       expect(rulesetType.rulesetTypeId).toBe(fsaeRulesetType.rulesetTypeId);
       expect(rulesetType.name).toBe(fsaeRulesetType.name);
+    });
+  });
+
+  describe('Referenced rule tests', () => {
+    it('Successfully deletes a referenced rule', async () => {
+      const car = await createUniqueCar(orgId);
+      const { referencedRule, referencingRule } = await setupRules(car);
+      const rule = await RulesService.removeRuleReferences(
+        admin,
+        referencingRule.ruleId,
+        referencedRule.ruleId,
+        organization
+      );
+      expect(rule.ruleId).toBe(referencingRule.ruleId);
+      expect(rule.referencedRules.length).toEqual(0);
+    });
+
+    it('Successfully adds a referenced rule', async () => {
+      const car = await createUniqueCar(orgId);
+      const { topLevelRule, referencedRule } = await setupRules(car);
+      const rule = await RulesService.addRuleReferences(admin, topLevelRule.ruleId, referencedRule.ruleId, organization);
+      expect(rule.ruleId).toBe(topLevelRule.ruleId);
+      expect(rule.referencedRules.length).toEqual(1);
+    });
+
+    it('Successfully adds multiple referenced rules', async () => {
+      const car = await createUniqueCar(orgId);
+      const { topLevelRule, leafRule1, referencedRule } = await setupRules(car);
+      await RulesService.addRuleReferences(admin, topLevelRule.ruleId, referencedRule.ruleId, organization);
+      const rule = await RulesService.addRuleReferences(admin, leafRule1.ruleId, referencedRule.ruleId, organization);
+      expect(rule.ruleId).toBe(topLevelRule.ruleId);
+      expect(rule.referencedRules.length).toEqual(2);
+      expect(rule.referencedRules[0].ruleId).toEqual(topLevelRule.ruleId);
+      expect(rule.referencedRules[1].ruleId).toEqual(leafRule1.ruleId);
+    });
+
+    it('Fails adding referenced rule if user is not admin', async () => {
+      const car = await createUniqueCar(orgId);
+      const { topLevelRule, referencedRule } = await setupRules(car);
+      await expect(
+        async () =>
+          await RulesService.addRuleReferences(nonLeadership, topLevelRule.ruleId, referencedRule.ruleId, organization)
+      ).rejects.toThrow(new AccessDeniedException('You do not have permissions to edit a rule'));
+    });
+
+    it('Fails adding referenced rule if rule does not exist', async () => {
+      const car = await createUniqueCar(orgId);
+      const { referencedRule } = await setupRules(car);
+      await expect(
+        async () => await RulesService.addRuleReferences(admin, 'fake-rule-id', referencedRule.ruleId, organization)
+      ).rejects.toThrow(new NotFoundException('Rule', 'fake-rule-id'));
+    });
+
+    it('Fails adding referenced rule if rule is not in the correct organization', async () => {
+      const otherCar = await createUniqueCar(otherOrg.organizationId);
+      const { topLevelRule: otherOrgRule, referencedRule } = await setupRules(otherCar);
+      await expect(
+        async () => await RulesService.addRuleReferences(admin, otherOrgRule.ruleId, referencedRule.ruleId, organization)
+      ).rejects.toThrow(new InvalidOrganizationException('Rule'));
+    });
+
+    it('Fails adding referenced rule if rule was deleted', async () => {
+      const car = await createUniqueCar(orgId);
+      const { topLevelRule, referencedRule } = await setupRules(car);
+
+      await prisma.rule.update({
+        where: { ruleId: topLevelRule.ruleId },
+        data: { dateDeleted: new Date() }
+      });
+      await expect(
+        async () => await RulesService.addRuleReferences(admin, topLevelRule.ruleId, referencedRule.ruleId, organization)
+      ).rejects.toThrow(new DeletedException('Rule', topLevelRule.ruleId));
+    });
+
+    it('Fails adding referenced rule if referenced rule was deleted', async () => {
+      const car = await createUniqueCar(orgId);
+      const { topLevelRule, referencedRule } = await setupRules(car);
+
+      await prisma.rule.update({
+        where: { ruleId: referencedRule.ruleId },
+        data: { dateDeleted: new Date() }
+      });
+      await expect(
+        async () => await RulesService.addRuleReferences(admin, topLevelRule.ruleId, referencedRule.ruleId, organization)
+      ).rejects.toThrow(new DeletedException('Rule', referencedRule.ruleId));
+    });
+
+    it('Fails adding referenced rule if referenced rule does not exist', async () => {
+      const car = await createUniqueCar(orgId);
+      const { topLevelRule } = await setupRules(car);
+      await expect(
+        async () => await RulesService.addRuleReferences(admin, topLevelRule.ruleId, 'fake-rule-id', organization)
+      ).rejects.toThrow(new NotFoundException('Referenced Rule', 'fake-rule-id'));
+    });
+
+    it('Fails adding referenced rule if referenced rule is in a different ruleset', async () => {
+      const car = await createUniqueCar(orgId);
+      const { topLevelRule, ruleset2 } = await setupRules(car);
+      const otherRulesetRule = await prisma.rule.create({
+        data: {
+          ruleCode: 'X1',
+          ruleContent: 'Rule in a different ruleset',
+          imageFileIds: [],
+          dateCreated: new Date(),
+          ruleset: { connect: { rulesetId: ruleset2.rulesetId } },
+          createdBy: { connect: { userId: admin.userId } }
+        }
+      });
+      await expect(
+        async () => await RulesService.addRuleReferences(admin, topLevelRule.ruleId, otherRulesetRule.ruleId, organization)
+      ).rejects.toThrow(new NotFoundException('Referenced Rule', otherRulesetRule.ruleId));
+    });
+
+    it('Fails adding referenced rule if referencing itself', async () => {
+      const car = await createUniqueCar(orgId);
+      const { referencingRule } = await setupRules(car);
+      await expect(
+        async () => await RulesService.addRuleReferences(admin, referencingRule.ruleId, referencingRule.ruleId, organization)
+      ).rejects.toThrow(new HttpException(400, 'A rule cannot reference itself'));
+    });
+
+    it('Fails removing referenced rule if user is not admin', async () => {
+      const car = await createUniqueCar(orgId);
+      const { referencedRule, referencingRule } = await setupRules(car);
+      await expect(
+        async () =>
+          await RulesService.removeRuleReferences(nonLeadership, referencingRule.ruleId, referencedRule.ruleId, organization)
+      ).rejects.toThrow(new AccessDeniedAdminOnlyException('edit a rule'));
+    });
+
+    it('Fails removing referenced rule if rule does not exist', async () => {
+      const car = await createUniqueCar(orgId);
+      const { referencedRule } = await setupRules(car);
+      await expect(
+        async () => await RulesService.removeRuleReferences(admin, 'fake-rule-id', referencedRule.ruleId, organization)
+      ).rejects.toThrow(new NotFoundException('Rule', 'fake-rule-id'));
+    });
+
+    it('Fails removing referenced rule if rule was deleted', async () => {
+      const car = await createUniqueCar(orgId);
+      const { referencedRule, referencingRule } = await setupRules(car);
+
+      await prisma.rule.update({
+        where: { ruleId: referencingRule.ruleId },
+        data: { dateDeleted: new Date() }
+      });
+      await expect(
+        async () =>
+          await RulesService.removeRuleReferences(admin, referencingRule.ruleId, referencedRule.ruleId, organization)
+      ).rejects.toThrow(new DeletedException('Rule', referencingRule.ruleId));
+    });
+
+    it('Fails removing referenced rule if rule is not in the correct organization', async () => {
+      const otherCar = await createUniqueCar(otherOrg.organizationId);
+      const { topLevelRule: otherOrgRule, referencedRule } = await setupRules(otherCar);
+      await expect(
+        async () => await RulesService.removeRuleReferences(admin, otherOrgRule.ruleId, referencedRule.ruleId, organization)
+      ).rejects.toThrow(new InvalidOrganizationException('Rule'));
     });
   });
 });

--- a/src/backend/tests/unit/rule.test.ts
+++ b/src/backend/tests/unit/rule.test.ts
@@ -2377,5 +2377,27 @@ describe('Rule Tests', () => {
         async () => await RulesService.removeRuleReferences(admin, otherOrgRule.ruleId, referencedRule.ruleId, organization)
       ).rejects.toThrow(new InvalidOrganizationException('Rule'));
     });
+
+    it('Fails removing referenced rule if referenced rule does not exist', async () => {
+      const car = await createUniqueCar(orgId);
+      const { referencingRule } = await setupRules(car);
+      await expect(
+        async () => await RulesService.removeRuleReferences(admin, referencingRule.ruleId, 'fake-rule-id', organization)
+      ).rejects.toThrow(new NotFoundException('Referenced Rule', 'fake-rule-id'));
+    });
+
+    it('Fails removing referenced rule if referenced rule was deleted', async () => {
+      const car = await createUniqueCar(orgId);
+      const { referencedRule, referencingRule } = await setupRules(car);
+
+      await prisma.rule.update({
+        where: { ruleId: referencedRule.ruleId },
+        data: { dateDeleted: new Date() }
+      });
+      await expect(
+        async () =>
+          await RulesService.removeRuleReferences(admin, referencingRule.ruleId, referencedRule.ruleId, organization)
+      ).rejects.toThrow(new DeletedException('Referenced Rule', referencedRule.ruleId));
+    });
   });
 });

--- a/src/backend/tests/unit/rule.test.ts
+++ b/src/backend/tests/unit/rule.test.ts
@@ -1561,7 +1561,7 @@ describe('Rule Tests', () => {
 
       const unassignedRules = await RulesService.getUnassignedRules(ruleset1.rulesetId, organization);
 
-      expect(unassignedRules.length).toBe(3);
+      expect(unassignedRules.length).toBe(5);
       expect(unassignedRules.map((r) => r.ruleCode)).toContain('T');
       expect(unassignedRules.map((r) => r.ruleCode)).toContain('T2');
       expect(unassignedRules.map((r) => r.ruleCode)).toContain('T2.1');
@@ -1582,7 +1582,7 @@ describe('Rule Tests', () => {
 
       const unassignedRules = await RulesService.getUnassignedRules(ruleset1.rulesetId, organization);
 
-      expect(unassignedRules.length).toBe(2);
+      expect(unassignedRules.length).toBe(4);
       expect(unassignedRules.map((r) => r.ruleId)).not.toContain(topLevelRule.ruleId);
       expect(unassignedRules.map((r) => r.ruleId)).toContain(leafRule1.ruleId);
       expect(unassignedRules.map((r) => r.ruleId)).toContain(leafRule2.ruleId);
@@ -1600,7 +1600,7 @@ describe('Rule Tests', () => {
 
       const unassignedRules = await RulesService.getUnassignedRules(ruleset1.rulesetId, organization);
 
-      expect(unassignedRules.length).toBe(2);
+      expect(unassignedRules.length).toBe(4);
       expect(unassignedRules.map((r) => r.ruleId)).not.toContain(leafRule1.ruleId);
       expect(unassignedRules.map((r) => r.ruleId)).toContain(topLevelRule.ruleId);
       expect(unassignedRules.map((r) => r.ruleId)).toContain(leafRule2.ruleId);
@@ -1633,7 +1633,7 @@ describe('Rule Tests', () => {
 
       const unassignedRules = await RulesService.getUnassignedRules(ruleset1.rulesetId, organization);
 
-      expect(unassignedRules.length).toBe(5);
+      expect(unassignedRules.length).toBe(7);
       // Check that rules are sorted by ruleCode
       for (let i = 0; i < unassignedRules.length - 1; i++) {
         expect(unassignedRules[i].ruleCode <= unassignedRules[i + 1].ruleCode).toBe(true);
@@ -1642,7 +1642,7 @@ describe('Rule Tests', () => {
 
     it('Returns empty array when all rules are assigned to teams', async () => {
       const car = await createUniqueCar(orgId);
-      const { ruleset1, topLevelRule, leafRule1, leafRule2 } = await setupRules(car);
+      const { ruleset1, topLevelRule, leafRule1, leafRule2, referencedRule, referencingRule } = await setupRules(car);
 
       // Create a team and assign all rules to it
       const teamType = await createTestTeamType('TestTeamType', orgId);
@@ -1673,6 +1673,20 @@ describe('Rule Tests', () => {
         }
       });
 
+      await prisma.rule.update({
+        where: { ruleId: referencedRule.ruleId },
+        data: {
+          teams: { connect: { teamId: team.teamId } }
+        }
+      });
+
+      await prisma.rule.update({
+        where: { ruleId: referencingRule.ruleId },
+        data: {
+          teams: { connect: { teamId: team.teamId } }
+        }
+      });
+
       const unassignedRules = await RulesService.getUnassignedRules(ruleset1.rulesetId, organization);
 
       expect(unassignedRules.length).toBe(0);
@@ -1680,7 +1694,7 @@ describe('Rule Tests', () => {
 
     it('Returns empty array when all rules are deleted', async () => {
       const car = await createUniqueCar(orgId);
-      const { ruleset1, topLevelRule, leafRule1, leafRule2 } = await setupRules(car);
+      const { ruleset1, topLevelRule, leafRule1, leafRule2, referencedRule, referencingRule } = await setupRules(car);
 
       // Delete all rules
       await prisma.rule.update({
@@ -1695,6 +1709,16 @@ describe('Rule Tests', () => {
 
       await prisma.rule.update({
         where: { ruleId: leafRule2.ruleId },
+        data: { dateDeleted: new Date(), deletedBy: { connect: { userId: admin.userId } } }
+      });
+
+      await prisma.rule.update({
+        where: { ruleId: referencedRule.ruleId },
+        data: { dateDeleted: new Date(), deletedBy: { connect: { userId: admin.userId } } }
+      });
+
+      await prisma.rule.update({
+        where: { ruleId: referencingRule.ruleId },
         data: { dateDeleted: new Date(), deletedBy: { connect: { userId: admin.userId } } }
       });
 
@@ -2116,9 +2140,9 @@ describe('Rule Tests', () => {
 
       const rules = await RulesService.getTopLevelRules(ruleset1.rulesetId, organization.organizationId);
 
-      expect(rules.length).toEqual(1);
-      expect(rules[0].ruleCode).toEqual('T');
-      expect(rules[0].ruleId).toEqual(topLevelRule.ruleId);
+      expect(rules.length).toEqual(3);
+      expect(rules.map((r) => r.ruleCode).sort()).toEqual(['A2', 'B2', 'T']);
+      expect(rules.find((r) => r.ruleId === topLevelRule.ruleId)?.ruleCode).toEqual('T');
     });
 
     it('Gets multiple top level rules', async () => {
@@ -2137,8 +2161,8 @@ describe('Rule Tests', () => {
 
       const rules = await RulesService.getTopLevelRules(ruleset1.rulesetId, organization.organizationId);
 
-      expect(rules.length).toEqual(2);
-      expect(rules.map((r) => r.ruleCode).sort()).toEqual(['A', 'T']);
+      expect(rules.length).toEqual(4);
+      expect(rules.map((r) => r.ruleCode).sort()).toEqual(['A', 'A2', 'B2', 'T']);
     });
 
     it('Returns empty array when no top level rules exist', async () => {
@@ -2164,8 +2188,8 @@ describe('Rule Tests', () => {
       const { ruleset1, topLevelRule, leafRule1, leafRule2 } = await setupRules(car);
       const rules = await RulesService.getTopLevelRules(ruleset1.rulesetId, organization.organizationId);
 
-      expect(rules.length).toEqual(1);
-      expect(rules[0].ruleId).toEqual(topLevelRule.ruleId);
+      expect(rules.length).toEqual(3);
+      expect(rules.find((r) => r.ruleId === topLevelRule.ruleId)).toBeDefined();
       expect(rules.find((r) => r.ruleId === leafRule1.ruleId)).toBeUndefined();
       expect(rules.find((r) => r.ruleId === leafRule2.ruleId)).toBeUndefined();
     });
@@ -2183,7 +2207,7 @@ describe('Rule Tests', () => {
       });
 
       const rules = await RulesService.getTopLevelRules(ruleset1.rulesetId, organization.organizationId);
-      expect(rules.length).toEqual(0);
+      expect(rules.find((r) => r.ruleId === topLevelRule.ruleId)).toBeUndefined();
     });
   });
 
@@ -2222,11 +2246,12 @@ describe('Rule Tests', () => {
       const car = await createUniqueCar(orgId);
       const { topLevelRule, leafRule1, referencedRule } = await setupRules(car);
       await RulesService.addRuleReferences(admin, topLevelRule.ruleId, referencedRule.ruleId, organization);
-      const rule = await RulesService.addRuleReferences(admin, leafRule1.ruleId, referencedRule.ruleId, organization);
+      const rule = await RulesService.addRuleReferences(admin, topLevelRule.ruleId, leafRule1.ruleId, organization);
       expect(rule.ruleId).toBe(topLevelRule.ruleId);
       expect(rule.referencedRules.length).toEqual(2);
-      expect(rule.referencedRules[0].ruleId).toEqual(topLevelRule.ruleId);
-      expect(rule.referencedRules[1].ruleId).toEqual(leafRule1.ruleId);
+      expect(rule.referencedRules.map((r) => r.ruleId)).toEqual(
+        expect.arrayContaining([referencedRule.ruleId, leafRule1.ruleId])
+      );
     });
 
     it('Fails adding referenced rule if user is not admin', async () => {
@@ -2235,7 +2260,7 @@ describe('Rule Tests', () => {
       await expect(
         async () =>
           await RulesService.addRuleReferences(nonLeadership, topLevelRule.ruleId, referencedRule.ruleId, organization)
-      ).rejects.toThrow(new AccessDeniedException('You do not have permissions to edit a rule'));
+      ).rejects.toThrow(new AccessDeniedAdminOnlyException('edit a rule'));
     });
 
     it('Fails adding referenced rule if rule does not exist', async () => {
@@ -2277,7 +2302,7 @@ describe('Rule Tests', () => {
       });
       await expect(
         async () => await RulesService.addRuleReferences(admin, topLevelRule.ruleId, referencedRule.ruleId, organization)
-      ).rejects.toThrow(new DeletedException('Rule', referencedRule.ruleId));
+      ).rejects.toThrow(new DeletedException('Referenced Rule', referencedRule.ruleId));
     });
 
     it('Fails adding referenced rule if referenced rule does not exist', async () => {

--- a/src/backend/tests/unit/rule.test.ts
+++ b/src/backend/tests/unit/rule.test.ts
@@ -105,7 +105,7 @@ describe('Create Rules Tests', () => {
       expect(rule.ruleContent).toBe('The vehicle must have four wheels');
       expect(rule.parentRule).toBeUndefined();
       expect(rule.subRuleIds).toHaveLength(0);
-      expect(rule.referencedRuleIds).toHaveLength(0);
+      expect(rule.referencedRules).toHaveLength(0);
       expect(rule.imageFileIds).toHaveLength(0);
     });
 
@@ -140,9 +140,10 @@ describe('Create Rules Tests', () => {
         [rule1.ruleId, rule2.ruleId]
       );
 
-      expect(rule3.referencedRuleIds).toHaveLength(2);
-      expect(rule3.referencedRuleIds).toContain(rule1.ruleId);
-      expect(rule3.referencedRuleIds).toContain(rule2.ruleId);
+      const referencedIds = rule3.referencedRules.map((ref) => ref.ruleId);
+      expect(referencedIds).toHaveLength(2);
+      expect(referencedIds).toContain(rule1.ruleId);
+      expect(referencedIds).toContain(rule2.ruleId);
     });
 
     it('successfully creates a rule with image file IDs', async () => {

--- a/src/frontend/src/apis/rules.api.ts
+++ b/src/frontend/src/apis/rules.api.ts
@@ -169,6 +169,24 @@ export const editRule = (ruleId: string, ruleContent: string) => {
 };
 
 /**
+ * Adds a referenced rule to a rule
+ * @param ruleId the rule receiving the reference
+ * @param referencedRuleId the rule ID to add as a reference
+ */
+export const addRuleReferences = (ruleId: string, referencedRuleId: string) => {
+  return axios.post<SharedRule>(apiUrls.rulesAddReferences(ruleId), { referencedRuleId });
+};
+
+/**
+ * Removes a referenced rule from a rule
+ * @param ruleId the rule losing the reference
+ * @param referencedRuleId the rule ID to remove from the references
+ */
+export const removeRuleReferences = (ruleId: string, referencedRuleId: string) => {
+  return axios.post<SharedRule>(apiUrls.rulesRemoveReferences(ruleId), { referencedRuleId });
+};
+
+/**
  * Updates a rulesets active status
  */
 export const updateRuleset = (rulesetId: string, name: string, isActive: boolean) => {

--- a/src/frontend/src/apis/transformers/rules.transformers.ts
+++ b/src/frontend/src/apis/transformers/rules.transformers.ts
@@ -15,7 +15,7 @@ export const ruleTransformer = (rule: Rule): Rule => {
   return {
     ...rule,
     subRuleIds: rule.subRuleIds || [],
-    referencedRuleIds: rule.referencedRuleIds || []
+    referencedRules: rule.referencedRules || []
   };
 };
 

--- a/src/frontend/src/hooks/rules.hooks.ts
+++ b/src/frontend/src/hooks/rules.hooks.ts
@@ -437,7 +437,6 @@ export const useEditRule = () => {
  */
 export const useAddRuleReferences = () => {
   const queryClient = useQueryClient();
-  const toast = useToast();
 
   return useMutation<SharedRule, Error, { ruleId: string; referencedRuleId: string }>(
     ['rules', 'addReference'],
@@ -447,11 +446,7 @@ export const useAddRuleReferences = () => {
     },
     {
       onSuccess: () => {
-        toast.success('Referenced rule added successfully');
         queryClient.invalidateQueries(['rules']);
-      },
-      onError: (error: Error) => {
-        toast.error(`Failed to add referenced rule: ${error.message}`);
       }
     }
   );
@@ -462,7 +457,6 @@ export const useAddRuleReferences = () => {
  */
 export const useRemoveRuleReferences = () => {
   const queryClient = useQueryClient();
-  const toast = useToast();
 
   return useMutation<SharedRule, Error, { ruleId: string; referencedRuleId: string }>(
     ['rules', 'removeReference'],
@@ -472,11 +466,7 @@ export const useRemoveRuleReferences = () => {
     },
     {
       onSuccess: () => {
-        toast.success('Referenced rule removed successfully');
         queryClient.invalidateQueries(['rules']);
-      },
-      onError: (error: Error) => {
-        toast.error(`Failed to remove referenced rule: ${error.message}`);
       }
     }
   );

--- a/src/frontend/src/hooks/rules.hooks.ts
+++ b/src/frontend/src/hooks/rules.hooks.ts
@@ -23,6 +23,8 @@ import {
   getRulesetsByRulesetType,
   deleteRule,
   editRule,
+  addRuleReferences,
+  removeRuleReferences,
   updateRuleset,
   deleteRuleset,
   deleteRulesetType,
@@ -425,6 +427,56 @@ export const useEditRule = () => {
       },
       onError: (error: Error) => {
         toast.error(`Failed to update rule: ${error.message}`);
+      }
+    }
+  );
+};
+
+/**
+ * React Query hook to add referenced rules to a rule
+ */
+export const useAddRuleReferences = () => {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+
+  return useMutation<SharedRule, Error, { ruleId: string; referencedRuleId: string }>(
+    ['rules', 'addReference'],
+    async ({ ruleId, referencedRuleId }) => {
+      const { data } = await addRuleReferences(ruleId, referencedRuleId);
+      return data;
+    },
+    {
+      onSuccess: () => {
+        toast.success('Referenced rule added successfully');
+        queryClient.invalidateQueries(['rules']);
+      },
+      onError: (error: Error) => {
+        toast.error(`Failed to add referenced rule: ${error.message}`);
+      }
+    }
+  );
+};
+
+/**
+ * React Query hook to remove referenced rules from a rule
+ */
+export const useRemoveRuleReferences = () => {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+
+  return useMutation<SharedRule, Error, { ruleId: string; referencedRuleId: string }>(
+    ['rules', 'removeReference'],
+    async ({ ruleId, referencedRuleId }) => {
+      const { data } = await removeRuleReferences(ruleId, referencedRuleId);
+      return data;
+    },
+    {
+      onSuccess: () => {
+        toast.success('Referenced rule removed successfully');
+        queryClient.invalidateQueries(['rules']);
+      },
+      onError: (error: Error) => {
+        toast.error(`Failed to remove referenced rule: ${error.message}`);
       }
     }
   );

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectRules/ProjectRulesTab.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/ProjectRules/ProjectRulesTab.tsx
@@ -24,6 +24,8 @@ import { Project, ProjectRule, Rule } from 'shared';
 import LoadingIndicator from '../../../../components/LoadingIndicator';
 import ErrorPage from '../../../ErrorPage';
 import RuleRow from '../../../RulesPage/RuleRow';
+import RuleContent from '../../../RulesPage/components/RuleContent';
+import { useRuleTreeNavigation } from '../../../RulesPage/useRuleTreeNavigation';
 import UpdateStatusPopover from './UpdateStatusPopover';
 import AddRuleModal from './AddProjectRuleModal';
 import {
@@ -97,6 +99,12 @@ export const ProjectRulesTab = ({ project }: ProjectRulesTabProps) => {
   const topLevelRules = useMemo(() => {
     return projectRuleList.filter((rule) => !rule.parentRule);
   }, [projectRuleList]);
+
+  // all referenced rules are shown, only referenced rules that exist in this project are clickable
+  const projectRuleIds = useMemo(() => new Set(projectRuleList.map((r) => r.ruleId)), [projectRuleList]);
+
+  // controlled expansion + click-to-navigate
+  const { expandedIds, toggleExpand, navigateToRule } = useRuleTreeNavigation(projectRuleList);
 
   // Handle completion update
   const handleStatusUpdate = async (ruleId: string, isComplete: boolean) => {
@@ -304,6 +312,16 @@ export const ProjectRulesTab = ({ project }: ProjectRulesTabProps) => {
                     key={rule.ruleId}
                     rule={rule}
                     allRules={projectRuleList}
+                    expandedIds={expandedIds}
+                    onToggleExpand={toggleExpand}
+                    middleContent={(r) => (
+                      <RuleContent
+                        rule={r}
+                        color={tableTextColor}
+                        onReferenceClick={navigateToRule}
+                        isReferenceInteractive={(id) => projectRuleIds.has(id)}
+                      />
+                    )}
                     rightContent={renderRightContent}
                     backgroundColor={tableBackgroundColor}
                     textColor={tableTextColor}

--- a/src/frontend/src/pages/RulesPage/RuleRow.tsx
+++ b/src/frontend/src/pages/RulesPage/RuleRow.tsx
@@ -31,6 +31,9 @@ interface RuleRowProps {
   indentRow?: boolean;
   // Amount of indentation per child depth when indentRow is enabled
   indentWidth?: number;
+  // Optional controlled expansion, otherwise each row manages its own open/closed state
+  expandedIds?: Set<string>;
+  onToggleExpand?: (ruleId: string) => void;
 }
 
 /**
@@ -56,9 +59,13 @@ const RuleRow: React.FC<RuleRowProps> = ({
   rightWidth = '10%',
   initiallyExpanded = false,
   indentRow = false,
-  indentWidth = 10
+  indentWidth = 10,
+  expandedIds,
+  onToggleExpand
 }) => {
-  const [isExpanded, setIsExpanded] = useState(initiallyExpanded);
+  const [localExpanded, setLocalExpanded] = useState(initiallyExpanded);
+  // Controlled by the parent when `expandedIds` is provided, otherwise from this row's own state
+  const isExpanded = expandedIds ? expandedIds.has(rule.ruleId) : localExpanded;
 
   // a parent rule whose sub rules aren't in the set (e.g. rule T.1 was assigned to a project but T.1.1 wasn't)
   // will render as a leaf rule but with no expand dropdown
@@ -75,7 +82,14 @@ const RuleRow: React.FC<RuleRowProps> = ({
   const color = typeof textColor === 'function' ? textColor(rule) : textColor;
   const hoverBgColor = typeof hoverColor === 'function' ? hoverColor(rule) : hoverColor;
 
-  const toggleExpand = () => hasSubRules && setIsExpanded(!isExpanded);
+  const toggleExpand = () => {
+    if (!hasSubRules) return;
+    if (onToggleExpand) {
+      onToggleExpand(rule.ruleId);
+    } else {
+      setLocalExpanded((prev) => !prev);
+    }
+  };
 
   const handleChevronClick = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -144,6 +158,8 @@ const RuleRow: React.FC<RuleRowProps> = ({
   return (
     <>
       <TableRow
+        // id so a parent can scroll to this row
+        id={`rule-row-${rule.ruleId}`}
         sx={{
           borderBottom: '1px solid #7d7d7d',
           backgroundColor: indentRow ? 'transparent' : bgColor,
@@ -228,6 +244,8 @@ const RuleRow: React.FC<RuleRowProps> = ({
             rightWidth={rightWidth}
             indentRow={indentRow}
             indentWidth={indentWidth}
+            expandedIds={expandedIds}
+            onToggleExpand={onToggleExpand}
           />
         ))}
     </>

--- a/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
@@ -4,7 +4,7 @@
  */
 
 import { Box, Button, Paper, Table, TableBody, TableContainer, TextField, useTheme } from '@mui/material';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import PageLayout from '../../components/PageLayout';
 import FullPageTabs from '../../components/FullPageTabs';
@@ -15,10 +15,19 @@ import ErrorPage from '../ErrorPage';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import AddRuleSectionModal from './components/AddRuleSectionModal';
 import AddRuleModal from './components/AddRuleModal';
+import AddReferencedRuleModal from './components/AddReferencedRuleModal';
+import RemoveReferencedRuleModal from './components/RemoveReferencedRuleModal';
+import RuleContent from './components/RuleContent';
 import { AddRuleBox } from './components/AddRuleBox';
 import AssignRulesTab from './AssignRulesTab';
 import DeleteRuleModal from './components/DeleteRuleModal';
-import { useDeleteRule, useEditRule, useSingleRuleset, useAllRulesForRuleset } from '../../hooks/rules.hooks';
+import {
+  useDeleteRule,
+  useEditRule,
+  useRemoveRuleReferences,
+  useSingleRuleset,
+  useAllRulesForRuleset
+} from '../../hooks/rules.hooks';
 import { countRulesToDelete } from '../../utils/rules.utils';
 import { Rule } from 'shared';
 
@@ -35,9 +44,12 @@ const RulesetEditPage: React.FC = () => {
   const [addMenuAnchorEl, setAddMenuAnchorEl] = useState<HTMLElement | null>(null);
   const [activeRuleId, setActiveRuleId] = useState<string | null>(null);
 
-  // temporary placeholder useState fns for the add rule section and add rule modals
   const [showAddRuleSectionModal, setShowAddRuleSectionModal] = useState(false);
   const [showAddRuleModal, setShowAddRuleModal] = useState(false);
+  const [showAddReferencedRuleModal, setShowAddReferencedRuleModal] = useState(false);
+  const [showRemoveReferenceModal, setShowRemoveReferenceModal] = useState(false);
+
+  const [referenceToRemove, setReferenceToRemove] = useState<{ rule: Rule; referencedRule: Rule } | null>(null);
 
   // Delete modal state
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
@@ -63,6 +75,9 @@ const RulesetEditPage: React.FC = () => {
   } = useAllRulesForRuleset(rulesetId!);
   const { mutateAsync: deleteRuleMutation } = useDeleteRule();
   const { mutateAsync: editRuleMutation } = useEditRule();
+  const { mutateAsync: removeRuleReferencesMutation } = useRemoveRuleReferences();
+
+  const rulesById = useMemo(() => new Map((allRules ?? []).map((r) => [r.ruleId, r])), [allRules]);
 
   const tabs = [
     { tabUrlValue: 'edit-rules', tabName: 'Edit Rules' },
@@ -104,6 +119,35 @@ const RulesetEditPage: React.FC = () => {
   const handleAddRuleFromMenu = () => {
     setShowAddRuleModal(true);
     handleCloseAddMenu();
+  };
+
+  const handleAddReferencedRuleFromMenu = () => {
+    setShowAddReferencedRuleModal(true);
+    handleCloseAddMenu();
+  };
+
+  const handleRemoveReference = (ruleId: string, referencedRuleId: string) => {
+    const rule = rulesById.get(ruleId);
+    const referencedRule = rulesById.get(referencedRuleId);
+    if (rule && referencedRule) {
+      setReferenceToRemove({ rule, referencedRule });
+      setShowRemoveReferenceModal(true);
+    }
+  };
+
+  const handleRemoveReferenceCancel = () => {
+    setShowRemoveReferenceModal(false);
+    setReferenceToRemove(null);
+  };
+
+  const handleConfirmRemoveReference = () => {
+    if (!referenceToRemove) return;
+    removeRuleReferencesMutation({
+      ruleId: referenceToRemove.rule.ruleId,
+      referencedRuleId: referenceToRemove.referencedRule.ruleId
+    });
+    setShowRemoveReferenceModal(false);
+    setReferenceToRemove(null);
   };
 
   const handleRemoveRule = (ruleId: string) => {
@@ -225,7 +269,12 @@ const RulesetEditPage: React.FC = () => {
                           );
                         }
                         return (
-                          currentRule.ruleContent && <span style={{ color: '#000000' }}>{currentRule.ruleContent}</span>
+                          <RuleContent
+                            rule={currentRule}
+                            rulesById={rulesById}
+                            color="#000000"
+                            onReferenceRemove={(refId) => handleRemoveReference(currentRule.ruleId, refId)}
+                          />
                         );
                       }}
                       rightContent={(currentRule) => (
@@ -253,6 +302,7 @@ const RulesetEditPage: React.FC = () => {
               anchorEl={addMenuAnchorEl}
               onClose={handleCloseAddMenu}
               onAddRule={handleAddRuleFromMenu}
+              onAddReferencedRule={handleAddReferencedRuleFromMenu}
             />
 
             <AddRuleSectionModal
@@ -267,6 +317,23 @@ const RulesetEditPage: React.FC = () => {
               rulesetId={rulesetId}
               initialParentRuleId={activeRuleId || undefined}
             />
+
+            <AddReferencedRuleModal
+              open={showAddReferencedRuleModal}
+              onClose={() => setShowAddReferencedRuleModal(false)}
+              ruleId={activeRuleId}
+              allRules={allRules}
+            />
+
+            {referenceToRemove && (
+              <RemoveReferencedRuleModal
+                open={showRemoveReferenceModal}
+                onHide={handleRemoveReferenceCancel}
+                onConfirm={handleConfirmRemoveReference}
+                rule={referenceToRemove.rule}
+                referencedRule={referenceToRemove.referencedRule}
+              />
+            )}
 
             {ruleToDelete && (
               <DeleteRuleModal

--- a/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
@@ -273,7 +273,6 @@ const RulesetEditPage: React.FC = () => {
                           currentRule.ruleContent && (
                             <RuleContent
                               rule={currentRule}
-                              rulesById={rulesById}
                               color={theme.palette.common.black}
                               onReferenceRemove={(refId) => handleRemoveReference(currentRule.ruleId, refId)}
                             />

--- a/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
@@ -31,6 +31,7 @@ import {
 } from '../../hooks/rules.hooks';
 import { countRulesToDelete, compareRuleCodes } from '../../utils/rules.utils';
 import { Rule } from 'shared';
+import { useToast } from '../../hooks/toasts.hooks';
 
 /**
  * RulesetPage component for displaying and managing ruleset rules.
@@ -61,6 +62,7 @@ const RulesetEditPage: React.FC = () => {
   const [editedContent, setEditedContent] = useState<string>('');
 
   const theme = useTheme();
+  const toast = useToast();
 
   const {
     data: ruleset,
@@ -141,14 +143,20 @@ const RulesetEditPage: React.FC = () => {
     setReferenceToRemove(null);
   };
 
-  const handleConfirmRemoveReference = () => {
+  const handleConfirmRemoveReference = async () => {
     if (!referenceToRemove) return;
-    removeRuleReferencesMutation({
-      ruleId: referenceToRemove.rule.ruleId,
-      referencedRuleId: referenceToRemove.referencedRule.ruleId
-    });
-    setShowRemoveReferenceModal(false);
-    setReferenceToRemove(null);
+
+    try {
+      await removeRuleReferencesMutation({
+        ruleId: referenceToRemove.rule.ruleId,
+        referencedRuleId: referenceToRemove.referencedRule.ruleId
+      });
+      toast.success('Referenced rule removed successfully');
+      setShowRemoveReferenceModal(false);
+      setReferenceToRemove(null);
+    } catch (err) {
+      toast.error('Failed to remove referenced rule');
+    }
   };
 
   const handleRemoveRule = (ruleId: string) => {

--- a/src/frontend/src/pages/RulesPage/components/AddReferencedRuleModal.tsx
+++ b/src/frontend/src/pages/RulesPage/components/AddReferencedRuleModal.tsx
@@ -1,0 +1,81 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { Box } from '@mui/material';
+import { useMemo, useState } from 'react';
+import { Rule } from 'shared';
+import NERModal from '../../../components/NERModal';
+import NERAutocomplete from '../../../components/NERAutocomplete';
+import { useAddRuleReferences } from '../../../hooks/rules.hooks';
+
+interface AddReferencedRuleModalProps {
+  open: boolean;
+  onClose: () => void;
+  // The rule recieving a reference, whose "+" menu was used to open this modal
+  ruleId: string | null;
+  allRules: Rule[];
+}
+
+type RuleOption = { label: string; id: string };
+
+/**
+ * Modal for attaching an existing rule as a referenced rule to the currently-edited rule
+ */
+const AddReferencedRuleModal: React.FC<AddReferencedRuleModalProps> = ({ open, onClose, ruleId, allRules }) => {
+  const [selected, setSelected] = useState<RuleOption | null>(null);
+  const { mutateAsync: addReferences, isLoading } = useAddRuleReferences();
+
+  const activeRule = ruleId ? allRules.find((r) => r.ruleId === ruleId) : undefined;
+
+  // Can attach any rule in the ruleset except the active rule itself and its already-referenced rules
+  const options = useMemo<RuleOption[]>(() => {
+    const excluded = new Set<string>([...(activeRule ? [activeRule.ruleId] : []), ...(activeRule?.referencedRuleIds ?? [])]);
+    return allRules
+      .filter((r) => !excluded.has(r.ruleId))
+      .sort((a, b) => a.ruleCode.localeCompare(b.ruleCode, undefined, { numeric: true }))
+      .map((r) => ({ label: r.ruleCode, id: r.ruleId }));
+  }, [allRules, activeRule]);
+
+  if (!activeRule) return null;
+
+  const handleClose = () => {
+    setSelected(null);
+    onClose();
+  };
+
+  const handleSubmit = async () => {
+    if (!ruleId || !selected) return;
+    try {
+      await addReferences({ ruleId, referencedRuleId: selected.id });
+      handleClose();
+    } catch {}
+  };
+
+  return (
+    <NERModal
+      open={open}
+      onHide={handleClose}
+      title="Add Referenced Rule"
+      onSubmit={handleSubmit}
+      submitText="Submit"
+      disabled={!selected || isLoading}
+      showCloseButton
+    >
+      <Box sx={{ minWidth: '500px', py: 1 }}>
+        <NERAutocomplete
+          id="referenced-rule-autocomplete"
+          options={options}
+          value={selected}
+          onChange={(_event, value) => setSelected(value)}
+          size="small"
+          placeholder="Search for an existing rule"
+          filterSelectedOptions
+        />
+      </Box>
+    </NERModal>
+  );
+};
+
+export default AddReferencedRuleModal;

--- a/src/frontend/src/pages/RulesPage/components/AddReferencedRuleModal.tsx
+++ b/src/frontend/src/pages/RulesPage/components/AddReferencedRuleModal.tsx
@@ -31,7 +31,10 @@ const AddReferencedRuleModal: React.FC<AddReferencedRuleModalProps> = ({ open, o
 
   // Can attach any rule in the ruleset except the active rule itself and its already-referenced rules
   const options = useMemo<RuleOption[]>(() => {
-    const excluded = new Set<string>([...(activeRule ? [activeRule.ruleId] : []), ...(activeRule?.referencedRuleIds ?? [])]);
+    const excluded = new Set<string>([
+      ...(activeRule ? [activeRule.ruleId] : []),
+      ...(activeRule?.referencedRules ?? []).map((ref) => ref.ruleId)
+    ]);
     return allRules
       .filter((r) => !excluded.has(r.ruleId))
       .sort((a, b) => a.ruleCode.localeCompare(b.ruleCode, undefined, { numeric: true }))

--- a/src/frontend/src/pages/RulesPage/components/AddReferencedRuleModal.tsx
+++ b/src/frontend/src/pages/RulesPage/components/AddReferencedRuleModal.tsx
@@ -9,6 +9,7 @@ import { Rule } from 'shared';
 import NERModal from '../../../components/NERModal';
 import NERAutocomplete from '../../../components/NERAutocomplete';
 import { useAddRuleReferences } from '../../../hooks/rules.hooks';
+import { useToast } from '../../../hooks/toasts.hooks';
 
 interface AddReferencedRuleModalProps {
   open: boolean;
@@ -26,6 +27,7 @@ type RuleOption = { label: string; id: string };
 const AddReferencedRuleModal: React.FC<AddReferencedRuleModalProps> = ({ open, onClose, ruleId, allRules }) => {
   const [selected, setSelected] = useState<RuleOption | null>(null);
   const { mutateAsync: addReferences, isLoading } = useAddRuleReferences();
+  const toast = useToast();
 
   const activeRule = ruleId ? allRules.find((r) => r.ruleId === ruleId) : undefined;
 
@@ -52,8 +54,11 @@ const AddReferencedRuleModal: React.FC<AddReferencedRuleModalProps> = ({ open, o
     if (!ruleId || !selected) return;
     try {
       await addReferences({ ruleId, referencedRuleId: selected.id });
+      toast.success('Referenced rule added successfully');
       handleClose();
-    } catch {}
+    } catch (err) {
+      toast.error('Failed to add referenced rule');
+    }
   };
 
   return (

--- a/src/frontend/src/pages/RulesPage/components/AddRuleBox.tsx
+++ b/src/frontend/src/pages/RulesPage/components/AddRuleBox.tsx
@@ -15,7 +15,6 @@ export const AddRuleBox: React.FC<AddRuleBoxProps> = ({ open, anchorEl, onClose,
 
   const optionButtonSx = {
     borderRadius: 0,
-    borderTop: '1px solid black',
     backgroundColor: 'transparent',
     color: theme.palette.common.white,
     lineHeight: 1.1,
@@ -49,11 +48,10 @@ export const AddRuleBox: React.FC<AddRuleBoxProps> = ({ open, anchorEl, onClose,
           minWidth: 'auto'
         }}
       >
-        <Box sx={{ height: 1, backgroundColor: 'rgba(255,255,255,0.18)' }} />
         <NERButton onClick={onAddRule} sx={optionButtonSx}>
           Add Rule
         </NERButton>
-        <NERButton onClick={onAddReferencedRule} sx={optionButtonSx}>
+        <NERButton onClick={onAddReferencedRule} sx={{ ...optionButtonSx, borderTop: '1px solid black' }}>
           Add Referenced Rule
         </NERButton>
       </Box>

--- a/src/frontend/src/pages/RulesPage/components/AddRuleBox.tsx
+++ b/src/frontend/src/pages/RulesPage/components/AddRuleBox.tsx
@@ -7,10 +7,21 @@ type AddRuleBoxProps = {
   anchorEl: HTMLElement | null;
   onClose: () => void;
   onAddRule: () => void;
+  onAddReferencedRule: () => void;
 };
 
-export const AddRuleBox: React.FC<AddRuleBoxProps> = ({ open, anchorEl, onClose, onAddRule }) => {
+export const AddRuleBox: React.FC<AddRuleBoxProps> = ({ open, anchorEl, onClose, onAddRule, onAddReferencedRule }) => {
   const theme = useTheme();
+
+  const optionButtonSx = {
+    borderRadius: 0,
+    borderTop: '1px solid black',
+    backgroundColor: 'transparent',
+    color: theme.palette.common.white,
+    lineHeight: 1.1,
+    justifyContent: 'flex-end',
+    '&:hover': { backgroundColor: 'rgba(255,255,255,0.12)' }
+  };
 
   return (
     <Popover
@@ -39,19 +50,11 @@ export const AddRuleBox: React.FC<AddRuleBoxProps> = ({ open, anchorEl, onClose,
         }}
       >
         <Box sx={{ height: 1, backgroundColor: 'rgba(255,255,255,0.18)' }} />
-        <NERButton
-          onClick={onAddRule}
-          sx={{
-            borderRadius: 0,
-            borderTop: '1px solid black',
-            backgroundColor: 'transparent',
-            color: theme.palette.common.white,
-            lineHeight: 1.1,
-            justifyContent: 'flex-end',
-            '&:hover': { backgroundColor: 'rgba(255,255,255,0.12)' }
-          }}
-        >
+        <NERButton onClick={onAddRule} sx={optionButtonSx}>
           Add Rule
+        </NERButton>
+        <NERButton onClick={onAddReferencedRule} sx={optionButtonSx}>
+          Add Referenced Rule
         </NERButton>
       </Box>
     </Popover>

--- a/src/frontend/src/pages/RulesPage/components/RemoveReferencedRuleModal.tsx
+++ b/src/frontend/src/pages/RulesPage/components/RemoveReferencedRuleModal.tsx
@@ -1,0 +1,38 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { Box, Typography } from '@mui/material';
+import { Rule } from 'shared';
+import NERModal from '../../../components/NERModal';
+
+interface RemoveReferencedRuleModalProps {
+  open: boolean;
+  onHide: () => void;
+  onConfirm: () => void;
+  rule: Rule; // The rule the reference is being removed from
+  referencedRule: Rule;
+}
+
+const RemoveReferencedRuleModal = ({ open, onHide, onConfirm, rule, referencedRule }: RemoveReferencedRuleModalProps) => {
+  return (
+    <NERModal
+      open={open}
+      onHide={onHide}
+      title="Confirm Removal"
+      cancelText="Cancel"
+      submitText="Save"
+      onSubmit={onConfirm}
+      formId="remove-referenced-rule-form"
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <Typography sx={{ fontWeight: 400, fontSize: '1rem' }}>
+          Remove referenced rule {referencedRule.ruleCode} from {rule.ruleCode}
+        </Typography>
+      </Box>
+    </NERModal>
+  );
+};
+
+export default RemoveReferencedRuleModal;

--- a/src/frontend/src/pages/RulesPage/components/RuleContent.tsx
+++ b/src/frontend/src/pages/RulesPage/components/RuleContent.tsx
@@ -1,0 +1,66 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { Box, useTheme } from '@mui/material';
+import { Rule } from 'shared';
+
+interface RuleContentProps {
+  rule: Rule;
+  rulesById: Map<string, Rule>;
+  color?: string;
+  onReferenceClick?: (ruleId: string) => void; // if true, clicking a referenced code navigates to it
+  onReferenceRemove?: (ruleId: string) => void; // if true, referenced code turns red on hover and clicking it starts removal (for edit view)
+}
+
+/**
+ * Renders a rule's content followed by a bracketed underlined list of its referenced rule codes.
+ */
+const RuleContent: React.FC<RuleContentProps> = ({ rule, rulesById, color, onReferenceClick, onReferenceRemove }) => {
+  const theme = useTheme();
+
+  const referencedRules = rule.referencedRuleIds.map((id) => rulesById.get(id)).filter((r): r is Rule => Boolean(r));
+
+  const handleReferenceClick = (referencedRuleId: string) => (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (onReferenceClick) {
+      onReferenceClick(referencedRuleId);
+    } else if (onReferenceRemove) {
+      onReferenceRemove(referencedRuleId);
+    }
+  };
+
+  const interactive = Boolean(onReferenceClick || onReferenceRemove);
+
+  return (
+    <span style={{ color }}>
+      {rule.ruleContent}
+      {referencedRules.length > 0 && (
+        <Box component="span" sx={{ ml: 0.5 }}>
+          {' [ '}
+          {referencedRules.map((ref, index) => (
+            <Box component="span" key={ref.ruleId}>
+              {index > 0 && ', '}
+              <Box
+                component="span"
+                onClick={interactive ? handleReferenceClick(ref.ruleId) : undefined}
+                sx={{
+                  textDecoration: 'underline',
+                  cursor: interactive ? 'pointer' : 'default',
+                  // In edit view, hovering over a referenced rule code highlights it red to signal removal
+                  ...(onReferenceRemove && { '&:hover': { color: theme.palette.primary.main } })
+                }}
+              >
+                {ref.ruleCode}
+              </Box>
+            </Box>
+          ))}
+          {' ]'}
+        </Box>
+      )}
+    </span>
+  );
+};
+
+export default RuleContent;

--- a/src/frontend/src/pages/RulesPage/components/RuleContent.tsx
+++ b/src/frontend/src/pages/RulesPage/components/RuleContent.tsx
@@ -8,19 +8,29 @@ import { Rule } from 'shared';
 
 interface RuleContentProps {
   rule: Rule;
-  rulesById: Map<string, Rule>;
   color?: string;
-  onReferenceClick?: (ruleId: string) => void; // if true, clicking a referenced code navigates to it
-  onReferenceRemove?: (ruleId: string) => void; // if true, referenced code turns red on hover and clicking it starts removal (for edit view)
+  // if set, clicking an interactive referenced code navigates to it
+  onReferenceClick?: (ruleId: string) => void;
+  // if set, referenced rule code turns red on hover and clicking it initiates removal process (for edit view)
+  onReferenceRemove?: (ruleId: string) => void;
+  // sets selected referenced rules as interactable, when omitted every reference is interactive
+  // used in project view since only references in that project will be clickable
+  isReferenceInteractive?: (ruleId: string) => boolean;
 }
 
 /**
- * Renders a rule's content followed by a bracketed underlined list of its referenced rule codes.
+ * Renders a rule's content followed by a bracketed list of its referenced rule codes.
  */
-const RuleContent: React.FC<RuleContentProps> = ({ rule, rulesById, color, onReferenceClick, onReferenceRemove }) => {
+const RuleContent: React.FC<RuleContentProps> = ({
+  rule,
+  color,
+  onReferenceClick,
+  onReferenceRemove,
+  isReferenceInteractive
+}) => {
   const theme = useTheme();
 
-  const referencedRules = rule.referencedRuleIds.map((id) => rulesById.get(id)).filter((r): r is Rule => Boolean(r));
+  const { referencedRules } = rule;
 
   const handleReferenceClick = (referencedRuleId: string) => (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -31,7 +41,11 @@ const RuleContent: React.FC<RuleContentProps> = ({ rule, rulesById, color, onRef
     }
   };
 
-  const interactive = Boolean(onReferenceClick || onReferenceRemove);
+  // determines if interaction is possible for this view
+  const interactionEnabled = Boolean(onReferenceClick || onReferenceRemove);
+  // determines if this specific referenced rule is interactable
+  const isReferenceInteractable = (ruleId: string) =>
+    interactionEnabled && (isReferenceInteractive ? isReferenceInteractive(ruleId) : true);
 
   return (
     <span style={{ color }}>
@@ -39,23 +53,26 @@ const RuleContent: React.FC<RuleContentProps> = ({ rule, rulesById, color, onRef
       {referencedRules.length > 0 && (
         <Box component="span" sx={{ ml: 0.5 }}>
           {' [ '}
-          {referencedRules.map((ref, index) => (
-            <Box component="span" key={ref.ruleId}>
-              {index > 0 && ', '}
-              <Box
-                component="span"
-                onClick={interactive ? handleReferenceClick(ref.ruleId) : undefined}
-                sx={{
-                  textDecoration: 'underline',
-                  cursor: interactive ? 'pointer' : 'default',
-                  // In edit view, hovering over a referenced rule code highlights it red to signal removal
-                  ...(onReferenceRemove && { '&:hover': { color: theme.palette.primary.main } })
-                }}
-              >
-                {ref.ruleCode}
+          {referencedRules.map((ref, index) => {
+            const interactive = isReferenceInteractable(ref.ruleId);
+            return (
+              <Box component="span" key={ref.ruleId}>
+                {index > 0 && ', '}
+                <Box
+                  component="span"
+                  onClick={interactive ? handleReferenceClick(ref.ruleId) : undefined}
+                  sx={{
+                    textDecoration: interactive ? 'underline' : 'none',
+                    cursor: interactive ? 'pointer' : 'default',
+                    // for edit view, hovering over a referenced code highlights it red to signal removal
+                    ...(interactive && onReferenceRemove && { '&:hover': { color: theme.palette.primary.main } })
+                  }}
+                >
+                  {ref.ruleCode}
+                </Box>
               </Box>
-            </Box>
-          ))}
+            );
+          })}
           {' ]'}
         </Box>
       )}

--- a/src/frontend/src/pages/RulesPage/components/RulesetGeneralView.tsx
+++ b/src/frontend/src/pages/RulesPage/components/RulesetGeneralView.tsx
@@ -1,11 +1,13 @@
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Box, Paper, Table, TableBody, TableContainer, useTheme } from '@mui/material';
 import { Rule } from 'shared';
 import RuleRow from '../RuleRow';
 import RuleStatusTag from './RuleStatusTag';
+import RuleContent from './RuleContent';
 import UpdateStatusPopover from '../../ProjectDetailPage/ProjectViewContainer/ProjectRules/UpdateStatusPopover';
 import { useSetRuleCompletion } from '../../../hooks/rules.hooks';
 import { useToast } from '../../../hooks/toasts.hooks';
+import { getAncestorIds } from '../../../utils/rules.utils';
 
 interface RulesetGeneralViewProps {
   allRules: Rule[];
@@ -21,6 +23,10 @@ const RulesetGeneralView: React.FC<RulesetGeneralViewProps> = ({ allRules, rules
   const [statusPopoverAnchor, setStatusPopoverAnchor] = useState<HTMLElement | null>(null);
   const [selectedRule, setSelectedRule] = useState<Rule | null>(null);
 
+  // Clicking referenced rule link opens target rule's ancestor chain and scrolls to it
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set()); // the set of ruleIds currently expanded
+  const [pendingScrollId, setPendingScrollId] = useState<string | null>(null); // a rule we want to scroll to
+
   const backgroundColor = theme.palette.background.default;
   const tableBackgroundColor = theme.palette.background.paper;
   const tableTextColor = theme.palette.text.primary;
@@ -30,6 +36,40 @@ const RulesetGeneralView: React.FC<RulesetGeneralViewProps> = ({ allRules, rules
   const { mutateAsync: setCompletion } = useSetRuleCompletion(rulesetId, '');
 
   const topLevelRules = allRules.filter((rule) => !rule.parentRule);
+  const rulesById = useMemo(() => new Map(allRules.map((r) => [r.ruleId, r])), [allRules]);
+
+  // Flip a single rule's expanded state
+  const toggleExpand = useCallback((ruleId: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(ruleId)) {
+        next.delete(ruleId);
+      } else {
+        next.add(ruleId);
+      }
+      return next;
+    });
+  }, []);
+
+  // Called when a referenced-rule link is clicked
+  const navigateToRule = useCallback(
+    (targetId: string) => {
+      const ancestors = getAncestorIds(targetId, allRules);
+      setExpandedIds((prev) => new Set([...prev, ...ancestors, targetId]));
+      setPendingScrollId(targetId);
+    },
+    [allRules]
+  );
+
+  // Once reference rule expansion is complete, scroll to it
+  useEffect(() => {
+    if (!pendingScrollId) return;
+    const node = document.getElementById(`rule-row-${pendingScrollId}`);
+    if (node) {
+      node.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      setPendingScrollId(null);
+    }
+  }, [pendingScrollId, expandedIds]);
 
   const handleStatusClose = () => {
     setStatusPopoverAnchor(null);
@@ -57,6 +97,11 @@ const RulesetGeneralView: React.FC<RulesetGeneralViewProps> = ({ allRules, rules
                 key={rule.ruleId}
                 rule={rule}
                 allRules={allRules}
+                expandedIds={expandedIds}
+                onToggleExpand={toggleExpand}
+                middleContent={(r) => (
+                  <RuleContent rule={r} rulesById={rulesById} onReferenceClick={navigateToRule} color={tableTextColor} />
+                )}
                 rightContent={(r) => (
                   <RuleStatusTag
                     rule={r}

--- a/src/frontend/src/pages/RulesPage/components/RulesetGeneralView.tsx
+++ b/src/frontend/src/pages/RulesPage/components/RulesetGeneralView.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Box, Paper, Table, TableBody, TableContainer, useTheme } from '@mui/material';
 import { Rule } from 'shared';
 import RuleRow from '../RuleRow';
@@ -7,7 +7,8 @@ import RuleContent from './RuleContent';
 import UpdateStatusPopover from '../../ProjectDetailPage/ProjectViewContainer/ProjectRules/UpdateStatusPopover';
 import { useSetRuleCompletion } from '../../../hooks/rules.hooks';
 import { useToast } from '../../../hooks/toasts.hooks';
-import { compareRuleCodes, getAncestorIds } from '../../../utils/rules.utils';
+import { compareRuleCodes } from '../../../utils/rules.utils';
+import { useRuleTreeNavigation } from '../useRuleTreeNavigation';
 
 interface RulesetGeneralViewProps {
   allRules: Rule[];
@@ -23,10 +24,6 @@ const RulesetGeneralView: React.FC<RulesetGeneralViewProps> = ({ allRules, rules
   const [statusPopoverAnchor, setStatusPopoverAnchor] = useState<HTMLElement | null>(null);
   const [selectedRule, setSelectedRule] = useState<Rule | null>(null);
 
-  // Clicking referenced rule link opens target rule's ancestor chain and scrolls to it
-  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set()); // the set of ruleIds currently expanded
-  const [pendingScrollId, setPendingScrollId] = useState<string | null>(null); // a rule we want to scroll to
-
   const backgroundColor = theme.palette.background.default;
   const tableBackgroundColor = theme.palette.background.paper;
   const tableTextColor = theme.palette.text.primary;
@@ -38,40 +35,9 @@ const RulesetGeneralView: React.FC<RulesetGeneralViewProps> = ({ allRules, rules
   // Sort once by rule code so both top-level rows and their children render in a stable numeric order.
   const sortedRules = useMemo(() => [...allRules].sort(compareRuleCodes), [allRules]);
   const topLevelRules = useMemo(() => sortedRules.filter((rule) => !rule.parentRule), [sortedRules]);
-  const rulesById = useMemo(() => new Map(allRules.map((r) => [r.ruleId, r])), [allRules]);
 
-  // Flip a single rule's expanded state
-  const toggleExpand = useCallback((ruleId: string) => {
-    setExpandedIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(ruleId)) {
-        next.delete(ruleId);
-      } else {
-        next.add(ruleId);
-      }
-      return next;
-    });
-  }, []);
-
-  // Called when a referenced-rule link is clicked
-  const navigateToRule = useCallback(
-    (targetId: string) => {
-      const ancestors = getAncestorIds(targetId, allRules);
-      setExpandedIds((prev) => new Set([...prev, ...ancestors, targetId]));
-      setPendingScrollId(targetId);
-    },
-    [allRules]
-  );
-
-  // Once reference rule expansion is complete, scroll to it
-  useEffect(() => {
-    if (!pendingScrollId) return;
-    const node = document.getElementById(`rule-row-${pendingScrollId}`);
-    if (node) {
-      node.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      setPendingScrollId(null);
-    }
-  }, [pendingScrollId, expandedIds]);
+  // Expand ancestors + scroll for referenced rules.
+  const { expandedIds, toggleExpand, navigateToRule } = useRuleTreeNavigation(sortedRules);
 
   const handleStatusClose = () => {
     setStatusPopoverAnchor(null);
@@ -101,9 +67,7 @@ const RulesetGeneralView: React.FC<RulesetGeneralViewProps> = ({ allRules, rules
                 allRules={sortedRules}
                 expandedIds={expandedIds}
                 onToggleExpand={toggleExpand}
-                middleContent={(r) => (
-                  <RuleContent rule={r} rulesById={rulesById} onReferenceClick={navigateToRule} color={tableTextColor} />
-                )}
+                middleContent={(r) => <RuleContent rule={r} onReferenceClick={navigateToRule} color={tableTextColor} />}
                 rightContent={(r) => (
                   <RuleStatusTag
                     rule={r}

--- a/src/frontend/src/pages/RulesPage/components/RulesetTeamView.tsx
+++ b/src/frontend/src/pages/RulesPage/components/RulesetTeamView.tsx
@@ -117,7 +117,7 @@ const makeSectionRow = (ruleId: string, ruleCode: string, subRuleIds: string[]):
   imageFileIds: [],
   parentRule: undefined,
   subRuleIds,
-  referencedRuleIds: [],
+  referencedRules: [],
   isComplete: false
 });
 

--- a/src/frontend/src/pages/RulesPage/components/RulesetTeamView.tsx
+++ b/src/frontend/src/pages/RulesPage/components/RulesetTeamView.tsx
@@ -134,7 +134,7 @@ const RulesetTeamView: React.FC<RulesetTeamViewProps> = ({ allRules }) => {
   const tableHoverColor = theme.palette.action.hover;
 
   // recompute row tree only when the rules change
-  const { topLevelItems, rowsById } = useMemo(() => {
+  const { topLevelItems, rowsById, actualRuleIds } = useMemo(() => {
     const { teamRules, unassignedToTeam } = getTeamOrganization(allRules);
 
     // real-rule rows (bucket-scoped)
@@ -181,11 +181,13 @@ const RulesetTeamView: React.FC<RulesetTeamViewProps> = ({ allRules }) => {
       topLevelItems.push(unassignedToTeamRow);
     }
 
-    return { topLevelItems, rowsById: [...sectionRows, ...ruleRows] };
+    // unassigned headers do not need rule content, "rule code" can span full width
+    return {
+      topLevelItems,
+      rowsById: [...sectionRows, ...ruleRows],
+      actualRuleIds: new Set<string>(ruleRows.map((r) => r.ruleId))
+    };
   }, [allRules]);
-
-  // Everything that isn't an actual rule (e.g., unassigned headers) should span the full row width
-  const actualRuleIds = new Set<string>(allRules.map((r) => r.ruleId));
 
   return (
     <Box>

--- a/src/frontend/src/pages/RulesPage/useRuleTreeNavigation.ts
+++ b/src/frontend/src/pages/RulesPage/useRuleTreeNavigation.ts
@@ -11,33 +11,37 @@ import { getAncestorIds } from '../../utils/rules.utils';
  * Controlled expand + click-to-navigate for referenced rules.
  * Clicking a referenced rule link expands its full ancestor path and scrolls to it on the page.
  * @param rules the rules currently rendered on this page
- * @returns 
+ * @returns expansion state + handlers
  */
 export const useRuleTreeNavigation = (rules: Rule[]) => {
+  // set of rule ids currently expanded
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+  // rule pending to scroll to
   const [pendingScrollId, setPendingScrollId] = useState<string | null>(null);
+  // list of rules in this view to determine if a referenced rule is able to be scrolled to (for project view)
   const ruleIds = useMemo(() => new Set(rules.map((r) => r.ruleId)), [rules]);
 
+  // flips a rule's expanded/collapsed state
   const toggleExpand = useCallback((ruleId: string) => {
     setExpandedIds((prev) => {
       const next = new Set(prev);
       if (next.has(ruleId)) {
-        next.delete(ruleId);
+        next.delete(ruleId); // expanded -> collapsed
       } else {
-        next.add(ruleId);
+        next.add(ruleId); // collapsed -> expanded
       }
       return next;
     });
   }, []);
 
-  // Expand the target's full ancestor path and queue a scroll to it. 
-  // The scroll doesnt happen until the newly-expanded ancestor rows are mounted
+  // Expand the target's full ancestor path and queue a scroll to it
+  // Scroll doesnt happen until the newly-expanded ancestor rows complete expansion
   const navigateToRule = useCallback(
     (targetId: string) => {
-      if (!ruleIds.has(targetId)) return;
+      if (!ruleIds.has(targetId)) return; // ensure target rule exists in this view
       const ancestors = getAncestorIds(targetId, rules);
       setExpandedIds((prev) => new Set([...prev, ...ancestors, targetId]));
-      setPendingScrollId(targetId);
+      setPendingScrollId(targetId); // queue the scroll
     },
     [rules, ruleIds]
   );

--- a/src/frontend/src/pages/RulesPage/useRuleTreeNavigation.ts
+++ b/src/frontend/src/pages/RulesPage/useRuleTreeNavigation.ts
@@ -1,0 +1,56 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Rule } from 'shared';
+import { getAncestorIds } from '../../utils/rules.utils';
+
+/**
+ * Controlled expand + click-to-navigate for referenced rules.
+ * Clicking a referenced rule link expands its full ancestor path and scrolls to it on the page.
+ * @param rules the rules currently rendered on this page
+ * @returns 
+ */
+export const useRuleTreeNavigation = (rules: Rule[]) => {
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+  const [pendingScrollId, setPendingScrollId] = useState<string | null>(null);
+  const ruleIds = useMemo(() => new Set(rules.map((r) => r.ruleId)), [rules]);
+
+  const toggleExpand = useCallback((ruleId: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(ruleId)) {
+        next.delete(ruleId);
+      } else {
+        next.add(ruleId);
+      }
+      return next;
+    });
+  }, []);
+
+  // Expand the target's full ancestor path and queue a scroll to it. 
+  // The scroll doesnt happen until the newly-expanded ancestor rows are mounted
+  const navigateToRule = useCallback(
+    (targetId: string) => {
+      if (!ruleIds.has(targetId)) return;
+      const ancestors = getAncestorIds(targetId, rules);
+      setExpandedIds((prev) => new Set([...prev, ...ancestors, targetId]));
+      setPendingScrollId(targetId);
+    },
+    [rules, ruleIds]
+  );
+
+  // Scrolls to target rule after ancestors expand
+  useEffect(() => {
+    if (!pendingScrollId) return;
+    const node = document.getElementById(`rule-row-${pendingScrollId}`);
+    if (node) {
+      node.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      setPendingScrollId(null);
+    }
+  }, [pendingScrollId, expandedIds]);
+
+  return { expandedIds, toggleExpand, navigateToRule };
+};

--- a/src/frontend/src/utils/urls.ts
+++ b/src/frontend/src/utils/urls.ts
@@ -472,6 +472,8 @@ const rulesDeleteProjectRule = (projectRuleId: string) => `${rules()}/projectRul
 const rulesSetRuleCompletion = (ruleId: string) => `${rules()}/rule/${ruleId}/setCompletion`;
 const rulesEdit = (ruleId: string) => `${rules()}/rule/${ruleId}/edit`;
 const rulesDelete = (ruleId: string) => `${rules()}/rule/${ruleId}/delete`;
+const rulesAddReferences = (ruleId: string) => `${rules()}/rule/${ruleId}/references/add`;
+const rulesRemoveReferences = (ruleId: string) => `${rules()}/rule/${ruleId}/references/delete`;
 const rulesetUpdate = (rulesetId: string) => `${ruleset()}/${rulesetId}/update`;
 const rulesetDelete = (rulesetId: string) => `${ruleset()}/${rulesetId}/delete`;
 const rulesetTypeDelete = (rulesetTypeId: string) => `${rules()}/rulesetType/${rulesetTypeId}/delete`;
@@ -890,6 +892,8 @@ export const apiUrls = {
   rulesSetRuleCompletion,
   rulesEdit,
   rulesDelete,
+  rulesAddReferences,
+  rulesRemoveReferences,
   rulesetUpdate,
   rulesetDelete,
   rulesetTypeDelete,

--- a/src/shared/src/types/rules-types.ts
+++ b/src/shared/src/types/rules-types.ts
@@ -35,7 +35,10 @@ export interface Rule {
     ruleCode: string;
   };
   subRuleIds: string[];
-  referencedRuleIds: string[];
+  referencedRules: Array<{
+    ruleId: string;
+    ruleCode: string;
+  }>;
   teams?: Array<{
     teamId: string;
     teamName: string;


### PR DESCRIPTION
## Changes
Functionality for referenced rules!!
- Added 'Add referenced rule' to the edit + dropdown
- Autocomplete rule code modal for adding referenced rules
- Confirm delete modal for removing a referenced rule
- General view clicking on referenced rule opens ancestry and scrolls to it
- Project view clicking on referenced rules **in this project** scrolls to them, others show up but are not interactive

## Notes
All manual currently until parser is updated
- Works in GENERAL and PROJECT views, not yet team view

## Screenshots
<img width="1407" height="199" alt="Screenshot 2026-07-11 at 3 56 17 PM" src="https://github.com/user-attachments/assets/bda58142-89e7-47e7-9e56-651f9d3ca98e" />
<img width="268" height="139" alt="Screenshot 2026-07-12 at 10 46 50 AM" src="https://github.com/user-attachments/assets/f734338c-023b-4849-adeb-ecb22ece3860" />

https://github.com/user-attachments/assets/7e0d471a-1122-47ea-80d1-60a1e3f00035


https://github.com/user-attachments/assets/5bb71c3f-fb42-47f2-808b-32d230d2b802


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #4282
