### PR TITLE
#4333 task blocking

### DIFF
--- a/src/backend/src/controllers/tasks.controllers.ts
+++ b/src/backend/src/controllers/tasks.controllers.ts
@@ -18,7 +18,7 @@ export default class TasksController {
         assignees,
         req.organization,
         labelIds,
-        blockedByIds ?? [],
+        blockedByIds,
         startDate ? new Date(startDate) : undefined,
         deadline ? new Date(deadline) : undefined
       );
@@ -42,7 +42,7 @@ export default class TasksController {
         notes,
         priority,
         labelIds,
-        blockedByIds ?? [],
+        blockedByIds,
         startDate ? new Date(startDate) : undefined,
         deadline ? new Date(deadline) : undefined,
         wbsNum

--- a/src/backend/src/controllers/tasks.controllers.ts
+++ b/src/backend/src/controllers/tasks.controllers.ts
@@ -5,7 +5,7 @@ import { validateWBS, WbsNumber } from 'shared';
 export default class TasksController {
   static async createTask(req: Request, res: Response, next: NextFunction) {
     try {
-      const { title, deadline, startDate, priority, status, assignees, notes, labelIds } = req.body;
+      const { title, deadline, startDate, priority, status, assignees, notes, labelIds, blockedByIds } = req.body;
       const wbsNum: WbsNumber = validateWBS(req.params.wbsNum as string);
 
       const task = await TasksService.createTask(
@@ -18,6 +18,7 @@ export default class TasksController {
         assignees,
         req.organization,
         labelIds,
+        blockedByIds ?? [],
         startDate ? new Date(startDate) : undefined,
         deadline ? new Date(deadline) : undefined
       );
@@ -30,7 +31,7 @@ export default class TasksController {
 
   static async editTask(req: Request, res: Response, next: NextFunction) {
     try {
-      const { title, notes, priority, deadline, startDate, wbsNum, labelIds } = req.body;
+      const { title, notes, priority, deadline, startDate, wbsNum, labelIds, blockedByIds } = req.body;
       const { taskId } = req.params as Record<string, string>;
 
       const updateTask = await TasksService.editTask(
@@ -41,6 +42,7 @@ export default class TasksController {
         notes,
         priority,
         labelIds,
+        blockedByIds ?? [],
         startDate ? new Date(startDate) : undefined,
         deadline ? new Date(deadline) : undefined,
         wbsNum

--- a/src/backend/src/prisma-query-args/tasks.query-args.ts
+++ b/src/backend/src/prisma-query-args/tasks.query-args.ts
@@ -18,10 +18,12 @@ export const getTaskLabelQueryArgs = () =>
   });
 
 export const getTaskBlockedByQueryArgs = () =>
-  Prisma.validator<Prisma.TaskDefaultArgs>()({
+  Prisma.validator<Prisma.TaskFindManyArgs>()({
+    where: { dateDeleted: null },
     select: {
       taskId: true,
-      title: true
+      title: true,
+      status: true
     }
   });
 

--- a/src/backend/src/prisma-query-args/tasks.query-args.ts
+++ b/src/backend/src/prisma-query-args/tasks.query-args.ts
@@ -5,6 +5,8 @@ export type TaskQueryArgs = ReturnType<typeof getTaskQueryArgs>;
 export type TaskPreviewQueryArgs = ReturnType<typeof getTaskPreviewQueryArgs>;
 export type CalendarTaskQueryArgs = ReturnType<typeof getCalendarTaskQueryArgs>;
 export type TaskLabelQueryArgs = ReturnType<typeof getTaskLabelQueryArgs>;
+export type TaskBlockedByQueryArgs = ReturnType<typeof getTaskBlockedByQueryArgs>;
+export type BlockingWorkPackagesQueryArgs = ReturnType<typeof getBlockingWorkPackagesArgs>;
 
 export const getTaskLabelQueryArgs = () =>
   Prisma.validator<Prisma.Task_LabelDefaultArgs>()({
@@ -15,14 +17,44 @@ export const getTaskLabelQueryArgs = () =>
     }
   });
 
+export const getTaskBlockedByQueryArgs = () =>
+  Prisma.validator<Prisma.TaskDefaultArgs>()({
+    select: {
+      taskId: true,
+      title: true
+    }
+  });
+
+// the work package (if any) that this task's own work package is blocked by, along with just enough
+// of its tasks to tell whether it's still incomplete
+export const getBlockingWorkPackagesArgs = () =>
+  Prisma.validator<Prisma.WBS_ElementDefaultArgs>()({
+    include: {
+      workPackage: {
+        include: {
+          blockedBy: {
+            select: {
+              carNumber: true,
+              projectNumber: true,
+              workPackageNumber: true,
+              name: true,
+              tasks: { where: { dateDeleted: null }, select: { status: true } }
+            }
+          }
+        }
+      }
+    }
+  });
+
 export const getTaskQueryArgs = (organizationId: string) =>
   Prisma.validator<Prisma.TaskDefaultArgs>()({
     include: {
-      wbsElement: true,
+      wbsElement: getBlockingWorkPackagesArgs(),
       createdBy: getUserQueryArgs(organizationId),
       deletedBy: getUserQueryArgs(organizationId),
       assignees: getUserQueryArgs(organizationId),
-      labels: getTaskLabelQueryArgs()
+      labels: getTaskLabelQueryArgs(),
+      blockedBy: getTaskBlockedByQueryArgs()
     }
   });
 
@@ -39,13 +71,15 @@ export const getCalendarTaskQueryArgs = (organizationId: string) =>
           dateDeleted: true,
           leadId: true,
           managerId: true,
-          name: true
+          name: true,
+          workPackage: getBlockingWorkPackagesArgs().include.workPackage
         }
       },
       createdBy: getUserQueryArgs(organizationId),
       deletedBy: getUserQueryArgs(organizationId),
       assignees: getUserQueryArgs(organizationId),
-      labels: getTaskLabelQueryArgs()
+      labels: getTaskLabelQueryArgs(),
+      blockedBy: getTaskBlockedByQueryArgs()
     }
   });
 

--- a/src/backend/src/prisma/migrations/20260721004505_blocked_tasks/migration.sql
+++ b/src/backend/src/prisma/migrations/20260721004505_blocked_tasks/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "_taskBlocking" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL,
+
+    CONSTRAINT "_taskBlocking_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE INDEX "_taskBlocking_B_index" ON "_taskBlocking"("B");
+
+-- AddForeignKey
+ALTER TABLE "_taskBlocking" ADD CONSTRAINT "_taskBlocking_A_fkey" FOREIGN KEY ("A") REFERENCES "Task"("taskId") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_taskBlocking" ADD CONSTRAINT "_taskBlocking_B_fkey" FOREIGN KEY ("B") REFERENCES "Task"("taskId") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/backend/src/prisma/schema.prisma
+++ b/src/backend/src/prisma/schema.prisma
@@ -654,6 +654,8 @@ model Task {
   wbsElement      WBS_Element   @relation(fields: [wbsElementId], references: [wbsElementId])
   wbsElementId    String
   labels          Task_Label[]
+  blockedBy       Task[]        @relation(name: "taskBlocking")
+  blocking        Task[]        @relation(name: "taskBlocking")
 
   @@index([wbsElementId])
 }

--- a/src/backend/src/prisma/seed.ts
+++ b/src/backend/src/prisma/seed.ts
@@ -2282,6 +2282,7 @@ const performSeed: () => Promise<void> = async () => {
     [joeShmoe.userId],
     ner,
     [taskLabelResearch.taskLabelId],
+    [],
     undefined,
     daysFromNow(10)
   );
@@ -2296,6 +2297,7 @@ const performSeed: () => Promise<void> = async () => {
     [joeShmoe.userId],
     ner,
     [taskLabelDesign.taskLabelId],
+    [],
     daysAgo(5),
     daysFromNow(15)
   );
@@ -2310,6 +2312,7 @@ const performSeed: () => Promise<void> = async () => {
     [joeShmoe.userId, joeBlow.userId],
     ner,
     [taskLabelResearch.taskLabelId, taskLabelBlocked.taskLabelId],
+    [],
     undefined,
     daysFromNow(8)
   );
@@ -2325,6 +2328,7 @@ const performSeed: () => Promise<void> = async () => {
     [joeBlow.userId],
     ner,
     [taskLabelTesting.taskLabelId],
+    [],
     undefined,
     daysFromNow(14)
   );
@@ -2339,6 +2343,7 @@ const performSeed: () => Promise<void> = async () => {
     [thomasEmrax.userId],
     ner,
     [taskLabelAdmin.taskLabelId],
+    [],
     daysAgo(14),
     daysFromNow(7)
   );
@@ -2353,6 +2358,7 @@ const performSeed: () => Promise<void> = async () => {
     [thomasEmrax.userId, joeBlow.userId, joeShmoe.userId],
     ner,
     [taskLabelDesign.taskLabelId],
+    [],
     undefined,
     daysFromNow(9)
   );
@@ -2367,6 +2373,7 @@ const performSeed: () => Promise<void> = async () => {
     [thomasEmrax.userId],
     ner,
     [taskLabelAdmin.taskLabelId],
+    [],
     undefined,
     daysFromNow(6)
   );
@@ -2381,6 +2388,7 @@ const performSeed: () => Promise<void> = async () => {
     [joeShmoe.userId],
     ner,
     [taskLabelBuild.taskLabelId],
+    [],
     undefined,
     daysAgo(30)
   );
@@ -2403,6 +2411,7 @@ const performSeed: () => Promise<void> = async () => {
     [joeShmoe.userId],
     ner,
     [taskLabelBuild.taskLabelId],
+    [],
     undefined,
     daysAgo(90)
   );
@@ -2417,6 +2426,7 @@ const performSeed: () => Promise<void> = async () => {
     [thomasEmrax.userId, joeBlow.userId, joeShmoe.userId],
     ner,
     [taskLabelAdmin.taskLabelId],
+    [],
     daysAgo(70),
     daysAgo(55)
   );
@@ -2431,6 +2441,7 @@ const performSeed: () => Promise<void> = async () => {
     [],
     ner,
     [taskLabelAdmin.taskLabelId],
+    [],
     undefined,
     daysFromNow(12)
   );
@@ -2445,6 +2456,7 @@ const performSeed: () => Promise<void> = async () => {
     [joeShmoe.userId],
     ner,
     [taskLabelTesting.taskLabelId],
+    [],
     undefined,
     daysFromNow(8)
   );
@@ -2459,6 +2471,7 @@ const performSeed: () => Promise<void> = async () => {
     [thomasEmrax.userId, joeShmoe.userId],
     ner,
     [taskLabelAdmin.taskLabelId],
+    [],
     undefined,
     daysFromNow(7)
   );
@@ -2473,6 +2486,7 @@ const performSeed: () => Promise<void> = async () => {
     [thomasEmrax.userId],
     ner,
     [taskLabelDesign.taskLabelId],
+    [],
     daysAgo(80),
     daysAgo(65)
   );
@@ -2487,6 +2501,7 @@ const performSeed: () => Promise<void> = async () => {
     [thomasEmrax, joeShmoe, joeBlow].map((user) => user.userId),
     ner,
     [taskLabelBuild.taskLabelId, taskLabelBlocked.taskLabelId],
+    [],
     undefined,
     daysFromNow(16)
   );
@@ -2501,6 +2516,7 @@ const performSeed: () => Promise<void> = async () => {
     [joeShmoe.userId],
     ner,
     [taskLabelBuild.taskLabelId],
+    [],
     undefined,
     daysFromNow(13)
   );
@@ -2515,6 +2531,7 @@ const performSeed: () => Promise<void> = async () => {
     [joeShmoe.userId],
     ner,
     [taskLabelTesting.taskLabelId],
+    [],
     undefined,
     daysFromNow(18)
   );
@@ -2528,6 +2545,7 @@ const performSeed: () => Promise<void> = async () => {
     Task_Status.DONE,
     [joeBlow.userId],
     ner,
+    [],
     [],
     undefined,
     daysAgo(45)
@@ -2543,6 +2561,7 @@ const performSeed: () => Promise<void> = async () => {
     [joeBlow.userId],
     ner,
     [taskLabelDesign.taskLabelId],
+    [],
     undefined,
     daysAgo(60)
   );
@@ -2557,6 +2576,7 @@ const performSeed: () => Promise<void> = async () => {
     [regina.userId],
     ner,
     [taskLabelResearch.taskLabelId, taskLabelAdmin.taskLabelId],
+    [],
     daysAgo(21),
     daysAgo(10)
   );
@@ -2571,6 +2591,7 @@ const performSeed: () => Promise<void> = async () => {
     [zatanna.userId],
     ner,
     [taskLabelAdmin.taskLabelId],
+    [],
     daysAgo(10),
     daysAgo(9)
   );
@@ -2585,6 +2606,7 @@ const performSeed: () => Promise<void> = async () => {
     [sandy.userId],
     ner,
     [taskLabelResearch.taskLabelId],
+    [],
     daysAgo(16),
     daysAgo(1)
   );

--- a/src/backend/src/prisma/seed.ts
+++ b/src/backend/src/prisma/seed.ts
@@ -1303,14 +1303,15 @@ const performSeed: () => Promise<void> = async () => {
   // await DescriptionBulletsService.checkDescriptionBullet(thomasEmrax, workPackage1.deliverables[0].descriptionId);
 
   /** Work Package 2 */
-  await seedWorkPackage(
+  // blockedBy Work Package Huskies 1 to demonstrate a work package that blocks another
+  const { workPackageWbsNumber: workPackageHuskies2WbsNumber } = await seedWorkPackage(
     thomasEmrax,
     'Adhesive Shear Strength Test',
     changeRequestProjectHuskies1Id,
     WorkPackageStage.Research,
     weeksAgo(10).toISOString().split('T')[0],
     5,
-    [],
+    [workPackageHuskies1WbsNumber],
     [],
     thomasEmrax,
     WbsElementStatus.Inactive,
@@ -2272,7 +2273,7 @@ const performSeed: () => Promise<void> = async () => {
   /**
    * Tasks
    */
-  await TasksService.createTask(
+  const taskResearchAttenuation = await TasksService.createTask(
     joeShmoe,
     projectHuskies1WbsNumber,
     'Research attenuation',
@@ -2287,6 +2288,7 @@ const performSeed: () => Promise<void> = async () => {
     daysFromNow(10)
   );
 
+  // blockedBy Research attenuation to demonstrate a task manually blocked by another task that isn't done yet
   await TasksService.createTask(
     joeShmoe,
     projectHuskies1WbsNumber,
@@ -2297,11 +2299,12 @@ const performSeed: () => Promise<void> = async () => {
     [joeShmoe.userId],
     ner,
     [taskLabelDesign.taskLabelId],
-    [],
+    [taskResearchAttenuation.taskId],
     daysAgo(5),
     daysFromNow(15)
   );
 
+  // blockedBy Research attenuation to demonstrate a task manually blocked by another task that isn't done yet
   await TasksService.createTask(
     joeBlow,
     projectHuskies1WbsNumber,
@@ -2312,9 +2315,26 @@ const performSeed: () => Promise<void> = async () => {
     [joeShmoe.userId, joeBlow.userId],
     ner,
     [taskLabelResearch.taskLabelId, taskLabelBlocked.taskLabelId],
-    [],
+    [taskResearchAttenuation.taskId],
     undefined,
     daysFromNow(8)
+  );
+
+  // relies purely on blockedByWorkPackages, since Work Package 2 is blockedBy Work Package Huskies 1,
+  // which still has an incomplete task ('Impact Test' below)
+  await TasksService.createTask(
+    joeShmoe,
+    workPackageHuskies2WbsNumber,
+    'Run Shear Strength Test',
+    'Run the shear strength test once the adhesive samples are ready',
+    Task_Priority.MEDIUM,
+    Task_Status.IN_BACKLOG,
+    [joeShmoe.userId],
+    ner,
+    [taskLabelTesting.taskLabelId, taskLabelBlocked.taskLabelId],
+    [],
+    undefined,
+    daysFromNow(20)
   );
 
   await TasksService.createTask(

--- a/src/backend/src/routes/tasks.routes.ts
+++ b/src/backend/src/routes/tasks.routes.ts
@@ -42,6 +42,8 @@ tasksRouter.post(
   nonEmptyString(body('assignees.*')),
   body('labelIds').isArray(),
   body('labelIds.*').isString(),
+  body('blockedByIds').optional().isArray(),
+  body('blockedByIds.*').optional().isString(),
   validateInputs,
   TasksController.createTask
 );
@@ -58,6 +60,8 @@ tasksRouter.post(
   intMinZero(body('wbsNum.workPackageNumber')),
   body('labelIds').isArray(),
   body('labelIds.*').isString(),
+  body('blockedByIds').optional().isArray(),
+  body('blockedByIds.*').optional().isString(),
   validateInputs,
   TasksController.editTask
 );

--- a/src/backend/src/routes/tasks.routes.ts
+++ b/src/backend/src/routes/tasks.routes.ts
@@ -42,8 +42,8 @@ tasksRouter.post(
   nonEmptyString(body('assignees.*')),
   body('labelIds').isArray(),
   body('labelIds.*').isString(),
-  body('blockedByIds').optional().isArray(),
-  body('blockedByIds.*').optional().isString(),
+  body('blockedByIds').isArray(),
+  body('blockedByIds.*').isString(),
   validateInputs,
   TasksController.createTask
 );
@@ -60,8 +60,8 @@ tasksRouter.post(
   intMinZero(body('wbsNum.workPackageNumber')),
   body('labelIds').isArray(),
   body('labelIds.*').isString(),
-  body('blockedByIds').optional().isArray(),
-  body('blockedByIds.*').optional().isString(),
+  body('blockedByIds').isArray(),
+  body('blockedByIds.*').isString(),
   validateInputs,
   TasksController.editTask
 );

--- a/src/backend/src/services/tasks.services.ts
+++ b/src/backend/src/services/tasks.services.ts
@@ -15,6 +15,7 @@ import {
 import prisma from '../prisma/prisma.js';
 import taskTransformer, {
   calendarTaskTransformer,
+  getBlockingWorkPackages,
   taskCardPreviewTransformer,
   taskLabelTransformer
 } from '../transformers/tasks.transformer.js';
@@ -34,6 +35,7 @@ import { getUsers, userHasPermission } from '../utils/users.utils.js';
 import { wbsNumOf } from '../utils/utils.js';
 import { getTeamQueryArgs } from '../prisma-query-args/teams.query-args.js';
 import {
+  getBlockingWorkPackagesArgs,
   getCalendarTaskQueryArgs,
   getTaskLabelQueryArgs,
   getTaskPreviewQueryArgs,
@@ -267,13 +269,32 @@ export default class TasksService {
     if (!hasPermission) throw new AccessDeniedException('Guests cannot edit tasks');
 
     // Get the original task and check if it exists
-    const originalTask = await prisma.task.findUnique({ where: { taskId }, include: { assignees: true, wbsElement: true } });
+    const originalTask = await prisma.task.findUnique({
+      where: { taskId },
+      include: {
+        assignees: true,
+        wbsElement: getBlockingWorkPackagesArgs(),
+        blockedBy: { select: { taskId: true, title: true, status: true } }
+      }
+    });
     if (!originalTask) throw new NotFoundException('Task', taskId);
     if (organizationId !== originalTask.wbsElement.organizationId) throw new InvalidOrganizationException('Task');
     if (originalTask.dateDeleted) throw new DeletedException('Task', taskId);
 
     if (status === 'IN_PROGRESS' && (!originalTask.deadline || originalTask.assignees.length === 0)) {
       throw new HttpException(400, 'A task in progress must have a deadline and assignees!');
+    }
+
+    if (status === 'DONE') {
+      const incompleteBlockers = originalTask.blockedBy.filter((blocker) => blocker.status !== 'DONE');
+      const blockingWorkPackages = getBlockingWorkPackages(originalTask.wbsElement);
+      if (incompleteBlockers.length > 0 || blockingWorkPackages.length > 0) {
+        const blockerNames = [
+          ...incompleteBlockers.map((blocker) => blocker.title),
+          ...blockingWorkPackages.map((wp) => wp.name)
+        ];
+        throw new HttpException(400, `Cannot mark task as done: blocked by ${blockerNames.join(', ')}`);
+      }
     }
 
     const updatedTask = await prisma.task.update({

--- a/src/backend/src/services/tasks.services.ts
+++ b/src/backend/src/services/tasks.services.ts
@@ -25,7 +25,7 @@ import {
   DeletedException,
   InvalidOrganizationException
 } from '../utils/errors.utils.js';
-import { sendSlackTaskAssignedNotificationToUsers, validateTaskLabels } from '../utils/tasks.utils.js';
+import { sendSlackTaskAssignedNotificationToUsers, validateTaskBlockedBys, validateTaskLabels } from '../utils/tasks.utils.js';
 import { getUsers, userHasPermission } from '../utils/users.utils.js';
 import { wbsNumOf } from '../utils/utils.js';
 import { getTeamQueryArgs } from '../prisma-query-args/teams.query-args.js';
@@ -49,6 +49,7 @@ export default class TasksService {
    * @param assignees the assignees ids of the task
    * @param organizationId the organization that the user is currently in
    * @param labelIds the label ids for the task
+   * @param blockedByIds the ids of the tasks that block this task
    * @param startDate the start date of the task
    * @param deadline the deadline of the task
    * @returns the id of the successfully created task
@@ -64,6 +65,7 @@ export default class TasksService {
     assignees: string[],
     organization: Organization,
     labelIds: string[],
+    blockedByIds: string[],
     startDate?: Date,
     deadline?: Date
   ): Promise<Task> {
@@ -121,6 +123,7 @@ export default class TasksService {
     }
 
     await validateTaskLabels(labelIds, organization.organizationId);
+    const blockedByTasks = await validateTaskBlockedBys(blockedByIds, organization.organizationId);
 
     const createdTask = await prisma.task.create({
       data: {
@@ -140,7 +143,8 @@ export default class TasksService {
         status,
         createdBy: { connect: { userId: createdBy.userId } },
         assignees: { connect: users.map((user) => ({ userId: user.userId })) },
-        labels: { connect: labelIds.map((id) => ({ taskLabelId: id })) }
+        labels: { connect: labelIds.map((id) => ({ taskLabelId: id })) },
+        blockedBy: { connect: blockedByTasks.map((task) => ({ taskId: task.taskId })) }
       },
       ...getTaskQueryArgs(organization.organizationId)
     });
@@ -162,6 +166,7 @@ export default class TasksService {
    * @param notes the new notes for the task
    * @param priority the new priority for the task
    * @param labelIds the new label ids for the task
+   * @param blockedByIds the new ids of the tasks that block this task
    * @param startDate the new start date for the task
    * @param deadline the new deadline for the task
    * @param wbsNum the new wbs element for the task
@@ -175,6 +180,7 @@ export default class TasksService {
     notes: string,
     priority: Task_Priority,
     labelIds: string[],
+    blockedByIds: string[],
     startDate?: Date,
     deadline?: Date,
     wbsNum?: WbsNumber
@@ -200,6 +206,7 @@ export default class TasksService {
     }
 
     await validateTaskLabels(labelIds, organizationId);
+    const blockedByTasks = await validateTaskBlockedBys(blockedByIds, organizationId, taskId);
 
     // if wbsNum passed, error if there's a problem with the wbs element
     if (wbsNum) {
@@ -234,7 +241,8 @@ export default class TasksService {
             }
           }
         }),
-        labels: { set: labelIds.map((id) => ({ taskLabelId: id })) }
+        labels: { set: labelIds.map((id) => ({ taskLabelId: id })) },
+        blockedBy: { set: blockedByTasks.map((task) => ({ taskId: task.taskId })) }
       },
       ...getTaskQueryArgs(originalTask.wbsElement.organizationId)
     });

--- a/src/backend/src/services/tasks.services.ts
+++ b/src/backend/src/services/tasks.services.ts
@@ -25,7 +25,11 @@ import {
   DeletedException,
   InvalidOrganizationException
 } from '../utils/errors.utils.js';
-import { sendSlackTaskAssignedNotificationToUsers, validateTaskBlockedBys, validateTaskLabels } from '../utils/tasks.utils.js';
+import {
+  sendSlackTaskAssignedNotificationToUsers,
+  validateTaskBlockedBys,
+  validateTaskLabels
+} from '../utils/tasks.utils.js';
 import { getUsers, userHasPermission } from '../utils/users.utils.js';
 import { wbsNumOf } from '../utils/utils.js';
 import { getTeamQueryArgs } from '../prisma-query-args/teams.query-args.js';

--- a/src/backend/src/services/tasks.services.ts
+++ b/src/backend/src/services/tasks.services.ts
@@ -15,7 +15,8 @@ import {
 import prisma from '../prisma/prisma.js';
 import taskTransformer, {
   calendarTaskTransformer,
-  getBlockingWorkPackages,
+  getActiveTaskBlockerNames,
+  taskBlockedByTransformer,
   taskCardPreviewTransformer,
   taskLabelTransformer
 } from '../transformers/tasks.transformer.js';
@@ -37,6 +38,7 @@ import { getTeamQueryArgs } from '../prisma-query-args/teams.query-args.js';
 import {
   getBlockingWorkPackagesArgs,
   getCalendarTaskQueryArgs,
+  getTaskBlockedByQueryArgs,
   getTaskLabelQueryArgs,
   getTaskPreviewQueryArgs,
   getTaskQueryArgs
@@ -130,6 +132,18 @@ export default class TasksService {
 
     await validateTaskLabels(labelIds, organization.organizationId);
     const blockedByTasks = await validateTaskBlockedBys(blockedByIds, organization.organizationId);
+
+    // only worth the extra nested fetch when actually attempting to create the task as done
+    if (status === 'DONE') {
+      const wbsElementForBlockCheck = await prisma.wBS_Element.findUniqueOrThrow({
+        where: { wbsNumber: { ...wbsNum, organizationId: organization.organizationId } },
+        ...getBlockingWorkPackagesArgs()
+      });
+      const blockerNames = getActiveTaskBlockerNames(blockedByTasks.map(taskBlockedByTransformer), wbsElementForBlockCheck);
+      if (blockerNames.length > 0) {
+        throw new HttpException(400, `Cannot create task as done: blocked by ${blockerNames.join(', ')}`);
+      }
+    }
 
     const createdTask = await prisma.task.create({
       data: {
@@ -269,14 +283,7 @@ export default class TasksService {
     if (!hasPermission) throw new AccessDeniedException('Guests cannot edit tasks');
 
     // Get the original task and check if it exists
-    const originalTask = await prisma.task.findUnique({
-      where: { taskId },
-      include: {
-        assignees: true,
-        wbsElement: getBlockingWorkPackagesArgs(),
-        blockedBy: { select: { taskId: true, title: true, status: true } }
-      }
-    });
+    const originalTask = await prisma.task.findUnique({ where: { taskId }, include: { assignees: true, wbsElement: true } });
     if (!originalTask) throw new NotFoundException('Task', taskId);
     if (organizationId !== originalTask.wbsElement.organizationId) throw new InvalidOrganizationException('Task');
     if (originalTask.dateDeleted) throw new DeletedException('Task', taskId);
@@ -285,14 +292,20 @@ export default class TasksService {
       throw new HttpException(400, 'A task in progress must have a deadline and assignees!');
     }
 
+    // only worth the extra nested fetch when actually attempting to complete the task
     if (status === 'DONE') {
-      const incompleteBlockers = originalTask.blockedBy.filter((blocker) => blocker.status !== 'DONE');
-      const blockingWorkPackages = getBlockingWorkPackages(originalTask.wbsElement);
-      if (incompleteBlockers.length > 0 || blockingWorkPackages.length > 0) {
-        const blockerNames = [
-          ...incompleteBlockers.map((blocker) => blocker.title),
-          ...blockingWorkPackages.map((wp) => wp.name)
-        ];
+      const taskForBlockCheck = await prisma.task.findUniqueOrThrow({
+        where: { taskId },
+        select: {
+          blockedBy: getTaskBlockedByQueryArgs(),
+          wbsElement: getBlockingWorkPackagesArgs()
+        }
+      });
+      const blockerNames = getActiveTaskBlockerNames(
+        taskForBlockCheck.blockedBy.map(taskBlockedByTransformer),
+        taskForBlockCheck.wbsElement
+      );
+      if (blockerNames.length > 0) {
         throw new HttpException(400, `Cannot mark task as done: blocked by ${blockerNames.join(', ')}`);
       }
     }

--- a/src/backend/src/transformers/tasks.transformer.ts
+++ b/src/backend/src/transformers/tasks.transformer.ts
@@ -14,11 +14,12 @@ import {
 
 export const taskBlockedByTransformer = (task: Prisma.TaskGetPayload<TaskBlockedByQueryArgs>): TaskBlockerPreview => ({
   taskId: task.taskId,
-  title: task.title
+  title: task.title,
+  status: convertTaskStatus(task.status)
 });
 
 // only surfaces a blocking work package if it still has at least one non-done task
-export const getBlockingWorkPackages = (
+export const getBlockingWorkPackagePreviews = (
   wbsElement: Pick<Prisma.WBS_ElementGetPayload<BlockingWorkPackagesQueryArgs>, 'workPackage'>
 ): BlockingWorkPackagePreview[] =>
   (wbsElement.workPackage?.blockedBy ?? [])
@@ -27,6 +28,19 @@ export const getBlockingWorkPackages = (
       wbsNum: wbsNumOf(blocker),
       name: blocker.name
     }));
+
+/**
+ * The names of everything currently, actively blocking a task from being marked done: any non-deleted,
+ * non-done blocking task, plus any work package that still blocks this task's own work package.
+ * Shared between task creation and status edits so "can this task be done" is answered in exactly one place.
+ */
+export const getActiveTaskBlockerNames = (
+  blockedBy: Pick<TaskBlockerPreview, 'title' | 'status'>[],
+  wbsElement: Pick<Prisma.WBS_ElementGetPayload<BlockingWorkPackagesQueryArgs>, 'workPackage'>
+): string[] => [
+  ...blockedBy.filter((blocker) => blocker.status !== 'DONE').map((blocker) => blocker.title),
+  ...getBlockingWorkPackagePreviews(wbsElement).map((wp) => wp.name)
+];
 
 export const taskTransformer = (task: Prisma.TaskGetPayload<TaskQueryArgs>): Task => {
   const wbsNum = wbsNumOf(task.wbsElement);
@@ -44,7 +58,7 @@ export const taskTransformer = (task: Prisma.TaskGetPayload<TaskQueryArgs>): Tas
     assignees: task.assignees.map(userTransformer),
     labels: task.labels.map(taskLabelTransformer),
     blockedBy: task.blockedBy.map(taskBlockedByTransformer),
-    blockedByWorkPackages: getBlockingWorkPackages(task.wbsElement),
+    blockedByWorkPackages: getBlockingWorkPackagePreviews(task.wbsElement),
     dateDeleted: task.dateDeleted ?? undefined,
     dateCreated: task.dateCreated,
     deletedBy: task.deletedBy ? userTransformer(task.deletedBy) : undefined
@@ -83,7 +97,7 @@ export const calendarTaskTransformer = (task: Prisma.TaskGetPayload<CalendarTask
     assignees: task.assignees.map(userTransformer),
     labels: task.labels.map(taskLabelTransformer),
     blockedBy: task.blockedBy.map(taskBlockedByTransformer),
-    blockedByWorkPackages: getBlockingWorkPackages(task.wbsElement),
+    blockedByWorkPackages: getBlockingWorkPackagePreviews(task.wbsElement),
     dateDeleted: task.dateDeleted ?? undefined,
     dateCreated: task.dateCreated,
     deletedBy: task.deletedBy ? userTransformer(task.deletedBy) : undefined,

--- a/src/backend/src/transformers/tasks.transformer.ts
+++ b/src/backend/src/transformers/tasks.transformer.ts
@@ -1,5 +1,5 @@
 import { Prisma } from '@prisma/client';
-import { CalendarTask, Task, TaskCardPreview, TaskLabel } from 'shared';
+import { BlockingWorkPackagePreview, CalendarTask, Task, TaskBlockerPreview, TaskCardPreview, TaskLabel } from 'shared';
 import { wbsNumOf } from '../utils/utils.js';
 import { convertTaskPriority, convertTaskStatus } from '../utils/tasks.utils.js';
 import { userTransformer } from './user.transformer.js';
@@ -7,8 +7,26 @@ import {
   CalendarTaskQueryArgs,
   TaskLabelQueryArgs,
   TaskQueryArgs,
-  TaskPreviewQueryArgs
+  TaskPreviewQueryArgs,
+  TaskBlockedByQueryArgs,
+  BlockingWorkPackagesQueryArgs
 } from '../prisma-query-args/tasks.query-args.js';
+
+export const taskBlockedByTransformer = (task: Prisma.TaskGetPayload<TaskBlockedByQueryArgs>): TaskBlockerPreview => ({
+  taskId: task.taskId,
+  title: task.title
+});
+
+// only surfaces a blocking work package if it still has at least one non-done task
+export const getBlockingWorkPackages = (
+  wbsElement: Pick<Prisma.WBS_ElementGetPayload<BlockingWorkPackagesQueryArgs>, 'workPackage'>
+): BlockingWorkPackagePreview[] =>
+  (wbsElement.workPackage?.blockedBy ?? [])
+    .filter((blocker) => blocker.tasks.some((t) => t.status !== 'DONE'))
+    .map((blocker) => ({
+      wbsNum: wbsNumOf(blocker),
+      name: blocker.name
+    }));
 
 export const taskTransformer = (task: Prisma.TaskGetPayload<TaskQueryArgs>): Task => {
   const wbsNum = wbsNumOf(task.wbsElement);
@@ -25,6 +43,8 @@ export const taskTransformer = (task: Prisma.TaskGetPayload<TaskQueryArgs>): Tas
     createdBy: userTransformer(task.createdBy),
     assignees: task.assignees.map(userTransformer),
     labels: task.labels.map(taskLabelTransformer),
+    blockedBy: task.blockedBy.map(taskBlockedByTransformer),
+    blockedByWorkPackages: getBlockingWorkPackages(task.wbsElement),
     dateDeleted: task.dateDeleted ?? undefined,
     dateCreated: task.dateCreated,
     deletedBy: task.deletedBy ? userTransformer(task.deletedBy) : undefined
@@ -62,6 +82,8 @@ export const calendarTaskTransformer = (task: Prisma.TaskGetPayload<CalendarTask
     createdBy: userTransformer(task.createdBy),
     assignees: task.assignees.map(userTransformer),
     labels: task.labels.map(taskLabelTransformer),
+    blockedBy: task.blockedBy.map(taskBlockedByTransformer),
+    blockedByWorkPackages: getBlockingWorkPackages(task.wbsElement),
     dateDeleted: task.dateDeleted ?? undefined,
     dateCreated: task.dateCreated,
     deletedBy: task.deletedBy ? userTransformer(task.deletedBy) : undefined,

--- a/src/backend/src/utils/tasks.utils.ts
+++ b/src/backend/src/utils/tasks.utils.ts
@@ -2,7 +2,7 @@ import { Task_Priority, Task_Status } from '@prisma/client';
 import { Task, TaskPriority, TaskStatus } from 'shared';
 import prisma from '../prisma/prisma.js';
 import { sendSlackTaskAssignedNotification } from './slack.utils.js';
-import { DeletedException, InvalidOrganizationException, NotFoundException } from './errors.utils.js';
+import { DeletedException, HttpException, InvalidOrganizationException, NotFoundException } from './errors.utils.js';
 
 export const convertTaskPriority = (priority: Task_Priority): TaskPriority =>
   ({
@@ -38,6 +38,41 @@ export const validateTaskLabels = async (labelIds: string[], organizationId: str
 
   const wrongOrgLabel = labels.find((l) => l.organizationId !== organizationId);
   if (wrongOrgLabel) throw new InvalidOrganizationException('Task Label');
+};
+
+/**
+ * Validates that all given task IDs exist, are not deleted, and belong to the given organization.
+ * @param blockedByIds the task ids that would block the task
+ * @param organizationId the organization the blocking tasks must belong to
+ * @param taskId the id of the task being blocked, if it already exists (omitted on create)
+ * @throws NotFoundException if any ID doesn't exist
+ * @throws DeletedException if any blocking task is soft-deleted
+ * @throws InvalidOrganizationException if any blocking task belongs to a different organization
+ * @throws HttpException if a task is listed as blocking itself
+ */
+export const validateTaskBlockedBys = async (blockedByIds: string[], organizationId: string, taskId?: string) => {
+  if (blockedByIds.length === 0) return [];
+
+  if (taskId && blockedByIds.includes(taskId)) {
+    throw new HttpException(400, 'A task cannot block itself');
+  }
+
+  const blockedByTasks = await prisma.task.findMany({
+    where: { taskId: { in: blockedByIds } },
+    include: { wbsElement: true }
+  });
+
+  const foundIds = blockedByTasks.map((t) => t.taskId);
+  const missingIds = blockedByIds.filter((id) => !foundIds.includes(id));
+  if (missingIds.length > 0) throw new NotFoundException('Task', missingIds.join(', '));
+
+  const deletedTask = blockedByTasks.find((t) => t.dateDeleted !== null);
+  if (deletedTask) throw new DeletedException('Task', deletedTask.taskId);
+
+  const wrongOrgTask = blockedByTasks.find((t) => t.wbsElement.organizationId !== organizationId);
+  if (wrongOrgTask) throw new InvalidOrganizationException('Task');
+
+  return blockedByTasks;
 };
 
 /**

--- a/src/backend/src/utils/tasks.utils.ts
+++ b/src/backend/src/utils/tasks.utils.ts
@@ -41,6 +41,31 @@ export const validateTaskLabels = async (labelIds: string[], organizationId: str
 };
 
 /**
+ * Checks whether connecting taskId as blockedBy each of blockedByIds would create a cycle, i.e. whether
+ * taskId is already reachable by walking the blockedBy chain starting from any of blockedByIds (meaning
+ * one of them already (transitively) depends on taskId).
+ */
+const wouldCreateBlockingCycle = async (taskId: string, blockedByIds: string[]): Promise<boolean> => {
+  const visited = new Set<string>();
+  const queue = [...blockedByIds];
+
+  while (queue.length > 0) {
+    const currentId = queue.pop()!;
+    if (currentId === taskId) return true;
+    if (visited.has(currentId)) continue;
+    visited.add(currentId);
+
+    const current = await prisma.task.findUnique({
+      where: { taskId: currentId },
+      select: { blockedBy: { select: { taskId: true } } }
+    });
+    if (current) queue.push(...current.blockedBy.map((blocker) => blocker.taskId));
+  }
+
+  return false;
+};
+
+/**
  * Validates that all given task IDs exist, are not deleted, and belong to the given organization.
  * @param blockedByIds the task ids that would block the task
  * @param organizationId the organization the blocking tasks must belong to
@@ -48,7 +73,7 @@ export const validateTaskLabels = async (labelIds: string[], organizationId: str
  * @throws NotFoundException if any ID doesn't exist
  * @throws DeletedException if any blocking task is soft-deleted
  * @throws InvalidOrganizationException if any blocking task belongs to a different organization
- * @throws HttpException if a task is listed as blocking itself
+ * @throws HttpException if a task is listed as blocking itself, or if the change would create a blocking cycle
  */
 export const validateTaskBlockedBys = async (blockedByIds: string[], organizationId: string, taskId?: string) => {
   if (blockedByIds.length === 0) return [];
@@ -71,6 +96,10 @@ export const validateTaskBlockedBys = async (blockedByIds: string[], organizatio
 
   const wrongOrgTask = blockedByTasks.find((t) => t.wbsElement.organizationId !== organizationId);
   if (wrongOrgTask) throw new InvalidOrganizationException('Task');
+
+  if (taskId && (await wouldCreateBlockingCycle(taskId, blockedByIds))) {
+    throw new HttpException(400, 'This would create a circular blocking dependency');
+  }
 
   return blockedByTasks;
 };

--- a/src/backend/tests/test-utils.ts
+++ b/src/backend/tests/test-utils.ts
@@ -797,6 +797,7 @@ export const createTestTaskWithOrganization = async (user: User, organization?: 
     [user.userId],
     organization,
     [],
+    [],
     new Date(),
     new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
   );

--- a/src/backend/tests/unmocked/task.test.ts
+++ b/src/backend/tests/unmocked/task.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   createTestOrganization,
   createTestTask,
+  createTestTaskWithOrganization,
   createTestUser,
   resetUsers,
   createTestCar,
@@ -216,6 +217,50 @@ describe('Task Tests', () => {
         TasksService.editTask(user, organizationId, task.taskId, 'Test Task', '', 'HIGH', [label.taskLabelId], [])
       ).rejects.toThrow(InvalidOrganizationException);
     });
+
+    it('fails to edit blockedBy when it would create a circular blocking dependency', async () => {
+      const user = await createTestUser(supermanAdmin, organizationId);
+      const taskA = await createTestTask(user, 'Task A', '', [], 'HIGH', 'IN_BACKLOG', organizationId);
+      const taskB = await prisma.task.create({
+        data: {
+          title: 'Task B',
+          notes: '',
+          priority: 'HIGH',
+          status: 'IN_BACKLOG',
+          dateCreated: new Date(),
+          createdBy: { connect: { userId: user.userId } },
+          wbsElement: { connect: { wbsElementId: taskA.wbsElementId } },
+          blockedBy: { connect: { taskId: taskA.taskId } }
+        }
+      });
+
+      // Task B is already blockedBy Task A; making Task A blockedBy Task B would close the cycle
+      await expect(async () =>
+        TasksService.editTask(user, organizationId, taskA.taskId, taskA.title, '', 'HIGH', [], [taskB.taskId])
+      ).rejects.toThrow(new HttpException(400, 'This would create a circular blocking dependency'));
+    });
+  });
+
+  describe('Create task', () => {
+    it('fails to create a task as done when blocked by an incomplete task', async () => {
+      const user = await createTestUser(supermanAdmin, organizationId);
+      const { task: blockerTask, organization: org } = await createTestTaskWithOrganization(user, organization);
+
+      await expect(async () =>
+        TasksService.createTask(
+          user,
+          { carNumber: 0, projectNumber: 1, workPackageNumber: 0 },
+          'New Task',
+          '',
+          'HIGH',
+          'DONE',
+          [],
+          org,
+          [],
+          [blockerTask.taskId]
+        )
+      ).rejects.toThrow(new HttpException(400, `Cannot create task as done: blocked by ${blockerTask.title}`));
+    });
   });
 
   describe('Edit task status', () => {
@@ -358,9 +403,35 @@ describe('Task Tests', () => {
         }
       });
 
-      await expect(async () =>
-        TasksService.editTaskStatus(user, organizationId, taskInWpB.taskId, 'DONE')
-      ).rejects.toThrow(new HttpException(400, 'Cannot mark task as done: blocked by WP 0.1.1'));
+      await expect(async () => TasksService.editTaskStatus(user, organizationId, taskInWpB.taskId, 'DONE')).rejects.toThrow(
+        new HttpException(400, 'Cannot mark task as done: blocked by WP 0.1.1')
+      );
+    });
+
+    it('successfully sets status to done when the only blocking task has been deleted', async () => {
+      const user = await createTestUser(supermanAdmin, organizationId);
+      const blockerTask = await createTestTask(user, 'Blocker', '', [], 'HIGH', 'IN_PROGRESS', organizationId);
+      const blockedTask = await prisma.task.create({
+        data: {
+          title: 'Blocked',
+          notes: '',
+          priority: 'HIGH',
+          status: 'IN_BACKLOG',
+          dateCreated: new Date(),
+          createdBy: { connect: { userId: user.userId } },
+          wbsElement: { connect: { wbsElementId: blockerTask.wbsElementId } },
+          blockedBy: { connect: { taskId: blockerTask.taskId } }
+        }
+      });
+
+      await prisma.task.update({
+        where: { taskId: blockerTask.taskId },
+        data: { dateDeleted: new Date(), deletedByUserId: user.userId }
+      });
+
+      await TasksService.editTaskStatus(user, organizationId, blockedTask.taskId, 'DONE');
+      const updatedTask = await prisma.task.findUnique({ where: { taskId: blockedTask.taskId } });
+      expect(updatedTask?.status).toBe('DONE');
     });
   });
 

--- a/src/backend/tests/unmocked/task.test.ts
+++ b/src/backend/tests/unmocked/task.test.ts
@@ -12,7 +12,8 @@ import {
   createTestUser,
   resetUsers,
   createTestCar,
-  createTestProject
+  createTestProject,
+  createTestWorkPackage
 } from '../test-utils.js';
 import prisma from '../../src/prisma/prisma.js';
 import TasksService from '../../src/services/tasks.services.js';
@@ -276,6 +277,90 @@ describe('Task Tests', () => {
           'IN_PROGRESS'
         )
       ).rejects.toThrow(new HttpException(400, 'A task in progress must have a deadline and assignees!'));
+    });
+
+    it('fails to set status to done when blocked by an incomplete task', async () => {
+      const user = await createTestUser(supermanAdmin, organizationId);
+      const blockerTask = await createTestTask(user, 'Blocker', '', [], 'HIGH', 'IN_PROGRESS', organizationId);
+      const blockedTask = await prisma.task.create({
+        data: {
+          title: 'Blocked',
+          notes: '',
+          priority: 'HIGH',
+          status: 'IN_PROGRESS',
+          dateCreated: new Date(),
+          createdBy: { connect: { userId: user.userId } },
+          wbsElement: { connect: { wbsElementId: blockerTask.wbsElementId } },
+          blockedBy: { connect: { taskId: blockerTask.taskId } }
+        }
+      });
+
+      await expect(async () =>
+        TasksService.editTaskStatus(user, organizationId, blockedTask.taskId, 'DONE')
+      ).rejects.toThrow(new HttpException(400, `Cannot mark task as done: blocked by ${blockerTask.title}`));
+    });
+
+    it('successfully sets status to done when all blocking tasks are already done', async () => {
+      const user = await createTestUser(supermanAdmin, organizationId);
+      const blockerTask = await createTestTask(user, 'Blocker', '', [], 'HIGH', 'DONE', organizationId);
+      const blockedTask = await prisma.task.create({
+        data: {
+          title: 'Blocked',
+          notes: '',
+          priority: 'HIGH',
+          status: 'IN_BACKLOG',
+          dateCreated: new Date(),
+          createdBy: { connect: { userId: user.userId } },
+          wbsElement: { connect: { wbsElementId: blockerTask.wbsElementId } },
+          blockedBy: { connect: { taskId: blockerTask.taskId } }
+        }
+      });
+
+      await TasksService.editTaskStatus(user, organizationId, blockedTask.taskId, 'DONE');
+      const updatedTask = await prisma.task.findUnique({ where: { taskId: blockedTask.taskId } });
+      expect(updatedTask?.status).toBe('DONE');
+    });
+
+    it('fails to set status to done when the work package is blocked by a work package with incomplete tasks', async () => {
+      const user = await createTestUser(supermanAdmin, organizationId);
+      const car = await createTestCar(organizationId, user.userId);
+      const project = await createTestProject(user, organizationId, undefined, car.carId);
+      const wpA = await createTestWorkPackage(user, organizationId, project.projectId, 0, 1, 1);
+      const wpB = await createTestWorkPackage(user, organizationId, project.projectId, 0, 1, 2);
+
+      await prisma.work_Package.update({
+        where: { workPackageId: wpB.workPackageId },
+        data: { blockedBy: { connect: { wbsElementId: wpA.wbsElement.wbsElementId } } }
+      });
+
+      // wpA still has an incomplete task, so it still counts as actively blocking
+      await prisma.task.create({
+        data: {
+          title: 'WP A task',
+          notes: '',
+          priority: 'HIGH',
+          status: 'IN_BACKLOG',
+          dateCreated: new Date(),
+          createdBy: { connect: { userId: user.userId } },
+          wbsElement: { connect: { wbsElementId: wpA.wbsElementId } }
+        }
+      });
+
+      const taskInWpB = await prisma.task.create({
+        data: {
+          title: 'WP B task',
+          notes: '',
+          priority: 'HIGH',
+          status: 'IN_BACKLOG',
+          dateCreated: new Date(),
+          createdBy: { connect: { userId: user.userId } },
+          wbsElement: { connect: { wbsElementId: wpB.wbsElementId } }
+        }
+      });
+
+      await expect(async () =>
+        TasksService.editTaskStatus(user, organizationId, taskInWpB.taskId, 'DONE')
+      ).rejects.toThrow(new HttpException(400, 'Cannot mark task as done: blocked by WP 0.1.1'));
     });
   });
 

--- a/src/backend/tests/unmocked/task.test.ts
+++ b/src/backend/tests/unmocked/task.test.ts
@@ -65,6 +65,7 @@ describe('Task Tests', () => {
         '',
         'HIGH',
         [],
+        [],
         undefined,
         undefined,
         newWbsNum
@@ -78,7 +79,16 @@ describe('Task Tests', () => {
       const user = await createTestUser(supermanAdmin, organizationId);
       const task = await createTestTask(user, 'Test Task', '', [], 'HIGH', 'IN_BACKLOG', organizationId);
 
-      const updatedTask = await TasksService.editTask(user, organizationId, task.taskId, 'Updated Title', '', 'HIGH', []);
+      const updatedTask = await TasksService.editTask(
+        user,
+        organizationId,
+        task.taskId,
+        'Updated Title',
+        '',
+        'HIGH',
+        [],
+        []
+      );
 
       expect(updatedTask.taskId).toBe(task.taskId);
       expect(updatedTask.title).toBe('Updated Title');
@@ -98,6 +108,7 @@ describe('Task Tests', () => {
           'Test Task',
           '',
           'HIGH',
+          [],
           [],
           undefined,
           undefined,
@@ -140,6 +151,7 @@ describe('Task Tests', () => {
           '',
           'HIGH',
           [],
+          [],
           undefined,
           undefined,
           deletedWbsNum
@@ -152,9 +164,16 @@ describe('Task Tests', () => {
       const task = await createTestTask(user, 'Test Task', '', [], 'HIGH', 'IN_BACKLOG', organizationId);
       const label = await TasksService.createTaskLabel(user, 'Test Label', '#3B82F6', organization);
 
-      const updatedTask = await TasksService.editTask(user, organizationId, task.taskId, 'Test Task', '', 'HIGH', [
-        label.taskLabelId
-      ]);
+      const updatedTask = await TasksService.editTask(
+        user,
+        organizationId,
+        task.taskId,
+        'Test Task',
+        '',
+        'HIGH',
+        [label.taskLabelId],
+        []
+      );
 
       expect(updatedTask.labels).toHaveLength(1);
       expect(updatedTask.labels[0].taskLabelId).toBe(label.taskLabelId);
@@ -165,7 +184,7 @@ describe('Task Tests', () => {
       const task = await createTestTask(user, 'Test Task', '', [], 'HIGH', 'IN_BACKLOG', organizationId);
 
       await expect(async () =>
-        TasksService.editTask(user, organizationId, task.taskId, 'Test Task', '', 'HIGH', ['nonexistent-label-id'])
+        TasksService.editTask(user, organizationId, task.taskId, 'Test Task', '', 'HIGH', ['nonexistent-label-id'], [])
       ).rejects.toThrow(NotFoundException);
     });
 
@@ -176,7 +195,7 @@ describe('Task Tests', () => {
       await prisma.task_Label.update({ where: { taskLabelId: label.taskLabelId }, data: { dateDeleted: new Date() } });
 
       await expect(async () =>
-        TasksService.editTask(user, organizationId, task.taskId, 'Test Task', '', 'HIGH', [label.taskLabelId])
+        TasksService.editTask(user, organizationId, task.taskId, 'Test Task', '', 'HIGH', [label.taskLabelId], [])
       ).rejects.toThrow(DeletedException);
     });
 
@@ -193,7 +212,7 @@ describe('Task Tests', () => {
       const label = await TasksService.createTaskLabel(otherUser, 'Test Label', '#3B82F6', otherOrg);
 
       await expect(async () =>
-        TasksService.editTask(user, organizationId, task.taskId, 'Test Task', '', 'HIGH', [label.taskLabelId])
+        TasksService.editTask(user, organizationId, task.taskId, 'Test Task', '', 'HIGH', [label.taskLabelId], [])
       ).rejects.toThrow(InvalidOrganizationException);
     });
   });
@@ -481,7 +500,7 @@ describe('Task Tests', () => {
       const admin = await createTestUser(supermanAdmin, organizationId);
       const task = await createTestTask(admin, 'Test', '', [], 'HIGH', 'DONE', organizationId, new Date());
       await expect(async () =>
-        TasksService.editTask(guest, organizationId, task.taskId, 'Title', 'Notes', 'HIGH', [], new Date())
+        TasksService.editTask(guest, organizationId, task.taskId, 'Title', 'Notes', 'HIGH', [], [], new Date())
       ).rejects.toThrow(new AccessDeniedException('Guests cannot edit tasks'));
     });
   });

--- a/src/frontend/src/apis/tasks.api.ts
+++ b/src/frontend/src/apis/tasks.api.ts
@@ -28,6 +28,7 @@ import { taskLabelTransformer, taskTransformer } from './transformers/tasks.tran
  * @param assignees the ids of the users assigned to the task
  * @param notes the notes for the task
  * @param labelIds the ids of the labels for the task
+ * @param blockedByIds the ids of the tasks that block this task
  * @param deadline the datestring deadline of the task
  * @param startDate the datestring start date of the task
  * @returns
@@ -40,6 +41,7 @@ export const createSingleTask = (
   assignees: string[],
   notes: string,
   labelIds: string[],
+  blockedByIds: string[],
   deadline?: string,
   startDate?: string
 ) => {
@@ -53,7 +55,8 @@ export const createSingleTask = (
       status,
       assignees,
       notes,
-      labelIds
+      labelIds,
+      blockedByIds
     },
     {
       transformResponse: (data) => taskTransformer(JSON.parse(data))
@@ -68,6 +71,7 @@ export const createSingleTask = (
  * @param notes the new notes
  * @param priority the new priority
  * @param labelIds the new label ids
+ * @param blockedByIds the new ids of the tasks that block this task
  * @param deadline the new deadline
  * @param startDate the new start date
  * @param wbsNum the new wbs element
@@ -79,6 +83,7 @@ export const editTask = (
   notes: string,
   priority: TaskPriority,
   labelIds: string[],
+  blockedByIds: string[],
   deadline?: Date,
   startDate?: Date,
   wbsNum?: WbsNumber
@@ -88,6 +93,7 @@ export const editTask = (
     notes,
     priority,
     labelIds,
+    blockedByIds,
     deadline: deadline ? dateToMidnightUTC(deadline) : undefined,
     startDate: startDate ? dateToMidnightUTC(startDate) : undefined,
     wbsNum

--- a/src/frontend/src/apis/tasks.api.ts
+++ b/src/frontend/src/apis/tasks.api.ts
@@ -20,21 +20,6 @@ import { apiUrls } from '../utils/urls';
 import { taskLabelTransformer, taskTransformer } from './transformers/tasks.transformers';
 
 /**
- * axios runs transformResponse on error bodies too (e.g. { message: string } from a rejected request),
- * so taskTransformer would otherwise crash trying to read a field (assignees, labels, etc.) that only
- * exists on success responses. Falling back to the raw parsed body lets the response interceptor in
- * axios.ts correctly read error.response.data.message instead of a confusing TypeError.
- */
-const transformTaskResponse = (data: string) => {
-  const parsed = JSON.parse(data);
-  try {
-    return taskTransformer(parsed);
-  } catch {
-    return parsed;
-  }
-};
-
-/**
  * Api call to create a task.
  * @param wbsNum wbsNum of the wbsElement that the task is associated with
  * @param title the title of the task
@@ -74,7 +59,18 @@ export const createSingleTask = (
       blockedByIds
     },
     {
-      transformResponse: transformTaskResponse
+      // axios runs transformResponse on error bodies too (e.g. { message: string } from a rejected
+      // request), so taskTransformer would otherwise crash reading a field that only exists on success
+      // responses. Falling back to the raw parsed body lets the interceptor in axios.ts read
+      // error.response.data.message instead of a confusing TypeError.
+      transformResponse: (data) => {
+        const parsed = JSON.parse(data);
+        try {
+          return taskTransformer(parsed);
+        } catch {
+          return parsed;
+        }
+      }
     }
   );
 };
@@ -128,7 +124,15 @@ export const editTaskAssignees = (taskId: string, assignees: string[]) => {
       assignees
     },
     {
-      transformResponse: transformTaskResponse
+      // same fallback as createSingleTask above: avoid crashing taskTransformer on an error body
+      transformResponse: (data) => {
+        const parsed = JSON.parse(data);
+        try {
+          return taskTransformer(parsed);
+        } catch {
+          return parsed;
+        }
+      }
     }
   );
 };

--- a/src/frontend/src/apis/tasks.api.ts
+++ b/src/frontend/src/apis/tasks.api.ts
@@ -20,6 +20,21 @@ import { apiUrls } from '../utils/urls';
 import { taskLabelTransformer, taskTransformer } from './transformers/tasks.transformers';
 
 /**
+ * axios runs transformResponse on error bodies too (e.g. { message: string } from a rejected request),
+ * so taskTransformer would otherwise crash trying to read a field (assignees, labels, etc.) that only
+ * exists on success responses. Falling back to the raw parsed body lets the response interceptor in
+ * axios.ts correctly read error.response.data.message instead of a confusing TypeError.
+ */
+const transformTaskResponse = (data: string) => {
+  const parsed = JSON.parse(data);
+  try {
+    return taskTransformer(parsed);
+  } catch {
+    return parsed;
+  }
+};
+
+/**
  * Api call to create a task.
  * @param wbsNum wbsNum of the wbsElement that the task is associated with
  * @param title the title of the task
@@ -59,7 +74,7 @@ export const createSingleTask = (
       blockedByIds
     },
     {
-      transformResponse: (data) => taskTransformer(JSON.parse(data))
+      transformResponse: transformTaskResponse
     }
   );
 };
@@ -113,7 +128,7 @@ export const editTaskAssignees = (taskId: string, assignees: string[]) => {
       assignees
     },
     {
-      transformResponse: (data) => taskTransformer(JSON.parse(data))
+      transformResponse: transformTaskResponse
     }
   );
 };

--- a/src/frontend/src/hooks/tasks.hooks.ts
+++ b/src/frontend/src/hooks/tasks.hooks.ts
@@ -29,6 +29,7 @@ export interface CreateTaskPayload {
   notes?: string;
   assignees: string[];
   labelIds: string[];
+  blockedByIds?: string[];
 }
 
 /**
@@ -62,6 +63,7 @@ export const useCreateTask = () => {
         createTaskPayload.assignees,
         createTaskPayload.notes ?? '',
         createTaskPayload.labelIds,
+        createTaskPayload.blockedByIds ?? [],
         createTaskPayload.deadline,
         createTaskPayload.startDate
       );
@@ -87,6 +89,7 @@ export interface TaskPayload {
   priority: TaskPriority;
   wbsNum?: WbsNumber;
   labelIds: string[];
+  blockedByIds?: string[];
 }
 
 /**
@@ -104,6 +107,7 @@ export const useEditTask = () => {
         taskPayload.notes ?? '',
         taskPayload.priority,
         taskPayload.labelIds,
+        taskPayload.blockedByIds ?? [],
         taskPayload.deadline,
         taskPayload.startDate,
         taskPayload.wbsNum

--- a/src/frontend/src/hooks/tasks.hooks.ts
+++ b/src/frontend/src/hooks/tasks.hooks.ts
@@ -29,7 +29,7 @@ export interface CreateTaskPayload {
   notes?: string;
   assignees: string[];
   labelIds: string[];
-  blockedByIds?: string[];
+  blockedByIds: string[];
 }
 
 /**
@@ -63,7 +63,7 @@ export const useCreateTask = () => {
         createTaskPayload.assignees,
         createTaskPayload.notes ?? '',
         createTaskPayload.labelIds,
-        createTaskPayload.blockedByIds ?? [],
+        createTaskPayload.blockedByIds,
         createTaskPayload.deadline,
         createTaskPayload.startDate
       );
@@ -89,7 +89,7 @@ export interface TaskPayload {
   priority: TaskPriority;
   wbsNum?: WbsNumber;
   labelIds: string[];
-  blockedByIds?: string[];
+  blockedByIds: string[];
 }
 
 /**
@@ -107,7 +107,7 @@ export const useEditTask = () => {
         taskPayload.notes ?? '',
         taskPayload.priority,
         taskPayload.labelIds,
-        taskPayload.blockedByIds ?? [],
+        taskPayload.blockedByIds,
         taskPayload.deadline,
         taskPayload.startDate,
         taskPayload.wbsNum

--- a/src/frontend/src/pages/CalendarPage/Components/CalendarCreateTaskModal.tsx
+++ b/src/frontend/src/pages/CalendarPage/Components/CalendarCreateTaskModal.tsx
@@ -110,6 +110,7 @@ const CalendarCreateTaskModal: React.FC<CalendarCreateTaskModalProps> = ({ open,
         assignees: data.assignees,
         notes: data.notes,
         labelIds: data.labels.map((l) => l.taskLabelId),
+        blockedByIds: [],
         deadline: data.deadline ? dateToMidnightUTC(data.deadline).toISOString() : undefined,
         startDate: data.startDate ? dateToMidnightUTC(data.startDate).toISOString() : undefined
       });

--- a/src/frontend/src/pages/CalendarPage/TaskClickPopup.tsx
+++ b/src/frontend/src/pages/CalendarPage/TaskClickPopup.tsx
@@ -64,6 +64,7 @@ export const TaskClickContent: React.FC<TaskClickContentProps> = ({ task, onClos
         notes: data.notes,
         priority: data.priority,
         labelIds: task.labels.map((l) => l.taskLabelId),
+        blockedByIds: data.blockedBy.map((b) => b.taskId),
         startDate: data.startDate,
         deadline: data.deadline,
         wbsNum: task.wbsNum

--- a/src/frontend/src/pages/GanttPage/ProjectGanttChart/ProjectGanttChangeModals/GanttProjectCreateModal.tsx
+++ b/src/frontend/src/pages/GanttPage/ProjectGanttChart/ProjectGanttChangeModals/GanttProjectCreateModal.tsx
@@ -74,6 +74,7 @@ export const GanttProjectCreateModal = ({ change, handleClose, open }: GanttProj
               assignees: task.assignees.map((user) => user.userId),
               notes: task.notes || '',
               labelIds: task.labels.map((l) => l.taskLabelId),
+              blockedByIds: task.blockedBy.map((b) => b.taskId),
               deadline: task.deadline ? dateToMidnightUTC(task.deadline).toISOString() : undefined,
               startDate: task.startDate ? dateToMidnightUTC(task.startDate).toISOString() : undefined
             });

--- a/src/frontend/src/pages/GanttPage/ProjectGanttChart/ProjectGanttChangeModals/GanttTimeLineChangeModal.tsx
+++ b/src/frontend/src/pages/GanttPage/ProjectGanttChart/ProjectGanttChangeModals/GanttTimeLineChangeModal.tsx
@@ -162,6 +162,7 @@ export const GanttTimeLineChangeModal = ({ change, handleClose, open }: GanttTim
             assignees: task.assignees?.map((user) => user.userId) || [],
             notes: task.notes || '',
             labelIds: task.labels.map((l) => l.taskLabelId),
+            blockedByIds: task.blockedBy.map((b) => b.taskId),
             deadline: task.deadline ? dateToMidnightUTC(task.deadline).toISOString() : undefined,
             startDate: task.startDate ? dateToMidnightUTC(task.startDate).toISOString() : undefined
           };
@@ -185,6 +186,7 @@ export const GanttTimeLineChangeModal = ({ change, handleClose, open }: GanttTim
             priority: task.priority,
             notes: task.notes || '',
             labelIds: task.labels.map((l) => l.taskLabelId),
+            blockedByIds: task.blockedBy.map((b) => b.taskId),
             deadline: task.deadline,
             startDate: task.startDate
           };

--- a/src/frontend/src/pages/GanttPage/ProjectGanttChart/ProjectGanttChartPage.tsx
+++ b/src/frontend/src/pages/GanttPage/ProjectGanttChart/ProjectGanttChartPage.tsx
@@ -362,6 +362,8 @@ const ProjectGanttChartPage: FC = () => {
       },
       assignees: [],
       labels: taskInfo.labels,
+      blockedBy: [],
+      blockedByWorkPackages: [],
       deadline,
       startDate,
       priority: taskInfo.priority,

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/TaskFormModal.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/TaskFormModal.tsx
@@ -121,7 +121,12 @@ const TaskFormModal: React.FC<TaskFormModalProps> = ({
 
   const projectWbsNum = { ...wbsNum, workPackageNumber: 0 };
   const { data: workPackages } = useWorkPackagesByProject(projectWbsNum);
-  const { data: projectTasks } = useFilterTasks({ wbsNum: projectWbsNum });
+  const {
+    data: projectTasks,
+    isLoading: projectTasksLoading,
+    isError: projectTasksIsError,
+    error: projectTasksError
+  } = useFilterTasks({ wbsNum: projectWbsNum });
   const blockedByOptions: TaskBlockerPreview[] = (projectTasks ?? []).filter((t) => t.taskId !== task?.taskId);
 
   const isWpContext = wbsNum.workPackageNumber !== 0;
@@ -152,7 +157,8 @@ const TaskFormModal: React.FC<TaskFormModalProps> = ({
 
   if (isError) return <ErrorPage error={error} />;
   if (labelsIsError) return <ErrorPage error={labelsError} />;
-  if (usersLoading || !users || labelsIsLoading || !taskLabels) return <LoadingIndicator />;
+  if (projectTasksIsError) return <ErrorPage error={projectTasksError} />;
+  if (usersLoading || !users || labelsIsLoading || !taskLabels || projectTasksLoading) return <LoadingIndicator />;
 
   const userOptions: { label: string; id: string }[] = users.map(taskUserToAutocompleteOption);
   const wpOptions: { label: string; wbsNum: WbsNumber }[] = (workPackages ?? []).map((wp) => ({

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/TaskFormModal.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/TaskFormModal.tsx
@@ -2,7 +2,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { Autocomplete, Box, Chip, FormControl, FormHelperText, FormLabel, Grid, MenuItem, TextField } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers';
 import { Controller, useForm } from 'react-hook-form';
-import { countWords, isGuest, isUnderWordCount, Task, TaskLabel, TaskPriority, TaskStatus, WbsNumber } from 'shared';
+import { countWords, isGuest, isUnderWordCount, Task, TaskLabel, TaskBlockerPreview, TaskPriority, TaskStatus, WbsNumber } from 'shared';
 import { useAllMembers, useCurrentUser } from '../../../../hooks/users.hooks';
 import * as yup from 'yup';
 import { taskUserToAutocompleteOption } from '../../../../utils/task.utils';
@@ -10,7 +10,7 @@ import NERFormModal from '../../../../components/NERFormModal';
 import LoadingIndicator from '../../../../components/LoadingIndicator';
 import ErrorPage from '../../../ErrorPage';
 import { useWorkPackagesByProject } from '../../../../hooks/work-packages.hooks';
-import { useAllTaskLabels } from '../../../../hooks/tasks.hooks';
+import { useAllTaskLabels, useFilterTasks } from '../../../../hooks/tasks.hooks';
 
 export interface EditTaskFormInput {
   taskId: string;
@@ -18,6 +18,7 @@ export interface EditTaskFormInput {
   notes?: string;
   assignees: string[];
   labels: TaskLabel[];
+  blockedBy: TaskBlockerPreview[];
   startDate?: Date;
   deadline?: Date;
   priority: TaskPriority;
@@ -69,6 +70,7 @@ const TaskFormModal: React.FC<TaskFormModalProps> = ({
       priority: yup.mixed<TaskPriority>().oneOf(Object.values(TaskPriority)).required(),
       assignees: yup.array().required().min(1, 'At least one assignee is required for In Progress tasks'),
       labels: yup.array().of(yup.mixed<TaskLabel>().required()).required(),
+      blockedBy: yup.array().of(yup.mixed<TaskBlockerPreview>().required()).required(),
       title: yup.string().required(),
       taskId: yup.string().required(),
       wpWbsNum: yup.mixed<WbsNumber>().optional()
@@ -95,6 +97,7 @@ const TaskFormModal: React.FC<TaskFormModalProps> = ({
       priority: yup.mixed<TaskPriority>().oneOf(Object.values(TaskPriority)).required(),
       assignees: yup.array().required(),
       labels: yup.array().of(yup.mixed<TaskLabel>().required()).required(),
+      blockedBy: yup.array().of(yup.mixed<TaskBlockerPreview>().required()).required(),
       title: yup.string().required(),
       taskId: yup.string().required(),
       wpWbsNum: yup.mixed<WbsNumber>().nullable().optional()
@@ -108,6 +111,8 @@ const TaskFormModal: React.FC<TaskFormModalProps> = ({
 
   const projectWbsNum = { ...wbsNum, workPackageNumber: 0 };
   const { data: workPackages } = useWorkPackagesByProject(projectWbsNum);
+  const { data: projectTasks } = useFilterTasks({ wbsNum: projectWbsNum });
+  const blockedByOptions: TaskBlockerPreview[] = (projectTasks ?? []).filter((t) => t.taskId !== task?.taskId);
 
   const isWpContext = wbsNum.workPackageNumber !== 0;
 
@@ -128,6 +133,7 @@ const TaskFormModal: React.FC<TaskFormModalProps> = ({
       priority: task?.priority ?? TaskPriority.Low,
       assignees: task?.assignees.map((assignee) => assignee.userId) ?? [],
       labels: task?.labels ?? [],
+      blockedBy: task?.blockedBy ?? [],
       wpWbsNum: task?.wbsNum.workPackageNumber !== 0 ? task?.wbsNum : undefined
     }
   });
@@ -317,6 +323,34 @@ const TaskFormModal: React.FC<TaskFormModalProps> = ({
                       ))
                     }
                     renderInput={(params) => <TextField {...params} variant="standard" placeholder="Select labels" />}
+                  />
+                )}
+              />
+            </FormControl>
+          </Grid>
+          <Grid item md={12}>
+            <FormControl fullWidth>
+              <FormLabel>Blocked By</FormLabel>
+              <Controller
+                name="blockedBy"
+                control={control}
+                render={({ field: { onChange, value } }) => (
+                  <Autocomplete
+                    multiple
+                    filterSelectedOptions
+                    options={blockedByOptions}
+                    getOptionLabel={(option: TaskBlockerPreview) => option.title}
+                    isOptionEqualToValue={(option, val) => option.taskId === val.taskId}
+                    onChange={(_, selected) => onChange(selected)}
+                    value={value}
+                    renderTags={(selected, getTagProps) =>
+                      selected.map((blocker, index) => (
+                        <Chip {...getTagProps({ index })} key={blocker.taskId} label={blocker.title} />
+                      ))
+                    }
+                    renderInput={(params) => (
+                      <TextField {...params} variant="standard" placeholder="Select tasks that block this task" />
+                    )}
                   />
                 )}
               />

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/TaskFormModal.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/TaskFormModal.tsx
@@ -2,7 +2,17 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { Autocomplete, Box, Chip, FormControl, FormHelperText, FormLabel, Grid, MenuItem, TextField } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers';
 import { Controller, useForm } from 'react-hook-form';
-import { countWords, isGuest, isUnderWordCount, Task, TaskLabel, TaskBlockerPreview, TaskPriority, TaskStatus, WbsNumber } from 'shared';
+import {
+  countWords,
+  isGuest,
+  isUnderWordCount,
+  Task,
+  TaskLabel,
+  TaskBlockerPreview,
+  TaskPriority,
+  TaskStatus,
+  WbsNumber
+} from 'shared';
 import { useAllMembers, useCurrentUser } from '../../../../hooks/users.hooks';
 import * as yup from 'yup';
 import { taskUserToAutocompleteOption } from '../../../../utils/task.utils';

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/TaskModal.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/TaskModal.tsx
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { fullNamePipe, datePipe } from '../../../../utils/pipes';
+import { fullNamePipe, datePipe, wbsPipe } from '../../../../utils/pipes';
 import { Task, WbsNumber } from 'shared';
 import { Box, Chip, Grid, Typography } from '@mui/material';
 import { useState } from 'react';
@@ -94,6 +94,24 @@ const TaskModal: React.FC<TaskModalProps> = ({ task, modalShow, onHide, onSubmit
               ))}
             </Box>
           </Grid>
+          {(task.blockedBy.length > 0 || task.blockedByWorkPackages.length > 0) && (
+            <Grid item xs={12} md={6}>
+              <Typography fontWeight={'bold'}>Blocked By:</Typography>
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.5 }}>
+                {task.blockedBy.map((blocker) => (
+                  <Chip key={blocker.taskId} label={blocker.title} size="small" />
+                ))}
+                {task.blockedByWorkPackages.map((blockingWp) => (
+                  <Chip
+                    key={wbsPipe(blockingWp.wbsNum)}
+                    label={`${blockingWp.name} (WP)`}
+                    size="small"
+                    variant="outlined"
+                  />
+                ))}
+              </Box>
+            </Grid>
+          )}
           <Grid item xs={12} md={6}>
             <Typography fontWeight={'bold'}>Notes:</Typography>
             <Box sx={{ height: 'auto', overflow: 'auto' }}>

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/TaskModal.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/TaskModal.tsx
@@ -102,12 +102,7 @@ const TaskModal: React.FC<TaskModalProps> = ({ task, modalShow, onHide, onSubmit
                   <Chip key={blocker.taskId} label={blocker.title} size="small" />
                 ))}
                 {task.blockedByWorkPackages.map((blockingWp) => (
-                  <Chip
-                    key={wbsPipe(blockingWp.wbsNum)}
-                    label={`${blockingWp.name} (WP)`}
-                    size="small"
-                    variant="outlined"
-                  />
+                  <Chip key={wbsPipe(blockingWp.wbsNum)} label={`${blockingWp.name} (WP)`} size="small" variant="outlined" />
                 ))}
               </Box>
             </Grid>

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/TaskModal.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/TaskModal.tsx
@@ -4,7 +4,7 @@
  */
 
 import { fullNamePipe, datePipe, wbsPipe } from '../../../../utils/pipes';
-import { Task, WbsNumber } from 'shared';
+import { Task, TaskStatus, WbsNumber } from 'shared';
 import { Box, Chip, Grid, Typography } from '@mui/material';
 import { useState } from 'react';
 import TaskFormModal, { EditTaskFormInput } from './TaskFormModal';
@@ -25,6 +25,7 @@ const TaskModal: React.FC<TaskModalProps> = ({ task, modalShow, onHide, onSubmit
   const priorityColor = task.priority === 'HIGH' ? '#ef4345' : task.priority === 'LOW' ? '#00ab41' : '#FFA500';
   const isWpTask = task.wbsNum.workPackageNumber !== 0;
   const isWpContext = wbsNum.workPackageNumber !== 0;
+  const activeBlockers = task.blockedBy.filter((blocker) => blocker.status !== TaskStatus.DONE);
 
   const ViewModal: React.FC = () => {
     return (
@@ -94,11 +95,11 @@ const TaskModal: React.FC<TaskModalProps> = ({ task, modalShow, onHide, onSubmit
               ))}
             </Box>
           </Grid>
-          {(task.blockedBy.length > 0 || task.blockedByWorkPackages.length > 0) && (
+          {(activeBlockers.length > 0 || task.blockedByWorkPackages.length > 0) && (
             <Grid item xs={12} md={6}>
               <Typography fontWeight={'bold'}>Blocked By:</Typography>
               <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.5 }}>
-                {task.blockedBy.map((blocker) => (
+                {activeBlockers.map((blocker) => (
                   <Chip key={blocker.taskId} label={blocker.title} size="small" />
                 ))}
                 {task.blockedByWorkPackages.map((blockingWp) => (

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskCard.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskCard.tsx
@@ -73,6 +73,7 @@ export const TaskCard = ({
     deadline,
     assignees,
     labels,
+    blockedBy,
     priority,
     startDate,
     wpWbsNum
@@ -88,6 +89,7 @@ export const TaskCard = ({
         startDate,
         priority,
         labelIds: labels.map((l) => l.taskLabelId),
+        blockedByIds: blockedBy.map((b) => b.taskId),
         wbsNum: targetWbsNum
       });
 

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskCard.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskCard.tsx
@@ -2,11 +2,11 @@ import { Draggable } from '@hello-pangea/dnd';
 import { Construction, Folder, Delete, Schedule } from '@mui/icons-material';
 import { Box, Card, CardContent, Chip, Grid, Typography, IconButton } from '@mui/material';
 import { useState } from 'react';
-import { notGuest, Task, WbsNumber } from 'shared';
+import { notGuest, Task, TaskStatus, WbsNumber } from 'shared';
 import { useDeleteTask, useEditTask, useEditTaskAssignees } from '../../../../../hooks/tasks.hooks';
 import { useToast } from '../../../../../hooks/toasts.hooks';
 import { useCurrentUser } from '../../../../../hooks/users.hooks';
-import { datePipe, fullNamePipe } from '../../../../../utils/pipes';
+import { datePipe, fullNamePipe, listPipe } from '../../../../../utils/pipes';
 import { EditTaskFormInput } from '../TaskFormModal';
 import TaskModal from '../TaskModal';
 import NERModal from '../../../../../components/NERModal';
@@ -100,12 +100,12 @@ export const TaskCard = ({
 
       onEditTask(newTask);
       toast.success('Task edited successfully!');
+      setShowModal(false);
     } catch (error: unknown) {
       if (error instanceof Error) {
         toast.error(error.message);
       }
     }
-    setShowModal(false);
   };
 
   const priorityColor = task.priority === 'HIGH' ? '#ef4345' : task.priority === 'LOW' ? '#00ab41' : '#FFA500';
@@ -113,6 +113,7 @@ export const TaskCard = ({
   const isWpTask = task.wbsNum.workPackageNumber !== 0;
   const isProjectContext = wbsNum.workPackageNumber === 0;
   const wpColor = wpColors[(task.wbsNum.workPackageNumber - 1) % wpColors.length];
+  const activeBlockers = task.blockedBy.filter((blocker) => blocker.status !== TaskStatus.DONE);
 
   return (
     <>
@@ -232,14 +233,13 @@ export const TaskCard = ({
                         )}
                       </Box>
                     </Grid>
-                    {(task.blockedBy.length > 0 || task.blockedByWorkPackages.length > 0) && (
+                    {(activeBlockers.length > 0 || task.blockedByWorkPackages.length > 0) && (
                       <Grid item xs={12}>
                         <Typography variant="body2" sx={{ color: '#ef4345', fontWeight: 500, mt: 1 }}>
                           Blocked by:{' '}
-                          {[
-                            ...task.blockedBy.map((b) => b.title),
-                            ...task.blockedByWorkPackages.map((wp) => `${wp.name} (WP)`)
-                          ].join(', ')}
+                          {listPipe([...activeBlockers, ...task.blockedByWorkPackages], (blocker) =>
+                            'wbsNum' in blocker ? `${blocker.name} (WP)` : blocker.title
+                          )}
                         </Typography>
                       </Grid>
                     )}

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskCard.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskCard.tsx
@@ -232,6 +232,17 @@ export const TaskCard = ({
                         )}
                       </Box>
                     </Grid>
+                    {(task.blockedBy.length > 0 || task.blockedByWorkPackages.length > 0) && (
+                      <Grid item xs={12}>
+                        <Typography variant="body2" sx={{ color: '#ef4345', fontWeight: 500, mt: 1 }}>
+                          Blocked by:{' '}
+                          {[
+                            ...task.blockedBy.map((b) => b.title),
+                            ...task.blockedByWorkPackages.map((wp) => `${wp.name} (WP)`)
+                          ].join(', ')}
+                        </Typography>
+                      </Grid>
+                    )}
                   </Grid>
                 </CardContent>
               </Card>

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskColumn.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskColumn.tsx
@@ -72,12 +72,12 @@ export const TaskColumn = ({
       });
       onAddTask(task);
       toast.success('Task Successfully Created!');
+      setShowCreateTaskModal(false);
     } catch (e: unknown) {
       if (e instanceof Error) {
         toast.error(e.message, 6000);
       }
     }
-    setShowCreateTaskModal(false);
   };
 
   return (

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskColumn.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskColumn.tsx
@@ -52,6 +52,7 @@ export const TaskColumn = ({
     deadline,
     assignees,
     labels,
+    blockedBy,
     priority,
     startDate,
     wpWbsNum
@@ -66,7 +67,8 @@ export const TaskColumn = ({
         status: status as TaskStatus,
         assignees,
         notes,
-        labelIds: labels.map((l) => l.taskLabelId)
+        labelIds: labels.map((l) => l.taskLabelId),
+        blockedByIds: blockedBy.map((b) => b.taskId)
       });
       onAddTask(task);
       toast.success('Task Successfully Created!');

--- a/src/frontend/src/tests/test-support/mock-hooks.ts
+++ b/src/frontend/src/tests/test-support/mock-hooks.ts
@@ -69,7 +69,9 @@ export const mockEditProjectReturnValue = mockUseMutationResult<Task>(
     dateCreated: new Date(),
     createdBy: exampleAdminUser,
     assignees: [],
-    labels: []
+    labels: [],
+    blockedBy: [],
+    blockedByWorkPackages: []
   },
   new Error()
 );
@@ -89,7 +91,9 @@ export const mockCreateTaskReturnValue = mockUseMutationResult<Task>(
     dateCreated: new Date(),
     createdBy: exampleAdminUser,
     assignees: [],
-    labels: []
+    labels: [],
+    blockedBy: [],
+    blockedByWorkPackages: []
   },
   new Error()
 ) as UseMutationResult<Task, Error, CreateTaskPayload, unknown>;
@@ -116,7 +120,9 @@ export const mockEditTaskAssigneesReturnValue = mockUseMutationResult<Task>(
     dateCreated: new Date(),
     createdBy: exampleAdminUser,
     assignees: [],
-    labels: []
+    labels: [],
+    blockedBy: [],
+    blockedByWorkPackages: []
   },
   new Error()
 ) as UseMutationResult<Task, Error, { taskId: string; assignees: string[] }, unknown>;

--- a/src/frontend/src/tests/test-support/test-data/tasks.stub.ts
+++ b/src/frontend/src/tests/test-support/test-data/tasks.stub.ts
@@ -17,6 +17,8 @@ export const exampleTask1: Task = {
   createdBy: exampleLeadershipUser,
   assignees: [exampleMemberUser],
   labels: [],
+  blockedBy: [],
+  blockedByWorkPackages: [],
   deadline: new Date('2024-03-01T00:00:00-05:00'),
   priority: TaskPriority.Medium,
   status: TaskStatus.IN_PROGRESS
@@ -32,6 +34,8 @@ export const exampleTask1DueSoon: Task = {
   createdBy: exampleLeadershipUser,
   assignees: [exampleMemberUser],
   labels: [],
+  blockedBy: [],
+  blockedByWorkPackages: [],
   deadline: new Date('2023-11-01T00:00:00-05:00'),
   priority: TaskPriority.Medium,
   status: TaskStatus.IN_PROGRESS

--- a/src/shared/src/types/task-types.ts
+++ b/src/shared/src/types/task-types.ts
@@ -34,7 +34,19 @@ export interface Task {
   deadline?: Date;
   priority: TaskPriority;
   status: TaskStatus;
+  blockedBy: TaskBlockerPreview[];
+  blockedByWorkPackages: BlockingWorkPackagePreview[];
 }
+
+export type TaskBlockerPreview = {
+  taskId: string;
+  title: string;
+};
+
+export type BlockingWorkPackagePreview = {
+  wbsNum: WbsNumber;
+  name: string;
+};
 
 export type TaskCardPreview = Pick<Task, 'taskId' | 'title' | 'deadline' | 'priority' | 'wbsNum'> & {
   assignees: { userId: string; firstName: string; lastName: string }[];

--- a/src/shared/src/types/task-types.ts
+++ b/src/shared/src/types/task-types.ts
@@ -41,6 +41,7 @@ export interface Task {
 export type TaskBlockerPreview = {
   taskId: string;
   title: string;
+  status: TaskStatus;
 };
 
 export type BlockingWorkPackagePreview = {


### PR DESCRIPTION
## Changes

Added blocking/blockedBy field to tasks in schema + updated edit/create task endpoints. Frontend create/edit modals have the option to add blocked by tasks. If a task is on a work package that is blocked by another work package, it will display that on the blocked by with '(WP)' following it.


## Screenshots
<img width="722" height="544" alt="Screenshot 2026-07-20 at 10 12 28 PM" src="https://github.com/user-attachments/assets/5444cc18-9ca6-4b17-9632-b70e7209bbca" />
<img width="741" height="672" alt="Screenshot 2026-07-20 at 10 12 44 PM" src="https://github.com/user-attachments/assets/9ed63394-faf2-4e3b-a74f-8f86b9ecedb9" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #4333
