### PR TITLE
#4315 editing rule codes

### DIFF
--- a/src/backend/src/routes/rules.routes.ts
+++ b/src/backend/src/routes/rules.routes.ts
@@ -13,7 +13,7 @@ rulesRouter.get('/ruleset/:rulesetId', RulesController.getRulesetById);
 rulesRouter.post(
   '/rule/create',
   nonEmptyString(body('ruleCode')),
-  nonEmptyString(body('ruleContent')),
+  body('ruleContent').isString(),
   nonEmptyString(body('rulesetId')),
   body('parentRuleId').optional().isString(),
   body('referencedRules').optional().isArray(),
@@ -25,8 +25,8 @@ rulesRouter.post(
 );
 rulesRouter.post(
   '/rule/:ruleId/edit',
-  nonEmptyString(body('ruleContent')),
-  body('ruleCode').optional().isString(),
+  body('ruleContent').isString(),
+  nonEmptyString(body('ruleCode').optional()),
   body('imageFileIds').optional().isArray(),
   body('imageFileIds.*').optional().isString(),
   body('parentRuleId').optional().isString(),

--- a/src/backend/src/services/rules.services.ts
+++ b/src/backend/src/services/rules.services.ts
@@ -507,6 +507,21 @@ export default class RulesService {
     if (currentRule.ruleset?.car?.wbsElement?.organizationId !== organization.organizationId)
       throw new InvalidOrganizationException('Rule');
 
+    if (ruleCode !== undefined && ruleCode !== currentRule.ruleCode) {
+      const existingRule = await prisma.rule.findUnique({
+        where: {
+          rulesetId_ruleCode: {
+            rulesetId: currentRule.rulesetId,
+            ruleCode
+          }
+        }
+      });
+
+      if (existingRule) {
+        throw new HttpException(400, `Rule with code ${ruleCode} already exists in this ruleset`);
+      }
+    }
+
     if (parentRuleId) {
       const parentRule = await prisma.rule.findUnique({
         where: { ruleId: parentRuleId }
@@ -518,6 +533,10 @@ export default class RulesService {
 
       if (parentRule.dateDeleted) {
         throw new DeletedException('Parent Rule', parentRuleId);
+      }
+
+      if (parentRule.rulesetId !== currentRule.rulesetId) {
+        throw new HttpException(400, 'Parent rule must be in the same ruleset');
       }
     }
 

--- a/src/backend/src/services/rules.services.ts
+++ b/src/backend/src/services/rules.services.ts
@@ -507,6 +507,10 @@ export default class RulesService {
     if (currentRule.ruleset?.car?.wbsElement?.organizationId !== organization.organizationId)
       throw new InvalidOrganizationException('Rule');
 
+    if (ruleCode !== undefined && ruleCode.trim() === '') {
+      throw new HttpException(400, 'Rule code cannot be empty');
+    }
+
     if (ruleCode !== undefined && ruleCode !== currentRule.ruleCode) {
       const existingRule = await prisma.rule.findUnique({
         where: {

--- a/src/backend/src/services/rules.services.ts
+++ b/src/backend/src/services/rules.services.ts
@@ -99,22 +99,20 @@ export default class RulesService {
   /**
    * Throws if a rule with the given code already exists in the given ruleset
    * @param rulesetId The ruleset to check for an existing rule code
-   * @param ruleCode The rule code to check
+   * @param ruleCode The trimmed rule code to check
    */
   private static async assertRuleCodeAvailable(rulesetId: string, ruleCode: string) {
-    const trimmedRuleCode = ruleCode.trim();
-
     const existingRule = await prisma.rule.findUnique({
       where: {
         rulesetId_ruleCode: {
           rulesetId,
-          ruleCode: trimmedRuleCode
+          ruleCode
         }
       }
     });
 
     if (existingRule) {
-      throw new HttpException(400, `Rule with code ${trimmedRuleCode} already exists in this ruleset`);
+      throw new HttpException(400, `Rule with code ${ruleCode} already exists in this ruleset`);
     }
   }
 

--- a/src/backend/src/services/rules.services.ts
+++ b/src/backend/src/services/rules.services.ts
@@ -97,6 +97,28 @@ export default class RulesService {
   }
 
   /**
+   * Throws if a rule with the given code already exists in the given ruleset
+   * @param rulesetId The ruleset to check for an existing rule code
+   * @param ruleCode The rule code to check
+   */
+  private static async assertRuleCodeAvailable(rulesetId: string, ruleCode: string) {
+    const trimmedRuleCode = ruleCode.trim();
+
+    const existingRule = await prisma.rule.findUnique({
+      where: {
+        rulesetId_ruleCode: {
+          rulesetId,
+          ruleCode: trimmedRuleCode
+        }
+      }
+    });
+
+    if (existingRule) {
+      throw new HttpException(400, `Rule with code ${trimmedRuleCode} already exists in this ruleset`);
+    }
+  }
+
+  /**
    * Creates a new rule in the database
    *
    * @param user The user creating the rule, must be a member or above
@@ -151,18 +173,7 @@ export default class RulesService {
     ruleCode = ruleCode.trim();
 
     // Check for duplicate rule code within the same ruleset
-    const existingRule = await prisma.rule.findUnique({
-      where: {
-        rulesetId_ruleCode: {
-          rulesetId,
-          ruleCode
-        }
-      }
-    });
-
-    if (existingRule) {
-      throw new HttpException(400, `Rule with code ${ruleCode} already exists in this ruleset`);
-    }
+    await RulesService.assertRuleCodeAvailable(rulesetId, ruleCode);
 
     // Verify parent rule exists if provided
     if (parentRuleId) {
@@ -517,18 +528,7 @@ export default class RulesService {
       }
 
       if (ruleCode !== currentRule.ruleCode) {
-        const existingRule = await prisma.rule.findUnique({
-          where: {
-            rulesetId_ruleCode: {
-              rulesetId: currentRule.rulesetId,
-              ruleCode
-            }
-          }
-        });
-
-        if (existingRule) {
-          throw new HttpException(400, `Rule with code ${ruleCode} already exists in this ruleset`);
-        }
+        await RulesService.assertRuleCodeAvailable(currentRule.rulesetId, ruleCode);
       }
     }
 

--- a/src/backend/src/services/rules.services.ts
+++ b/src/backend/src/services/rules.services.ts
@@ -148,6 +148,8 @@ export default class RulesService {
       throw new AccessDeniedException('Cannot create rule in a ruleset from another organization');
     }
 
+    ruleCode = ruleCode.trim();
+
     // Check for duplicate rule code within the same ruleset
     const existingRule = await prisma.rule.findUnique({
       where: {
@@ -507,22 +509,26 @@ export default class RulesService {
     if (currentRule.ruleset?.car?.wbsElement?.organizationId !== organization.organizationId)
       throw new InvalidOrganizationException('Rule');
 
-    if (ruleCode !== undefined && ruleCode.trim() === '') {
-      throw new HttpException(400, 'Rule code cannot be empty');
-    }
+    if (ruleCode !== undefined) {
+      ruleCode = ruleCode.trim();
 
-    if (ruleCode !== undefined && ruleCode !== currentRule.ruleCode) {
-      const existingRule = await prisma.rule.findUnique({
-        where: {
-          rulesetId_ruleCode: {
-            rulesetId: currentRule.rulesetId,
-            ruleCode
+      if (ruleCode === '') {
+        throw new HttpException(400, 'Rule code cannot be empty');
+      }
+
+      if (ruleCode !== currentRule.ruleCode) {
+        const existingRule = await prisma.rule.findUnique({
+          where: {
+            rulesetId_ruleCode: {
+              rulesetId: currentRule.rulesetId,
+              ruleCode
+            }
           }
-        }
-      });
+        });
 
-      if (existingRule) {
-        throw new HttpException(400, `Rule with code ${ruleCode} already exists in this ruleset`);
+        if (existingRule) {
+          throw new HttpException(400, `Rule with code ${ruleCode} already exists in this ruleset`);
+        }
       }
     }
 

--- a/src/backend/tests/unit/rule.test.ts
+++ b/src/backend/tests/unit/rule.test.ts
@@ -1270,6 +1270,22 @@ describe('Rule Tests', () => {
       ).rejects.toThrow(new HttpException(400, `Rule with code ${leafRule2.ruleCode} already exists in this ruleset`));
     });
 
+    it('Fails when new rule code duplicates another rule code padded with whitespace', async () => {
+      const car = await createUniqueCar(orgId);
+      const { leafRule1, leafRule2 } = await setupRules(car);
+
+      await expect(
+        RulesService.editRule(
+          admin,
+          leafRule1.ruleContent,
+          leafRule1.ruleId,
+          `  ${leafRule2.ruleCode}  `,
+          leafRule1.imageFileIds,
+          organization
+        )
+      ).rejects.toThrow(new HttpException(400, `Rule with code ${leafRule2.ruleCode} already exists in this ruleset`));
+    });
+
     it('Allows a new rule code that does not start with the existing parent rule code', async () => {
       const car = await createUniqueCar(orgId);
       const { leafRule2 } = await setupRules(car); // leafRule2's parent code is 'T'

--- a/src/backend/tests/unit/rule.test.ts
+++ b/src/backend/tests/unit/rule.test.ts
@@ -232,6 +232,21 @@ describe('Create Rules Tests', () => {
       ).rejects.toThrow(new HttpException(400, 'Parent rule must be in the same ruleset'));
     });
 
+    // this is allowed but with warning in case a parent needs to be renamed which won't break all existing children
+    it('allows a child rule code that does not start with the parent rule code', async () => {
+      const parentRule = await RulesService.createRule(batman, 'T.1', 'Parent', rulesetId, organization);
+
+      const childRule = await RulesService.createRule(superman, 'TH.1', 'Child', rulesetId, organization, parentRule.ruleId);
+
+      expect(childRule.ruleCode).toBe('TH.1');
+      expect(childRule.parentRule?.ruleId).toBe(parentRule.ruleId);
+    });
+
+    it('successfully creates a rule with blank content', async () => {
+      const rule = await RulesService.createRule(batman, 'T.9.1', '', rulesetId, organization);
+      expect(rule.ruleContent).toBe('');
+    });
+
     it('fails when referenced rule does not exist', async () => {
       await expect(
         RulesService.createRule(batman, 'T.1.1', 'Some rule', rulesetId, organization, undefined, ['fake-rule-id'])
@@ -1197,6 +1212,70 @@ describe('Rule Tests', () => {
       );
 
       expect(updatedRule.ruleContent).toEqual('BRAND NEW RULE CONTENT');
+    });
+
+    it('Succeeds and edits a rule to have blank content', async () => {
+      const car = await createUniqueCar(orgId);
+      const { leafRule1 } = await setupRules(car);
+      const updatedRule = await RulesService.editRule(
+        admin,
+        '',
+        leafRule1.ruleId,
+        leafRule1.ruleCode,
+        leafRule1.imageFileIds,
+        organization
+      );
+
+      expect(updatedRule.ruleContent).toEqual('');
+    });
+
+    it('Succeeds and changes a rule code that still satisfies the parent prefix', async () => {
+      const car = await createUniqueCar(orgId);
+      const { leafRule1 } = await setupRules(car);
+
+      const updatedRule = await RulesService.editRule(
+        admin,
+        leafRule1.ruleContent,
+        leafRule1.ruleId,
+        'T99',
+        leafRule1.imageFileIds,
+        organization
+      );
+
+      expect(updatedRule.ruleCode).toEqual('T99');
+    });
+
+    it('Fails when new rule code duplicates another rule in the same ruleset', async () => {
+      const car = await createUniqueCar(orgId);
+      const { leafRule1, leafRule2 } = await setupRules(car);
+
+      await expect(
+        RulesService.editRule(
+          admin,
+          leafRule1.ruleContent,
+          leafRule1.ruleId,
+          leafRule2.ruleCode,
+          leafRule1.imageFileIds,
+          organization
+        )
+      ).rejects.toThrow(new HttpException(400, `Rule with code ${leafRule2.ruleCode} already exists in this ruleset`));
+    });
+
+    it('Allows a new rule code that does not start with the existing parent rule code', async () => {
+      const car = await createUniqueCar(orgId);
+      const { leafRule2 } = await setupRules(car); // leafRule2's parent code is 'T'
+
+      const updatedRule = await RulesService.editRule(
+        admin,
+        leafRule2.ruleContent,
+        leafRule2.ruleId,
+        'X2.1',
+        leafRule2.imageFileIds,
+        organization
+      );
+      
+      expect(updatedRule.parentRule?.ruleCode).not.toEqual('X2');
+      expect(updatedRule.ruleCode).toEqual('X2.1');
     });
   });
 

--- a/src/backend/tests/unit/rule.test.ts
+++ b/src/backend/tests/unit/rule.test.ts
@@ -232,7 +232,7 @@ describe('Create Rules Tests', () => {
       ).rejects.toThrow(new HttpException(400, 'Parent rule must be in the same ruleset'));
     });
 
-    // this is allowed but with warning in case a parent needs to be renamed which won't break all existing children
+    // this is allowed but with warning in case a parent code needs to be updated which won't break all existing children
     it('allows a child rule code that does not start with the parent rule code', async () => {
       const parentRule = await RulesService.createRule(batman, 'T.1', 'Parent', rulesetId, organization);
 
@@ -1227,6 +1227,15 @@ describe('Rule Tests', () => {
       );
 
       expect(updatedRule.ruleContent).toEqual('');
+    });
+
+    it('Fails when new rule code is blank', async () => {
+      const car = await createUniqueCar(orgId);
+      const { leafRule1 } = await setupRules(car);
+
+      await expect(
+        RulesService.editRule(admin, leafRule1.ruleContent, leafRule1.ruleId, '', leafRule1.imageFileIds, organization)
+      ).rejects.toThrow(new HttpException(400, 'Rule code cannot be empty'));
     });
 
     it('Succeeds and changes a rule code that still satisfies the parent prefix', async () => {

--- a/src/backend/tests/unit/rule.test.ts
+++ b/src/backend/tests/unit/rule.test.ts
@@ -1286,6 +1286,34 @@ describe('Rule Tests', () => {
       ).rejects.toThrow(new HttpException(400, `Rule with code ${leafRule2.ruleCode} already exists in this ruleset`));
     });
 
+    it('Fails when parent rule is in a different ruleset', async () => {
+      const car = await createUniqueCar(orgId);
+      const { ruleset2, leafRule1 } = await setupRules(car);
+
+      const otherRulesetRule = await prisma.rule.create({
+        data: {
+          ruleCode: 'X1',
+          ruleContent: 'Rule in a different ruleset',
+          imageFileIds: [],
+          dateCreated: new Date(),
+          ruleset: { connect: { rulesetId: ruleset2.rulesetId } },
+          createdBy: { connect: { userId: admin.userId } }
+        }
+      });
+
+      await expect(
+        RulesService.editRule(
+          admin,
+          leafRule1.ruleContent,
+          leafRule1.ruleId,
+          leafRule1.ruleCode,
+          leafRule1.imageFileIds,
+          organization,
+          otherRulesetRule.ruleId
+        )
+      ).rejects.toThrow(new HttpException(400, 'Parent rule must be in the same ruleset'));
+    });
+
     it('Allows a new rule code that does not start with the existing parent rule code', async () => {
       const car = await createUniqueCar(orgId);
       const { leafRule2 } = await setupRules(car); // leafRule2's parent code is 'T'

--- a/src/backend/tests/unit/rule.test.ts
+++ b/src/backend/tests/unit/rule.test.ts
@@ -1273,7 +1273,7 @@ describe('Rule Tests', () => {
         leafRule2.imageFileIds,
         organization
       );
-      
+
       expect(updatedRule.parentRule?.ruleCode).not.toEqual('X2');
       expect(updatedRule.ruleCode).toEqual('X2.1');
     });

--- a/src/frontend/src/apis/rules.api.ts
+++ b/src/frontend/src/apis/rules.api.ts
@@ -160,12 +160,13 @@ export const deleteRule = (ruleId: string) => {
 };
 
 /**
- * Edits a rule's content
+ * Edits a rule's content and/or code
  * @param ruleId - The ID of the rule to edit
  * @param ruleContent - The new content for the rule
+ * @param ruleCode - The new code for the rule (optional, keeps existing if not provided)
  */
-export const editRule = (ruleId: string, ruleContent: string) => {
-  return axios.post<SharedRule>(apiUrls.rulesEdit(ruleId), { ruleContent });
+export const editRule = (ruleId: string, ruleContent: string, ruleCode?: string) => {
+  return axios.post<SharedRule>(apiUrls.rulesEdit(ruleId), { ruleContent, ruleCode });
 };
 
 /**

--- a/src/frontend/src/hooks/rules.hooks.ts
+++ b/src/frontend/src/hooks/rules.hooks.ts
@@ -413,10 +413,10 @@ export const useEditRule = () => {
   const queryClient = useQueryClient();
   const toast = useToast();
 
-  return useMutation<SharedRule, Error, { ruleId: string; ruleContent: string }>(
+  return useMutation<SharedRule, Error, { ruleId: string; ruleContent: string; ruleCode?: string }>(
     ['rules', 'edit'],
-    async ({ ruleId, ruleContent }) => {
-      const { data } = await editRule(ruleId, ruleContent);
+    async ({ ruleId, ruleContent, ruleCode }) => {
+      const { data } = await editRule(ruleId, ruleContent, ruleCode);
       return data;
     },
     {

--- a/src/frontend/src/pages/RulesPage/AssignRulesTab.tsx
+++ b/src/frontend/src/pages/RulesPage/AssignRulesTab.tsx
@@ -102,7 +102,6 @@ const AssignRulesTab: React.FC<AssignRulesTabProps> = ({ rules }) => {
   const { data: teams, isLoading: teamsLoading, isError: teamsError, error: teamsErrorData } = useAllTeams();
   const { mutate: bulkToggle, isLoading: isSaving } = useBulkToggleRuleTeam();
 
-  const hasAppliedTeamParamRef = useRef(false);
   // background refetches ensure current toggles remain
   const hasPendingChangesRef = useRef(false);
 
@@ -122,14 +121,13 @@ const AssignRulesTab: React.FC<AssignRulesTabProps> = ({ rules }) => {
       setAssignments(new Set(initialAssignments));
     }
 
-    if (!hasAppliedTeamParamRef.current) {
+    if (!selectedTeamId) {
       const teamIdParam = new URLSearchParams(location.search).get('teamId');
       if (teamIdParam && teams.some((team) => team.teamId === teamIdParam)) {
         setSelectedTeamId(teamIdParam);
       }
-      hasAppliedTeamParamRef.current = true;
     }
-  }, [rules, teams, location.search]);
+  }, [rules, teams, location.search, selectedTeamId]);
 
   const handleTeamSelect = (teamId: string) => setSelectedTeamId(teamId);
 

--- a/src/frontend/src/pages/RulesPage/AssignRulesTab.tsx
+++ b/src/frontend/src/pages/RulesPage/AssignRulesTab.tsx
@@ -103,20 +103,24 @@ const AssignRulesTab: React.FC<AssignRulesTabProps> = ({ rules }) => {
   const { mutate: bulkToggle, isLoading: isSaving } = useBulkToggleRuleTeam();
 
   const hasAppliedTeamParamRef = useRef(false);
+  // background refetches ensure current toggles remain
+  const hasPendingChangesRef = useRef(false);
 
-  // Reload when rule data changes
+  // Reload when rule data changes, unless the user has unsaved toggles pending
   useEffect(() => {
     if (!teams || teams.length === 0) return;
 
-    const initialAssignments = new Set<string>();
-    rules.forEach((rule) => {
-      rule.teams?.forEach((team) => {
-        initialAssignments.add(`${team.teamId}:${rule.ruleId}`);
+    if (!hasPendingChangesRef.current) {
+      const initialAssignments = new Set<string>();
+      rules.forEach((rule) => {
+        rule.teams?.forEach((team) => {
+          initialAssignments.add(`${team.teamId}:${rule.ruleId}`);
+        });
       });
-    });
 
-    setOriginalAssignments(initialAssignments);
-    setAssignments(new Set(initialAssignments));
+      setOriginalAssignments(initialAssignments);
+      setAssignments(new Set(initialAssignments));
+    }
 
     if (!hasAppliedTeamParamRef.current) {
       const teamIdParam = new URLSearchParams(location.search).get('teamId');
@@ -212,6 +216,7 @@ const AssignRulesTab: React.FC<AssignRulesTabProps> = ({ rules }) => {
       getAncestorIds(ruleId, rules).forEach((id) => newAssignments.add(teamAssignmentKey(id)));
     }
 
+    hasPendingChangesRef.current = true;
     setAssignments(newAssignments);
   };
 
@@ -247,6 +252,7 @@ const AssignRulesTab: React.FC<AssignRulesTabProps> = ({ rules }) => {
   const executeToggles = (toggles: Array<{ ruleId: string; teamId: string }>) => {
     bulkToggle(toggles, {
       onSuccess: () => {
+        hasPendingChangesRef.current = false;
         history.push(routes.RULESET_EDIT.replace(':rulesetId', rulesetId));
       },
       onSettled: () => {

--- a/src/frontend/src/pages/RulesPage/AssignRulesTab.tsx
+++ b/src/frontend/src/pages/RulesPage/AssignRulesTab.tsx
@@ -15,7 +15,7 @@ import {
   Typography,
   useTheme
 } from '@mui/material';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Rule, TeamPreview } from 'shared';
 import { useAllTeams } from '../../hooks/teams.hooks';
 import LoadingIndicator from '../../components/LoadingIndicator';
@@ -92,7 +92,6 @@ const AssignRulesTab: React.FC<AssignRulesTabProps> = ({ rules }) => {
   const [selectedTeamId, setSelectedTeamId] = useState<string | null>(null);
   const [assignments, setAssignments] = useState<Set<string>>(new Set());
   const [originalAssignments, setOriginalAssignments] = useState<Set<string>>(new Set());
-  const [isInitialized, setIsInitialized] = useState(false);
   // unassign impact for the amount of project rules that would be deleted by this action, used to warn the user before saving
   const [pendingToggles, setPendingToggles] = useState<Array<{ ruleId: string; teamId: string }> | null>(null);
   const [unassignImpact, setUnassignImpact] = useState<{ ruleCount: number; projectCount: number }>({
@@ -103,9 +102,11 @@ const AssignRulesTab: React.FC<AssignRulesTabProps> = ({ rules }) => {
   const { data: teams, isLoading: teamsLoading, isError: teamsError, error: teamsErrorData } = useAllTeams();
   const { mutate: bulkToggle, isLoading: isSaving } = useBulkToggleRuleTeam();
 
-  // Load initial team assignments from rule data
+  const hasAppliedTeamParamRef = useRef(false);
+
+  // Reload when rule data changes
   useEffect(() => {
-    if (isInitialized || !teams || teams.length === 0) return;
+    if (!teams || teams.length === 0) return;
 
     const initialAssignments = new Set<string>();
     rules.forEach((rule) => {
@@ -117,14 +118,14 @@ const AssignRulesTab: React.FC<AssignRulesTabProps> = ({ rules }) => {
     setOriginalAssignments(initialAssignments);
     setAssignments(new Set(initialAssignments));
 
-    // Pre-select the team passed in via query param (e.g. when navigating from a project's rules tab)
-    const teamIdParam = new URLSearchParams(location.search).get('teamId');
-    if (teamIdParam && teams.some((team) => team.teamId === teamIdParam)) {
-      setSelectedTeamId(teamIdParam);
+    if (!hasAppliedTeamParamRef.current) {
+      const teamIdParam = new URLSearchParams(location.search).get('teamId');
+      if (teamIdParam && teams.some((team) => team.teamId === teamIdParam)) {
+        setSelectedTeamId(teamIdParam);
+      }
+      hasAppliedTeamParamRef.current = true;
     }
-
-    setIsInitialized(true);
-  }, [rules, teams, isInitialized, location.search]);
+  }, [rules, teams, location.search]);
 
   const handleTeamSelect = (teamId: string) => setSelectedTeamId(teamId);
 

--- a/src/frontend/src/pages/RulesPage/RuleRow.tsx
+++ b/src/frontend/src/pages/RulesPage/RuleRow.tsx
@@ -14,7 +14,13 @@ interface RuleRowProps {
   rule: Rule;
   allRules?: Rule[];
   level?: number;
-  leftContent?: (rule: Rule, level: number, isExpanded: boolean, hasSubRules: boolean) => React.ReactNode;
+  leftContent?: (
+    rule: Rule,
+    level: number,
+    isExpanded: boolean,
+    hasSubRules: boolean,
+    toggleExpand: () => void
+  ) => React.ReactNode;
   middleContent?: (rule: Rule, level: number) => React.ReactNode;
   rightContent: (rule: Rule, level: number) => React.ReactNode;
   backgroundColor: string | ((rule: Rule) => string);
@@ -203,7 +209,7 @@ const RuleRow: React.FC<RuleRowProps> = ({
               whiteSpace: 'normal'
             }}
           >
-            {leftContent ? leftContent(rule, level, isExpanded, hasSubRules) : defaultLeftContent}
+            {leftContent ? leftContent(rule, level, isExpanded, hasSubRules, toggleExpand) : defaultLeftContent}
           </TableCell>
         ) : (
           <>
@@ -222,7 +228,7 @@ const RuleRow: React.FC<RuleRowProps> = ({
                 width: leftWidth
               }}
             >
-              {leftContent ? leftContent(rule, level, isExpanded, hasSubRules) : defaultLeftContent}
+              {leftContent ? leftContent(rule, level, isExpanded, hasSubRules, toggleExpand) : defaultLeftContent}
             </TableCell>
             <TableCell
               align="left"

--- a/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
@@ -37,7 +37,7 @@ import { useToast } from '../../hooks/toasts.hooks';
 
 /**
  * RulesetPage component for displaying and managing ruleset rules.
- * Supports editing and assigning rules to projects and teams.
+ * Supports editing and adding rules.
  */
 const RulesetEditPage: React.FC = () => {
   const { rulesetId } = useParams<{ rulesetId: string; tabValue?: string }>(); //why tab value??
@@ -63,7 +63,8 @@ const RulesetEditPage: React.FC = () => {
   const [editingRuleId, setEditingRuleId] = useState<string | null>(null);
   const [editedContent, setEditedContent] = useState<string>('');
   const [editedCode, setEditedCode] = useState<string>('');
-  // Rule code warnings (parent-prefix mismatch / affected sub-rules)
+
+  // Editing rule code warnings
   const [pendingCodeWarnings, setPendingCodeWarnings] = useState<string[] | null>(null);
 
   const theme = useTheme();
@@ -213,6 +214,11 @@ const RulesetEditPage: React.FC = () => {
 
   const handleSaveEdit = async () => {
     if (!editingRuleId) return;
+
+    if (!editedCode.trim()) {
+      toast.error('Rule code cannot be empty');
+      return;
+    }
 
     const currentRule = allRules.find((r) => r.ruleId === editingRuleId);
     const warnings: string[] = [];

--- a/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
@@ -227,13 +227,15 @@ const RulesetEditPage: React.FC = () => {
       warnings.push(`This code doesn't start with its parent rule's code: ${currentRule.parentRule.ruleCode}.`);
     }
 
-    if (currentRule && currentRule.ruleCode !== editedCode && currentRule.subRuleIds.length > 0) {
+    if (currentRule && currentRule.ruleCode !== editedCode) {
       const affectedCount = countRulesToDelete(currentRule, allRules) - 1;
-      warnings.push(
-        `This rule has ${affectedCount} child rule${affectedCount === 1 ? '' : 's'} whose code${
-          affectedCount === 1 ? '' : 's'
-        } won't update with the new prefix.`
-      );
+      if (affectedCount > 0) {
+        warnings.push(
+          `This rule has ${affectedCount} child rule${affectedCount === 1 ? '' : 's'} whose code${
+            affectedCount === 1 ? '' : 's'
+          } won't update with the new prefix.`
+        );
+      }
     }
 
     if (warnings.length > 0) {

--- a/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
@@ -393,7 +393,7 @@ const RulesetEditPage: React.FC = () => {
                           );
                         }
                         return (
-                          currentRule.ruleContent && (
+                          (currentRule.ruleContent || currentRule.referencedRules.length > 0) && (
                             <RuleContent
                               rule={currentRule}
                               color={theme.palette.common.black}

--- a/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
@@ -223,11 +223,11 @@ const RulesetEditPage: React.FC = () => {
     const currentRule = allRules.find((r) => r.ruleId === editingRuleId);
     const warnings: string[] = [];
 
-    if (currentRule?.parentRule && !editedCode.startsWith(currentRule.parentRule.ruleCode)) {
-      warnings.push(`This code doesn't start with its parent rule's code: ${currentRule.parentRule.ruleCode}.`);
-    }
-
     if (currentRule && currentRule.ruleCode !== editedCode) {
+      if (currentRule.parentRule && !editedCode.startsWith(currentRule.parentRule.ruleCode)) {
+        warnings.push(`This code doesn't start with its parent rule's code: ${currentRule.parentRule.ruleCode}.`);
+      }
+
       const affectedCount = countRulesToDelete(currentRule, allRules) - 1;
       if (affectedCount > 0) {
         warnings.push(

--- a/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
+++ b/src/frontend/src/pages/RulesPage/RulesetEditPage.tsx
@@ -4,6 +4,7 @@
  */
 
 import { Box, Button, Paper, Table, TableBody, TableContainer, TextField, useTheme } from '@mui/material';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import PageLayout from '../../components/PageLayout';
@@ -22,6 +23,7 @@ import { AddRuleBox } from './components/AddRuleBox';
 import AssignRulesTab from './AssignRulesTab';
 import { NERButton } from '../../components/NERButton';
 import DeleteRuleModal from './components/DeleteRuleModal';
+import MismatchedRuleCodeModal from './components/MismatchedRuleCodeModal';
 import {
   useDeleteRule,
   useEditRule,
@@ -60,6 +62,9 @@ const RulesetEditPage: React.FC = () => {
   // Editing state
   const [editingRuleId, setEditingRuleId] = useState<string | null>(null);
   const [editedContent, setEditedContent] = useState<string>('');
+  const [editedCode, setEditedCode] = useState<string>('');
+  // Rule code warnings (parent-prefix mismatch / affected sub-rules)
+  const [pendingCodeWarnings, setPendingCodeWarnings] = useState<string[] | null>(null);
 
   const theme = useTheme();
   const toast = useToast();
@@ -189,24 +194,63 @@ const RulesetEditPage: React.FC = () => {
     if (rule) {
       setEditingRuleId(ruleId);
       setEditedContent(rule.ruleContent);
+      setEditedCode(rule.ruleCode);
+    }
+  };
+
+  const performSaveEdit = async () => {
+    if (!editingRuleId) return;
+
+    try {
+      await editRuleMutation({ ruleId: editingRuleId, ruleContent: editedContent, ruleCode: editedCode });
+      setEditingRuleId(null);
+      setEditedContent('');
+      setEditedCode('');
+    } catch (err) {
+      console.error('Failed to update rule:', err);
     }
   };
 
   const handleSaveEdit = async () => {
     if (!editingRuleId) return;
 
-    try {
-      await editRuleMutation({ ruleId: editingRuleId, ruleContent: editedContent });
-      setEditingRuleId(null);
-      setEditedContent('');
-    } catch (err) {
-      console.error('Failed to update rule:', err);
+    const currentRule = allRules.find((r) => r.ruleId === editingRuleId);
+    const warnings: string[] = [];
+
+    if (currentRule?.parentRule && !editedCode.startsWith(currentRule.parentRule.ruleCode)) {
+      warnings.push(`This code doesn't start with its parent rule's code: ${currentRule.parentRule.ruleCode}.`);
     }
+
+    if (currentRule && currentRule.ruleCode !== editedCode && currentRule.subRuleIds.length > 0) {
+      const affectedCount = countRulesToDelete(currentRule, allRules) - 1;
+      warnings.push(
+        `This rule has ${affectedCount} child rule${affectedCount === 1 ? '' : 's'} whose code${
+          affectedCount === 1 ? '' : 's'
+        } won't update with the new prefix.`
+      );
+    }
+
+    if (warnings.length > 0) {
+      setPendingCodeWarnings(warnings);
+      return;
+    }
+
+    await performSaveEdit();
+  };
+
+  const handleConfirmCodeWarning = async () => {
+    setPendingCodeWarnings(null);
+    await performSaveEdit();
+  };
+
+  const handleCancelCodeWarning = () => {
+    setPendingCodeWarnings(null);
   };
 
   const handleCancelEdit = () => {
     setEditingRuleId(null);
     setEditedContent('');
+    setEditedCode('');
   };
 
   const totalRulesToDelete = ruleToDelete ? countRulesToDelete(ruleToDelete, allRules) : 0;
@@ -247,6 +291,69 @@ const RulesetEditPage: React.FC = () => {
                       key={rule.ruleId}
                       rule={rule}
                       allRules={allRules}
+                      leftContent={(currentRule, level, isExpanded, hasSubRules, toggleExpand) => {
+                        const isEditing = editingRuleId === currentRule.ruleId;
+                        return (
+                          <Box
+                            sx={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              gap: 1,
+                              paddingLeft: `${level * 20}px`,
+                              color: theme.palette.common.black
+                            }}
+                          >
+                            {hasSubRules && (
+                              <ChevronRightIcon
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  toggleExpand();
+                                }}
+                                sx={{
+                                  fontSize: '20px',
+                                  color: theme.palette.common.black,
+                                  transform: isExpanded ? 'rotate(90deg)' : 'rotate(0deg)',
+                                  transition: 'transform 0.2s',
+                                  cursor: 'pointer',
+                                  '&:hover': {
+                                    backgroundColor: 'rgba(0, 0, 0, 0.04)',
+                                    borderRadius: '50%'
+                                  }
+                                }}
+                              />
+                            )}
+                            {isEditing ? (
+                              <TextField
+                                value={editedCode}
+                                onChange={(e) => setEditedCode(e.target.value)}
+                                onClick={(e) => e.stopPropagation()}
+                                variant="outlined"
+                                size="small"
+                                autoFocus
+                                sx={{
+                                  width: '80px',
+                                  flexShrink: 0,
+                                  backgroundColor: theme.palette.grey[100],
+                                  '& .MuiOutlinedInput-root': {
+                                    color: theme.palette.common.black,
+                                    '& fieldset': {
+                                      borderColor: '#dd514c'
+                                    },
+                                    '&:hover fieldset': {
+                                      borderColor: '#dd514c'
+                                    },
+                                    '&.Mui-focused fieldset': {
+                                      borderColor: '#dd514c'
+                                    }
+                                  }
+                                }}
+                              />
+                            ) : (
+                              <span style={{ color: theme.palette.common.black }}>{currentRule.ruleCode}</span>
+                            )}
+                          </Box>
+                        );
+                      }}
                       middleContent={(currentRule) => {
                         const isEditing = editingRuleId === currentRule.ruleId;
                         if (isEditing) {
@@ -328,6 +435,7 @@ const RulesetEditPage: React.FC = () => {
               onClose={() => setShowAddRuleModal(false)}
               rulesetId={rulesetId}
               initialParentRuleId={activeRuleId || undefined}
+              parentRuleCode={activeRuleId ? rulesById.get(activeRuleId)?.ruleCode : undefined}
             />
 
             <AddReferencedRuleModal
@@ -335,6 +443,15 @@ const RulesetEditPage: React.FC = () => {
               onClose={() => setShowAddReferencedRuleModal(false)}
               ruleId={activeRuleId}
               allRules={allRules}
+            />
+
+            <MismatchedRuleCodeModal
+              open={!!pendingCodeWarnings}
+              onHide={handleCancelCodeWarning}
+              onConfirm={handleConfirmCodeWarning}
+              messages={pendingCodeWarnings ?? []}
+              originalCode={editingRuleId ? rulesById.get(editingRuleId)?.ruleCode : undefined}
+              updatedCode={editedCode}
             />
 
             {referenceToRemove && (

--- a/src/frontend/src/pages/RulesPage/components/AddRuleModal.tsx
+++ b/src/frontend/src/pages/RulesPage/components/AddRuleModal.tsx
@@ -148,7 +148,7 @@ const AddRuleModal: React.FC<AddRuleModalProps> = ({ open, onClose, rulesetId, i
           {showPrefixWarning && (
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 1 }}>
               <Typography sx={{ color: '#ef4345', fontSize: '0.9rem' }}>
-                Note: This code doesn't start with the parent's code '{parentRuleCode}'
+                Note: Rule Code should start with '{parentRuleCode}' to match parent code
               </Typography>
             </Box>
           )}

--- a/src/frontend/src/pages/RulesPage/components/AddRuleModal.tsx
+++ b/src/frontend/src/pages/RulesPage/components/AddRuleModal.tsx
@@ -12,19 +12,20 @@ interface AddRuleModalProps {
   onClose: () => void;
   rulesetId: string;
   initialParentRuleId?: string;
+  parentRuleCode?: string;
 }
 
 interface FormData {
   ruleCode: string;
-  ruleContent: string;
+  ruleContent?: string;
 }
 
 const schema = yup.object().shape({
   ruleCode: yup.string().required('Rule Code is required'),
-  ruleContent: yup.string().required('Rule Content is required')
+  ruleContent: yup.string()
 });
 
-const AddRuleModal: React.FC<AddRuleModalProps> = ({ open, onClose, rulesetId, initialParentRuleId }) => {
+const AddRuleModal: React.FC<AddRuleModalProps> = ({ open, onClose, rulesetId, initialParentRuleId, parentRuleCode }) => {
   const theme = useTheme();
   const toast = useToast();
   const { mutateAsync: createRule } = useCreateRule();
@@ -36,6 +37,7 @@ const AddRuleModal: React.FC<AddRuleModalProps> = ({ open, onClose, rulesetId, i
     handleSubmit,
     control,
     reset,
+    watch,
     formState: { errors }
   } = useForm<FormData>({
     resolver: yupResolver(schema),
@@ -45,12 +47,19 @@ const AddRuleModal: React.FC<AddRuleModalProps> = ({ open, onClose, rulesetId, i
     }
   });
 
-  // Reset reference hierarchy when modal opens/closes or parent changes
+  const watchedRuleCode = watch('ruleCode');
+  const showPrefixWarning = !!parentRuleCode && !!watchedRuleCode && !watchedRuleCode.startsWith(parentRuleCode);
+
+  // Reset reference hierarchy and prefill the code field with the parent's code when modal opens
   useEffect(() => {
     if (open) {
       setSelectedReferenceHierarchy([]);
+      reset({
+        ruleCode: parentRuleCode ? `${parentRuleCode}.` : '',
+        ruleContent: ''
+      });
     }
-  }, [open, initialParentRuleId]);
+  }, [open, initialParentRuleId, parentRuleCode, reset]);
 
   const onSubmit = async (data: FormData) => {
     try {
@@ -59,7 +68,7 @@ const AddRuleModal: React.FC<AddRuleModalProps> = ({ open, onClose, rulesetId, i
 
       await createRule({
         ruleCode: data.ruleCode,
-        ruleContent: data.ruleContent,
+        ruleContent: data.ruleContent ?? '',
         rulesetId,
         parentRuleId: initialParentRuleId,
         referencedRules,
@@ -136,6 +145,13 @@ const AddRuleModal: React.FC<AddRuleModalProps> = ({ open, onClose, rulesetId, i
               />
             )}
           />
+          {showPrefixWarning && (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 1 }}>
+              <Typography sx={{ color: '#ef4345', fontSize: '0.9rem' }}>
+                Note: This code doesn't start with the parent's code '{parentRuleCode}'
+              </Typography>
+            </Box>
+          )}
         </Box>
 
         {/* Rule Content */}
@@ -144,7 +160,7 @@ const AddRuleModal: React.FC<AddRuleModalProps> = ({ open, onClose, rulesetId, i
             variant="h4"
             sx={{ color: theme.palette.primary.main, textDecoration: 'underline', fontSize: 30, mb: 2 }}
           >
-            Rule Content*
+            Rule Content
           </Typography>
           <Controller
             name="ruleContent"

--- a/src/frontend/src/pages/RulesPage/components/AddRuleModal.tsx
+++ b/src/frontend/src/pages/RulesPage/components/AddRuleModal.tsx
@@ -78,7 +78,9 @@ const AddRuleModal: React.FC<AddRuleModalProps> = ({ open, onClose, rulesetId, i
       toast.success('Rule created successfully');
       handleClose();
     } catch (error) {
-      toast.error('Failed to create rule');
+      if (error instanceof Error) {
+        toast.error(`Failed to create rule: ${error.message}`);
+      }
     }
   };
 

--- a/src/frontend/src/pages/RulesPage/components/AddRuleModal.tsx
+++ b/src/frontend/src/pages/RulesPage/components/AddRuleModal.tsx
@@ -50,7 +50,7 @@ const AddRuleModal: React.FC<AddRuleModalProps> = ({ open, onClose, rulesetId, i
   const watchedRuleCode = watch('ruleCode');
   const showPrefixWarning = !!parentRuleCode && !!watchedRuleCode && !watchedRuleCode.startsWith(parentRuleCode);
 
-  // Reset reference hierarchy and prefill the code field with the parent's code when modal opens
+  // Prefill code field with the parent's code when modal opens
   useEffect(() => {
     if (open) {
       setSelectedReferenceHierarchy([]);

--- a/src/frontend/src/pages/RulesPage/components/AddRuleSectionModal.tsx
+++ b/src/frontend/src/pages/RulesPage/components/AddRuleSectionModal.tsx
@@ -41,7 +41,7 @@ const AddRuleSectionModal: React.FC<AddRuleSectionModalProps> = ({ open, onClose
     try {
       await createRule({
         ruleCode: data.name,
-        ruleContent: 'content placeholder',
+        ruleContent: '',
         rulesetId,
         referencedRules: [],
         imageFileIds: []

--- a/src/frontend/src/pages/RulesPage/components/MismatchedRuleCodeModal.tsx
+++ b/src/frontend/src/pages/RulesPage/components/MismatchedRuleCodeModal.tsx
@@ -1,0 +1,59 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { Box, Typography } from '@mui/material';
+import WarningIcon from '@mui/icons-material/Warning';
+import NERModal from '../../../components/NERModal';
+
+interface MismatchedRuleCodeModalProps {
+  open: boolean;
+  onHide: () => void;
+  onConfirm: () => void;
+  messages: string[];
+  originalCode?: string;
+  updatedCode?: string;
+}
+
+/**
+ * Warns that a rule code doesn't follow the parent-code-prefix convention, without blocking
+ * the action. Rule codes aren't required to share their parent's prefix, but it does make the display a bit more confusing.
+ */
+const MismatchedRuleCodeModal = ({
+  open,
+  onHide,
+  onConfirm,
+  messages,
+  originalCode,
+  updatedCode
+}: MismatchedRuleCodeModalProps) => {
+  const confirmationQuestion =
+    originalCode !== undefined && updatedCode !== undefined
+      ? `Update rule code from ${originalCode} to ${updatedCode}?`
+      : undefined;
+
+  return (
+    <NERModal
+      open={open}
+      onHide={onHide}
+      title="Rule Code Update"
+      cancelText="Cancel"
+      submitText="Yes"
+      onSubmit={onConfirm}
+      formId="mismatched-rule-code-form"
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+        {messages.map((message, index) => (
+          <Box key={index} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <WarningIcon sx={{ color: '#ef4345', fontSize: 24, flexShrink: 0 }} />
+            <Typography sx={{ fontSize: '1rem' }}>{message}</Typography>
+          </Box>
+        ))}
+        {confirmationQuestion && <Typography sx={{ fontSize: '1rem', fontWeight: 600 }}>{confirmationQuestion}</Typography>}
+      </Box>
+    </NERModal>
+  );
+};
+
+export default MismatchedRuleCodeModal;

--- a/src/frontend/src/pages/RulesPage/components/MismatchedRuleCodeModal.tsx
+++ b/src/frontend/src/pages/RulesPage/components/MismatchedRuleCodeModal.tsx
@@ -39,7 +39,7 @@ const MismatchedRuleCodeModal = ({
       onHide={onHide}
       title="Rule Code Update"
       cancelText="Cancel"
-      submitText="Yes"
+      submitText="Submit"
       onSubmit={onConfirm}
       formId="mismatched-rule-code-form"
     >


### PR DESCRIPTION
## Changes

Edit rule code functionality added

## Notes

- Rule content is now allowed to be empty on create & edit
- Update add rule modal to autofill with parent rule code
- Warning if adding new rule doesn't match parent rule code
- Warning modal for editing rule code if parent or children are misaligned

## Notes
Decided to allow parents and children to have misaligned rule codes by recommending but not strictly enforcing rule code prefixes

## Screenshots
<img width="1372" height="486" alt="Screenshot 2026-07-17 at 10 42 17 PM" src="https://github.com/user-attachments/assets/6a002635-6a0c-476d-90b7-04a2bdb38da1" />

<img width="672" height="321" alt="Screenshot 2026-07-20 at 10 20 59 AM" src="https://github.com/user-attachments/assets/1c8c4760-e8f1-4d37-a043-3f24dbf7522e" />
<img width="685" height="304" alt="Screenshot 2026-07-20 at 10 20 44 AM" src="https://github.com/user-attachments/assets/9723344d-f1f1-4e14-a73b-befba4eb70e0" />

<img width="645" height="500" alt="Screenshot 2026-07-19 at 11 29 20 AM" src="https://github.com/user-attachments/assets/2380e3d7-087e-44f7-aa50-90f6d3dc1a8f" />
<img width="641" height="524" alt="Screenshot 2026-07-19 at 11 56 06 AM" src="https://github.com/user-attachments/assets/7a489b26-bac8-43e4-ba24-5336cc3ecdf4" />

<img width="636" height="93" alt="Screenshot 2026-07-17 at 10 41 47 PM" src="https://github.com/user-attachments/assets/e61b2b34-1acb-4401-aa6e-734b2381d743" />
<img width="628" height="124" alt="Screenshot 2026-07-20 at 10 29 38 AM" src="https://github.com/user-attachments/assets/19313538-1da5-47aa-a68d-9eabf5f875b1" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #4315 