### PR TITLE
#4328 reschedule notification only happens if time changes

### DIFF
--- a/src/backend/src/services/calendar.services.ts
+++ b/src/backend/src/services/calendar.services.ts
@@ -821,17 +821,16 @@ export default class CalendarService {
 
   static scheduleChanged(before: ScheduleSlot[], after: ScheduleSlot[]): boolean {
     if (before.length !== after.length) return true;
-    let index = 0;
     for (const scheduleSlot of before) {
+      const afterSlot = after.find((s) => s.scheduleSlotId === scheduleSlot.scheduleSlotId);
       if (
-        scheduleSlot.startTime.getTime() !== after[index].startTime.getTime() ||
-        scheduleSlot.endTime.getTime() !== after[index].endTime.getTime() ||
-        scheduleSlot.allDay !== after[index].allDay
+        !afterSlot ||
+        scheduleSlot.startTime.getTime() !== afterSlot.startTime.getTime() ||
+        scheduleSlot.endTime.getTime() !== afterSlot.endTime.getTime() ||
+        scheduleSlot.allDay !== afterSlot.allDay
       ) {
         return true;
       }
-
-      index = index + 1;
     }
 
     return false;
@@ -1107,14 +1106,20 @@ export default class CalendarService {
     if (!updatedEvent) throw new NotFoundException('Event', event.eventId);
     const updatedEventTransform = eventTransformer(updatedEvent);
 
+    const foundEventType = await prisma.event_Type.findUnique({
+      where: { eventTypeId: updatedEventTransform.eventTypeId }
+    });
+
     if (
       updatedEventTransform.status === Event_Status.SCHEDULED &&
+      foundEventType &&
+      foundEventType.sendSlackNotifications === true &&
       this.scheduleChanged(event.scheduledTimes, updatedEvent.scheduledTimes)
     ) {
       await sendEventScheduledSlackNotif(updatedEvent.notificationSlackThreads, updatedEventTransform, true);
     }
 
-    return eventTransformer(updatedEvent);
+    return updatedEventTransform;
   }
 
   /**

--- a/src/backend/src/services/calendar.services.ts
+++ b/src/backend/src/services/calendar.services.ts
@@ -813,14 +813,28 @@ export default class CalendarService {
 
     const edittedEvent = eventTransformer(updatedEvent);
 
-    if (status === Event_Status.SCHEDULED && foundEventType.sendSlackNotifications) {
-      await sendEventScheduledSlackNotif(updatedEvent.notificationSlackThreads, edittedEvent, true);
-    }
-
     if (status === Event_Status.CONFIRMED && foundEventType.sendSlackNotifications) {
       await sendEventConfirmationToThread(updatedEvent.notificationSlackThreads, updatedEvent.userCreated);
     }
     return edittedEvent;
+  }
+
+  static scheduleChanged(before: ScheduleSlot[], after: ScheduleSlot[]): boolean {
+    if (before.length != after.length) return true;
+    var index = 0;
+    for (const scheduleSlot of before) {
+      if (
+        scheduleSlot.startTime.getTime() !== after[index].startTime.getTime() ||
+        scheduleSlot.endTime.getTime() !== after[index].endTime.getTime() ||
+        scheduleSlot.allDay !== after[index].allDay
+      ) {
+        return true;
+      }
+
+      index = index + 1;
+    }
+
+    return false;
   }
 
   /**
@@ -1091,6 +1105,14 @@ export default class CalendarService {
     });
 
     if (!updatedEvent) throw new NotFoundException('Event', event.eventId);
+    const updatedEventTransform = eventTransformer(updatedEvent);
+
+    if (
+      updatedEventTransform.status === Event_Status.SCHEDULED &&
+      this.scheduleChanged(event.scheduledTimes, updatedEvent.scheduledTimes)
+    ) {
+      await sendEventScheduledSlackNotif(updatedEvent.notificationSlackThreads, updatedEventTransform, true);
+    }
 
     return eventTransformer(updatedEvent);
   }

--- a/src/backend/src/services/calendar.services.ts
+++ b/src/backend/src/services/calendar.services.ts
@@ -820,8 +820,8 @@ export default class CalendarService {
   }
 
   static scheduleChanged(before: ScheduleSlot[], after: ScheduleSlot[]): boolean {
-    if (before.length != after.length) return true;
-    var index = 0;
+    if (before.length !== after.length) return true;
+    let index = 0;
     for (const scheduleSlot of before) {
       if (
         scheduleSlot.startTime.getTime() !== after[index].startTime.getTime() ||
@@ -1106,6 +1106,10 @@ export default class CalendarService {
 
     if (!updatedEvent) throw new NotFoundException('Event', event.eventId);
     const updatedEventTransform = eventTransformer(updatedEvent);
+
+    const foundEventType = await prisma.event_Type.findUnique({
+      where: { eventTypeId }
+    });
 
     if (
       updatedEventTransform.status === Event_Status.SCHEDULED &&

--- a/src/backend/src/services/calendar.services.ts
+++ b/src/backend/src/services/calendar.services.ts
@@ -1107,10 +1107,6 @@ export default class CalendarService {
     if (!updatedEvent) throw new NotFoundException('Event', event.eventId);
     const updatedEventTransform = eventTransformer(updatedEvent);
 
-    const foundEventType = await prisma.event_Type.findUnique({
-      where: { eventTypeId }
-    });
-
     if (
       updatedEventTransform.status === Event_Status.SCHEDULED &&
       this.scheduleChanged(event.scheduledTimes, updatedEvent.scheduledTimes)

--- a/src/backend/src/services/calendar.services.ts
+++ b/src/backend/src/services/calendar.services.ts
@@ -819,7 +819,7 @@ export default class CalendarService {
     return edittedEvent;
   }
 
-  static scheduleChanged(before: ScheduleSlot[], after: ScheduleSlot[]): boolean {
+  static hasScheduleChanged(before: ScheduleSlot[], after: ScheduleSlot[]): boolean {
     if (before.length !== after.length) return true;
     for (const scheduleSlot of before) {
       const afterSlot = after.find((s) => s.scheduleSlotId === scheduleSlot.scheduleSlotId);
@@ -1113,8 +1113,8 @@ export default class CalendarService {
     if (
       updatedEventTransform.status === Event_Status.SCHEDULED &&
       foundEventType &&
-      foundEventType.sendSlackNotifications === true &&
-      this.scheduleChanged(event.scheduledTimes, updatedEvent.scheduledTimes)
+      foundEventType.sendSlackNotifications &&
+      this.hasScheduleChanged(event.scheduledTimes, updatedEvent.scheduledTimes)
     ) {
       await sendEventScheduledSlackNotif(updatedEvent.notificationSlackThreads, updatedEventTransform, true);
     }


### PR DESCRIPTION
## Changes

When an meeting/event is edited, the reschedule message only appears when time is changed. 

## Test Cases

- Changing a non time field such as name of an event doesn't send a notification
- Changing the hour of an event sends a notification 
- Changing from all day to a specific time and vice versa for an event sends a notification

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #4328
