### PR TITLE
#4347 change request sorting bug

### DIFF
--- a/src/frontend/src/pages/ChangeRequestsPage/ChangeRequestsTable.tsx
+++ b/src/frontend/src/pages/ChangeRequestsPage/ChangeRequestsTable.tsx
@@ -18,7 +18,7 @@ import ErrorPage from '../ErrorPage';
 import TableCustomToolbar from '../../components/TableCustomToolbar';
 
 function isWBSElement(value: any): value is WbsElement {
-  return value && 'wbsNum' in value;
+  return typeof value === 'object' && value !== null && 'wbsNum' in value;
 }
 
 const ChangeRequestsTable: React.FC = () => {
@@ -56,6 +56,22 @@ const ChangeRequestsTable: React.FC = () => {
 
   if (isError) return <ErrorPage message={error?.message} />;
 
+  const rows = data.map((v) => ({
+    ...v,
+    carNumber: v.wbsNum ? v.wbsNum.carNumber : undefined,
+    wbsOrCategoryOrAccountCode: v.wbsNum
+      ? { wbsNum: v.wbsNum, name: v.wbsName }
+      : v.category
+        ? { category: v.category, name: v.category.name }
+        : v.accountCode
+          ? { accountCode: v.accountCode, name: v.accountCode.name }
+          : undefined,
+    submitter: fullNamePipe(v.submitter),
+    reviewer: fullNamePipe(v.reviewer)
+  }));
+
+  const wbsOrCategoryOrAccountCodeById = new Map(rows.map((row) => [row.crId, row.wbsOrCategoryOrAccountCode]));
+
   const idColumn: GridColDef = {
     ...baseColDef,
     field: 'identifier',
@@ -88,8 +104,8 @@ const ChangeRequestsTable: React.FC = () => {
       return `${value?.name ? displayEnum(value?.name) : ''}`;
     },
     sortComparator: (_v1, _v2, param1, param2) => {
-      const val1 = param1.value;
-      const val2 = param2.value;
+      const val1 = wbsOrCategoryOrAccountCodeById.get(param1.id as string);
+      const val2 = wbsOrCategoryOrAccountCodeById.get(param2.id as string);
 
       if (isWBSElement(val1) && isWBSElement(val2)) {
         const wbs1 = val1.wbsNum;
@@ -101,7 +117,7 @@ const ChangeRequestsTable: React.FC = () => {
       }
 
       if (!isWBSElement(val1) && !isWBSElement(val2)) {
-        return val1.budget - val2.budget;
+        return (val1?.name ?? '').localeCompare(val2?.name ?? '');
       }
 
       // Prefer WBS entries first, or reverse depending on your preference
@@ -220,21 +236,7 @@ const ChangeRequestsTable: React.FC = () => {
         }}
         loading={isLoading}
         error={error}
-        rows={
-          data.map((v) => ({
-            ...v,
-            carNumber: v.wbsNum ? v.wbsNum.carNumber : undefined,
-            wbsOrCategoryOrAccountCode: v.wbsNum
-              ? { wbsNum: v.wbsNum, name: v.wbsName }
-              : v.category
-                ? { category: v.category, name: v.category.name }
-                : v.accountCode
-                  ? { accountCode: v.accountCode, name: v.accountCode.name }
-                  : undefined,
-            submitter: fullNamePipe(v.submitter),
-            reviewer: fullNamePipe(v.reviewer)
-          })) || []
-        }
+        rows={rows}
         columns={windowSize < 900 ? smallColumns : columns}
         getRowId={(row) => row.crId}
         sx={{


### PR DESCRIPTION
## Changes

Reproduced the bug by sorting on the WBS / Category / Account Codes column and then tabbing out and then back into the all cr page. Updated the sorting compartor for the WBS / Category / Account Codes to look at the raw object instead of the stringified version, so the in doesn't hit a string and crash. 

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #4347
