### PR TITLE
4237-view-availability-button-event-modal-warning update event button text and modal warning for creators

### DIFF
--- a/src/frontend/src/pages/CalendarPage/EventClickPopup.tsx
+++ b/src/frontend/src/pages/CalendarPage/EventClickPopup.tsx
@@ -370,7 +370,7 @@ export const EventClickContent: React.FC<EventClickContentProps> = ({
                 }
               }}
             >
-              View availability
+              {event.userCreated.userId === currentUser.userId ? 'View availability / Schedule event' : 'View availability'}
             </Button>
           </Stack>
         )}

--- a/src/frontend/src/pages/CalendarPage/EventClickPopup.tsx
+++ b/src/frontend/src/pages/CalendarPage/EventClickPopup.tsx
@@ -137,6 +137,9 @@ export const EventClickContent: React.FC<EventClickContentProps> = ({
   const canEditOrDelete =
     event.userCreated.userId === currentUser.userId || isAdmin(currentUser.role) || isHead(currentUser.role);
 
+  // Creators and admins can schedule the event from the availability page
+  const canScheduleEvent = event.userCreated.userId === currentUser.userId || isAdmin(currentUser.role);
+
   const eventDate = event.initialDateScheduled || clickedDate || event.startTime;
 
   const availabilityUrl = `${routes.CALENDAR}/event/${event.eventId}?date=${eventDate.toISOString()}`;
@@ -370,7 +373,7 @@ export const EventClickContent: React.FC<EventClickContentProps> = ({
                 }
               }}
             >
-              {event.userCreated.userId === currentUser.userId ? 'View availability / Schedule event' : 'View availability'}
+              {canScheduleEvent ? 'View availability / Schedule event' : 'View availability'}
             </Button>
           </Stack>
         )}

--- a/src/frontend/src/utils/calendar.utils.ts
+++ b/src/frontend/src/utils/calendar.utils.ts
@@ -16,6 +16,8 @@ export const getPendingReason = (event: EventInstance): string | null => {
     return 'This event has a scheduling conflict and requires approval.';
   } else if (event.approved === ConflictStatus.DENIED) {
     return 'This event was denied due to a scheduling conflict.';
+  } else if (event.status === EventStatus.CONFIRMED) {
+    return 'This event is waiting to be scheduled.';
   } else if (event.status !== EventStatus.SCHEDULED) {
     return 'This event is unconfirmed and waiting to be scheduled.';
   }


### PR DESCRIPTION
## Changes
- Updated the "View availability" button to show "View availability / Schedule event" for the event creator, so it's clear they can schedule the event from there
- Updated the pending warning message to show "This event is waiting to be scheduled." for confirmed events, instead of the generic unconfirmed message

## Screenshots
Old:
<img width="787" height="620" alt="image" src="https://github.com/user-attachments/assets/36e1b9a2-2179-4968-a866-3bb118d76f67" />

New (Event creator):
<img width="445" height="273" alt="Meeting" src="https://github.com/user-attachments/assets/ade24d03-e2f0-46fe-8f60-005834d75b7a" />

New (Event participant):
<img width="441" height="254" alt="Meeting" src="https://github.com/user-attachments/assets/e688e331-fcf7-4f21-ad7e-4d64e40ad672" />

Closes #4237
