### PR TITLE
global task board

### DIFF
--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -30,6 +30,7 @@ import calendarRouter from './src/routes/calendar.routes.js';
 import prospectiveSponsorRouter from './src/routes/prospective-sponsor.routes.js';
 import attendanceRouter from './src/routes/attendance.routes.js';
 import icsRouter from './src/routes/ics.routes.js';
+import dashboardsRouter from './src/routes/dashboards.routes.js';
 
 const app = express();
 
@@ -122,6 +123,7 @@ app.use('/finance', financeRouter);
 app.use('/calendar', calendarRouter);
 app.use('/prospective-sponsors', prospectiveSponsorRouter);
 app.use('/attendance', attendanceRouter);
+app.use('/dashboards', dashboardsRouter);
 app.use('/', (_req, res) => {
   res.status(200).json('Welcome to FinishLine');
 });

--- a/src/backend/src/controllers/cars.controllers.ts
+++ b/src/backend/src/controllers/cars.controllers.ts
@@ -12,6 +12,16 @@ export default class CarsController {
     }
   }
 
+  static async getAllSlimCars(req: Request, res: Response, next: NextFunction) {
+    try {
+      const cars = await CarsService.getAllSlimCars(req.organization);
+
+      res.status(200).json(cars);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
   static async createCar(req: Request, res: Response, next: NextFunction) {
     try {
       const { name } = req.body;

--- a/src/backend/src/controllers/cars.controllers.ts
+++ b/src/backend/src/controllers/cars.controllers.ts
@@ -12,16 +12,6 @@ export default class CarsController {
     }
   }
 
-  static async getAllSlimCars(req: Request, res: Response, next: NextFunction) {
-    try {
-      const cars = await CarsService.getAllSlimCars(req.organization);
-
-      res.status(200).json(cars);
-    } catch (error: unknown) {
-      next(error);
-    }
-  }
-
   static async createCar(req: Request, res: Response, next: NextFunction) {
     try {
       const { name } = req.body;

--- a/src/backend/src/controllers/dashboards.controllers.ts
+++ b/src/backend/src/controllers/dashboards.controllers.ts
@@ -1,0 +1,52 @@
+import { NextFunction, Request, Response } from 'express';
+import DashboardService from '../services/dashboards.services.js';
+
+export default class DashboardsController {
+  static async createDashboard(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { name, link } = req.body;
+      const { currentUser, organization } = req;
+
+      const dashboard = await DashboardService.createDashboard(currentUser, organization, name, link);
+      res.status(200).json(dashboard);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
+  static async getUserDashboards(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { currentUser, organization } = req;
+
+      const dashboards = await DashboardService.getUserDashboards(currentUser, organization);
+      res.status(200).json(dashboards);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
+  static async editDashboard(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { dashboardId } = req.params as Record<string, string>;
+      const { link } = req.body;
+      const { currentUser, organization } = req;
+
+      const dashboard = await DashboardService.editDashboard(currentUser, organization, dashboardId, link);
+      res.status(200).json(dashboard);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
+  static async deleteDashboard(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { dashboardId } = req.params as Record<string, string>;
+      const { currentUser, organization } = req;
+
+      const dashboard = await DashboardService.deleteDashboard(currentUser, organization, dashboardId);
+      res.status(200).json(dashboard);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+}

--- a/src/backend/src/controllers/projects.controllers.ts
+++ b/src/backend/src/controllers/projects.controllers.ts
@@ -32,6 +32,15 @@ export default class ProjectsController {
     }
   }
 
+  static async getAllSlimProjects(req: Request, res: Response, next: NextFunction) {
+    try {
+      const projects = await ProjectsService.getAllSlimProjects(req.organization);
+      res.status(200).json(projects);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
   static async getUsersTeamsProjects(req: Request, res: Response, next: NextFunction) {
     try {
       const projects: ProjectOverview[] = await ProjectsService.getUsersTeamsProjects(

--- a/src/backend/src/controllers/projects.controllers.ts
+++ b/src/backend/src/controllers/projects.controllers.ts
@@ -32,9 +32,9 @@ export default class ProjectsController {
     }
   }
 
-  static async getAllSlimProjects(req: Request, res: Response, next: NextFunction) {
+  static async getAllProjectsDropdown(req: Request, res: Response, next: NextFunction) {
     try {
-      const projects = await ProjectsService.getAllSlimProjects(req.organization);
+      const projects = await ProjectsService.getAllProjectsDropdown(req.organization);
       res.status(200).json(projects);
     } catch (error: unknown) {
       next(error);

--- a/src/backend/src/controllers/tasks.controllers.ts
+++ b/src/backend/src/controllers/tasks.controllers.ts
@@ -99,7 +99,19 @@ export default class TasksController {
 
   static async getFilteredTasks(req: Request, res: Response, next: NextFunction) {
     try {
-      const { memberIds, teamIds, startPeriod, endPeriod, labelIds, wbsNum } = req.body;
+      const {
+        memberIds,
+        teamIds,
+        startPeriod,
+        endPeriod,
+        labelIds,
+        wbsNum,
+        carNumbers,
+        projectWbsNums,
+        workPackageWbsNums,
+        search,
+        andMemberTeam
+      } = req.body;
 
       const tasks = await TasksService.getFilteredTasks(
         {
@@ -108,7 +120,12 @@ export default class TasksController {
           startPeriod: startPeriod ? new Date(startPeriod) : undefined,
           endPeriod: endPeriod ? new Date(endPeriod) : undefined,
           labelIds,
-          wbsNum
+          wbsNum,
+          carNumbers,
+          projectWbsNums,
+          workPackageWbsNums,
+          search,
+          andMemberTeam
         },
         req.organization
       );

--- a/src/backend/src/controllers/teams.controllers.ts
+++ b/src/backend/src/controllers/teams.controllers.ts
@@ -23,6 +23,16 @@ export default class TeamsController {
     }
   }
 
+  static async getAllSlimTeams(req: Request, res: Response, next: NextFunction) {
+    try {
+      const teams = await TeamsService.getAllSlimTeams(req.organization);
+
+      res.status(200).json(teams);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
   static async getAllArchivedTeams(req: Request, res: Response, next: NextFunction) {
     try {
       const teams = await TeamsService.getAllArchivedTeams(req.organization);

--- a/src/backend/src/controllers/teams.controllers.ts
+++ b/src/backend/src/controllers/teams.controllers.ts
@@ -23,9 +23,9 @@ export default class TeamsController {
     }
   }
 
-  static async getAllSlimTeams(req: Request, res: Response, next: NextFunction) {
+  static async getAllTeamsDropdown(req: Request, res: Response, next: NextFunction) {
     try {
-      const teams = await TeamsService.getAllSlimTeams(req.organization);
+      const teams = await TeamsService.getAllTeamsDropdown(req.organization);
 
       res.status(200).json(teams);
     } catch (error: unknown) {

--- a/src/backend/src/controllers/users.controllers.ts
+++ b/src/backend/src/controllers/users.controllers.ts
@@ -30,10 +30,10 @@ export default class UsersController {
     }
   }
 
-  static async getAllSlimUsers(req: Request, res: Response, next: NextFunction) {
+  static async getAllMembersDropdown(req: Request, res: Response, next: NextFunction) {
     try {
-      const users = await UsersService.getAllSlimUsers(req.organization.organizationId);
-      res.status(200).json(users);
+      const members = await UsersService.getAllMembersDropdown(req.organization.organizationId);
+      res.status(200).json(members);
     } catch (error: unknown) {
       next(error);
     }

--- a/src/backend/src/controllers/users.controllers.ts
+++ b/src/backend/src/controllers/users.controllers.ts
@@ -30,6 +30,15 @@ export default class UsersController {
     }
   }
 
+  static async getAllSlimUsers(req: Request, res: Response, next: NextFunction) {
+    try {
+      const users = await UsersService.getAllSlimUsers(req.organization.organizationId);
+      res.status(200).json(users);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
   static async getCurrentUser(req: Request, res: Response, next: NextFunction) {
     try {
       const user = await UsersService.getCurrentUser(req.currentUser);

--- a/src/backend/src/controllers/work-packages.controllers.ts
+++ b/src/backend/src/controllers/work-packages.controllers.ts
@@ -38,6 +38,16 @@ export default class WorkPackagesController {
     }
   }
 
+  // Fetch a minimal list of work packages for dropdowns (id + name + wbsNum + projectName)
+  static async getAllSlimWorkPackages(req: Request, res: Response, next: NextFunction) {
+    try {
+      const workPackages = await WorkPackagesService.getAllSlimWorkPackages(req.organization);
+      res.status(200).json(workPackages);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }
+
   // Fetch the work package for the specified WBS number
   static async getSingleWorkPackage(req: Request, res: Response, next: NextFunction) {
     try {

--- a/src/backend/src/controllers/work-packages.controllers.ts
+++ b/src/backend/src/controllers/work-packages.controllers.ts
@@ -39,9 +39,9 @@ export default class WorkPackagesController {
   }
 
   // Fetch a minimal list of work packages for dropdowns (id + name + wbsNum + projectName)
-  static async getAllSlimWorkPackages(req: Request, res: Response, next: NextFunction) {
+  static async getAllWorkPackagesDropdown(req: Request, res: Response, next: NextFunction) {
     try {
-      const workPackages = await WorkPackagesService.getAllSlimWorkPackages(req.organization);
+      const workPackages = await WorkPackagesService.getAllWorkPackagesDropdown(req.organization);
       res.status(200).json(workPackages);
     } catch (error: unknown) {
       next(error);

--- a/src/backend/src/prisma-query-args/dashboards.query-args.ts
+++ b/src/backend/src/prisma-query-args/dashboards.query-args.ts
@@ -1,0 +1,8 @@
+import { Prisma } from '@prisma/client';
+
+export type DashboardQueryArgs = ReturnType<typeof getDashboardQueryArgs>;
+
+export const getDashboardQueryArgs = (_organizationId: string) =>
+  Prisma.validator<Prisma.DashboardDefaultArgs>()({
+    include: {}
+  });

--- a/src/backend/src/prisma-query-args/dropdown.query-args.ts
+++ b/src/backend/src/prisma-query-args/dropdown.query-args.ts
@@ -1,0 +1,58 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { Prisma } from '@prisma/client';
+
+/**
+ * Minimal query args backing the `/slim` dropdown endpoints. Each selects only the id, display name,
+ * and just enough context to render/disambiguate the item in a dropdown.
+ */
+
+export type SlimCarQueryArgs = ReturnType<typeof getSlimCarQueryArgs>;
+export type SlimProjectQueryArgs = ReturnType<typeof getSlimProjectQueryArgs>;
+export type SlimWorkPackageQueryArgs = ReturnType<typeof getSlimWorkPackageQueryArgs>;
+export type SlimUserQueryArgs = ReturnType<typeof getSlimUserQueryArgs>;
+export type SlimTeamQueryArgs = ReturnType<typeof getSlimTeamQueryArgs>;
+
+export const getSlimCarQueryArgs = () =>
+  Prisma.validator<Prisma.CarDefaultArgs>()({
+    select: {
+      carId: true,
+      wbsElement: {
+        select: { name: true, carNumber: true, projectNumber: true, workPackageNumber: true }
+      }
+    }
+  });
+
+export const getSlimProjectQueryArgs = () =>
+  Prisma.validator<Prisma.ProjectDefaultArgs>()({
+    select: {
+      projectId: true,
+      wbsElement: {
+        select: { name: true, carNumber: true, projectNumber: true, workPackageNumber: true }
+      }
+    }
+  });
+
+export const getSlimWorkPackageQueryArgs = () =>
+  Prisma.validator<Prisma.Work_PackageDefaultArgs>()({
+    select: {
+      workPackageId: true,
+      wbsElement: {
+        select: { name: true, carNumber: true, projectNumber: true, workPackageNumber: true }
+      },
+      project: { select: { wbsElement: { select: { name: true } } } }
+    }
+  });
+
+export const getSlimUserQueryArgs = () =>
+  Prisma.validator<Prisma.UserDefaultArgs>()({
+    select: { userId: true, firstName: true, lastName: true, email: true }
+  });
+
+export const getSlimTeamQueryArgs = () =>
+  Prisma.validator<Prisma.TeamDefaultArgs>()({
+    select: { teamId: true, teamName: true }
+  });

--- a/src/backend/src/prisma-query-args/dropdown.query-args.ts
+++ b/src/backend/src/prisma-query-args/dropdown.query-args.ts
@@ -6,27 +6,16 @@
 import { Prisma } from '@prisma/client';
 
 /**
- * Minimal query args backing the `/slim` dropdown endpoints. Each selects only the id, display name,
- * and just enough context to render/disambiguate the item in a dropdown.
+ * Minimal query args backing the `/dropdown` endpoints. Each selects only the id, display name, and
+ * just enough context to render/disambiguate the item in a dropdown.
  */
 
-export type SlimCarQueryArgs = ReturnType<typeof getSlimCarQueryArgs>;
-export type SlimProjectQueryArgs = ReturnType<typeof getSlimProjectQueryArgs>;
-export type SlimWorkPackageQueryArgs = ReturnType<typeof getSlimWorkPackageQueryArgs>;
-export type SlimUserQueryArgs = ReturnType<typeof getSlimUserQueryArgs>;
-export type SlimTeamQueryArgs = ReturnType<typeof getSlimTeamQueryArgs>;
+export type ProjectDropdownQueryArgs = ReturnType<typeof getProjectDropdownQueryArgs>;
+export type WorkPackageDropdownQueryArgs = ReturnType<typeof getWorkPackageDropdownQueryArgs>;
+export type MemberDropdownQueryArgs = ReturnType<typeof getMemberDropdownQueryArgs>;
+export type TeamDropdownQueryArgs = ReturnType<typeof getTeamDropdownQueryArgs>;
 
-export const getSlimCarQueryArgs = () =>
-  Prisma.validator<Prisma.CarDefaultArgs>()({
-    select: {
-      carId: true,
-      wbsElement: {
-        select: { name: true, carNumber: true, projectNumber: true, workPackageNumber: true }
-      }
-    }
-  });
-
-export const getSlimProjectQueryArgs = () =>
+export const getProjectDropdownQueryArgs = () =>
   Prisma.validator<Prisma.ProjectDefaultArgs>()({
     select: {
       projectId: true,
@@ -36,7 +25,7 @@ export const getSlimProjectQueryArgs = () =>
     }
   });
 
-export const getSlimWorkPackageQueryArgs = () =>
+export const getWorkPackageDropdownQueryArgs = () =>
   Prisma.validator<Prisma.Work_PackageDefaultArgs>()({
     select: {
       workPackageId: true,
@@ -47,12 +36,12 @@ export const getSlimWorkPackageQueryArgs = () =>
     }
   });
 
-export const getSlimUserQueryArgs = () =>
+export const getMemberDropdownQueryArgs = () =>
   Prisma.validator<Prisma.UserDefaultArgs>()({
     select: { userId: true, firstName: true, lastName: true, email: true }
   });
 
-export const getSlimTeamQueryArgs = () =>
+export const getTeamDropdownQueryArgs = () =>
   Prisma.validator<Prisma.TeamDefaultArgs>()({
     select: { teamId: true, teamName: true }
   });

--- a/src/backend/src/prisma-query-args/projects.query-args.ts
+++ b/src/backend/src/prisma-query-args/projects.query-args.ts
@@ -22,7 +22,7 @@ export const getProjectQueryArgs = (organizationId: string) =>
           lead: getUserQueryArgs(organizationId),
           manager: getUserQueryArgs(organizationId),
           descriptionBullets: { where: { dateDeleted: null }, ...getDescriptionBulletQueryArgs(organizationId) },
-          tasks: { where: { dateDeleted: null }, ...getTaskQueryArgs(organizationId) },
+          tasks: { where: { dateDeleted: null }, ...getTaskQueryArgs() },
           links: { where: { dateDeleted: null }, ...getLinkQueryArgs() },
           changes: {
             where: { changeRequest: { dateDeleted: null } },
@@ -55,7 +55,7 @@ export const getProjectGanttQueryArgs = (organizationId: string) =>
             where: {
               dateDeleted: null
             },
-            ...getTaskQueryArgs(organizationId)
+            ...getTaskQueryArgs()
           }
         }
       },

--- a/src/backend/src/prisma-query-args/tasks.query-args.ts
+++ b/src/backend/src/prisma-query-args/tasks.query-args.ts
@@ -1,5 +1,5 @@
 import { Prisma } from '@prisma/client';
-import { getUserQueryArgs } from './user.query-args.js';
+import { getUserPreviewWithEmailQueryArgs, getUserQueryArgs } from './user.query-args.js';
 
 export type TaskQueryArgs = ReturnType<typeof getTaskQueryArgs>;
 export type TaskPreviewQueryArgs = ReturnType<typeof getTaskPreviewQueryArgs>;
@@ -33,7 +33,7 @@ export const getBlockingWorkPackagesArgs = () =>
   Prisma.validator<Prisma.WBS_ElementDefaultArgs>()({
     include: {
       workPackage: {
-        include: {
+        select: {
           blockedBy: {
             select: {
               carNumber: true,
@@ -48,19 +48,19 @@ export const getBlockingWorkPackagesArgs = () =>
     }
   });
 
-export const getTaskQueryArgs = (organizationId: string) =>
+export const getTaskQueryArgs = () =>
   Prisma.validator<Prisma.TaskDefaultArgs>()({
     include: {
       wbsElement: getBlockingWorkPackagesArgs(),
-      createdBy: getUserQueryArgs(organizationId),
-      deletedBy: getUserQueryArgs(organizationId),
-      assignees: getUserQueryArgs(organizationId),
+      createdBy: getUserPreviewWithEmailQueryArgs(),
+      deletedBy: getUserPreviewWithEmailQueryArgs(),
+      assignees: getUserPreviewWithEmailQueryArgs(),
       labels: getTaskLabelQueryArgs(),
       blockedBy: getTaskBlockedByQueryArgs()
     }
   });
 
-export const getCalendarTaskQueryArgs = (organizationId: string) =>
+export const getCalendarTaskQueryArgs = () =>
   Prisma.validator<Prisma.TaskDefaultArgs>()({
     include: {
       wbsElement: {
@@ -77,9 +77,8 @@ export const getCalendarTaskQueryArgs = (organizationId: string) =>
           workPackage: getBlockingWorkPackagesArgs().include.workPackage
         }
       },
-      createdBy: getUserQueryArgs(organizationId),
-      deletedBy: getUserQueryArgs(organizationId),
-      assignees: getUserQueryArgs(organizationId),
+      createdBy: getUserPreviewWithEmailQueryArgs(),
+      assignees: getUserPreviewWithEmailQueryArgs(),
       labels: getTaskLabelQueryArgs(),
       blockedBy: getTaskBlockedByQueryArgs()
     }

--- a/src/backend/src/prisma-query-args/user.query-args.ts
+++ b/src/backend/src/prisma-query-args/user.query-args.ts
@@ -2,6 +2,8 @@ import { Prisma } from '@prisma/client';
 
 export type UserQueryArgs = ReturnType<typeof getUserQueryArgs>;
 
+export type UserPreviewWithEmailQueryArgs = ReturnType<typeof getUserPreviewWithEmailQueryArgs>;
+
 export type UserWithSettingsQueryArgs = ReturnType<typeof getUserWithSettingsQueryArgs>;
 
 export type UserScheduleSettingsQueryArgs = ReturnType<typeof getUserScheduleSettingsQueryArgs>;
@@ -24,6 +26,16 @@ export const getUserPreviewQueryArgs = () =>
       userId: true,
       firstName: true,
       lastName: true
+    }
+  });
+
+export const getUserPreviewWithEmailQueryArgs = () =>
+  Prisma.validator<Prisma.UserDefaultArgs>()({
+    select: {
+      userId: true,
+      firstName: true,
+      lastName: true,
+      email: true
     }
   });
 

--- a/src/backend/src/prisma/migrations/20260723224118_add_dashboard/migration.sql
+++ b/src/backend/src/prisma/migrations/20260723224118_add_dashboard/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable
+CREATE TABLE "Dashboard" (
+    "dashboardId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "link" TEXT NOT NULL,
+    "dateCreated" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "dateDeleted" TIMESTAMP(3),
+    "userId" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+
+    CONSTRAINT "Dashboard_pkey" PRIMARY KEY ("dashboardId")
+);
+
+-- CreateIndex
+CREATE INDEX "Dashboard_organizationId_idx" ON "Dashboard"("organizationId");
+
+-- CreateIndex
+CREATE INDEX "Dashboard_userId_idx" ON "Dashboard"("userId");
+
+-- AddForeignKey
+ALTER TABLE "Dashboard" ADD CONSTRAINT "Dashboard_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("userId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Dashboard" ADD CONSTRAINT "Dashboard_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("organizationId") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/src/backend/src/prisma/schema.prisma
+++ b/src/backend/src/prisma/schema.prisma
@@ -292,6 +292,7 @@ model User {
   attendedMeetingAttendances              Meeting_Attendance[]                 @relation(name: "meetingAttendees")
   createdTaskLabels                       Task_Label[]                         @relation(name: "taskLabelCreator")
   deletedTaskLabels                       Task_Label[]                         @relation(name: "taskLabelDeleter")
+  dashboards                              Dashboard[]                          @relation(name: "userDashboards")
 }
 
 model Role {
@@ -1415,6 +1416,22 @@ model Organization {
   eventTypes               Event_Type[]
   meetingAttendances       Meeting_Attendance[]
   taskLabels               Task_Label[]
+  dashboards               Dashboard[]
+}
+
+model Dashboard {
+  dashboardId    String       @id @default(uuid())
+  name           String
+  link           String
+  dateCreated    DateTime     @default(now())
+  dateDeleted    DateTime?
+  user           User         @relation(fields: [userId], references: [userId], name: "userDashboards")
+  userId         String
+  organization   Organization @relation(fields: [organizationId], references: [organizationId])
+  organizationId String
+
+  @@index([organizationId])
+  @@index([userId])
 }
 
 model FrequentlyAskedQuestion {

--- a/src/backend/src/routes/cars.routes.ts
+++ b/src/backend/src/routes/cars.routes.ts
@@ -6,6 +6,7 @@ import { body } from 'express-validator';
 const carsRouter = express.Router();
 
 carsRouter.get('/', CarsController.getAllCars);
+carsRouter.get('/slim', CarsController.getAllSlimCars);
 
 carsRouter.post('/create', CarsController.createCar);
 carsRouter.post('/:carId/edit', nonEmptyString(body('name')), validateInputs, CarsController.editCar);

--- a/src/backend/src/routes/cars.routes.ts
+++ b/src/backend/src/routes/cars.routes.ts
@@ -6,7 +6,6 @@ import { body } from 'express-validator';
 const carsRouter = express.Router();
 
 carsRouter.get('/', CarsController.getAllCars);
-carsRouter.get('/slim', CarsController.getAllSlimCars);
 
 carsRouter.post('/create', CarsController.createCar);
 carsRouter.post('/:carId/edit', nonEmptyString(body('name')), validateInputs, CarsController.editCar);

--- a/src/backend/src/routes/dashboards.routes.ts
+++ b/src/backend/src/routes/dashboards.routes.ts
@@ -1,0 +1,31 @@
+import express from 'express';
+import { body } from 'express-validator';
+import { nonEmptyString, validateInputs } from '../utils/validation.utils.js';
+import DashboardsController from '../controllers/dashboards.controllers.js';
+
+const dashboardsRouter = express.Router();
+
+// Create dashboard
+dashboardsRouter.post(
+  '/create',
+  nonEmptyString(body('name')),
+  nonEmptyString(body('link')),
+  validateInputs,
+  DashboardsController.createDashboard
+);
+
+// Get the current user's dashboards
+dashboardsRouter.get('/', DashboardsController.getUserDashboards);
+
+// Edit dashboard (save current filters into it)
+dashboardsRouter.post(
+  '/:dashboardId/edit',
+  nonEmptyString(body('link')),
+  validateInputs,
+  DashboardsController.editDashboard
+);
+
+// Delete dashboard
+dashboardsRouter.post('/:dashboardId/delete', DashboardsController.deleteDashboard);
+
+export default dashboardsRouter;

--- a/src/backend/src/routes/projects.routes.ts
+++ b/src/backend/src/routes/projects.routes.ts
@@ -14,7 +14,7 @@ const projectRouter = express.Router();
 
 projectRouter.get('/all-gantt', ProjectsController.getAllProjectsGantt);
 projectRouter.get('/all-previews', ProjectsController.getAllProjects);
-projectRouter.get('/slim', ProjectsController.getAllSlimProjects);
+projectRouter.get('/dropdown', ProjectsController.getAllProjectsDropdown);
 projectRouter.get('/users-teams', ProjectsController.getUsersTeamsProjects);
 projectRouter.get('/leading', ProjectsController.getUsersLeadingProjects);
 projectRouter.get('/teams-projects/:teamId', ProjectsController.getTeamsProjects);

--- a/src/backend/src/routes/projects.routes.ts
+++ b/src/backend/src/routes/projects.routes.ts
@@ -14,6 +14,7 @@ const projectRouter = express.Router();
 
 projectRouter.get('/all-gantt', ProjectsController.getAllProjectsGantt);
 projectRouter.get('/all-previews', ProjectsController.getAllProjects);
+projectRouter.get('/slim', ProjectsController.getAllSlimProjects);
 projectRouter.get('/users-teams', ProjectsController.getUsersTeamsProjects);
 projectRouter.get('/leading', ProjectsController.getUsersLeadingProjects);
 projectRouter.get('/teams-projects/:teamId', ProjectsController.getTeamsProjects);

--- a/src/backend/src/routes/tasks.routes.ts
+++ b/src/backend/src/routes/tasks.routes.ts
@@ -26,6 +26,18 @@ tasksRouter.post(
   intMinZero(body('wbsNum.carNumber').optional()),
   intMinZero(body('wbsNum.projectNumber').optional()),
   intMinZero(body('wbsNum.workPackageNumber').optional()),
+  body('carNumbers').optional().isArray(),
+  intMinZero(body('carNumbers.*').optional()),
+  body('projectWbsNums').optional().isArray(),
+  intMinZero(body('projectWbsNums.*.carNumber').optional()),
+  intMinZero(body('projectWbsNums.*.projectNumber').optional()),
+  intMinZero(body('projectWbsNums.*.workPackageNumber').optional()),
+  body('workPackageWbsNums').optional().isArray(),
+  intMinZero(body('workPackageWbsNums.*.carNumber').optional()),
+  intMinZero(body('workPackageWbsNums.*.projectNumber').optional()),
+  intMinZero(body('workPackageWbsNums.*.workPackageNumber').optional()),
+  body('search').optional().isString(),
+  body('andMemberTeam').optional().isBoolean(),
   validateInputs,
   TasksController.getFilteredTasks
 );

--- a/src/backend/src/routes/teams.routes.ts
+++ b/src/backend/src/routes/teams.routes.ts
@@ -10,6 +10,7 @@ const upload = multer({ limits: { fileSize: MAX_FILE_SIZE }, storage: memoryStor
 
 teamsRouter.get('/', TeamsController.getAllTeams);
 teamsRouter.get('/previews/', TeamsController.getAllTeamPreviews);
+teamsRouter.get('/slim', TeamsController.getAllSlimTeams);
 teamsRouter.get('/archive', TeamsController.getAllArchivedTeams);
 teamsRouter.get('/users-teams', TeamsController.getUsersTeams);
 teamsRouter.get('/my-team-as-head', TeamsController.getMyTeamAsHead);

--- a/src/backend/src/routes/teams.routes.ts
+++ b/src/backend/src/routes/teams.routes.ts
@@ -10,7 +10,7 @@ const upload = multer({ limits: { fileSize: MAX_FILE_SIZE }, storage: memoryStor
 
 teamsRouter.get('/', TeamsController.getAllTeams);
 teamsRouter.get('/previews/', TeamsController.getAllTeamPreviews);
-teamsRouter.get('/slim', TeamsController.getAllSlimTeams);
+teamsRouter.get('/dropdown', TeamsController.getAllTeamsDropdown);
 teamsRouter.get('/archive', TeamsController.getAllArchivedTeams);
 teamsRouter.get('/users-teams', TeamsController.getUsersTeams);
 teamsRouter.get('/my-team-as-head', TeamsController.getMyTeamAsHead);

--- a/src/backend/src/routes/users.routes.ts
+++ b/src/backend/src/routes/users.routes.ts
@@ -9,7 +9,7 @@ const userRouter = express.Router();
 userRouter.get('/', UsersController.getAllUsers);
 userRouter.get('/organization', UsersController.getAllOrgUsers);
 userRouter.get('/members', UsersController.getAllMembers);
-userRouter.get('/slim', UsersController.getAllSlimUsers);
+userRouter.get('/members/dropdown', UsersController.getAllMembersDropdown);
 userRouter.post(
   '/scheduleSettings',
   body('userIds').isArray(),

--- a/src/backend/src/routes/users.routes.ts
+++ b/src/backend/src/routes/users.routes.ts
@@ -9,6 +9,7 @@ const userRouter = express.Router();
 userRouter.get('/', UsersController.getAllUsers);
 userRouter.get('/organization', UsersController.getAllOrgUsers);
 userRouter.get('/members', UsersController.getAllMembers);
+userRouter.get('/slim', UsersController.getAllSlimUsers);
 userRouter.post(
   '/scheduleSettings',
   body('userIds').isArray(),

--- a/src/backend/src/routes/work-packages.routes.ts
+++ b/src/backend/src/routes/work-packages.routes.ts
@@ -14,7 +14,7 @@ import { WorkPackageSelection, WbsElementStatus } from 'shared';
 const workPackagesRouter = express.Router();
 
 workPackagesRouter.get('/', WorkPackagesController.getAllWorkPackages);
-workPackagesRouter.get('/slim', WorkPackagesController.getAllSlimWorkPackages);
+workPackagesRouter.get('/dropdown', WorkPackagesController.getAllWorkPackagesDropdown);
 workPackagesRouter.get(
   '/all-preview',
   query('status').optional().isIn(Object.values(WbsElementStatus)),

--- a/src/backend/src/routes/work-packages.routes.ts
+++ b/src/backend/src/routes/work-packages.routes.ts
@@ -14,6 +14,7 @@ import { WorkPackageSelection, WbsElementStatus } from 'shared';
 const workPackagesRouter = express.Router();
 
 workPackagesRouter.get('/', WorkPackagesController.getAllWorkPackages);
+workPackagesRouter.get('/slim', WorkPackagesController.getAllSlimWorkPackages);
 workPackagesRouter.get(
   '/all-preview',
   query('status').optional().isIn(Object.values(WbsElementStatus)),

--- a/src/backend/src/services/car.services.ts
+++ b/src/backend/src/services/car.services.ts
@@ -1,8 +1,10 @@
 import { Organization } from '@prisma/client';
-import { isAdmin, User } from 'shared';
+import { isAdmin, SlimCar, User } from 'shared';
 import { getCarQueryArgs } from '../prisma-query-args/cars.query-args.js';
+import { getSlimCarQueryArgs } from '../prisma-query-args/dropdown.query-args.js';
 import prisma from '../prisma/prisma.js';
 import { carTransformer } from '../transformers/cars.transformer.js';
+import { slimCarTransformer } from '../transformers/dropdown.transformer.js';
 import { AccessDeniedAdminOnlyException, NotFoundException } from '../utils/errors.utils.js';
 import { userHasPermission } from '../utils/users.utils.js';
 
@@ -18,6 +20,20 @@ export default class CarsService {
     });
 
     return cars.map(carTransformer);
+  }
+
+  /**
+   * Gets a minimal list of cars for use in dropdowns (id + name + wbsNum only).
+   * @param organization the organization the user is in
+   * @returns the slim cars
+   */
+  static async getAllSlimCars(organization: Organization): Promise<SlimCar[]> {
+    const cars = await prisma.car.findMany({
+      where: { wbsElement: { organizationId: organization.organizationId, dateDeleted: null } },
+      ...getSlimCarQueryArgs()
+    });
+
+    return cars.map(slimCarTransformer);
   }
 
   static async createCar(organization: Organization, user: User, name: string) {

--- a/src/backend/src/services/car.services.ts
+++ b/src/backend/src/services/car.services.ts
@@ -1,10 +1,8 @@
 import { Organization } from '@prisma/client';
-import { isAdmin, SlimCar, User } from 'shared';
+import { isAdmin, User } from 'shared';
 import { getCarQueryArgs } from '../prisma-query-args/cars.query-args.js';
-import { getSlimCarQueryArgs } from '../prisma-query-args/dropdown.query-args.js';
 import prisma from '../prisma/prisma.js';
 import { carTransformer } from '../transformers/cars.transformer.js';
-import { slimCarTransformer } from '../transformers/dropdown.transformer.js';
 import { AccessDeniedAdminOnlyException, NotFoundException } from '../utils/errors.utils.js';
 import { userHasPermission } from '../utils/users.utils.js';
 
@@ -20,20 +18,6 @@ export default class CarsService {
     });
 
     return cars.map(carTransformer);
-  }
-
-  /**
-   * Gets a minimal list of cars for use in dropdowns (id + name + wbsNum only).
-   * @param organization the organization the user is in
-   * @returns the slim cars
-   */
-  static async getAllSlimCars(organization: Organization): Promise<SlimCar[]> {
-    const cars = await prisma.car.findMany({
-      where: { wbsElement: { organizationId: organization.organizationId, dateDeleted: null } },
-      ...getSlimCarQueryArgs()
-    });
-
-    return cars.map(slimCarTransformer);
   }
 
   static async createCar(organization: Organization, user: User, name: string) {

--- a/src/backend/src/services/dashboards.services.ts
+++ b/src/backend/src/services/dashboards.services.ts
@@ -1,0 +1,112 @@
+import { Dashboard, User } from 'shared';
+import { Organization } from '@prisma/client';
+import { getDashboardQueryArgs } from '../prisma-query-args/dashboards.query-args.js';
+import {
+  AccessDeniedException,
+  DeletedException,
+  InvalidOrganizationException,
+  NotFoundException
+} from '../utils/errors.utils.js';
+import prisma from '../prisma/prisma.js';
+import dashboardTransformer from '../transformers/dashboards.transformer.js';
+
+export default class DashboardService {
+  /**
+   * Creates a new dashboard (saved filter configuration) for the current user.
+   * @param submitter the user creating the dashboard
+   * @param organization the organization the dashboard belongs to
+   * @param name the display name of the dashboard
+   * @param link the relative path (pathname + query string) the dashboard restores
+   * @returns the created dashboard
+   */
+  static async createDashboard(submitter: User, organization: Organization, name: string, link: string): Promise<Dashboard> {
+    const dashboard = await prisma.dashboard.create({
+      data: {
+        name,
+        link,
+        userId: submitter.userId,
+        organizationId: organization.organizationId
+      },
+      ...getDashboardQueryArgs(organization.organizationId)
+    });
+
+    return dashboardTransformer(dashboard);
+  }
+
+  /**
+   * Returns all of the current user's non-deleted dashboards for the organization.
+   * @param submitter the user whose dashboards to fetch
+   * @param organization the organization to scope to
+   * @returns the user's dashboards
+   */
+  static async getUserDashboards(submitter: User, organization: Organization): Promise<Dashboard[]> {
+    const dashboards = await prisma.dashboard.findMany({
+      where: {
+        organizationId: organization.organizationId,
+        userId: submitter.userId,
+        dateDeleted: null
+      },
+      ...getDashboardQueryArgs(organization.organizationId)
+    });
+
+    return dashboards.map(dashboardTransformer);
+  }
+
+  /**
+   * Overwrites the saved link (filters) of an existing dashboard the current user owns.
+   * @param submitter the user editing the dashboard
+   * @param organization the organization the dashboard belongs to
+   * @param dashboardId the id of the dashboard to edit
+   * @param link the new relative path to save
+   * @returns the updated dashboard
+   */
+  static async editDashboard(
+    submitter: User,
+    organization: Organization,
+    dashboardId: string,
+    link: string
+  ): Promise<Dashboard> {
+    const dashboard = await prisma.dashboard.findUnique({ where: { dashboardId } });
+
+    if (!dashboard) throw new NotFoundException('Dashboard', dashboardId);
+    if (dashboard.organizationId !== organization.organizationId) throw new InvalidOrganizationException('Dashboard');
+    if (dashboard.dateDeleted) throw new DeletedException('Dashboard', dashboardId);
+    if (dashboard.userId !== submitter.userId) {
+      throw new AccessDeniedException('Only the owner can edit this dashboard');
+    }
+
+    const updatedDashboard = await prisma.dashboard.update({
+      where: { dashboardId },
+      data: { link },
+      ...getDashboardQueryArgs(organization.organizationId)
+    });
+
+    return dashboardTransformer(updatedDashboard);
+  }
+
+  /**
+   * Soft-deletes a dashboard the current user owns.
+   * @param deleter the user deleting the dashboard
+   * @param organization the organization the dashboard belongs to
+   * @param dashboardId the id of the dashboard to delete
+   * @returns the deleted dashboard
+   */
+  static async deleteDashboard(deleter: User, organization: Organization, dashboardId: string): Promise<Dashboard> {
+    const dashboard = await prisma.dashboard.findUnique({ where: { dashboardId } });
+
+    if (!dashboard) throw new NotFoundException('Dashboard', dashboardId);
+    if (dashboard.organizationId !== organization.organizationId) throw new InvalidOrganizationException('Dashboard');
+    if (dashboard.dateDeleted) throw new DeletedException('Dashboard', dashboardId);
+    if (dashboard.userId !== deleter.userId) {
+      throw new AccessDeniedException('Only the owner can delete this dashboard');
+    }
+
+    const deletedDashboard = await prisma.dashboard.update({
+      where: { dashboardId },
+      data: { dateDeleted: new Date() },
+      ...getDashboardQueryArgs(organization.organizationId)
+    });
+
+    return dashboardTransformer(deletedDashboard);
+  }
+}

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -10,11 +10,14 @@ import {
   ProjectOverview,
   ProjectGantt,
   ProjectPreview,
+  SlimProject,
   WbsNumber,
   wbsPipe,
   User
 } from 'shared';
 import prisma from '../prisma/prisma.js';
+import { getSlimProjectQueryArgs } from '../prisma-query-args/dropdown.query-args.js';
+import { slimProjectTransformer } from '../transformers/dropdown.transformer.js';
 import projectTransformer, {
   projectOverviewTransformer,
   projectGanttTransformer,
@@ -73,6 +76,21 @@ export default class ProjectsService {
     });
 
     return projects.map(projectPreviewTransformer);
+  }
+
+  /**
+   * Gets a minimal list of projects for use in dropdowns (id + name + wbsNum + carNumber only).
+   * @param organization the organization the user is in
+   * @returns the slim projects
+   */
+  static async getAllSlimProjects(organization: Organization): Promise<SlimProject[]> {
+    const projects = await prisma.project.findMany({
+      where: { wbsElement: { dateDeleted: null, organizationId: organization.organizationId } },
+      orderBy: { wbsElement: { carNumber: 'desc' } },
+      ...getSlimProjectQueryArgs()
+    });
+
+    return projects.map(slimProjectTransformer);
   }
 
   /**

--- a/src/backend/src/services/projects.services.ts
+++ b/src/backend/src/services/projects.services.ts
@@ -10,14 +10,14 @@ import {
   ProjectOverview,
   ProjectGantt,
   ProjectPreview,
-  SlimProject,
+  ProjectDropdownItem,
   WbsNumber,
   wbsPipe,
   User
 } from 'shared';
 import prisma from '../prisma/prisma.js';
-import { getSlimProjectQueryArgs } from '../prisma-query-args/dropdown.query-args.js';
-import { slimProjectTransformer } from '../transformers/dropdown.transformer.js';
+import { getProjectDropdownQueryArgs } from '../prisma-query-args/dropdown.query-args.js';
+import { projectDropdownTransformer } from '../transformers/dropdown.transformer.js';
 import projectTransformer, {
   projectOverviewTransformer,
   projectGanttTransformer,
@@ -81,16 +81,16 @@ export default class ProjectsService {
   /**
    * Gets a minimal list of projects for use in dropdowns (id + name + wbsNum + carNumber only).
    * @param organization the organization the user is in
-   * @returns the slim projects
+   * @returns the projects for a dropdown
    */
-  static async getAllSlimProjects(organization: Organization): Promise<SlimProject[]> {
+  static async getAllProjectsDropdown(organization: Organization): Promise<ProjectDropdownItem[]> {
     const projects = await prisma.project.findMany({
       where: { wbsElement: { dateDeleted: null, organizationId: organization.organizationId } },
       orderBy: { wbsElement: { carNumber: 'desc' } },
-      ...getSlimProjectQueryArgs()
+      ...getProjectDropdownQueryArgs()
     });
 
-    return projects.map(slimProjectTransformer);
+    return projects.map(projectDropdownTransformer);
   }
 
   /**

--- a/src/backend/src/services/tasks.services.ts
+++ b/src/backend/src/services/tasks.services.ts
@@ -38,7 +38,6 @@ import { getTeamQueryArgs } from '../prisma-query-args/teams.query-args.js';
 import {
   getBlockingWorkPackagesArgs,
   getCalendarTaskQueryArgs,
-  getTaskBlockedByQueryArgs,
   getTaskLabelQueryArgs,
   getTaskPreviewQueryArgs,
   getTaskQueryArgs
@@ -127,7 +126,7 @@ export default class TasksService {
     }
 
     if (status === 'IN_PROGRESS' && (!deadline || assignees.length === 0)) {
-      throw new HttpException(400, 'Tasks in progress must have a dealine and assignees');
+      throw new HttpException(400, 'A task in progress must have a deadline and assignees!');
     }
 
     await validateTaskLabels(labelIds, organization.organizationId);
@@ -166,7 +165,7 @@ export default class TasksService {
         labels: { connect: labelIds.map((id) => ({ taskLabelId: id })) },
         blockedBy: { connect: blockedByTasks.map((task) => ({ taskId: task.taskId })) }
       },
-      ...getTaskQueryArgs(organization.organizationId)
+      ...getTaskQueryArgs()
     });
 
     const newTask = taskTransformer(createdTask);
@@ -264,7 +263,7 @@ export default class TasksService {
         labels: { set: labelIds.map((id) => ({ taskLabelId: id })) },
         blockedBy: { set: blockedByTasks.map((task) => ({ taskId: task.taskId })) }
       },
-      ...getTaskQueryArgs(originalTask.wbsElement.organizationId)
+      ...getTaskQueryArgs()
     });
     return taskTransformer(updatedTask);
   }
@@ -292,28 +291,14 @@ export default class TasksService {
       throw new HttpException(400, 'A task in progress must have a deadline and assignees!');
     }
 
-    // only worth the extra nested fetch when actually attempting to complete the task
-    if (status === 'DONE') {
-      const taskForBlockCheck = await prisma.task.findUniqueOrThrow({
-        where: { taskId },
-        select: {
-          blockedBy: getTaskBlockedByQueryArgs(),
-          wbsElement: getBlockingWorkPackagesArgs()
-        }
-      });
-      const blockerNames = getActiveTaskBlockerNames(
-        taskForBlockCheck.blockedBy.map(taskBlockedByTransformer),
-        taskForBlockCheck.wbsElement
-      );
-      if (blockerNames.length > 0) {
-        throw new HttpException(400, `Cannot mark task as done: blocked by ${blockerNames.join(', ')}`);
-      }
-    }
+    // Blocked-by is advisory when completing a task: the frontend warns the user about any incomplete
+    // blockers (using the blockedBy data already on the task) and only calls this once they confirm, so
+    // we intentionally don't reject a blocked task here.
 
     const updatedTask = await prisma.task.update({
       where: { taskId },
       data: { status },
-      ...getTaskQueryArgs(originalTask.wbsElement.organizationId)
+      ...getTaskQueryArgs()
     });
     return taskTransformer(updatedTask);
   }
@@ -368,7 +353,7 @@ export default class TasksService {
             set: transformedAssigneeUsers
           }
         },
-        ...getTaskQueryArgs(organization.organizationId)
+        ...getTaskQueryArgs()
       })
     );
 
@@ -387,7 +372,7 @@ export default class TasksService {
    * @throws if the user does not have permission
    */
   static async deleteTask(currentUser: User, taskId: string, organization: Organization): Promise<string> {
-    const task = await prisma.task.findUnique({ where: { taskId }, ...getTaskQueryArgs(organization.organizationId) });
+    const task = await prisma.task.findUnique({ where: { taskId }, ...getTaskQueryArgs() });
     if (!task) throw new NotFoundException('Task', taskId);
     if (task.dateDeleted) throw new DeletedException('Task', taskId);
 
@@ -416,7 +401,19 @@ export default class TasksService {
   }
 
   static async getFilteredTasks(filters: FilterTaskArgs, organization: Organization): Promise<CalendarTask[]> {
-    const { memberIds, teamIds, startPeriod, endPeriod, labelIds, wbsNum } = filters;
+    const {
+      memberIds,
+      teamIds,
+      startPeriod,
+      endPeriod,
+      labelIds,
+      wbsNum,
+      carNumbers,
+      projectWbsNums,
+      workPackageWbsNums,
+      search,
+      andMemberTeam
+    } = filters;
 
     // Validate memberIds if provided
     if (memberIds && memberIds.length > 0) {
@@ -445,18 +442,66 @@ export default class TasksService {
       await validateTaskLabels(labelIds, organization.organizationId);
     }
 
+    // Legacy calendar semantics: member and team OR together (and member also matches the task creator).
     const orFilters: any[] = [];
-    if (memberIds && memberIds.length > 0) {
-      orFilters.push({ assignees: { some: { userId: { in: memberIds } } } });
-      orFilters.push({ createdByUserId: { in: memberIds } });
-    }
-    if (teamIds && teamIds.length > 0) {
-      orFilters.push({
-        wbsElement: {
-          project: {
-            teams: { some: { teamId: { in: teamIds } } }
+    // Global-page semantics: each filter is its own AND condition, OR-ing only within its own selections.
+    const andConditions: any[] = [];
+
+    if (andMemberTeam) {
+      if (memberIds && memberIds.length > 0) {
+        andConditions.push({ assignees: { some: { userId: { in: memberIds } } } });
+      }
+      if (teamIds && teamIds.length > 0) {
+        // match tasks whose project OR whose work package's project belongs to a selected team
+        andConditions.push({
+          wbsElement: {
+            OR: [
+              { project: { teams: { some: { teamId: { in: teamIds } } } } },
+              { workPackage: { wbsElement: { project: { teams: { some: { teamId: { in: teamIds } } } } } } }
+            ]
           }
+        });
+      }
+    } else {
+      if (memberIds && memberIds.length > 0) {
+        orFilters.push({ assignees: { some: { userId: { in: memberIds } } } });
+        orFilters.push({ createdByUserId: { in: memberIds } });
+      }
+      if (teamIds && teamIds.length > 0) {
+        orFilters.push({
+          wbsElement: {
+            project: {
+              teams: { some: { teamId: { in: teamIds } } }
+            }
+          }
+        });
+      }
+    }
+
+    if (carNumbers && carNumbers.length > 0) {
+      andConditions.push({ wbsElement: { carNumber: { in: carNumbers } } });
+    }
+    if (projectWbsNums && projectWbsNums.length > 0) {
+      andConditions.push({
+        wbsElement: {
+          OR: projectWbsNums.map((wbs) => ({ carNumber: wbs.carNumber, projectNumber: wbs.projectNumber }))
         }
+      });
+    }
+    if (workPackageWbsNums && workPackageWbsNums.length > 0) {
+      andConditions.push({
+        wbsElement: {
+          OR: workPackageWbsNums.map((wbs) => ({
+            carNumber: wbs.carNumber,
+            projectNumber: wbs.projectNumber,
+            workPackageNumber: wbs.workPackageNumber
+          }))
+        }
+      });
+    }
+    if (search && search.trim().length > 0) {
+      andConditions.push({
+        OR: [{ title: { contains: search, mode: 'insensitive' } }, { notes: { contains: search, mode: 'insensitive' } }]
       });
     }
 
@@ -490,9 +535,10 @@ export default class TasksService {
           organizationId: organization.organizationId,
           dateDeleted: null
         },
-        ...(orFilters.length > 0 ? { OR: orFilters } : {})
+        ...(orFilters.length > 0 ? { OR: orFilters } : {}),
+        ...(andConditions.length > 0 ? { AND: andConditions } : {})
       },
-      ...getCalendarTaskQueryArgs(organization.organizationId)
+      ...getCalendarTaskQueryArgs()
     });
 
     return tasks.map(calendarTaskTransformer);

--- a/src/backend/src/services/tasks.services.ts
+++ b/src/backend/src/services/tasks.services.ts
@@ -457,7 +457,7 @@ export default class TasksService {
           wbsElement: {
             OR: [
               { project: { teams: { some: { teamId: { in: teamIds } } } } },
-              { workPackage: { wbsElement: { project: { teams: { some: { teamId: { in: teamIds } } } } } } }
+              { workPackage: { project: { teams: { some: { teamId: { in: teamIds } } } } } }
             ]
           }
         });

--- a/src/backend/src/services/teams.services.ts
+++ b/src/backend/src/services/teams.services.ts
@@ -1,6 +1,8 @@
-import { isAdmin, isHead, Team, TeamPreview, TeamType, User, WbsElementStatus } from 'shared';
+import { isAdmin, isHead, SlimTeam, Team, TeamPreview, TeamType, User, WbsElementStatus } from 'shared';
 import { Organization } from '@prisma/client';
 import prisma from '../prisma/prisma.js';
+import { getSlimTeamQueryArgs } from '../prisma-query-args/dropdown.query-args.js';
+import { slimTeamTransformer } from '../transformers/dropdown.transformer.js';
 import { calculateProjectStatus } from '../utils/projects.utils.js';
 import teamTransformer, { teamBaseTransformer, teamPreviewTransformer } from '../transformers/teams.transformer.js';
 import {
@@ -26,6 +28,20 @@ export default class TeamsService {
       ...getTeamBaseQueryArgs()
     });
     return teams.map(teamBaseTransformer);
+  }
+
+  /**
+   * Gets a minimal list of teams for use in dropdowns (id + name only).
+   * @param organization the organization the user is in
+   * @returns the slim teams
+   */
+  static async getAllSlimTeams(organization: Organization): Promise<SlimTeam[]> {
+    const teams = await prisma.team.findMany({
+      where: { dateArchived: null, organizationId: organization.organizationId },
+      orderBy: { teamName: 'asc' },
+      ...getSlimTeamQueryArgs()
+    });
+    return teams.map(slimTeamTransformer);
   }
 
   /**

--- a/src/backend/src/services/teams.services.ts
+++ b/src/backend/src/services/teams.services.ts
@@ -1,8 +1,8 @@
-import { isAdmin, isHead, SlimTeam, Team, TeamPreview, TeamType, User, WbsElementStatus } from 'shared';
+import { isAdmin, isHead, TeamDropdownItem, Team, TeamPreview, TeamType, User, WbsElementStatus } from 'shared';
 import { Organization } from '@prisma/client';
 import prisma from '../prisma/prisma.js';
-import { getSlimTeamQueryArgs } from '../prisma-query-args/dropdown.query-args.js';
-import { slimTeamTransformer } from '../transformers/dropdown.transformer.js';
+import { getTeamDropdownQueryArgs } from '../prisma-query-args/dropdown.query-args.js';
+import { teamDropdownTransformer } from '../transformers/dropdown.transformer.js';
 import { calculateProjectStatus } from '../utils/projects.utils.js';
 import teamTransformer, { teamBaseTransformer, teamPreviewTransformer } from '../transformers/teams.transformer.js';
 import {
@@ -33,15 +33,15 @@ export default class TeamsService {
   /**
    * Gets a minimal list of teams for use in dropdowns (id + name only).
    * @param organization the organization the user is in
-   * @returns the slim teams
+   * @returns the teams for a dropdown
    */
-  static async getAllSlimTeams(organization: Organization): Promise<SlimTeam[]> {
+  static async getAllTeamsDropdown(organization: Organization): Promise<TeamDropdownItem[]> {
     const teams = await prisma.team.findMany({
       where: { dateArchived: null, organizationId: organization.organizationId },
       orderBy: { teamName: 'asc' },
-      ...getSlimTeamQueryArgs()
+      ...getTeamDropdownQueryArgs()
     });
-    return teams.map(slimTeamTransformer);
+    return teams.map(teamDropdownTransformer);
   }
 
   /**

--- a/src/backend/src/services/users.services.ts
+++ b/src/backend/src/services/users.services.ts
@@ -15,11 +15,11 @@ import {
   isAtLeastRank,
   BusySlots,
   IcsBusyInterval,
-  SlimUser
+  MemberDropdownItem
 } from 'shared';
 import prisma from '../prisma/prisma.js';
-import { getSlimUserQueryArgs } from '../prisma-query-args/dropdown.query-args.js';
-import { slimUserTransformer } from '../transformers/dropdown.transformer.js';
+import { getMemberDropdownQueryArgs } from '../prisma-query-args/dropdown.query-args.js';
+import { memberDropdownTransformer } from '../transformers/dropdown.transformer.js';
 import { AccessDeniedException, HttpException, NotFoundException } from '../utils/errors.utils.js';
 import { busyIntervalsToSlots, fetchIcsBusyTimes, validateIcsUrl } from '../utils/ics.utils.js';
 import CalendarService from './calendar.services.js';
@@ -56,16 +56,16 @@ export default class UsersService {
    * Gets a minimal list of the current organization's members for use in dropdowns (id + name + email).
    * Only users with a non-guest role in the organization are returned, so guests are excluded.
    * @param organizationId the organization to get the members from
-   * @returns the slim users
+   * @returns the members for a dropdown
    */
-  static async getAllSlimUsers(organizationId: string): Promise<SlimUser[]> {
+  static async getAllMembersDropdown(organizationId: string): Promise<MemberDropdownItem[]> {
     const users = await prisma.user.findMany({
       where: { roles: { some: { organizationId, roleType: { not: Role_Type.GUEST } } } },
       orderBy: { firstName: 'asc' },
-      ...getSlimUserQueryArgs()
+      ...getMemberDropdownQueryArgs()
     });
 
-    return users.map(slimUserTransformer);
+    return users.map(memberDropdownTransformer);
   }
 
   /**

--- a/src/backend/src/services/users.services.ts
+++ b/src/backend/src/services/users.services.ts
@@ -53,13 +53,14 @@ export default class UsersService {
   }
 
   /**
-   * Gets a minimal list of the current organization's users for use in dropdowns (id + name + email).
-   * @param organizationId the organization to get the users from
+   * Gets a minimal list of the current organization's members for use in dropdowns (id + name + email).
+   * Only users with a non-guest role in the organization are returned, so guests are excluded.
+   * @param organizationId the organization to get the members from
    * @returns the slim users
    */
   static async getAllSlimUsers(organizationId: string): Promise<SlimUser[]> {
     const users = await prisma.user.findMany({
-      where: { organizations: { some: { organizationId } } },
+      where: { roles: { some: { organizationId, roleType: { not: Role_Type.GUEST } } } },
       orderBy: { firstName: 'asc' },
       ...getSlimUserQueryArgs()
     });

--- a/src/backend/src/services/users.services.ts
+++ b/src/backend/src/services/users.services.ts
@@ -14,9 +14,12 @@ import {
   ProjectOverview,
   isAtLeastRank,
   BusySlots,
-  IcsBusyInterval
+  IcsBusyInterval,
+  SlimUser
 } from 'shared';
 import prisma from '../prisma/prisma.js';
+import { getSlimUserQueryArgs } from '../prisma-query-args/dropdown.query-args.js';
+import { slimUserTransformer } from '../transformers/dropdown.transformer.js';
 import { AccessDeniedException, HttpException, NotFoundException } from '../utils/errors.utils.js';
 import { busyIntervalsToSlots, fetchIcsBusyTimes, validateIcsUrl } from '../utils/ics.utils.js';
 import CalendarService from './calendar.services.js';
@@ -47,6 +50,21 @@ export default class UsersService {
     });
 
     return users.map(userTransformer);
+  }
+
+  /**
+   * Gets a minimal list of the current organization's users for use in dropdowns (id + name + email).
+   * @param organizationId the organization to get the users from
+   * @returns the slim users
+   */
+  static async getAllSlimUsers(organizationId: string): Promise<SlimUser[]> {
+    const users = await prisma.user.findMany({
+      where: { organizations: { some: { organizationId } } },
+      orderBy: { firstName: 'asc' },
+      ...getSlimUserQueryArgs()
+    });
+
+    return users.map(slimUserTransformer);
   }
 
   /**
@@ -580,7 +598,7 @@ export default class UsersService {
     const requestedUser = await prisma.user.findUnique({
       where: { userId },
       include: {
-        assignedTasks: { where: { dateDeleted: null }, ...getTaskQueryArgs(organization.organizationId) },
+        assignedTasks: { where: { dateDeleted: null }, ...getTaskQueryArgs() },
         organizations: true
       }
     });

--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -14,7 +14,7 @@ import {
   WorkPackageStage,
   User,
   WorkPackageSelection,
-  SlimWorkPackage
+  WorkPackageDropdownItem
 } from 'shared';
 import prisma from '../prisma/prisma.js';
 import {
@@ -26,9 +26,9 @@ import {
   InvalidOrganizationException
 } from '../utils/errors.utils.js';
 import { getWorkPackageQueryArgs, getWorkPackagePreviewQueryArgs } from '../prisma-query-args/work-packages.query-args.js';
-import { getSlimWorkPackageQueryArgs } from '../prisma-query-args/dropdown.query-args.js';
+import { getWorkPackageDropdownQueryArgs } from '../prisma-query-args/dropdown.query-args.js';
 import workPackageTransformer, { workPackagePreviewTransformer } from '../transformers/work-packages.transformer.js';
-import { slimWorkPackageTransformer } from '../transformers/dropdown.transformer.js';
+import { workPackageDropdownTransformer } from '../transformers/dropdown.transformer.js';
 import { validateChangeRequestAccepted } from '../utils/change-requests.utils.js';
 import { sendSlackUpcomingDeadlineNotification } from '../utils/slack.utils.js';
 import { getWorkPackageChanges } from '../utils/changes.utils.js';
@@ -114,15 +114,15 @@ export default class WorkPackagesService {
   /**
    * Gets a minimal list of work packages for use in dropdowns (id + name + wbsNum + projectName only).
    * @param organization the organization the user is in
-   * @returns the slim work packages
+   * @returns the work packages for a dropdown
    */
-  static async getAllSlimWorkPackages(organization: Organization): Promise<SlimWorkPackage[]> {
+  static async getAllWorkPackagesDropdown(organization: Organization): Promise<WorkPackageDropdownItem[]> {
     const workPackages = await prisma.work_Package.findMany({
       where: { wbsElement: { dateDeleted: null, organizationId: organization.organizationId } },
-      ...getSlimWorkPackageQueryArgs()
+      ...getWorkPackageDropdownQueryArgs()
     });
 
-    return workPackages.map(slimWorkPackageTransformer);
+    return workPackages.map(workPackageDropdownTransformer);
   }
 
   /**

--- a/src/backend/src/services/work-packages.services.ts
+++ b/src/backend/src/services/work-packages.services.ts
@@ -13,7 +13,8 @@ import {
   WorkPackagePreview,
   WorkPackageStage,
   User,
-  WorkPackageSelection
+  WorkPackageSelection,
+  SlimWorkPackage
 } from 'shared';
 import prisma from '../prisma/prisma.js';
 import {
@@ -25,7 +26,9 @@ import {
   InvalidOrganizationException
 } from '../utils/errors.utils.js';
 import { getWorkPackageQueryArgs, getWorkPackagePreviewQueryArgs } from '../prisma-query-args/work-packages.query-args.js';
+import { getSlimWorkPackageQueryArgs } from '../prisma-query-args/dropdown.query-args.js';
 import workPackageTransformer, { workPackagePreviewTransformer } from '../transformers/work-packages.transformer.js';
+import { slimWorkPackageTransformer } from '../transformers/dropdown.transformer.js';
 import { validateChangeRequestAccepted } from '../utils/change-requests.utils.js';
 import { sendSlackUpcomingDeadlineNotification } from '../utils/slack.utils.js';
 import { getWorkPackageChanges } from '../utils/changes.utils.js';
@@ -106,6 +109,20 @@ export default class WorkPackagesService {
     });
 
     return workPackages.map(workPackagePreviewTransformer);
+  }
+
+  /**
+   * Gets a minimal list of work packages for use in dropdowns (id + name + wbsNum + projectName only).
+   * @param organization the organization the user is in
+   * @returns the slim work packages
+   */
+  static async getAllSlimWorkPackages(organization: Organization): Promise<SlimWorkPackage[]> {
+    const workPackages = await prisma.work_Package.findMany({
+      where: { wbsElement: { dateDeleted: null, organizationId: organization.organizationId } },
+      ...getSlimWorkPackageQueryArgs()
+    });
+
+    return workPackages.map(slimWorkPackageTransformer);
   }
 
   /**

--- a/src/backend/src/transformers/dashboards.transformer.ts
+++ b/src/backend/src/transformers/dashboards.transformer.ts
@@ -1,0 +1,14 @@
+import { Prisma } from '@prisma/client';
+import { DashboardQueryArgs } from '../prisma-query-args/dashboards.query-args.js';
+import { Dashboard } from 'shared';
+
+const dashboardTransformer = (dashboard: Prisma.DashboardGetPayload<DashboardQueryArgs>): Dashboard => {
+  return {
+    dashboardId: dashboard.dashboardId,
+    name: dashboard.name,
+    link: dashboard.link,
+    dateCreated: dashboard.dateCreated
+  };
+};
+
+export default dashboardTransformer;

--- a/src/backend/src/transformers/dropdown.transformer.ts
+++ b/src/backend/src/transformers/dropdown.transformer.ts
@@ -4,46 +4,41 @@
  */
 
 import { Prisma } from '@prisma/client';
-import { SlimCar, SlimProject, SlimTeam, SlimUser, SlimWorkPackage } from 'shared';
+import { MemberDropdownItem, ProjectDropdownItem, TeamDropdownItem, WorkPackageDropdownItem } from 'shared';
 import {
-  SlimCarQueryArgs,
-  SlimProjectQueryArgs,
-  SlimTeamQueryArgs,
-  SlimUserQueryArgs,
-  SlimWorkPackageQueryArgs
+  MemberDropdownQueryArgs,
+  ProjectDropdownQueryArgs,
+  TeamDropdownQueryArgs,
+  WorkPackageDropdownQueryArgs
 } from '../prisma-query-args/dropdown.query-args.js';
 import { wbsNumOf } from '../utils/utils.js';
 
-export const slimCarTransformer = (car: Prisma.CarGetPayload<SlimCarQueryArgs>): SlimCar => ({
-  id: car.carId,
-  name: car.wbsElement.name,
-  wbsNum: wbsNumOf(car.wbsElement)
-});
-
-export const slimProjectTransformer = (project: Prisma.ProjectGetPayload<SlimProjectQueryArgs>): SlimProject => ({
+export const projectDropdownTransformer = (
+  project: Prisma.ProjectGetPayload<ProjectDropdownQueryArgs>
+): ProjectDropdownItem => ({
   id: project.projectId,
   name: project.wbsElement.name,
   wbsNum: wbsNumOf(project.wbsElement),
   carNumber: project.wbsElement.carNumber
 });
 
-export const slimWorkPackageTransformer = (
-  workPackage: Prisma.Work_PackageGetPayload<SlimWorkPackageQueryArgs>
-): SlimWorkPackage => ({
+export const workPackageDropdownTransformer = (
+  workPackage: Prisma.Work_PackageGetPayload<WorkPackageDropdownQueryArgs>
+): WorkPackageDropdownItem => ({
   id: workPackage.workPackageId,
   name: workPackage.wbsElement.name,
   wbsNum: wbsNumOf(workPackage.wbsElement),
   projectName: workPackage.project.wbsElement.name
 });
 
-export const slimUserTransformer = (user: Prisma.UserGetPayload<SlimUserQueryArgs>): SlimUser => ({
+export const memberDropdownTransformer = (user: Prisma.UserGetPayload<MemberDropdownQueryArgs>): MemberDropdownItem => ({
   userId: user.userId,
   firstName: user.firstName,
   lastName: user.lastName,
   email: user.email
 });
 
-export const slimTeamTransformer = (team: Prisma.TeamGetPayload<SlimTeamQueryArgs>): SlimTeam => ({
+export const teamDropdownTransformer = (team: Prisma.TeamGetPayload<TeamDropdownQueryArgs>): TeamDropdownItem => ({
   teamId: team.teamId,
   name: team.teamName
 });

--- a/src/backend/src/transformers/dropdown.transformer.ts
+++ b/src/backend/src/transformers/dropdown.transformer.ts
@@ -1,0 +1,49 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { Prisma } from '@prisma/client';
+import { SlimCar, SlimProject, SlimTeam, SlimUser, SlimWorkPackage } from 'shared';
+import {
+  SlimCarQueryArgs,
+  SlimProjectQueryArgs,
+  SlimTeamQueryArgs,
+  SlimUserQueryArgs,
+  SlimWorkPackageQueryArgs
+} from '../prisma-query-args/dropdown.query-args.js';
+import { wbsNumOf } from '../utils/utils.js';
+
+export const slimCarTransformer = (car: Prisma.CarGetPayload<SlimCarQueryArgs>): SlimCar => ({
+  id: car.carId,
+  name: car.wbsElement.name,
+  wbsNum: wbsNumOf(car.wbsElement)
+});
+
+export const slimProjectTransformer = (project: Prisma.ProjectGetPayload<SlimProjectQueryArgs>): SlimProject => ({
+  id: project.projectId,
+  name: project.wbsElement.name,
+  wbsNum: wbsNumOf(project.wbsElement),
+  carNumber: project.wbsElement.carNumber
+});
+
+export const slimWorkPackageTransformer = (
+  workPackage: Prisma.Work_PackageGetPayload<SlimWorkPackageQueryArgs>
+): SlimWorkPackage => ({
+  id: workPackage.workPackageId,
+  name: workPackage.wbsElement.name,
+  wbsNum: wbsNumOf(workPackage.wbsElement),
+  projectName: workPackage.project.wbsElement.name
+});
+
+export const slimUserTransformer = (user: Prisma.UserGetPayload<SlimUserQueryArgs>): SlimUser => ({
+  userId: user.userId,
+  firstName: user.firstName,
+  lastName: user.lastName,
+  email: user.email
+});
+
+export const slimTeamTransformer = (team: Prisma.TeamGetPayload<SlimTeamQueryArgs>): SlimTeam => ({
+  teamId: team.teamId,
+  name: team.teamName
+});

--- a/src/backend/src/transformers/tasks.transformer.ts
+++ b/src/backend/src/transformers/tasks.transformer.ts
@@ -2,7 +2,7 @@ import { Prisma } from '@prisma/client';
 import { BlockingWorkPackagePreview, CalendarTask, Task, TaskBlockerPreview, TaskCardPreview, TaskLabel } from 'shared';
 import { wbsNumOf } from '../utils/utils.js';
 import { convertTaskPriority, convertTaskStatus } from '../utils/tasks.utils.js';
-import { userTransformer } from './user.transformer.js';
+import { userPreviewWithEmailTransformer } from './user.transformer.js';
 import {
   CalendarTaskQueryArgs,
   TaskLabelQueryArgs,
@@ -54,14 +54,14 @@ export const taskTransformer = (task: Prisma.TaskGetPayload<TaskQueryArgs>): Tas
     startDate: task.startDate ?? undefined,
     priority: convertTaskPriority(task.priority),
     status: convertTaskStatus(task.status),
-    createdBy: userTransformer(task.createdBy),
-    assignees: task.assignees.map(userTransformer),
+    createdBy: userPreviewWithEmailTransformer(task.createdBy),
+    assignees: task.assignees.map(userPreviewWithEmailTransformer),
     labels: task.labels.map(taskLabelTransformer),
     blockedBy: task.blockedBy.map(taskBlockedByTransformer),
     blockedByWorkPackages: getBlockingWorkPackagePreviews(task.wbsElement),
     dateDeleted: task.dateDeleted ?? undefined,
     dateCreated: task.dateCreated,
-    deletedBy: task.deletedBy ? userTransformer(task.deletedBy) : undefined
+    deletedBy: task.deletedBy ? userPreviewWithEmailTransformer(task.deletedBy) : undefined
   };
 };
 
@@ -93,14 +93,13 @@ export const calendarTaskTransformer = (task: Prisma.TaskGetPayload<CalendarTask
     startDate: task.startDate ?? undefined,
     priority: convertTaskPriority(task.priority),
     status: convertTaskStatus(task.status),
-    createdBy: userTransformer(task.createdBy),
-    assignees: task.assignees.map(userTransformer),
+    createdBy: userPreviewWithEmailTransformer(task.createdBy),
+    assignees: task.assignees.map(userPreviewWithEmailTransformer),
     labels: task.labels.map(taskLabelTransformer),
     blockedBy: task.blockedBy.map(taskBlockedByTransformer),
     blockedByWorkPackages: getBlockingWorkPackagePreviews(task.wbsElement),
     dateDeleted: task.dateDeleted ?? undefined,
     dateCreated: task.dateCreated,
-    deletedBy: task.deletedBy ? userTransformer(task.deletedBy) : undefined,
     projectLeadId: task.wbsElement.leadId ?? undefined,
     projectManagerId: task.wbsElement.managerId ?? undefined
   };

--- a/src/backend/src/transformers/user.transformer.ts
+++ b/src/backend/src/transformers/user.transformer.ts
@@ -1,12 +1,27 @@
 import { Prisma } from '@prisma/client';
-import { RoleEnum, User, UserWithScheduleSettings } from 'shared';
+import { RoleEnum, User, UserPreviewWithEmail, UserWithScheduleSettings } from 'shared';
 import userScheduleSettingsTransformer from './user-schedule-settings.transformer.js';
-import { UserQueryArgs, UserWithSettingsQueryArgs } from '../prisma-query-args/user.query-args.js';
+import {
+  UserPreviewWithEmailQueryArgs,
+  UserQueryArgs,
+  UserWithSettingsQueryArgs
+} from '../prisma-query-args/user.query-args.js';
 
 export const userTransformer = (user: Prisma.UserGetPayload<UserQueryArgs>): User => {
   return {
     ...user,
     role: user.roles.length > 0 ? user.roles[0].roleType : RoleEnum.GUEST
+  };
+};
+
+export const userPreviewWithEmailTransformer = (
+  user: Prisma.UserGetPayload<UserPreviewWithEmailQueryArgs>
+): UserPreviewWithEmail => {
+  return {
+    userId: user.userId,
+    firstName: user.firstName,
+    lastName: user.lastName,
+    email: user.email
   };
 };
 

--- a/src/backend/src/utils/errors.utils.ts
+++ b/src/backend/src/utils/errors.utils.ts
@@ -217,4 +217,5 @@ export type ExceptionObjectNames =
   | 'Guest Definition'
   | 'Meeting Attendance'
   | 'Task Label'
-  | 'Notification Channel';
+  | 'Notification Channel'
+  | 'Dashboard';

--- a/src/backend/tests/test-utils.ts
+++ b/src/backend/tests/test-utils.ts
@@ -181,6 +181,7 @@ export const resetUsers = async () => {
   await prisma.description_Bullet.deleteMany();
   await prisma.description_Bullet_Type.deleteMany();
   await prisma.unit.deleteMany();
+  await prisma.dashboard.deleteMany();
   await prisma.organization.deleteMany();
   await prisma.user.deleteMany();
 };

--- a/src/backend/tests/unmocked/dashboard.test.ts
+++ b/src/backend/tests/unmocked/dashboard.test.ts
@@ -1,0 +1,108 @@
+import { flashAdmin, supermanAdmin } from '../test-data/users.test-data.js';
+import { AccessDeniedException, DeletedException, NotFoundException } from '../../src/utils/errors.utils.js';
+import { createTestOrganization, createTestUser, resetUsers } from '../test-utils.js';
+import prisma from '../../src/prisma/prisma.js';
+import DashboardService from '../../src/services/dashboards.services.js';
+import { Organization } from '@prisma/client';
+
+describe('Dashboard Tests', () => {
+  let organization: Organization;
+  let organizationId: string;
+
+  beforeEach(async () => {
+    organization = await createTestOrganization();
+    ({ organizationId } = organization);
+  });
+
+  afterEach(async () => {
+    await resetUsers();
+  });
+
+  it('creates a dashboard that shows up in the user’s dashboards', async () => {
+    const user = await createTestUser(supermanAdmin, organizationId);
+
+    const created = await DashboardService.createDashboard(user, organization, 'My View', '/tasks?cars=1');
+
+    expect(created.name).toBe('My View');
+    expect(created.link).toBe('/tasks?cars=1');
+
+    const dashboards = await DashboardService.getUserDashboards(user, organization);
+    expect(dashboards).toHaveLength(1);
+    expect(dashboards[0].dashboardId).toBe(created.dashboardId);
+  });
+
+  it('does not return another user’s dashboards', async () => {
+    const owner = await createTestUser(supermanAdmin, organizationId);
+    const other = await createTestUser(flashAdmin, organizationId);
+
+    await DashboardService.createDashboard(owner, organization, 'Owner View', '/tasks?teams=abc');
+
+    const ownerDashboards = await DashboardService.getUserDashboards(owner, organization);
+    const otherDashboards = await DashboardService.getUserDashboards(other, organization);
+
+    expect(ownerDashboards).toHaveLength(1);
+    expect(otherDashboards).toHaveLength(0);
+  });
+
+  it('edits the link (saved filters) of a dashboard', async () => {
+    const user = await createTestUser(supermanAdmin, organizationId);
+    const created = await DashboardService.createDashboard(user, organization, 'My View', '/tasks?cars=1');
+
+    const edited = await DashboardService.editDashboard(user, organization, created.dashboardId, '/tasks?cars=2&labels=x');
+
+    expect(edited.link).toBe('/tasks?cars=2&labels=x');
+    expect(edited.name).toBe('My View');
+  });
+
+  it('soft-deletes a dashboard so it is hidden but still in the database', async () => {
+    const user = await createTestUser(supermanAdmin, organizationId);
+    const created = await DashboardService.createDashboard(user, organization, 'My View', '/tasks?cars=1');
+
+    await DashboardService.deleteDashboard(user, organization, created.dashboardId);
+
+    const dashboards = await DashboardService.getUserDashboards(user, organization);
+    expect(dashboards).toHaveLength(0);
+
+    const row = await prisma.dashboard.findUnique({ where: { dashboardId: created.dashboardId } });
+    expect(row).not.toBeNull();
+    expect(row?.dateDeleted).not.toBeNull();
+  });
+
+  it('throws when editing a dashboard the user does not own', async () => {
+    const owner = await createTestUser(supermanAdmin, organizationId);
+    const other = await createTestUser(flashAdmin, organizationId);
+    const created = await DashboardService.createDashboard(owner, organization, 'Owner View', '/tasks?cars=1');
+
+    await expect(DashboardService.editDashboard(other, organization, created.dashboardId, '/tasks?cars=2')).rejects.toThrow(
+      AccessDeniedException
+    );
+  });
+
+  it('throws when deleting a dashboard the user does not own', async () => {
+    const owner = await createTestUser(supermanAdmin, organizationId);
+    const other = await createTestUser(flashAdmin, organizationId);
+    const created = await DashboardService.createDashboard(owner, organization, 'Owner View', '/tasks?cars=1');
+
+    await expect(DashboardService.deleteDashboard(other, organization, created.dashboardId)).rejects.toThrow(
+      AccessDeniedException
+    );
+  });
+
+  it('throws NotFoundException when editing a nonexistent dashboard', async () => {
+    const user = await createTestUser(supermanAdmin, organizationId);
+
+    await expect(DashboardService.editDashboard(user, organization, 'does-not-exist', '/tasks')).rejects.toThrow(
+      NotFoundException
+    );
+  });
+
+  it('throws DeletedException when deleting an already-deleted dashboard', async () => {
+    const user = await createTestUser(supermanAdmin, organizationId);
+    const created = await DashboardService.createDashboard(user, organization, 'My View', '/tasks?cars=1');
+    await DashboardService.deleteDashboard(user, organization, created.dashboardId);
+
+    await expect(DashboardService.deleteDashboard(user, organization, created.dashboardId)).rejects.toThrow(
+      DeletedException
+    );
+  });
+});

--- a/src/backend/tests/unmocked/members-dropdown.test.ts
+++ b/src/backend/tests/unmocked/members-dropdown.test.ts
@@ -4,7 +4,7 @@ import UsersService from '../../src/services/users.services.js';
 import prisma from '../../src/prisma/prisma.js';
 import { Organization } from '@prisma/client';
 
-describe('Slim Users Tests', () => {
+describe('Members Dropdown Tests', () => {
   let organization: Organization;
   let organizationId: string;
 
@@ -22,8 +22,8 @@ describe('Slim Users Tests', () => {
     const member = await createTestUser(financeMember, organizationId);
     const guest = await createTestUser(theVisitorGuest, organizationId);
 
-    const slimUsers = await UsersService.getAllSlimUsers(organizationId);
-    const returnedIds = slimUsers.map((user) => user.userId);
+    const members = await UsersService.getAllMembersDropdown(organizationId);
+    const returnedIds = members.map((user) => user.userId);
 
     expect(returnedIds).toEqual(expect.arrayContaining([admin.userId, member.userId]));
     expect(returnedIds).not.toContain(guest.userId);
@@ -44,8 +44,8 @@ describe('Slim Users Tests', () => {
     });
     await createTestUser(financeMember, otherOrganization.organizationId);
 
-    const slimUsers = await UsersService.getAllSlimUsers(organizationId);
+    const members = await UsersService.getAllMembersDropdown(organizationId);
 
-    expect(slimUsers).toHaveLength(0);
+    expect(members).toHaveLength(0);
   });
 });

--- a/src/backend/tests/unmocked/slim-users.test.ts
+++ b/src/backend/tests/unmocked/slim-users.test.ts
@@ -1,0 +1,51 @@
+import { financeMember, supermanAdmin, theVisitorGuest } from '../test-data/users.test-data.js';
+import { createTestOrganization, createTestUser, resetUsers } from '../test-utils.js';
+import UsersService from '../../src/services/users.services.js';
+import prisma from '../../src/prisma/prisma.js';
+import { Organization } from '@prisma/client';
+
+describe('Slim Users Tests', () => {
+  let organization: Organization;
+  let organizationId: string;
+
+  beforeEach(async () => {
+    organization = await createTestOrganization();
+    ({ organizationId } = organization);
+  });
+
+  afterEach(async () => {
+    await resetUsers();
+  });
+
+  it('returns members and above but excludes guests', async () => {
+    const admin = await createTestUser(supermanAdmin, organizationId);
+    const member = await createTestUser(financeMember, organizationId);
+    const guest = await createTestUser(theVisitorGuest, organizationId);
+
+    const slimUsers = await UsersService.getAllSlimUsers(organizationId);
+    const returnedIds = slimUsers.map((user) => user.userId);
+
+    expect(returnedIds).toEqual(expect.arrayContaining([admin.userId, member.userId]));
+    expect(returnedIds).not.toContain(guest.userId);
+  });
+
+  it('does not return members of a different organization', async () => {
+    // build a second org inline (createTestOrganization reuses a fixed googleAuthId, so it can't run twice)
+    const otherCreator = await prisma.user.create({
+      data: { firstName: 'Other', lastName: 'Creator', email: 'other-org-creator@test.com', googleAuthId: 'otherOrgCreator' }
+    });
+    const otherOrganization = await prisma.organization.create({
+      data: {
+        name: 'Other Org',
+        description: '',
+        applicationLink: '',
+        userCreated: { connect: { userId: otherCreator.userId } }
+      }
+    });
+    await createTestUser(financeMember, otherOrganization.organizationId);
+
+    const slimUsers = await UsersService.getAllSlimUsers(organizationId);
+
+    expect(slimUsers).toHaveLength(0);
+  });
+});

--- a/src/backend/tests/unmocked/task.test.ts
+++ b/src/backend/tests/unmocked/task.test.ts
@@ -324,7 +324,7 @@ describe('Task Tests', () => {
       ).rejects.toThrow(new HttpException(400, 'A task in progress must have a deadline and assignees!'));
     });
 
-    it('fails to set status to done when blocked by an incomplete task', async () => {
+    it('sets status to done even when blocked by an incomplete task (block is advisory, frontend confirms)', async () => {
       const user = await createTestUser(supermanAdmin, organizationId);
       const blockerTask = await createTestTask(user, 'Blocker', '', [], 'HIGH', 'IN_PROGRESS', organizationId);
       const blockedTask = await prisma.task.create({
@@ -340,9 +340,9 @@ describe('Task Tests', () => {
         }
       });
 
-      await expect(async () =>
-        TasksService.editTaskStatus(user, organizationId, blockedTask.taskId, 'DONE')
-      ).rejects.toThrow(new HttpException(400, `Cannot mark task as done: blocked by ${blockerTask.title}`));
+      await TasksService.editTaskStatus(user, organizationId, blockedTask.taskId, 'DONE');
+      const updatedTask = await prisma.task.findUnique({ where: { taskId: blockedTask.taskId } });
+      expect(updatedTask?.status).toBe('DONE');
     });
 
     it('successfully sets status to done when all blocking tasks are already done', async () => {
@@ -366,7 +366,7 @@ describe('Task Tests', () => {
       expect(updatedTask?.status).toBe('DONE');
     });
 
-    it('fails to set status to done when the work package is blocked by a work package with incomplete tasks', async () => {
+    it('sets status to done even when the work package is blocked by a work package with incomplete tasks', async () => {
       const user = await createTestUser(supermanAdmin, organizationId);
       const car = await createTestCar(organizationId, user.userId);
       const project = await createTestProject(user, organizationId, undefined, car.carId);
@@ -403,9 +403,9 @@ describe('Task Tests', () => {
         }
       });
 
-      await expect(async () => TasksService.editTaskStatus(user, organizationId, taskInWpB.taskId, 'DONE')).rejects.toThrow(
-        new HttpException(400, 'Cannot mark task as done: blocked by WP 0.1.1')
-      );
+      await TasksService.editTaskStatus(user, organizationId, taskInWpB.taskId, 'DONE');
+      const updatedTask = await prisma.task.findUnique({ where: { taskId: taskInWpB.taskId } });
+      expect(updatedTask?.status).toBe('DONE');
     });
 
     it('successfully sets status to done when the only blocking task has been deleted', async () => {
@@ -647,6 +647,172 @@ describe('Task Tests', () => {
       expect(tasks.length).toBe(2);
       expect(tasks.map((t) => t.title)).toContain('Task 1');
       expect(tasks.map((t) => t.title)).toContain('Task 2');
+    });
+
+    it('filters tasks by carNumbers, OR-ing within the filter', async () => {
+      const user = await createTestUser(supermanAdmin, organizationId);
+      const car1 = await createTestCar(organizationId, user.userId, 1);
+      const car2 = await createTestCar(organizationId, user.userId, 2);
+      const projectA = await createTestProject(user, organizationId, undefined, car1.carId, 1, 1);
+      const projectB = await createTestProject(user, organizationId, undefined, car2.carId, 2, 1);
+
+      await prisma.task.create({
+        data: {
+          title: 'Car1 Task',
+          notes: '',
+          priority: 'HIGH',
+          status: 'IN_BACKLOG',
+          dateCreated: new Date(),
+          createdBy: { connect: { userId: user.userId } },
+          wbsElement: { connect: { wbsElementId: projectA.wbsElementId } }
+        }
+      });
+      await prisma.task.create({
+        data: {
+          title: 'Car2 Task',
+          notes: '',
+          priority: 'HIGH',
+          status: 'IN_BACKLOG',
+          dateCreated: new Date(),
+          createdBy: { connect: { userId: user.userId } },
+          wbsElement: { connect: { wbsElementId: projectB.wbsElementId } }
+        }
+      });
+
+      const both = await TasksService.getFilteredTasks({ carNumbers: [1, 2] }, organization);
+      expect(both.map((t) => t.title).sort()).toEqual(['Car1 Task', 'Car2 Task']);
+
+      const onlyCar1 = await TasksService.getFilteredTasks({ carNumbers: [1] }, organization);
+      expect(onlyCar1.map((t) => t.title)).toEqual(['Car1 Task']);
+    });
+
+    it('filters tasks by projectWbsNums, OR-ing within the filter', async () => {
+      const user = await createTestUser(supermanAdmin, organizationId);
+      const car = await createTestCar(organizationId, user.userId, 1);
+      const projectA = await createTestProject(user, organizationId, undefined, car.carId, 1, 1);
+      const projectB = await createTestProject(user, organizationId, undefined, car.carId, 1, 2);
+
+      await prisma.task.create({
+        data: {
+          title: 'Project A Task',
+          notes: '',
+          priority: 'HIGH',
+          status: 'IN_BACKLOG',
+          dateCreated: new Date(),
+          createdBy: { connect: { userId: user.userId } },
+          wbsElement: { connect: { wbsElementId: projectA.wbsElementId } }
+        }
+      });
+      await prisma.task.create({
+        data: {
+          title: 'Project B Task',
+          notes: '',
+          priority: 'HIGH',
+          status: 'IN_BACKLOG',
+          dateCreated: new Date(),
+          createdBy: { connect: { userId: user.userId } },
+          wbsElement: { connect: { wbsElementId: projectB.wbsElementId } }
+        }
+      });
+
+      const both = await TasksService.getFilteredTasks(
+        {
+          projectWbsNums: [
+            { carNumber: 1, projectNumber: 1, workPackageNumber: 0 },
+            { carNumber: 1, projectNumber: 2, workPackageNumber: 0 }
+          ]
+        },
+        organization
+      );
+      expect(both.map((t) => t.title).sort()).toEqual(['Project A Task', 'Project B Task']);
+
+      const onlyA = await TasksService.getFilteredTasks(
+        { projectWbsNums: [{ carNumber: 1, projectNumber: 1, workPackageNumber: 0 }] },
+        organization
+      );
+      expect(onlyA.map((t) => t.title)).toEqual(['Project A Task']);
+    });
+
+    it('AND-s the project and team filters when andMemberTeam is set', async () => {
+      const user = await createTestUser(supermanAdmin, organizationId);
+      const car = await createTestCar(organizationId, user.userId, 1);
+      const team = await prisma.team.create({
+        data: { teamName: 'Team X', slackId: 'slack-x', description: '', headId: user.userId, organizationId }
+      });
+      const projectA = await createTestProject(user, organizationId, team.teamId, car.carId, 1, 1);
+      const projectB = await createTestProject(user, organizationId, undefined, car.carId, 1, 2);
+
+      await prisma.task.create({
+        data: {
+          title: 'Team Project Task',
+          notes: '',
+          priority: 'HIGH',
+          status: 'IN_BACKLOG',
+          dateCreated: new Date(),
+          createdBy: { connect: { userId: user.userId } },
+          wbsElement: { connect: { wbsElementId: projectA.wbsElementId } }
+        }
+      });
+      await prisma.task.create({
+        data: {
+          title: 'Other Project Task',
+          notes: '',
+          priority: 'HIGH',
+          status: 'IN_BACKLOG',
+          dateCreated: new Date(),
+          createdBy: { connect: { userId: user.userId } },
+          wbsElement: { connect: { wbsElementId: projectB.wbsElementId } }
+        }
+      });
+
+      const tasks = await TasksService.getFilteredTasks(
+        {
+          projectWbsNums: [
+            { carNumber: 1, projectNumber: 1, workPackageNumber: 0 },
+            { carNumber: 1, projectNumber: 2, workPackageNumber: 0 }
+          ],
+          teamIds: [team.teamId],
+          andMemberTeam: true
+        },
+        organization
+      );
+
+      expect(tasks.map((t) => t.title)).toEqual(['Team Project Task']);
+    });
+
+    it('filters tasks by a fuzzy search over title and notes', async () => {
+      const user = await createTestUser(supermanAdmin, organizationId);
+      const car = await createTestCar(organizationId, user.userId, 1);
+      const project = await createTestProject(user, organizationId, undefined, car.carId, 1, 1);
+
+      await prisma.task.create({
+        data: {
+          title: 'Fix Brakes',
+          notes: '',
+          priority: 'HIGH',
+          status: 'IN_BACKLOG',
+          dateCreated: new Date(),
+          createdBy: { connect: { userId: user.userId } },
+          wbsElement: { connect: { wbsElementId: project.wbsElementId } }
+        }
+      });
+      await prisma.task.create({
+        data: {
+          title: 'Other Work',
+          notes: 'needs suspension tuning',
+          priority: 'HIGH',
+          status: 'IN_BACKLOG',
+          dateCreated: new Date(),
+          createdBy: { connect: { userId: user.userId } },
+          wbsElement: { connect: { wbsElementId: project.wbsElementId } }
+        }
+      });
+
+      const byTitle = await TasksService.getFilteredTasks({ search: 'brake' }, organization);
+      expect(byTitle.map((t) => t.title)).toEqual(['Fix Brakes']);
+
+      const byNotes = await TasksService.getFilteredTasks({ search: 'suspension' }, organization);
+      expect(byNotes.map((t) => t.title)).toEqual(['Other Work']);
     });
   });
 

--- a/src/backend/tests/unmocked/task.test.ts
+++ b/src/backend/tests/unmocked/task.test.ts
@@ -856,10 +856,7 @@ describe('Task Tests', () => {
         }
       });
 
-      const tasks = await TasksService.getFilteredTasks(
-        { teamIds: [team.teamId], andMemberTeam: true },
-        organization
-      );
+      const tasks = await TasksService.getFilteredTasks({ teamIds: [team.teamId], andMemberTeam: true }, organization);
 
       expect(tasks.map((t) => t.title)).toEqual(['Team WP Task']);
     });

--- a/src/backend/tests/unmocked/task.test.ts
+++ b/src/backend/tests/unmocked/task.test.ts
@@ -780,6 +780,90 @@ describe('Task Tests', () => {
       expect(tasks.map((t) => t.title)).toEqual(['Team Project Task']);
     });
 
+    it('matches work package tasks via their parent project team when andMemberTeam is set', async () => {
+      const user = await createTestUser(supermanAdmin, organizationId);
+      const car = await createTestCar(organizationId, user.userId, 1);
+      const team = await prisma.team.create({
+        data: { teamName: 'Team Y', slackId: 'slack-y', description: '', headId: user.userId, organizationId }
+      });
+      // projectA belongs to the team, projectB does not
+      const projectA = await createTestProject(user, organizationId, team.teamId, car.carId, 1, 1);
+      const projectB = await createTestProject(user, organizationId, undefined, car.carId, 1, 2);
+
+      const wpA = await prisma.work_Package.create({
+        data: {
+          wbsElement: {
+            create: {
+              carNumber: 1,
+              projectNumber: 1,
+              workPackageNumber: 1,
+              dateCreated: new Date(),
+              name: 'Team WP',
+              status: 'INACTIVE',
+              leadId: user.userId,
+              managerId: user.userId,
+              organizationId
+            }
+          },
+          project: { connect: { projectId: projectA.projectId } },
+          orderInProject: 1,
+          startDate: new Date(),
+          duration: 2
+        }
+      });
+      const wpB = await prisma.work_Package.create({
+        data: {
+          wbsElement: {
+            create: {
+              carNumber: 1,
+              projectNumber: 2,
+              workPackageNumber: 1,
+              dateCreated: new Date(),
+              name: 'Other WP',
+              status: 'INACTIVE',
+              leadId: user.userId,
+              managerId: user.userId,
+              organizationId
+            }
+          },
+          project: { connect: { projectId: projectB.projectId } },
+          orderInProject: 1,
+          startDate: new Date(),
+          duration: 2
+        }
+      });
+
+      await prisma.task.create({
+        data: {
+          title: 'Team WP Task',
+          notes: '',
+          priority: 'HIGH',
+          status: 'IN_BACKLOG',
+          dateCreated: new Date(),
+          createdBy: { connect: { userId: user.userId } },
+          wbsElement: { connect: { wbsElementId: wpA.wbsElementId } }
+        }
+      });
+      await prisma.task.create({
+        data: {
+          title: 'Other WP Task',
+          notes: '',
+          priority: 'HIGH',
+          status: 'IN_BACKLOG',
+          dateCreated: new Date(),
+          createdBy: { connect: { userId: user.userId } },
+          wbsElement: { connect: { wbsElementId: wpB.wbsElementId } }
+        }
+      });
+
+      const tasks = await TasksService.getFilteredTasks(
+        { teamIds: [team.teamId], andMemberTeam: true },
+        organization
+      );
+
+      expect(tasks.map((t) => t.title)).toEqual(['Team WP Task']);
+    });
+
     it('filters tasks by a fuzzy search over title and notes', async () => {
       const user = await createTestUser(supermanAdmin, organizationId);
       const car = await createTestCar(organizationId, user.userId, 1);

--- a/src/frontend/src/apis/dashboards.api.ts
+++ b/src/frontend/src/apis/dashboards.api.ts
@@ -1,0 +1,27 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { Dashboard } from 'shared';
+import axios from '../utils/axios';
+import { apiUrls } from '../utils/urls';
+import { CreateDashboardPayload, EditDashboardPayload } from '../hooks/dashboards.hooks';
+
+export const getUserDashboards = () => {
+  return axios.get<Dashboard[]>(apiUrls.dashboardsGet(), {
+    transformResponse: (data) => JSON.parse(data)
+  });
+};
+
+export const createDashboard = (payload: CreateDashboardPayload) => {
+  return axios.post<Dashboard>(apiUrls.dashboardsCreate(), payload);
+};
+
+export const editDashboard = (id: string, payload: EditDashboardPayload) => {
+  return axios.post<Dashboard>(apiUrls.dashboardEdit(id), payload);
+};
+
+export const deleteDashboard = (id: string) => {
+  return axios.post<Dashboard>(apiUrls.dashboardDelete(id));
+};

--- a/src/frontend/src/apis/dropdowns.api.ts
+++ b/src/frontend/src/apis/dropdowns.api.ts
@@ -3,16 +3,14 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { SlimCar, SlimProject, SlimTeam, SlimUser, SlimWorkPackage } from 'shared';
+import { MemberDropdownItem, ProjectDropdownItem, TeamDropdownItem, WorkPackageDropdownItem } from 'shared';
 import axios from '../utils/axios';
 import { apiUrls } from '../utils/urls';
 
-export const getSlimCars = () => axios.get<SlimCar[]>(apiUrls.carsSlim());
+export const getAllProjectsDropdown = () => axios.get<ProjectDropdownItem[]>(apiUrls.projectsDropdown());
 
-export const getSlimProjects = () => axios.get<SlimProject[]>(apiUrls.projectsSlim());
+export const getAllWorkPackagesDropdown = () => axios.get<WorkPackageDropdownItem[]>(apiUrls.workPackagesDropdown());
 
-export const getSlimWorkPackages = () => axios.get<SlimWorkPackage[]>(apiUrls.workPackagesSlim());
+export const getAllMembersDropdown = () => axios.get<MemberDropdownItem[]>(apiUrls.membersDropdown());
 
-export const getSlimUsers = () => axios.get<SlimUser[]>(apiUrls.usersSlim());
-
-export const getSlimTeams = () => axios.get<SlimTeam[]>(apiUrls.teamsSlim());
+export const getAllTeamsDropdown = () => axios.get<TeamDropdownItem[]>(apiUrls.teamsDropdown());

--- a/src/frontend/src/apis/dropdowns.api.ts
+++ b/src/frontend/src/apis/dropdowns.api.ts
@@ -1,0 +1,18 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { SlimCar, SlimProject, SlimTeam, SlimUser, SlimWorkPackage } from 'shared';
+import axios from '../utils/axios';
+import { apiUrls } from '../utils/urls';
+
+export const getSlimCars = () => axios.get<SlimCar[]>(apiUrls.carsSlim());
+
+export const getSlimProjects = () => axios.get<SlimProject[]>(apiUrls.projectsSlim());
+
+export const getSlimWorkPackages = () => axios.get<SlimWorkPackage[]>(apiUrls.workPackagesSlim());
+
+export const getSlimUsers = () => axios.get<SlimUser[]>(apiUrls.usersSlim());
+
+export const getSlimTeams = () => axios.get<SlimTeam[]>(apiUrls.teamsSlim());

--- a/src/frontend/src/app/AppAuthenticated.tsx
+++ b/src/frontend/src/app/AppAuthenticated.tsx
@@ -12,6 +12,7 @@ import Home from '../pages/HomePage/Home';
 import Settings from '../pages/SettingsPage/SettingsPage';
 import InfoPage from '../pages/InfoPage';
 import GanttChartPage from '../pages/GanttPage/ProjectGanttChart/ProjectGanttChartPage';
+import GlobalTasksPage from '../pages/GlobalTasksPage/GlobalTasksPage';
 import Teams from '../pages/TeamsPage/Teams';
 import AdminTools from '../pages/AdminToolsPage/AdminTools';
 import Credits from '../pages/CreditsPage/Credits';
@@ -72,6 +73,7 @@ const AppAuthenticated: React.FC<AppAuthenticatedProps> = ({ userId, userRole })
               <Redirect from={routes.CR_BY_ID} to={routes.CHANGE_REQUESTS_BY_ID} />
               <Route path={routes.CHANGE_REQUESTS} component={ChangeRequests} />
               <Route path={routes.GANTT} component={GanttChartPage} />
+              <Route path={routes.TASKS} component={GlobalTasksPage} />
               <Route path={routes.TEAMS} component={Teams} />
               <Route path={routes.SETTINGS} component={Settings} />
               <Route path={routes.ADMIN_TOOLS} component={AdminTools} />

--- a/src/frontend/src/components/TaskFilterBar.tsx
+++ b/src/frontend/src/components/TaskFilterBar.tsx
@@ -25,7 +25,8 @@ interface TaskFilterBarProps {
   scopeProjectWbsNum?: WbsNumber;
 }
 
-const fieldSx = { minWidth: 200, flex: '1 1 200px', maxWidth: 320 };
+// each control flexes to an equal share of the single filter row, shrinking so they all stay on one row
+const fieldSx = { flex: '1 1 0', minWidth: 0 };
 
 /**
  * Shared dropdown filter bar for every task board. Which controls appear depends on the context:
@@ -51,7 +52,7 @@ const TaskFilterBar: React.FC<TaskFilterBarProps> = ({
   const workPackageScope = context === 'global' ? filters.projectWbsNums : scopeProjectWbsNum ? [scopeProjectWbsNum] : [];
 
   return (
-    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, mb: 2 }}>
+    <Box sx={{ display: 'flex', flexWrap: 'nowrap', gap: 2, mb: 2 }}>
       {showCar && <CarDropdown value={filters.carNumbers} onChange={(carNumbers) => patch({ carNumbers })} sx={fieldSx} />}
       {showProject && (
         <ProjectDropdown

--- a/src/frontend/src/components/TaskFilterBar.tsx
+++ b/src/frontend/src/components/TaskFilterBar.tsx
@@ -1,0 +1,79 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { Box } from '@mui/material';
+import { WbsNumber } from 'shared';
+import { TaskFilterFields } from '../hooks/task-filters.hooks';
+import CarDropdown from './dropdowns/CarDropdown';
+import ProjectDropdown from './dropdowns/ProjectDropdown';
+import WorkPackageDropdown from './dropdowns/WorkPackageDropdown';
+import AssigneeDropdown from './dropdowns/AssigneeDropdown';
+import TeamDropdown from './dropdowns/TeamDropdown';
+import LabelDropdown from './dropdowns/LabelDropdown';
+
+export type TaskFilterContext = 'global' | 'project' | 'workPackage';
+
+interface TaskFilterBarProps {
+  context: TaskFilterContext;
+  filters: TaskFilterFields;
+  patch: (partial: Partial<TaskFilterFields>) => void;
+  /** global only: show the car dropdown (hidden when a global car is already selected) */
+  showCarDropdown?: boolean;
+  /** project only: constrain the work package dropdown to this project's work packages */
+  scopeProjectWbsNum?: WbsNumber;
+}
+
+const fieldSx = { minWidth: 200, flex: '1 1 200px', maxWidth: 320 };
+
+/**
+ * Shared dropdown filter bar for every task board. Which controls appear depends on the context:
+ *  - global: car (optional), project, work package, assignee, team, label
+ *  - project: work package, assignee, team, label
+ *  - workPackage: assignee, team, label
+ * Each control OR's within its own selections; the backend AND's across the different controls. The
+ * fuzzy text search is intentionally not here — it lives beside the board and filters loaded tasks.
+ */
+const TaskFilterBar: React.FC<TaskFilterBarProps> = ({
+  context,
+  filters,
+  patch,
+  showCarDropdown = false,
+  scopeProjectWbsNum
+}) => {
+  const showCar = context === 'global' && showCarDropdown;
+  const showProject = context === 'global';
+  const showWorkPackage = context === 'global' || context === 'project';
+
+  // constrain the work package options: to the selected projects on the global page, or to the page's
+  // own project on a project board
+  const workPackageScope = context === 'global' ? filters.projectWbsNums : scopeProjectWbsNum ? [scopeProjectWbsNum] : [];
+
+  return (
+    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, mb: 2 }}>
+      {showCar && <CarDropdown value={filters.carNumbers} onChange={(carNumbers) => patch({ carNumbers })} sx={fieldSx} />}
+      {showProject && (
+        <ProjectDropdown
+          value={filters.projectWbsNums}
+          onChange={(projectWbsNums) => patch({ projectWbsNums })}
+          carNumbers={filters.carNumbers}
+          sx={fieldSx}
+        />
+      )}
+      {showWorkPackage && (
+        <WorkPackageDropdown
+          value={filters.workPackageWbsNums}
+          onChange={(workPackageWbsNums) => patch({ workPackageWbsNums })}
+          projectWbsNums={workPackageScope}
+          sx={fieldSx}
+        />
+      )}
+      <AssigneeDropdown value={filters.memberIds} onChange={(memberIds) => patch({ memberIds })} sx={fieldSx} />
+      <TeamDropdown value={filters.teamIds} onChange={(teamIds) => patch({ teamIds })} sx={fieldSx} />
+      <LabelDropdown value={filters.labelIds} onChange={(labelIds) => patch({ labelIds })} sx={fieldSx} />
+    </Box>
+  );
+};
+
+export default TaskFilterBar;

--- a/src/frontend/src/components/dropdowns/AssigneeDropdown.tsx
+++ b/src/frontend/src/components/dropdowns/AssigneeDropdown.tsx
@@ -1,0 +1,36 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { SxProps, Theme } from '@mui/material';
+import { useSlimUsers } from '../../hooks/dropdowns.hooks';
+import DropdownSelect from './DropdownSelect';
+
+interface AssigneeDropdownProps {
+  /** selected user ids */
+  value: string[];
+  onChange: (userIds: string[]) => void;
+  sx?: SxProps<Theme>;
+}
+
+/** Reusable multi-select of org members (FilterTaskArgs.memberIds). */
+const AssigneeDropdown: React.FC<AssigneeDropdownProps> = ({ value, onChange, sx }) => {
+  const { data: users, isLoading } = useSlimUsers();
+
+  const options = (users ?? []).map((user) => ({ key: user.userId, label: `${user.firstName} ${user.lastName}` }));
+
+  return (
+    <DropdownSelect
+      label="Assignee"
+      placeholder="Filter by assignee"
+      options={options}
+      selectedKeys={value}
+      onChange={onChange}
+      loading={isLoading}
+      sx={sx}
+    />
+  );
+};
+
+export default AssigneeDropdown;

--- a/src/frontend/src/components/dropdowns/AssigneeDropdown.tsx
+++ b/src/frontend/src/components/dropdowns/AssigneeDropdown.tsx
@@ -4,7 +4,7 @@
  */
 
 import { SxProps, Theme } from '@mui/material';
-import { useSlimUsers } from '../../hooks/dropdowns.hooks';
+import { useMembersDropdown } from '../../hooks/dropdowns.hooks';
 import DropdownSelect from './DropdownSelect';
 
 interface AssigneeDropdownProps {
@@ -16,7 +16,7 @@ interface AssigneeDropdownProps {
 
 /** Reusable multi-select of org members (FilterTaskArgs.memberIds). */
 const AssigneeDropdown: React.FC<AssigneeDropdownProps> = ({ value, onChange, sx }) => {
-  const { data: users, isLoading } = useSlimUsers();
+  const { data: users, isLoading } = useMembersDropdown();
 
   const options = (users ?? []).map((user) => ({ key: user.userId, label: `${user.firstName} ${user.lastName}` }));
 

--- a/src/frontend/src/components/dropdowns/AssigneeDropdown.tsx
+++ b/src/frontend/src/components/dropdowns/AssigneeDropdown.tsx
@@ -5,6 +5,7 @@
 
 import { SxProps, Theme } from '@mui/material';
 import { useMembersDropdown } from '../../hooks/dropdowns.hooks';
+import ErrorPage from '../../pages/ErrorPage';
 import DropdownSelect from './DropdownSelect';
 
 interface AssigneeDropdownProps {
@@ -16,7 +17,9 @@ interface AssigneeDropdownProps {
 
 /** Reusable multi-select of org members (FilterTaskArgs.memberIds). */
 const AssigneeDropdown: React.FC<AssigneeDropdownProps> = ({ value, onChange, sx }) => {
-  const { data: users, isLoading } = useMembersDropdown();
+  const { data: users, isLoading, isError, error } = useMembersDropdown();
+
+  if (isError) return <ErrorPage message={error?.message} />;
 
   const options = (users ?? []).map((user) => ({ key: user.userId, label: `${user.firstName} ${user.lastName}` }));
 

--- a/src/frontend/src/components/dropdowns/CarDropdown.tsx
+++ b/src/frontend/src/components/dropdowns/CarDropdown.tsx
@@ -4,7 +4,7 @@
  */
 
 import { SxProps, Theme } from '@mui/material';
-import { useSlimCars } from '../../hooks/dropdowns.hooks';
+import { useGetAllCars } from '../../hooks/cars.hooks';
 import DropdownSelect from './DropdownSelect';
 
 interface CarDropdownProps {
@@ -14,9 +14,12 @@ interface CarDropdownProps {
   sx?: SxProps<Theme>;
 }
 
-/** Reusable multi-select of cars. Selection is by car number (matches FilterTaskArgs.carNumbers). */
+/**
+ * Reusable multi-select of cars. Selection is by car number (matches FilterTaskArgs.carNumbers). There
+ * are few cars, so this reuses the existing full cars endpoint rather than a dedicated dropdown one.
+ */
 const CarDropdown: React.FC<CarDropdownProps> = ({ value, onChange, sx }) => {
-  const { data: cars, isLoading } = useSlimCars();
+  const { data: cars, isLoading } = useGetAllCars();
 
   const options = (cars ?? []).map((car) => ({ key: String(car.wbsNum.carNumber), label: car.name }));
 

--- a/src/frontend/src/components/dropdowns/CarDropdown.tsx
+++ b/src/frontend/src/components/dropdowns/CarDropdown.tsx
@@ -1,0 +1,36 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { SxProps, Theme } from '@mui/material';
+import { useSlimCars } from '../../hooks/dropdowns.hooks';
+import DropdownSelect from './DropdownSelect';
+
+interface CarDropdownProps {
+  /** selected car numbers */
+  value: number[];
+  onChange: (carNumbers: number[]) => void;
+  sx?: SxProps<Theme>;
+}
+
+/** Reusable multi-select of cars. Selection is by car number (matches FilterTaskArgs.carNumbers). */
+const CarDropdown: React.FC<CarDropdownProps> = ({ value, onChange, sx }) => {
+  const { data: cars, isLoading } = useSlimCars();
+
+  const options = (cars ?? []).map((car) => ({ key: String(car.wbsNum.carNumber), label: car.name }));
+
+  return (
+    <DropdownSelect
+      label="Car"
+      placeholder="Filter by car"
+      options={options}
+      selectedKeys={value.map(String)}
+      onChange={(keys) => onChange(keys.map(Number))}
+      loading={isLoading}
+      sx={sx}
+    />
+  );
+};
+
+export default CarDropdown;

--- a/src/frontend/src/components/dropdowns/CarDropdown.tsx
+++ b/src/frontend/src/components/dropdowns/CarDropdown.tsx
@@ -5,6 +5,7 @@
 
 import { SxProps, Theme } from '@mui/material';
 import { useGetAllCars } from '../../hooks/cars.hooks';
+import ErrorPage from '../../pages/ErrorPage';
 import DropdownSelect from './DropdownSelect';
 
 interface CarDropdownProps {
@@ -19,7 +20,9 @@ interface CarDropdownProps {
  * are few cars, so this reuses the existing full cars endpoint rather than a dedicated dropdown one.
  */
 const CarDropdown: React.FC<CarDropdownProps> = ({ value, onChange, sx }) => {
-  const { data: cars, isLoading } = useGetAllCars();
+  const { data: cars, isLoading, isError, error } = useGetAllCars();
+
+  if (isError) return <ErrorPage message={error?.message} />;
 
   const options = (cars ?? []).map((car) => ({ key: String(car.wbsNum.carNumber), label: car.name }));
 

--- a/src/frontend/src/components/dropdowns/DropdownSelect.tsx
+++ b/src/frontend/src/components/dropdowns/DropdownSelect.tsx
@@ -1,0 +1,85 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { Autocomplete, Chip, SxProps, TextField, Theme } from '@mui/material';
+
+export interface DropdownOption {
+  /** stable string key used for selection/equality (e.g. a userId or a piped wbs number) */
+  key: string;
+  label: string;
+}
+
+interface DropdownSelectProps {
+  label: string;
+  placeholder?: string;
+  options: DropdownOption[];
+  /** currently selected option keys */
+  selectedKeys: string[];
+  onChange: (keys: string[]) => void;
+  /** defaults to true; pass false for a single-select (selectedKeys will hold 0 or 1 key) */
+  multiple?: boolean;
+  loading?: boolean;
+  size?: 'small' | 'medium';
+  sx?: SxProps<Theme>;
+  variant?: 'outlined' | 'standard';
+}
+
+/**
+ * Generic, reusable single/multi-select built on MUI Autocomplete. Works purely on string keys so
+ * callers can map any domain value (userId, wbs number, car number, ...) to/from a key. This backs
+ * the abstracted entity dropdowns used across the task filter bar and task form.
+ */
+const DropdownSelect: React.FC<DropdownSelectProps> = ({
+  label,
+  placeholder,
+  options,
+  selectedKeys,
+  onChange,
+  multiple = true,
+  loading = false,
+  size = 'small',
+  sx,
+  variant = 'outlined'
+}) => {
+  const selectedOptions = options.filter((option) => selectedKeys.includes(option.key));
+
+  if (multiple) {
+    return (
+      <Autocomplete
+        multiple
+        size={size}
+        loading={loading}
+        options={options}
+        value={selectedOptions}
+        getOptionLabel={(option) => option.label}
+        isOptionEqualToValue={(option, val) => option.key === val.key}
+        onChange={(_, selected) => onChange(selected.map((option) => option.key))}
+        renderTags={(selected, getTagProps) =>
+          selected.map((option, index) => (
+            <Chip {...getTagProps({ index })} key={option.key} label={option.label} size="small" />
+          ))
+        }
+        renderInput={(params) => <TextField {...params} variant={variant} label={label} placeholder={placeholder} />}
+        sx={sx}
+      />
+    );
+  }
+
+  return (
+    <Autocomplete
+      size={size}
+      loading={loading}
+      options={options}
+      value={selectedOptions[0] ?? null}
+      getOptionLabel={(option) => option.label}
+      isOptionEqualToValue={(option, val) => option.key === val.key}
+      onChange={(_, selected) => onChange(selected ? [selected.key] : [])}
+      renderInput={(params) => <TextField {...params} variant={variant} label={label} placeholder={placeholder} />}
+      sx={sx}
+    />
+  );
+};
+
+export default DropdownSelect;

--- a/src/frontend/src/components/dropdowns/LabelDropdown.tsx
+++ b/src/frontend/src/components/dropdowns/LabelDropdown.tsx
@@ -6,6 +6,7 @@
 import { Autocomplete, Box, Chip, SxProps, TextField, Theme } from '@mui/material';
 import { TaskLabel } from 'shared';
 import { useAllTaskLabels } from '../../hooks/tasks.hooks';
+import ErrorPage from '../../pages/ErrorPage';
 
 interface LabelDropdownProps {
   /** selected task label ids */
@@ -20,7 +21,9 @@ interface LabelDropdownProps {
  * global task pages.
  */
 const LabelDropdown: React.FC<LabelDropdownProps> = ({ value, onChange, sx }) => {
-  const { data: taskLabels, isLoading } = useAllTaskLabels();
+  const { data: taskLabels, isLoading, isError, error } = useAllTaskLabels();
+
+  if (isError) return <ErrorPage message={error?.message} />;
 
   const labels = taskLabels ?? [];
 

--- a/src/frontend/src/components/dropdowns/LabelDropdown.tsx
+++ b/src/frontend/src/components/dropdowns/LabelDropdown.tsx
@@ -1,0 +1,77 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { Autocomplete, Box, Chip, SxProps, TextField, Theme } from '@mui/material';
+import { TaskLabel } from 'shared';
+import { useAllTaskLabels } from '../../hooks/tasks.hooks';
+
+interface LabelDropdownProps {
+  /** selected task label ids */
+  value: string[];
+  onChange: (labelIds: string[]) => void;
+  sx?: SxProps<Theme>;
+}
+
+/**
+ * Reusable multi-select of task labels with the colored-chip styling. Lifted from the project task
+ * board's inline label filter so the same control is shared across the project, work package, and
+ * global task pages.
+ */
+const LabelDropdown: React.FC<LabelDropdownProps> = ({ value, onChange, sx }) => {
+  const { data: taskLabels, isLoading } = useAllTaskLabels();
+
+  const labels = taskLabels ?? [];
+
+  return (
+    <Autocomplete
+      multiple
+      size="small"
+      loading={isLoading}
+      options={labels}
+      getOptionLabel={(option: TaskLabel) => option.name}
+      isOptionEqualToValue={(option, val) => option.taskLabelId === val.taskLabelId}
+      value={labels.filter((label) => value.includes(label.taskLabelId))}
+      onChange={(_, selected) => onChange(selected.map((label) => label.taskLabelId))}
+      renderOption={(props, option) => (
+        <li {...props} key={option.taskLabelId}>
+          <Box
+            sx={{
+              display: 'inline-block',
+              px: 1.5,
+              py: 0.25,
+              borderRadius: '999px',
+              backgroundColor: option.colorHexCode,
+              color: 'white',
+              fontWeight: 500,
+              fontSize: '0.875rem'
+            }}
+          >
+            {option.name}
+          </Box>
+        </li>
+      )}
+      renderTags={(selected, getTagProps) =>
+        selected.map((label, index) => (
+          <Chip
+            {...getTagProps({ index })}
+            key={label.taskLabelId}
+            label={label.name}
+            size="small"
+            sx={{
+              backgroundColor: label.colorHexCode,
+              color: 'white',
+              fontWeight: 500,
+              '& .MuiChip-deleteIcon': { color: 'rgba(255,255,255,0.7)' }
+            }}
+          />
+        ))
+      }
+      renderInput={(params) => <TextField {...params} variant="outlined" label="Labels" placeholder="Filter by label" />}
+      sx={sx}
+    />
+  );
+};
+
+export default LabelDropdown;

--- a/src/frontend/src/components/dropdowns/ProjectDropdown.tsx
+++ b/src/frontend/src/components/dropdowns/ProjectDropdown.tsx
@@ -6,6 +6,7 @@
 import { SxProps, Theme } from '@mui/material';
 import { WbsNumber, wbsPipe } from 'shared';
 import { useProjectsDropdown } from '../../hooks/dropdowns.hooks';
+import ErrorPage from '../../pages/ErrorPage';
 import DropdownSelect from './DropdownSelect';
 
 interface ProjectDropdownProps {
@@ -21,7 +22,9 @@ interface ProjectDropdownProps {
 
 /** Reusable select of projects. Selection is by project WBS number (FilterTaskArgs.projectWbsNums). */
 const ProjectDropdown: React.FC<ProjectDropdownProps> = ({ value, onChange, carNumbers, multiple = true, sx }) => {
-  const { data: projects, isLoading } = useProjectsDropdown();
+  const { data: projects, isLoading, isError, error } = useProjectsDropdown();
+
+  if (isError) return <ErrorPage message={error?.message} />;
 
   const visible = (projects ?? []).filter(
     (project) => !carNumbers || carNumbers.length === 0 || carNumbers.includes(project.carNumber)

--- a/src/frontend/src/components/dropdowns/ProjectDropdown.tsx
+++ b/src/frontend/src/components/dropdowns/ProjectDropdown.tsx
@@ -5,7 +5,7 @@
 
 import { SxProps, Theme } from '@mui/material';
 import { WbsNumber, wbsPipe } from 'shared';
-import { useSlimProjects } from '../../hooks/dropdowns.hooks';
+import { useProjectsDropdown } from '../../hooks/dropdowns.hooks';
 import DropdownSelect from './DropdownSelect';
 
 interface ProjectDropdownProps {
@@ -21,7 +21,7 @@ interface ProjectDropdownProps {
 
 /** Reusable select of projects. Selection is by project WBS number (FilterTaskArgs.projectWbsNums). */
 const ProjectDropdown: React.FC<ProjectDropdownProps> = ({ value, onChange, carNumbers, multiple = true, sx }) => {
-  const { data: projects, isLoading } = useSlimProjects();
+  const { data: projects, isLoading } = useProjectsDropdown();
 
   const visible = (projects ?? []).filter(
     (project) => !carNumbers || carNumbers.length === 0 || carNumbers.includes(project.carNumber)

--- a/src/frontend/src/components/dropdowns/ProjectDropdown.tsx
+++ b/src/frontend/src/components/dropdowns/ProjectDropdown.tsx
@@ -1,0 +1,45 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { SxProps, Theme } from '@mui/material';
+import { WbsNumber, wbsPipe } from 'shared';
+import { useSlimProjects } from '../../hooks/dropdowns.hooks';
+import DropdownSelect from './DropdownSelect';
+
+interface ProjectDropdownProps {
+  /** selected project wbs numbers */
+  value: WbsNumber[];
+  onChange: (projectWbsNums: WbsNumber[]) => void;
+  /** if provided, only show projects belonging to these car numbers */
+  carNumbers?: number[];
+  /** false renders a single-select (value holds 0 or 1 wbs number) */
+  multiple?: boolean;
+  sx?: SxProps<Theme>;
+}
+
+/** Reusable select of projects. Selection is by project WBS number (FilterTaskArgs.projectWbsNums). */
+const ProjectDropdown: React.FC<ProjectDropdownProps> = ({ value, onChange, carNumbers, multiple = true, sx }) => {
+  const { data: projects, isLoading } = useSlimProjects();
+
+  const visible = (projects ?? []).filter(
+    (project) => !carNumbers || carNumbers.length === 0 || carNumbers.includes(project.carNumber)
+  );
+  const options = visible.map((project) => ({ key: wbsPipe(project.wbsNum), label: project.name }));
+
+  return (
+    <DropdownSelect
+      label="Project"
+      placeholder="Filter by project"
+      options={options}
+      multiple={multiple}
+      selectedKeys={value.map(wbsPipe)}
+      onChange={(keys) => onChange(visible.filter((project) => keys.includes(wbsPipe(project.wbsNum))).map((p) => p.wbsNum))}
+      loading={isLoading}
+      sx={sx}
+    />
+  );
+};
+
+export default ProjectDropdown;

--- a/src/frontend/src/components/dropdowns/TeamDropdown.tsx
+++ b/src/frontend/src/components/dropdowns/TeamDropdown.tsx
@@ -1,0 +1,36 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { SxProps, Theme } from '@mui/material';
+import { useSlimTeams } from '../../hooks/dropdowns.hooks';
+import DropdownSelect from './DropdownSelect';
+
+interface TeamDropdownProps {
+  /** selected team ids */
+  value: string[];
+  onChange: (teamIds: string[]) => void;
+  sx?: SxProps<Theme>;
+}
+
+/** Reusable multi-select of teams (FilterTaskArgs.teamIds). */
+const TeamDropdown: React.FC<TeamDropdownProps> = ({ value, onChange, sx }) => {
+  const { data: teams, isLoading } = useSlimTeams();
+
+  const options = (teams ?? []).map((team) => ({ key: team.teamId, label: team.name }));
+
+  return (
+    <DropdownSelect
+      label="Team"
+      placeholder="Filter by team"
+      options={options}
+      selectedKeys={value}
+      onChange={onChange}
+      loading={isLoading}
+      sx={sx}
+    />
+  );
+};
+
+export default TeamDropdown;

--- a/src/frontend/src/components/dropdowns/TeamDropdown.tsx
+++ b/src/frontend/src/components/dropdowns/TeamDropdown.tsx
@@ -5,6 +5,7 @@
 
 import { SxProps, Theme } from '@mui/material';
 import { useTeamsDropdown } from '../../hooks/dropdowns.hooks';
+import ErrorPage from '../../pages/ErrorPage';
 import DropdownSelect from './DropdownSelect';
 
 interface TeamDropdownProps {
@@ -16,7 +17,9 @@ interface TeamDropdownProps {
 
 /** Reusable multi-select of teams (FilterTaskArgs.teamIds). */
 const TeamDropdown: React.FC<TeamDropdownProps> = ({ value, onChange, sx }) => {
-  const { data: teams, isLoading } = useTeamsDropdown();
+  const { data: teams, isLoading, isError, error } = useTeamsDropdown();
+
+  if (isError) return <ErrorPage message={error?.message} />;
 
   const options = (teams ?? []).map((team) => ({ key: team.teamId, label: team.name }));
 

--- a/src/frontend/src/components/dropdowns/TeamDropdown.tsx
+++ b/src/frontend/src/components/dropdowns/TeamDropdown.tsx
@@ -4,7 +4,7 @@
  */
 
 import { SxProps, Theme } from '@mui/material';
-import { useSlimTeams } from '../../hooks/dropdowns.hooks';
+import { useTeamsDropdown } from '../../hooks/dropdowns.hooks';
 import DropdownSelect from './DropdownSelect';
 
 interface TeamDropdownProps {
@@ -16,7 +16,7 @@ interface TeamDropdownProps {
 
 /** Reusable multi-select of teams (FilterTaskArgs.teamIds). */
 const TeamDropdown: React.FC<TeamDropdownProps> = ({ value, onChange, sx }) => {
-  const { data: teams, isLoading } = useSlimTeams();
+  const { data: teams, isLoading } = useTeamsDropdown();
 
   const options = (teams ?? []).map((team) => ({ key: team.teamId, label: team.name }));
 

--- a/src/frontend/src/components/dropdowns/WorkPackageDropdown.tsx
+++ b/src/frontend/src/components/dropdowns/WorkPackageDropdown.tsx
@@ -6,6 +6,7 @@
 import { SxProps, Theme } from '@mui/material';
 import { WbsNumber, wbsPipe } from 'shared';
 import { useWorkPackagesDropdown } from '../../hooks/dropdowns.hooks';
+import ErrorPage from '../../pages/ErrorPage';
 import DropdownSelect from './DropdownSelect';
 
 interface WorkPackageDropdownProps {
@@ -19,7 +20,9 @@ interface WorkPackageDropdownProps {
 
 /** Reusable multi-select of work packages (FilterTaskArgs.workPackageWbsNums). */
 const WorkPackageDropdown: React.FC<WorkPackageDropdownProps> = ({ value, onChange, projectWbsNums, sx }) => {
-  const { data: workPackages, isLoading } = useWorkPackagesDropdown();
+  const { data: workPackages, isLoading, isError, error } = useWorkPackagesDropdown();
+
+  if (isError) return <ErrorPage message={error?.message} />;
 
   const projectKeys = (projectWbsNums ?? []).map((wbs) => `${wbs.carNumber}.${wbs.projectNumber}`);
   const selectedKeys = value.map(wbsPipe);

--- a/src/frontend/src/components/dropdowns/WorkPackageDropdown.tsx
+++ b/src/frontend/src/components/dropdowns/WorkPackageDropdown.tsx
@@ -5,7 +5,7 @@
 
 import { SxProps, Theme } from '@mui/material';
 import { WbsNumber, wbsPipe } from 'shared';
-import { useSlimWorkPackages } from '../../hooks/dropdowns.hooks';
+import { useWorkPackagesDropdown } from '../../hooks/dropdowns.hooks';
 import DropdownSelect from './DropdownSelect';
 
 interface WorkPackageDropdownProps {
@@ -19,11 +19,17 @@ interface WorkPackageDropdownProps {
 
 /** Reusable multi-select of work packages (FilterTaskArgs.workPackageWbsNums). */
 const WorkPackageDropdown: React.FC<WorkPackageDropdownProps> = ({ value, onChange, projectWbsNums, sx }) => {
-  const { data: workPackages, isLoading } = useSlimWorkPackages();
+  const { data: workPackages, isLoading } = useWorkPackagesDropdown();
 
   const projectKeys = (projectWbsNums ?? []).map((wbs) => `${wbs.carNumber}.${wbs.projectNumber}`);
+  const selectedKeys = value.map(wbsPipe);
+  // show every work package in the selected projects, plus any already-selected work package (so a
+  // selection stays visible/removable even if its project isn't currently in the project filter)
   const visible = (workPackages ?? []).filter(
-    (wp) => projectKeys.length === 0 || projectKeys.includes(`${wp.wbsNum.carNumber}.${wp.wbsNum.projectNumber}`)
+    (wp) =>
+      projectKeys.length === 0 ||
+      projectKeys.includes(`${wp.wbsNum.carNumber}.${wp.wbsNum.projectNumber}`) ||
+      selectedKeys.includes(wbsPipe(wp.wbsNum))
   );
   const options = visible.map((wp) => ({ key: wbsPipe(wp.wbsNum), label: `${wbsPipe(wp.wbsNum)} - ${wp.name}` }));
 
@@ -32,7 +38,7 @@ const WorkPackageDropdown: React.FC<WorkPackageDropdownProps> = ({ value, onChan
       label="Work Package"
       placeholder="Filter by work package"
       options={options}
-      selectedKeys={value.map(wbsPipe)}
+      selectedKeys={selectedKeys}
       onChange={(keys) => onChange(visible.filter((wp) => keys.includes(wbsPipe(wp.wbsNum))).map((wp) => wp.wbsNum))}
       loading={isLoading}
       sx={sx}

--- a/src/frontend/src/components/dropdowns/WorkPackageDropdown.tsx
+++ b/src/frontend/src/components/dropdowns/WorkPackageDropdown.tsx
@@ -1,0 +1,43 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { SxProps, Theme } from '@mui/material';
+import { WbsNumber, wbsPipe } from 'shared';
+import { useSlimWorkPackages } from '../../hooks/dropdowns.hooks';
+import DropdownSelect from './DropdownSelect';
+
+interface WorkPackageDropdownProps {
+  /** selected work package wbs numbers */
+  value: WbsNumber[];
+  onChange: (workPackageWbsNums: WbsNumber[]) => void;
+  /** if provided, only show work packages belonging to these projects */
+  projectWbsNums?: WbsNumber[];
+  sx?: SxProps<Theme>;
+}
+
+/** Reusable multi-select of work packages (FilterTaskArgs.workPackageWbsNums). */
+const WorkPackageDropdown: React.FC<WorkPackageDropdownProps> = ({ value, onChange, projectWbsNums, sx }) => {
+  const { data: workPackages, isLoading } = useSlimWorkPackages();
+
+  const projectKeys = (projectWbsNums ?? []).map((wbs) => `${wbs.carNumber}.${wbs.projectNumber}`);
+  const visible = (workPackages ?? []).filter(
+    (wp) => projectKeys.length === 0 || projectKeys.includes(`${wp.wbsNum.carNumber}.${wp.wbsNum.projectNumber}`)
+  );
+  const options = visible.map((wp) => ({ key: wbsPipe(wp.wbsNum), label: `${wbsPipe(wp.wbsNum)} - ${wp.name}` }));
+
+  return (
+    <DropdownSelect
+      label="Work Package"
+      placeholder="Filter by work package"
+      options={options}
+      selectedKeys={value.map(wbsPipe)}
+      onChange={(keys) => onChange(visible.filter((wp) => keys.includes(wbsPipe(wp.wbsNum))).map((wp) => wp.wbsNum))}
+      loading={isLoading}
+      sx={sx}
+    />
+  );
+};
+
+export default WorkPackageDropdown;

--- a/src/frontend/src/hooks/dashboards.hooks.ts
+++ b/src/frontend/src/hooks/dashboards.hooks.ts
@@ -1,0 +1,94 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { useQueryClient, useMutation, useQuery } from 'react-query';
+import { Dashboard } from 'shared';
+import { createDashboard, deleteDashboard, editDashboard, getUserDashboards } from '../apis/dashboards.api';
+
+export interface CreateDashboardPayload {
+  name: string;
+  link: string;
+}
+
+export interface EditDashboardPayload {
+  link: string;
+}
+
+/**
+ * Custom react hook to get the current user's dashboards
+ *
+ * @returns the current user's dashboards
+ */
+export const useUserDashboards = () => {
+  return useQuery<Dashboard[], Error>(['dashboards'], async () => {
+    const { data } = await getUserDashboards();
+    return data;
+  });
+};
+
+/**
+ * Custom react hook to create a dashboard
+ *
+ * @returns the created dashboard
+ */
+export const useCreateDashboard = () => {
+  const queryClient = useQueryClient();
+  return useMutation<Dashboard, Error, CreateDashboardPayload>(
+    ['dashboards', 'create'],
+    async (payload) => {
+      const { data } = await createDashboard(payload);
+      return data;
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(['dashboards']);
+      }
+    }
+  );
+};
+
+/**
+ * Custom react hook to edit a dashboard's saved filters
+ *
+ * @param dashboardId id of the dashboard to edit
+ * @returns the updated dashboard
+ */
+export const useEditDashboard = (dashboardId: string) => {
+  const queryClient = useQueryClient();
+  return useMutation<Dashboard, Error, EditDashboardPayload>(
+    ['dashboards', 'edit'],
+    async (payload) => {
+      const { data } = await editDashboard(dashboardId, payload);
+      return data;
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(['dashboards']);
+      }
+    }
+  );
+};
+
+/**
+ * Custom react hook to delete a dashboard
+ *
+ * @param dashboardId id of the dashboard to delete
+ * @returns the deleted dashboard
+ */
+export const useDeleteDashboard = (dashboardId: string) => {
+  const queryClient = useQueryClient();
+  return useMutation<Dashboard, Error, void>(
+    ['dashboards', 'delete'],
+    async () => {
+      const { data } = await deleteDashboard(dashboardId);
+      return data;
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(['dashboards']);
+      }
+    }
+  );
+};

--- a/src/frontend/src/hooks/dropdowns.hooks.ts
+++ b/src/frontend/src/hooks/dropdowns.hooks.ts
@@ -19,8 +19,11 @@ const SLIM_QUERY_OPTIONS = { staleTime: 1000 * 60 * 5 } as const;
 export const useSlimCars = () =>
   useQuery<SlimCar[], Error>(['slim', 'cars'], async () => (await getSlimCars()).data, SLIM_QUERY_OPTIONS);
 
-export const useSlimProjects = () =>
-  useQuery<SlimProject[], Error>(['slim', 'projects'], async () => (await getSlimProjects()).data, SLIM_QUERY_OPTIONS);
+export const useSlimProjects = (enabled = true) =>
+  useQuery<SlimProject[], Error>(['slim', 'projects'], async () => (await getSlimProjects()).data, {
+    ...SLIM_QUERY_OPTIONS,
+    enabled
+  });
 
 export const useSlimWorkPackages = () =>
   useQuery<SlimWorkPackage[], Error>(

--- a/src/frontend/src/hooks/dropdowns.hooks.ts
+++ b/src/frontend/src/hooks/dropdowns.hooks.ts
@@ -4,36 +4,47 @@
  */
 
 import { useQuery } from 'react-query';
-import { SlimCar, SlimProject, SlimTeam, SlimUser, SlimWorkPackage } from 'shared';
-import { getSlimCars, getSlimProjects, getSlimTeams, getSlimUsers, getSlimWorkPackages } from '../apis/dropdowns.api';
+import { MemberDropdownItem, ProjectDropdownItem, TeamDropdownItem, WorkPackageDropdownItem } from 'shared';
+import {
+  getAllMembersDropdown,
+  getAllProjectsDropdown,
+  getAllTeamsDropdown,
+  getAllWorkPackagesDropdown
+} from '../apis/dropdowns.api';
 
 /**
- * Hooks backing the abstracted dropdown components. Each fetches a minimal ("slim") list of items
+ * Hooks backing the abstracted dropdown components. Each fetches a minimal ("dropdown") list of items
  * from a dedicated backend endpoint so dropdowns don't over-fetch the full, deeply-nested objects.
  * They fetch once on mount and stay fresh for a while so opening/closing a dropdown never refetches.
+ * (Cars are few, so the car dropdown reuses the existing full cars endpoint via useGetAllCars.)
  */
 
 // dropdown option lists rarely change within a session, so keep them fresh for 5 minutes
-const SLIM_QUERY_OPTIONS = { staleTime: 1000 * 60 * 5 } as const;
+const DROPDOWN_QUERY_OPTIONS = { staleTime: 1000 * 60 * 5 } as const;
 
-export const useSlimCars = () =>
-  useQuery<SlimCar[], Error>(['slim', 'cars'], async () => (await getSlimCars()).data, SLIM_QUERY_OPTIONS);
-
-export const useSlimProjects = (enabled = true) =>
-  useQuery<SlimProject[], Error>(['slim', 'projects'], async () => (await getSlimProjects()).data, {
-    ...SLIM_QUERY_OPTIONS,
+export const useProjectsDropdown = (enabled = true) =>
+  useQuery<ProjectDropdownItem[], Error>(['dropdown', 'projects'], async () => (await getAllProjectsDropdown()).data, {
+    ...DROPDOWN_QUERY_OPTIONS,
     enabled
   });
 
-export const useSlimWorkPackages = () =>
-  useQuery<SlimWorkPackage[], Error>(
-    ['slim', 'work-packages'],
-    async () => (await getSlimWorkPackages()).data,
-    SLIM_QUERY_OPTIONS
+export const useWorkPackagesDropdown = () =>
+  useQuery<WorkPackageDropdownItem[], Error>(
+    ['dropdown', 'work-packages'],
+    async () => (await getAllWorkPackagesDropdown()).data,
+    DROPDOWN_QUERY_OPTIONS
   );
 
-export const useSlimUsers = () =>
-  useQuery<SlimUser[], Error>(['slim', 'users'], async () => (await getSlimUsers()).data, SLIM_QUERY_OPTIONS);
+export const useMembersDropdown = () =>
+  useQuery<MemberDropdownItem[], Error>(
+    ['dropdown', 'members'],
+    async () => (await getAllMembersDropdown()).data,
+    DROPDOWN_QUERY_OPTIONS
+  );
 
-export const useSlimTeams = () =>
-  useQuery<SlimTeam[], Error>(['slim', 'teams'], async () => (await getSlimTeams()).data, SLIM_QUERY_OPTIONS);
+export const useTeamsDropdown = () =>
+  useQuery<TeamDropdownItem[], Error>(
+    ['dropdown', 'teams'],
+    async () => (await getAllTeamsDropdown()).data,
+    DROPDOWN_QUERY_OPTIONS
+  );

--- a/src/frontend/src/hooks/dropdowns.hooks.ts
+++ b/src/frontend/src/hooks/dropdowns.hooks.ts
@@ -1,0 +1,36 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { useQuery } from 'react-query';
+import { SlimCar, SlimProject, SlimTeam, SlimUser, SlimWorkPackage } from 'shared';
+import { getSlimCars, getSlimProjects, getSlimTeams, getSlimUsers, getSlimWorkPackages } from '../apis/dropdowns.api';
+
+/**
+ * Hooks backing the abstracted dropdown components. Each fetches a minimal ("slim") list of items
+ * from a dedicated backend endpoint so dropdowns don't over-fetch the full, deeply-nested objects.
+ * They fetch once on mount and stay fresh for a while so opening/closing a dropdown never refetches.
+ */
+
+// dropdown option lists rarely change within a session, so keep them fresh for 5 minutes
+const SLIM_QUERY_OPTIONS = { staleTime: 1000 * 60 * 5 } as const;
+
+export const useSlimCars = () =>
+  useQuery<SlimCar[], Error>(['slim', 'cars'], async () => (await getSlimCars()).data, SLIM_QUERY_OPTIONS);
+
+export const useSlimProjects = () =>
+  useQuery<SlimProject[], Error>(['slim', 'projects'], async () => (await getSlimProjects()).data, SLIM_QUERY_OPTIONS);
+
+export const useSlimWorkPackages = () =>
+  useQuery<SlimWorkPackage[], Error>(
+    ['slim', 'work-packages'],
+    async () => (await getSlimWorkPackages()).data,
+    SLIM_QUERY_OPTIONS
+  );
+
+export const useSlimUsers = () =>
+  useQuery<SlimUser[], Error>(['slim', 'users'], async () => (await getSlimUsers()).data, SLIM_QUERY_OPTIONS);
+
+export const useSlimTeams = () =>
+  useQuery<SlimTeam[], Error>(['slim', 'teams'], async () => (await getSlimTeams()).data, SLIM_QUERY_OPTIONS);

--- a/src/frontend/src/hooks/task-filters.hooks.ts
+++ b/src/frontend/src/hooks/task-filters.hooks.ts
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import { validateWBS, WbsNumber, wbsPipe } from 'shared';
 
@@ -76,60 +76,57 @@ const deserializeFilters = (search: string): TaskFilterFields => {
   };
 };
 
-const hasFilterParams = (search: string): boolean => {
-  const params = new URLSearchParams(search);
-  return FILTER_PARAM_KEYS.some((key) => params.has(key));
-};
-
 interface UseTaskFiltersOptions {
   /**
-   * When set, filters are persisted to the URL query string (shareable) and to localStorage under
-   * this key (sticky across visits). The URL takes precedence on load. When omitted, filters are
-   * ephemeral local state (used by the project/work package boards).
+   * When set, the URL query string is the single source of truth for the filters, so a filtered view
+   * is shareable via link and can be applied by simply navigating to a saved dashboard link. When
+   * omitted, filters are ephemeral local state (used by the project/work package boards).
    */
   persistKey?: string;
 }
 
 /**
- * Manages task filter state. Optionally mirrors the state into the URL and localStorage so a filtered
- * view can be shared via link and restored on return.
+ * Manages task filter state. When `persistKey` is set the filters are read from and written to the URL
+ * query string (the single source of truth), so shared links and saved dashboards reproduce the exact
+ * view. Otherwise the filters are ephemeral local state.
  */
 export const useTaskFilters = ({ persistKey }: UseTaskFiltersOptions = {}) => {
   const history = useHistory();
   const location = useLocation();
 
-  const [filters, setFilters] = useState<TaskFilterFields>(() => {
-    if (!persistKey) return emptyTaskFilters;
-    // URL wins so shared links reproduce the exact view
-    if (hasFilterParams(location.search)) return deserializeFilters(location.search);
-    const stored = localStorage.getItem(persistKey);
-    if (stored) {
-      try {
-        return { ...emptyTaskFilters, ...(JSON.parse(stored) as Partial<TaskFilterFields>) };
-      } catch {
-        // ignore malformed storage
+  // ephemeral filters for the uncontrolled project / work package boards
+  const [localFilters, setLocalFilters] = useState<TaskFilterFields>(emptyTaskFilters);
+
+  // when persisting, the URL is the single source of truth, so navigating to a saved dashboard link
+  // (or a shared link) drives the filters directly
+  const urlFilters = useMemo(() => deserializeFilters(location.search), [location.search]);
+
+  const filters = persistKey ? urlFilters : localFilters;
+
+  const setFilters = useCallback(
+    (update: TaskFilterFields | ((prev: TaskFilterFields) => TaskFilterFields)) => {
+      if (!persistKey) {
+        setLocalFilters(update);
+        return;
       }
-    }
-    return emptyTaskFilters;
-  });
+      const prev = deserializeFilters(location.search);
+      const next = typeof update === 'function' ? update(prev) : update;
+      const currentSearch = location.search.replace(/^\?/, '');
+      // preserve any non-filter params (e.g. the `?task=` param that opens a task modal)
+      const nextSearch = serializeFilters(next, currentSearch);
+      if (nextSearch !== currentSearch) {
+        history.replace({ pathname: location.pathname, search: nextSearch });
+      }
+    },
+    [persistKey, history, location.pathname, location.search]
+  );
 
-  // keep the URL + localStorage in sync with the current filters, without disturbing other query
-  // params (e.g. the `?task=` param that opens a task modal)
-  useEffect(() => {
-    if (!persistKey) return;
-    localStorage.setItem(persistKey, JSON.stringify(filters));
-    const currentSearch = location.search.replace(/^\?/, '');
-    const nextSearch = serializeFilters(filters, currentSearch);
-    if (nextSearch !== currentSearch) {
-      history.replace({ pathname: location.pathname, search: nextSearch });
-    }
-  }, [filters, persistKey, history, location.pathname, location.search]);
+  const patch = useCallback(
+    (partial: Partial<TaskFilterFields>) => setFilters((prev) => ({ ...prev, ...partial })),
+    [setFilters]
+  );
 
-  const patch = useCallback((partial: Partial<TaskFilterFields>) => {
-    setFilters((prev) => ({ ...prev, ...partial }));
-  }, []);
-
-  const clear = useCallback(() => setFilters(emptyTaskFilters), []);
+  const clear = useCallback(() => setFilters(emptyTaskFilters), [setFilters]);
 
   return { filters, setFilters, patch, clear };
 };

--- a/src/frontend/src/hooks/task-filters.hooks.ts
+++ b/src/frontend/src/hooks/task-filters.hooks.ts
@@ -1,0 +1,135 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
+import { validateWBS, WbsNumber, wbsPipe } from 'shared';
+
+/** The set of task filters shared by the project, work package, and global task boards. */
+export interface TaskFilterFields {
+  carNumbers: number[];
+  projectWbsNums: WbsNumber[];
+  workPackageWbsNums: WbsNumber[];
+  memberIds: string[];
+  teamIds: string[];
+  labelIds: string[];
+  search: string;
+}
+
+export const emptyTaskFilters: TaskFilterFields = {
+  carNumbers: [],
+  projectWbsNums: [],
+  workPackageWbsNums: [],
+  memberIds: [],
+  teamIds: [],
+  labelIds: [],
+  search: ''
+};
+
+const FILTER_PARAM_KEYS = ['cars', 'projects', 'workPackages', 'assignees', 'teams', 'labels', 'search'];
+
+const safeValidateWBS = (raw: string): WbsNumber | undefined => {
+  try {
+    return validateWBS(raw);
+  } catch {
+    return undefined;
+  }
+};
+
+// serializes the filters into the given (existing) query string, preserving any non-filter params such
+// as the `?task=` param used to deep-link a task modal
+const serializeFilters = (filters: TaskFilterFields, existingSearch: string): string => {
+  const params = new URLSearchParams(existingSearch);
+  FILTER_PARAM_KEYS.forEach((key) => params.delete(key));
+  if (filters.carNumbers.length) params.set('cars', filters.carNumbers.join(','));
+  if (filters.projectWbsNums.length) params.set('projects', filters.projectWbsNums.map(wbsPipe).join(','));
+  if (filters.workPackageWbsNums.length) params.set('workPackages', filters.workPackageWbsNums.map(wbsPipe).join(','));
+  if (filters.memberIds.length) params.set('assignees', filters.memberIds.join(','));
+  if (filters.teamIds.length) params.set('teams', filters.teamIds.join(','));
+  if (filters.labelIds.length) params.set('labels', filters.labelIds.join(','));
+  if (filters.search) params.set('search', filters.search);
+  return params.toString();
+};
+
+const deserializeFilters = (search: string): TaskFilterFields => {
+  const params = new URLSearchParams(search);
+  const list = (key: string): string[] => {
+    const value = params.get(key);
+    return value ? value.split(',').filter(Boolean) : [];
+  };
+  return {
+    carNumbers: list('cars')
+      .map(Number)
+      .filter((num) => !Number.isNaN(num)),
+    projectWbsNums: list('projects')
+      .map(safeValidateWBS)
+      .filter((wbs): wbs is WbsNumber => wbs !== undefined),
+    workPackageWbsNums: list('workPackages')
+      .map(safeValidateWBS)
+      .filter((wbs): wbs is WbsNumber => wbs !== undefined),
+    memberIds: list('assignees'),
+    teamIds: list('teams'),
+    labelIds: list('labels'),
+    search: params.get('search') ?? ''
+  };
+};
+
+const hasFilterParams = (search: string): boolean => {
+  const params = new URLSearchParams(search);
+  return FILTER_PARAM_KEYS.some((key) => params.has(key));
+};
+
+interface UseTaskFiltersOptions {
+  /**
+   * When set, filters are persisted to the URL query string (shareable) and to localStorage under
+   * this key (sticky across visits). The URL takes precedence on load. When omitted, filters are
+   * ephemeral local state (used by the project/work package boards).
+   */
+  persistKey?: string;
+}
+
+/**
+ * Manages task filter state. Optionally mirrors the state into the URL and localStorage so a filtered
+ * view can be shared via link and restored on return.
+ */
+export const useTaskFilters = ({ persistKey }: UseTaskFiltersOptions = {}) => {
+  const history = useHistory();
+  const location = useLocation();
+
+  const [filters, setFilters] = useState<TaskFilterFields>(() => {
+    if (!persistKey) return emptyTaskFilters;
+    // URL wins so shared links reproduce the exact view
+    if (hasFilterParams(location.search)) return deserializeFilters(location.search);
+    const stored = localStorage.getItem(persistKey);
+    if (stored) {
+      try {
+        return { ...emptyTaskFilters, ...(JSON.parse(stored) as Partial<TaskFilterFields>) };
+      } catch {
+        // ignore malformed storage
+      }
+    }
+    return emptyTaskFilters;
+  });
+
+  // keep the URL + localStorage in sync with the current filters, without disturbing other query
+  // params (e.g. the `?task=` param that opens a task modal)
+  useEffect(() => {
+    if (!persistKey) return;
+    localStorage.setItem(persistKey, JSON.stringify(filters));
+    const currentSearch = location.search.replace(/^\?/, '');
+    const nextSearch = serializeFilters(filters, currentSearch);
+    if (nextSearch !== currentSearch) {
+      history.replace({ pathname: location.pathname, search: nextSearch });
+    }
+  }, [filters, persistKey, history, location.pathname, location.search]);
+
+  const patch = useCallback((partial: Partial<TaskFilterFields>) => {
+    setFilters((prev) => ({ ...prev, ...partial }));
+  }, []);
+
+  const clear = useCallback(() => setFilters(emptyTaskFilters), []);
+
+  return { filters, setFilters, patch, clear };
+};

--- a/src/frontend/src/hooks/tasks.hooks.ts
+++ b/src/frontend/src/hooks/tasks.hooks.ts
@@ -153,18 +153,22 @@ export const useEditTaskAssignees = () => {
  * @returns the edit task status mutation
  */
 export const useSetTaskStatus = () => {
-  // const queryClient = useQueryClient();
+  const queryClient = useQueryClient();
   return useMutation<{ message: string }, Error, { taskId: string; status: TaskStatus }>(
     ['tasks', 'edit-status'],
     async (editStatusTaskPayload: { taskId: string; status: TaskStatus }) => {
       const { data } = await editSingleTaskStatus(editStatusTaskPayload.taskId, editStatusTaskPayload.status);
       return data;
+    },
+    {
+      // the board updates optimistically, but the cached tasks must also be refreshed or a later
+      // rebuild from the cache (e.g. when the client-side search changes) would revert the move
+      onSuccess: () => {
+        queryClient.invalidateQueries(['projects']);
+        queryClient.invalidateQueries(['filter-tasks']);
+        queryClient.invalidateQueries(['tasks']);
+      }
     }
-    // {
-    //   onSuccess: () => {
-    //     queryClient.invalidateQueries(['projects']);
-    //   }
-    // }
   );
 };
 

--- a/src/frontend/src/hooks/work-packages.hooks.ts
+++ b/src/frontend/src/hooks/work-packages.hooks.ts
@@ -67,11 +67,15 @@ export const useSingleWorkPackage = (wbsNum: WbsNumber) => {
  * Custom React Hook to get all work packages for a given project
  * @param projectWbsNum the wbs number of the project
  */
-export const useWorkPackagesByProject = (projectWbsNum: WbsNumber) => {
-  return useQuery<WorkPackage[], Error>(['work-packages', 'by-project', wbsPipe(projectWbsNum)], async () => {
-    const { data } = await getWorkPackagesByProject(projectWbsNum);
-    return data;
-  });
+export const useWorkPackagesByProject = (projectWbsNum: WbsNumber, enabled = true) => {
+  return useQuery<WorkPackage[], Error>(
+    ['work-packages', 'by-project', wbsPipe(projectWbsNum)],
+    async () => {
+      const { data } = await getWorkPackagesByProject(projectWbsNum);
+      return data;
+    },
+    { enabled }
+  );
 };
 
 /**

--- a/src/frontend/src/layouts/Sidebar/Sidebar.tsx
+++ b/src/frontend/src/layouts/Sidebar/Sidebar.tsx
@@ -17,6 +17,7 @@ import GroupIcon from '@mui/icons-material/Group';
 import QuestionMarkIcon from '@mui/icons-material/QuestionMark';
 import AttachMoneyIcon from '@mui/icons-material/AttachMoney';
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
+import ChecklistIcon from '@mui/icons-material/Checklist';
 import NavPageLink from './NavPageLink';
 import NERDrawer from '../../components/NERDrawer';
 import NavUserMenu from '../PageTitle/NavUserMenu';
@@ -73,6 +74,11 @@ const Sidebar = ({ drawerOpen, setDrawerOpen, moveContent, setMoveContent }: Sid
       name: 'Gantt',
       icon: <AlignHorizontalLeftIcon />,
       route: routes.GANTT
+    },
+    !onGuestHomePage && {
+      name: 'Tasks',
+      icon: <ChecklistIcon />,
+      route: routes.TASKS
     },
     !onGuestHomePage
       ? {

--- a/src/frontend/src/layouts/Sidebar/Sidebar.tsx
+++ b/src/frontend/src/layouts/Sidebar/Sidebar.tsx
@@ -75,11 +75,6 @@ const Sidebar = ({ drawerOpen, setDrawerOpen, moveContent, setMoveContent }: Sid
       icon: <AlignHorizontalLeftIcon />,
       route: routes.GANTT
     },
-    !onGuestHomePage && {
-      name: 'Tasks',
-      icon: <ChecklistIcon />,
-      route: routes.TASKS
-    },
     !onGuestHomePage
       ? {
           name: 'Projects',
@@ -113,6 +108,11 @@ const Sidebar = ({ drawerOpen, setDrawerOpen, moveContent, setMoveContent }: Sid
             }
           ]
         },
+    !onGuestHomePage && {
+      name: 'Tasks',
+      icon: <ChecklistIcon />,
+      route: routes.TASKS
+    },
     !onGuestHomePage && {
       name: 'Change Requests',
       icon: <SyncAltIcon />,

--- a/src/frontend/src/pages/GanttPage/ProjectGanttChart/ProjectGanttChartPage.tsx
+++ b/src/frontend/src/pages/GanttPage/ProjectGanttChart/ProjectGanttChartPage.tsx
@@ -357,8 +357,7 @@ const ProjectGanttChartPage: FC = () => {
         userId: user.userId,
         firstName: user.firstName,
         lastName: user.lastName,
-        email: user.email,
-        role: user.role
+        email: user.email
       },
       assignees: [],
       labels: taskInfo.labels,

--- a/src/frontend/src/pages/GlobalTasksPage/DashboardCard.tsx
+++ b/src/frontend/src/pages/GlobalTasksPage/DashboardCard.tsx
@@ -1,0 +1,166 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import React, { useState } from 'react';
+import { Box, IconButton, Stack, Tooltip, Typography } from '@mui/material';
+import SaveIcon from '@mui/icons-material/Save';
+import DeleteIcon from '@mui/icons-material/Delete';
+import CloseIcon from '@mui/icons-material/Close';
+import { useForm } from 'react-hook-form';
+import { useHistory } from 'react-router-dom';
+import { Dashboard } from 'shared';
+import NERFormModal from '../../components/NERFormModal';
+import NERDeleteModal from '../../components/NERDeleteModal';
+import { useToast } from '../../hooks/toasts.hooks';
+import { datePipe } from '../../utils/pipes';
+import { useDeleteDashboard, useEditDashboard } from '../../hooks/dashboards.hooks';
+
+interface DashboardCardProps {
+  dashboard: Dashboard;
+  /** The relative path (pathname + query string) the "save" action stores into this dashboard. */
+  currentLink: string;
+  /** Whether this dashboard's saved view matches the current view. */
+  selected: boolean;
+}
+
+const DashboardCard: React.FC<DashboardCardProps> = ({ dashboard, currentLink, selected }) => {
+  const history = useHistory();
+  const toast = useToast();
+  const [showSaveModal, setShowSaveModal] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+  const { mutateAsync: editMutateAsync } = useEditDashboard(dashboard.dashboardId);
+  const { mutateAsync: deleteMutateAsync } = useDeleteDashboard(dashboard.dashboardId);
+
+  const { handleSubmit: handleSaveSubmit, reset: resetSaveForm } = useForm({ mode: 'onChange' });
+
+  const onSave = async () => {
+    try {
+      await editMutateAsync({ link: currentLink });
+      setShowSaveModal(false);
+    } catch (error: unknown) {
+      if (error instanceof Error) toast.error(error.message);
+    }
+  };
+
+  const onDelete = async () => {
+    try {
+      await deleteMutateAsync();
+      setShowDeleteModal(false);
+    } catch (error: unknown) {
+      if (error instanceof Error) toast.error(error.message);
+    }
+  };
+
+  return (
+    <>
+      <Box
+        onClick={() => history.push(dashboard.link)}
+        sx={{
+          position: 'relative',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 1,
+          minWidth: 200,
+          px: 1.5,
+          py: 0.75,
+          cursor: 'pointer',
+          borderRadius: 2,
+          border: selected ? '3px solid' : '1px solid',
+          borderColor: selected ? 'common.white' : 'error.main',
+          transform: selected ? 'scale(1.04)' : 'none',
+          transition: 'transform 0.15s ease, border-color 0.15s ease, border-width 0.15s ease'
+        }}
+      >
+        {selected && (
+          <Tooltip title="Clear dashboard">
+            <IconButton
+              size="small"
+              onClick={(event) => {
+                event.stopPropagation();
+                // navigate to the page with no filters, deselecting this dashboard
+                history.push(currentLink.split('?')[0]);
+              }}
+              sx={{
+                position: 'absolute',
+                top: -8,
+                right: -8,
+                zIndex: 1,
+                padding: '1px',
+                backgroundColor: 'background.paper',
+                border: '1px solid',
+                borderColor: 'common.white',
+                color: 'common.white',
+                '&:hover': { backgroundColor: 'background.paper' }
+              }}
+            >
+              <CloseIcon sx={{ fontSize: 13 }} />
+            </IconButton>
+          </Tooltip>
+        )}
+        <Box sx={{ overflow: 'hidden' }}>
+          <Typography variant="body2" fontWeight="bold" noWrap>
+            {dashboard.name}
+          </Typography>
+          <Typography variant="caption" sx={{ opacity: 0.7 }}>
+            {datePipe(dashboard.dateCreated)}
+          </Typography>
+        </Box>
+        <Stack direction="row">
+          <Tooltip title="Save current filters">
+            <IconButton
+              size="small"
+              sx={{ color: 'inherit' }}
+              onClick={(event) => {
+                event.stopPropagation();
+                setShowSaveModal(true);
+              }}
+            >
+              <SaveIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Delete dashboard">
+            <IconButton
+              size="small"
+              sx={{ color: 'inherit' }}
+              onClick={(event) => {
+                event.stopPropagation();
+                setShowDeleteModal(true);
+              }}
+            >
+              <DeleteIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        </Stack>
+      </Box>
+
+      <NERFormModal
+        open={showSaveModal}
+        onHide={() => setShowSaveModal(false)}
+        title={`Save filters to "${dashboard.name}"`}
+        reset={resetSaveForm}
+        handleUseFormSubmit={handleSaveSubmit}
+        onFormSubmit={onSave}
+        formId="save-dashboard-form"
+        submitText="Save"
+        showCloseButton
+      >
+        <Typography>
+          Overwrite the saved filters of <b>{dashboard.name}</b> with your current view?
+        </Typography>
+      </NERFormModal>
+
+      <NERDeleteModal
+        open={showDeleteModal}
+        onHide={() => setShowDeleteModal(false)}
+        dataType="Dashboard"
+        onFormSubmit={onDelete}
+      />
+    </>
+  );
+};
+
+export default DashboardCard;

--- a/src/frontend/src/pages/GlobalTasksPage/DashboardFormModal.tsx
+++ b/src/frontend/src/pages/GlobalTasksPage/DashboardFormModal.tsx
@@ -1,0 +1,79 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import React, { useCallback } from 'react';
+import { Box, FormControl, FormHelperText, FormLabel } from '@mui/material';
+import { useForm } from 'react-hook-form';
+import * as yup from 'yup';
+import { yupResolver } from '@hookform/resolvers/yup';
+import ReactHookTextField from '../../components/ReactHookTextField';
+import NERFormModal from '../../components/NERFormModal';
+import { useToast } from '../../hooks/toasts.hooks';
+import { useCreateDashboard } from '../../hooks/dashboards.hooks';
+
+const schema = yup.object().shape({
+  name: yup.string().required('Name is required')
+});
+
+interface DashboardFormModalProps {
+  showModal: boolean;
+  handleClose: () => void;
+  /** The relative path (pathname + query string) whose filters this dashboard saves. */
+  currentLink: string;
+}
+
+const DashboardFormModal: React.FC<DashboardFormModalProps> = ({ showModal, handleClose, currentLink }) => {
+  const toast = useToast();
+  const { mutateAsync } = useCreateDashboard();
+
+  const {
+    handleSubmit,
+    control,
+    reset,
+    formState: { errors }
+  } = useForm({
+    resolver: yupResolver(schema),
+    defaultValues: { name: '' }
+  });
+
+  const handleReset = useCallback(() => {
+    reset({ name: '' });
+  }, [reset]);
+
+  const onSubmit = async (data: { name: string }) => {
+    try {
+      await mutateAsync({ name: data.name, link: currentLink });
+      handleClose();
+    } catch (error: unknown) {
+      if (error instanceof Error) toast.error(error.message);
+    }
+  };
+
+  return (
+    <NERFormModal
+      open={showModal}
+      onHide={() => {
+        handleReset();
+        handleClose();
+      }}
+      title="Save Dashboard"
+      reset={handleReset}
+      handleUseFormSubmit={handleSubmit}
+      onFormSubmit={onSubmit}
+      formId="dashboard-form"
+      showCloseButton
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+        <FormControl fullWidth>
+          <FormLabel>Dashboard Name</FormLabel>
+          <ReactHookTextField name="name" control={control} sx={{ width: 1 }} />
+          <FormHelperText error>{errors.name?.message}</FormHelperText>
+        </FormControl>
+      </Box>
+    </NERFormModal>
+  );
+};
+
+export default DashboardFormModal;

--- a/src/frontend/src/pages/GlobalTasksPage/GlobalTasksPage.tsx
+++ b/src/frontend/src/pages/GlobalTasksPage/GlobalTasksPage.tsx
@@ -1,0 +1,56 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { TextField } from '@mui/material';
+import PageLayout from '../../components/PageLayout';
+import { useGlobalCarFilter } from '../../app/AppGlobalCarFilterContext';
+import { TaskListContent } from '../ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskListContent';
+import { useTaskFilters } from '../../hooks/task-filters.hooks';
+
+/**
+ * Top-level page showing every task across the organization, driven by a rich filter bar. Reuses the
+ * same kanban board (drag-to-move, create, etc.) as the project and work package task views.
+ */
+const GlobalTasksPage: React.FC = () => {
+  const { selectedCar, allCars } = useGlobalCarFilter();
+  // filters are owned here so the search box can live in the page header while the dropdowns live on the board
+  const { filters, patch } = useTaskFilters({ persistKey: 'globalTaskFilters' });
+
+  const hasGlobalCar = selectedCar !== 'all-cars';
+  // when a global car is selected we scope to it and hide the car dropdown; otherwise the user picks
+  const forcedCarNumbers = hasGlobalCar ? [selectedCar.wbsNum.carNumber] : undefined;
+
+  // the car a newly-created task should belong to: the selected car, or the most recent one
+  const mostRecentCar =
+    allCars.length > 0 ? allCars.reduce((a, b) => (a.wbsNum.carNumber > b.wbsNum.carNumber ? a : b)) : undefined;
+  const createCar = hasGlobalCar ? selectedCar : mostRecentCar;
+  const projectCarNumbers = createCar ? [createCar.wbsNum.carNumber] : undefined;
+
+  return (
+    <PageLayout
+      title="Global Task Kanban"
+      headerRight={
+        <TextField
+          size="small"
+          placeholder="Search tasks"
+          value={filters.search}
+          onChange={(event) => patch({ search: event.target.value })}
+          sx={{ minWidth: 260 }}
+        />
+      }
+    >
+      <TaskListContent
+        context="global"
+        showCarDropdown={!hasGlobalCar}
+        forcedCarNumbers={forcedCarNumbers}
+        projectCarNumbers={projectCarNumbers}
+        filters={filters}
+        patch={patch}
+      />
+    </PageLayout>
+  );
+};
+
+export default GlobalTasksPage;

--- a/src/frontend/src/pages/GlobalTasksPage/GlobalTasksPage.tsx
+++ b/src/frontend/src/pages/GlobalTasksPage/GlobalTasksPage.tsx
@@ -3,11 +3,16 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { TextField } from '@mui/material';
+import { useState } from 'react';
+import { Box, Button, Stack, Typography } from '@mui/material';
+import { useLocation } from 'react-router-dom';
 import PageLayout from '../../components/PageLayout';
 import { useGlobalCarFilter } from '../../app/AppGlobalCarFilterContext';
 import { TaskListContent } from '../ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskListContent';
 import { useTaskFilters } from '../../hooks/task-filters.hooks';
+import { useUserDashboards } from '../../hooks/dashboards.hooks';
+import DashboardCard from './DashboardCard';
+import DashboardFormModal from './DashboardFormModal';
 
 /**
  * Top-level page showing every task across the organization, driven by a rich filter bar. Reuses the
@@ -17,6 +22,12 @@ const GlobalTasksPage: React.FC = () => {
   const { selectedCar, allCars } = useGlobalCarFilter();
   // filters are owned here so the search box can live in the page header while the dropdowns live on the board
   const { filters, patch } = useTaskFilters({ persistKey: 'globalTaskFilters' });
+
+  // the current filters are fully encoded in the URL, so a dashboard just saves this relative path
+  const location = useLocation();
+  const currentLink = location.pathname + location.search;
+  const { data: dashboards } = useUserDashboards();
+  const [showSaveDashboardModal, setShowSaveDashboardModal] = useState(false);
 
   const hasGlobalCar = selectedCar !== 'all-cars';
   // when a global car is selected we scope to it and hide the car dropdown; otherwise the user picks
@@ -29,26 +40,41 @@ const GlobalTasksPage: React.FC = () => {
   const projectCarNumbers = createCar ? [createCar.wbsNum.carNumber] : undefined;
 
   return (
-    <PageLayout
-      title="Global Task Kanban"
-      headerRight={
-        <TextField
-          size="small"
-          placeholder="Search tasks"
-          value={filters.search}
-          onChange={(event) => patch({ search: event.target.value })}
-          sx={{ minWidth: 260 }}
+    <PageLayout title="Global Task Kanban" hidePageTitle>
+      {/* header: title flexes to its text on the left, dashboards scroll in the middle, save button on the right */}
+      <Stack direction="row" alignItems="center" spacing={2} sx={{ mt: 2, mb: 2 }}>
+        <Typography variant="h4" fontSize={30} sx={{ flexShrink: 0 }}>
+          Global Task Kanban
+        </Typography>
+        <Stack direction="row" spacing={1} sx={{ flex: 1, minWidth: 0, overflowX: 'auto', px: 2, py: 1.5 }}>
+          {dashboards?.map((dashboard) => (
+            <DashboardCard
+              key={dashboard.dashboardId}
+              dashboard={dashboard}
+              currentLink={currentLink}
+              selected={dashboard.link === currentLink}
+            />
+          ))}
+        </Stack>
+        <Button variant="contained" sx={{ flexShrink: 0 }} onClick={() => setShowSaveDashboardModal(true)}>
+          Save Dashboard
+        </Button>
+      </Stack>
+      <Box>
+        <TaskListContent
+          context="global"
+          showCarDropdown={!hasGlobalCar}
+          forcedCarNumbers={forcedCarNumbers}
+          projectCarNumbers={projectCarNumbers}
+          filters={filters}
+          patch={patch}
         />
-      }
-    >
-      <TaskListContent
-        context="global"
-        showCarDropdown={!hasGlobalCar}
-        forcedCarNumbers={forcedCarNumbers}
-        projectCarNumbers={projectCarNumbers}
-        filters={filters}
-        patch={patch}
-      />
+        <DashboardFormModal
+          showModal={showSaveDashboardModal}
+          handleClose={() => setShowSaveDashboardModal(false)}
+          currentLink={currentLink}
+        />
+      </Box>
     </PageLayout>
   );
 };

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/TaskFormModal.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/TaskFormModal.tsx
@@ -74,7 +74,9 @@ const TaskFormModal: React.FC<TaskFormModalProps> = ({
 }) => {
   // In progress tasks must have a deadline and at least one assignee; backlog/done tasks don't.
   const isInProgress = status === TaskStatus.IN_PROGRESS;
-  const isGlobalCreate = context === 'global';
+  // only the global *create* form surfaces the project picker; editing an existing task always derives
+  // its project from the task itself, even when opened from the global board.
+  const isGlobalCreate = context === 'global' && !task;
   const schema = yup.object().shape({
     notes: yup
       .string()
@@ -171,8 +173,10 @@ const TaskFormModal: React.FC<TaskFormModalProps> = ({
     (t) => t.taskId !== task?.taskId && t.status !== TaskStatus.DONE
   );
 
-  // whether the form is scoped to a specific work package (hides the WP picker). Never true for global.
-  const isWpContext = !isGlobalCreate && !!wbsNum && wbsNum.workPackageNumber !== 0;
+  // whether the *board* itself is scoped to a single work package (hides the WP picker). Driven by the
+  // board context, not the task's own wbs — a WP task opened from the global/project board still needs
+  // the WP picker so it can be reassigned.
+  const isWpContext = context === 'workPackage';
 
   // highlight the missing required fields right away when asked to (e.g. dragged into In Progress)
   useEffect(() => {

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/TaskFormModal.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/TaskFormModal.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Autocomplete, Box, Chip, FormControl, FormHelperText, FormLabel, Grid, MenuItem, TextField } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers';
@@ -21,6 +22,7 @@ import LoadingIndicator from '../../../../components/LoadingIndicator';
 import ErrorPage from '../../../ErrorPage';
 import { useWorkPackagesByProject } from '../../../../hooks/work-packages.hooks';
 import { useAllTaskLabels, useFilterTasks } from '../../../../hooks/tasks.hooks';
+import ProjectDropdown from '../../../../components/dropdowns/ProjectDropdown';
 
 export interface EditTaskFormInput {
   taskId: string;
@@ -33,6 +35,8 @@ export interface EditTaskFormInput {
   deadline?: Date;
   priority: TaskPriority;
   wpWbsNum?: WbsNumber | null;
+  // only used by the global-create form: the project the new task belongs to
+  projectWbsNum?: WbsNumber | null;
 }
 
 interface TaskFormModalProps {
@@ -43,7 +47,16 @@ interface TaskFormModalProps {
   onSubmit: (data: EditTaskFormInput) => Promise<void>;
   onReset?: () => void;
   isLoading?: boolean;
-  wbsNum: WbsNumber;
+  // optional so the global board can create/edit tasks without a fixed project/work package scope
+  wbsNum?: WbsNumber;
+  // 'global' surfaces a project picker (and hides any car picker) so a task can be created without a
+  // pre-selected project. Defaults to the existing project/work package behavior.
+  context?: 'global' | 'project' | 'workPackage';
+  // global create only: constrain the project picker to these car numbers
+  projectCarNumbers?: number[];
+  // when true, surfaces validation errors as soon as the modal opens (used to highlight the missing
+  // deadline/assignee when a task is dragged into In Progress without them)
+  validateOnOpen?: boolean;
 }
 
 const TaskFormModal: React.FC<TaskFormModalProps> = ({
@@ -54,89 +67,64 @@ const TaskFormModal: React.FC<TaskFormModalProps> = ({
   onHide,
   onReset,
   isLoading,
-  wbsNum
+  wbsNum,
+  context,
+  projectCarNumbers,
+  validateOnOpen = false
 }) => {
-  let schema;
-
-  if (status === TaskStatus.IN_PROGRESS) {
-    schema = yup.object().shape({
-      notes: yup
-        .string()
-        .optional()
-        .test((value) => {
-          if (!value) return true;
-          const wordCount = countWords(value);
-          return wordCount < 250;
-        }),
-      startDate: yup.date().optional(),
-      deadline: yup
-        .date()
-        .required('Deadline is required for In Progress tasks')
-        .test('deadline-after-start', 'Deadline must be on or after the start date', function (deadline) {
-          const { startDate } = this.parent;
-          if (!startDate || !deadline) return true;
-          return deadline >= startDate;
-        }),
-      priority: yup.mixed<TaskPriority>().oneOf(Object.values(TaskPriority)).required(),
-      assignees: yup.array().required().min(1, 'At least one assignee is required for In Progress tasks'),
-      labels: yup.array().of(yup.mixed<TaskLabel>().required()).required(),
-      blockedBy: yup.array().of(yup.mixed<TaskBlockerPreview>().required()).required(),
-      title: yup.string().required(),
-      taskId: yup.string().required(),
-      wpWbsNum: yup.mixed<WbsNumber>().optional()
-    });
-  } else {
-    schema = yup.object().shape({
-      notes: yup
-        .string()
-        .optional()
-        .test((value) => {
-          if (!value) return true;
-          const wordCount = countWords(value);
-          return wordCount < 250;
-        }),
-      startDate: yup.date().optional(),
-      deadline: yup
-        .date()
-        .optional()
-        .test('deadline-after-start', 'Deadline must be on or after the start date', function (deadline) {
-          const { startDate } = this.parent;
-          if (!startDate || !deadline) return true;
-          return deadline >= startDate;
-        }),
-      priority: yup.mixed<TaskPriority>().oneOf(Object.values(TaskPriority)).required(),
-      assignees: yup.array().required(),
-      labels: yup.array().of(yup.mixed<TaskLabel>().required()).required(),
-      blockedBy: yup.array().of(yup.mixed<TaskBlockerPreview>().required()).required(),
-      title: yup.string().required(),
-      taskId: yup.string().required(),
-      wpWbsNum: yup.mixed<WbsNumber>().nullable().optional()
-    });
-  }
+  // In progress tasks must have a deadline and at least one assignee; backlog/done tasks don't.
+  const isInProgress = status === TaskStatus.IN_PROGRESS;
+  const isGlobalCreate = context === 'global';
+  const schema = yup.object().shape({
+    notes: yup
+      .string()
+      .optional()
+      .test((value) => {
+        if (!value) return true;
+        const wordCount = countWords(value);
+        return wordCount < 250;
+      }),
+    startDate: yup.date().optional(),
+    deadline: isInProgress
+      ? yup
+          .date()
+          .required('Deadline is required for In Progress tasks')
+          .test('deadline-after-start', 'Deadline must be on or after the start date', function (deadline) {
+            const { startDate } = this.parent;
+            if (!startDate || !deadline) return true;
+            return deadline >= startDate;
+          })
+      : yup
+          .date()
+          .optional()
+          .test('deadline-after-start', 'Deadline must be on or after the start date', function (deadline) {
+            const { startDate } = this.parent;
+            if (!startDate || !deadline) return true;
+            return deadline >= startDate;
+          }),
+    priority: yup.mixed<TaskPriority>().oneOf(Object.values(TaskPriority)).required(),
+    assignees: isInProgress
+      ? yup.array().required().min(1, 'At least one assignee is required for In Progress tasks')
+      : yup.array().required(),
+    labels: yup.array().of(yup.mixed<TaskLabel>().required()).required(),
+    blockedBy: yup.array().of(yup.mixed<TaskBlockerPreview>().required()).required(),
+    title: yup.string().required(),
+    taskId: yup.string().required(),
+    wpWbsNum: yup.mixed<WbsNumber>().nullable().optional(),
+    projectWbsNum: isGlobalCreate
+      ? yup.mixed<WbsNumber>().required('Project is required')
+      : yup.mixed<WbsNumber>().nullable().optional()
+  });
 
   const user = useCurrentUser();
-
-  const { data: users, isLoading: usersLoading, isError, error } = useAllMembers();
-  const { data: taskLabels, isLoading: labelsIsLoading, isError: labelsIsError, error: labelsError } = useAllTaskLabels();
-
-  const projectWbsNum = { ...wbsNum, workPackageNumber: 0 };
-  const { data: workPackages } = useWorkPackagesByProject(projectWbsNum);
-  const {
-    data: projectTasks,
-    isLoading: projectTasksLoading,
-    isError: projectTasksIsError,
-    error: projectTasksError
-  } = useFilterTasks({ wbsNum: projectWbsNum });
-  const blockedByOptions: TaskBlockerPreview[] = (projectTasks ?? []).filter((t) => t.taskId !== task?.taskId);
-
-  const isWpContext = wbsNum.workPackageNumber !== 0;
 
   const {
     handleSubmit,
     control,
     watch,
     formState: { errors },
-    reset
+    reset,
+    trigger
   } = useForm<EditTaskFormInput>({
     resolver: yupResolver(schema),
     defaultValues: {
@@ -149,16 +137,52 @@ const TaskFormModal: React.FC<TaskFormModalProps> = ({
       assignees: task?.assignees.map((assignee) => assignee.userId) ?? [],
       labels: task?.labels ?? [],
       blockedBy: task?.blockedBy ?? [],
-      wpWbsNum: task?.wbsNum.workPackageNumber !== 0 ? task?.wbsNum : undefined
+      wpWbsNum: task?.wbsNum.workPackageNumber !== 0 ? task?.wbsNum : undefined,
+      projectWbsNum: null
     }
   });
 
   const startDate = watch('startDate');
+  const selectedProjectWbsNum = watch('projectWbsNum');
+
+  // The project the task belongs to: chosen in the picker on the global-create form, otherwise derived
+  // from the board's own wbs number.
+  const effectiveProjectWbsNum: WbsNumber | undefined = isGlobalCreate
+    ? (selectedProjectWbsNum ?? undefined)
+    : wbsNum
+      ? { ...wbsNum, workPackageNumber: 0 }
+      : undefined;
+
+  const { data: users, isLoading: usersLoading, isError, error } = useAllMembers();
+  const { data: taskLabels, isLoading: labelsIsLoading, isError: labelsIsError, error: labelsError } = useAllTaskLabels();
+
+  const placeholderWbs: WbsNumber = { carNumber: 0, projectNumber: 0, workPackageNumber: 0 };
+  const { data: workPackages } = useWorkPackagesByProject(
+    effectiveProjectWbsNum ?? placeholderWbs,
+    !!effectiveProjectWbsNum
+  );
+  const {
+    data: projectTasks,
+    isError: projectTasksIsError,
+    error: projectTasksError
+  } = useFilterTasks(effectiveProjectWbsNum ? { wbsNum: effectiveProjectWbsNum } : null);
+  // only tasks that aren't the task being edited and aren't already done can block a task
+  const blockedByOptions: TaskBlockerPreview[] = (projectTasks ?? []).filter(
+    (t) => t.taskId !== task?.taskId && t.status !== TaskStatus.DONE
+  );
+
+  // whether the form is scoped to a specific work package (hides the WP picker). Never true for global.
+  const isWpContext = !isGlobalCreate && !!wbsNum && wbsNum.workPackageNumber !== 0;
+
+  // highlight the missing required fields right away when asked to (e.g. dragged into In Progress)
+  useEffect(() => {
+    if (modalShow && validateOnOpen) trigger();
+  }, [modalShow, validateOnOpen, trigger]);
 
   if (isError) return <ErrorPage error={error} />;
   if (labelsIsError) return <ErrorPage error={labelsError} />;
   if (projectTasksIsError) return <ErrorPage error={projectTasksError} />;
-  if (usersLoading || !users || labelsIsLoading || !taskLabels || projectTasksLoading) return <LoadingIndicator />;
+  if (usersLoading || !users || labelsIsLoading || !taskLabels) return <LoadingIndicator />;
 
   const userOptions: { label: string; id: string }[] = users.map(taskUserToAutocompleteOption);
   const wpOptions: { label: string; wbsNum: WbsNumber }[] = (workPackages ?? []).map((wp) => ({
@@ -199,6 +223,26 @@ const TaskFormModal: React.FC<TaskFormModalProps> = ({
         }}
       >
         <Grid container spacing={2}>
+          {isGlobalCreate && (
+            <Grid item xs={12}>
+              <FormControl fullWidth>
+                <FormLabel>Project</FormLabel>
+                <Controller
+                  name="projectWbsNum"
+                  control={control}
+                  render={({ field: { onChange, value } }) => (
+                    <ProjectDropdown
+                      multiple={false}
+                      carNumbers={projectCarNumbers}
+                      value={value ? [value] : []}
+                      onChange={(wbsNums) => onChange(wbsNums[0] ?? null)}
+                    />
+                  )}
+                />
+                <FormHelperText error={!!errors.projectWbsNum}>{errors.projectWbsNum?.message}</FormHelperText>
+              </FormControl>
+            </Grid>
+          )}
           <Grid item xs={12} md={7}>
             <FormControl sx={{ width: '100%' }}>
               <FormLabel>Title</FormLabel>

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/TaskModal.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/TaskModal.tsx
@@ -5,9 +5,11 @@
 
 import { fullNamePipe, datePipe, wbsPipe } from '../../../../utils/pipes';
 import { Task, TaskStatus, WbsNumber } from 'shared';
-import { Box, Chip, Grid, IconButton, Link, Tooltip, Typography } from '@mui/material';
+import { Box, Button, Chip, Grid, IconButton, Link, Tooltip, Typography } from '@mui/material';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import { Link as RouterLink } from 'react-router-dom';
 import { useState } from 'react';
+import { routes } from '../../../../utils/routes';
 import TaskFormModal, { EditTaskFormInput } from './TaskFormModal';
 import NERModal from '../../../../components/NERModal';
 import { useToast } from '../../../../hooks/toasts.hooks';
@@ -19,6 +21,8 @@ interface TaskModalProps {
   onSubmit: (data: EditTaskFormInput) => Promise<void>;
   hasEditPermissions: boolean;
   wbsNum: WbsNumber;
+  // the board this task was opened from, so the edit form knows whether it's WP-scoped
+  context?: 'global' | 'project' | 'workPackage';
   // opens another task's modal by taskId (used by the "Blocked By" task links)
   onOpenTask: (taskId: string) => void;
 }
@@ -30,6 +34,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
   onSubmit,
   hasEditPermissions,
   wbsNum,
+  context,
   onOpenTask
 }) => {
   const [isEditMode, setIsEditMode] = useState(false);
@@ -43,7 +48,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
 
   const priorityColor = task.priority === 'HIGH' ? '#ef4345' : task.priority === 'LOW' ? '#00ab41' : '#FFA500';
   const isWpTask = task.wbsNum.workPackageNumber !== 0;
-  const isWpContext = wbsNum.workPackageNumber !== 0;
+  const isWpContext = context === 'workPackage';
   const activeBlockers = task.blockedBy.filter((blocker) => blocker.status !== TaskStatus.DONE);
 
   const ViewModal: React.FC = () => {
@@ -60,11 +65,24 @@ const TaskModal: React.FC<TaskModalProps> = ({
           }
         }}
         actionsLeftChildren={
-          <Tooltip title="Copy link to this task">
-            <IconButton onClick={handleCopyLink}>
-              <ContentCopyIcon />
-            </IconButton>
-          </Tooltip>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Tooltip title="Copy link to this task">
+              <IconButton onClick={handleCopyLink}>
+                <ContentCopyIcon />
+              </IconButton>
+            </Tooltip>
+            {/* on the global board only, offer a shortcut to the task's own project/work package task page */}
+            {context === 'global' && (
+              <Button
+                variant="outlined"
+                component={RouterLink}
+                to={`${routes.PROJECTS}/${wbsPipe(task.wbsNum)}/tasks`}
+                onClick={onHide}
+              >
+                {isWpTask ? 'Go to Work Package' : 'Go to Project'}
+              </Button>
+            )}
+          </Box>
         }
       >
         <Grid container spacing={4}>
@@ -169,6 +187,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
         setIsEditMode(false);
       }}
       wbsNum={wbsNum}
+      context={context}
     />
   ) : (
     <ViewModal />

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/TaskModal.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/TaskModal.tsx
@@ -5,10 +5,12 @@
 
 import { fullNamePipe, datePipe, wbsPipe } from '../../../../utils/pipes';
 import { Task, TaskStatus, WbsNumber } from 'shared';
-import { Box, Chip, Grid, Typography } from '@mui/material';
+import { Box, Chip, Grid, IconButton, Link, Tooltip, Typography } from '@mui/material';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { useState } from 'react';
 import TaskFormModal, { EditTaskFormInput } from './TaskFormModal';
 import NERModal from '../../../../components/NERModal';
+import { useToast } from '../../../../hooks/toasts.hooks';
 
 interface TaskModalProps {
   task: Task;
@@ -17,10 +19,27 @@ interface TaskModalProps {
   onSubmit: (data: EditTaskFormInput) => Promise<void>;
   hasEditPermissions: boolean;
   wbsNum: WbsNumber;
+  // opens another task's modal by taskId (used by the "Blocked By" task links)
+  onOpenTask: (taskId: string) => void;
 }
 
-const TaskModal: React.FC<TaskModalProps> = ({ task, modalShow, onHide, onSubmit, hasEditPermissions, wbsNum }) => {
+const TaskModal: React.FC<TaskModalProps> = ({
+  task,
+  modalShow,
+  onHide,
+  onSubmit,
+  hasEditPermissions,
+  wbsNum,
+  onOpenTask
+}) => {
   const [isEditMode, setIsEditMode] = useState(false);
+  const toast = useToast();
+
+  const handleCopyLink = () => {
+    const url = `${window.location.origin}${window.location.pathname}?task=${task.taskId}`;
+    navigator.clipboard.writeText(url);
+    toast.success('Task link copied to clipboard!');
+  };
 
   const priorityColor = task.priority === 'HIGH' ? '#ef4345' : task.priority === 'LOW' ? '#00ab41' : '#FFA500';
   const isWpTask = task.wbsNum.workPackageNumber !== 0;
@@ -40,6 +59,13 @@ const TaskModal: React.FC<TaskModalProps> = ({ task, modalShow, onHide, onSubmit
             setIsEditMode(true);
           }
         }}
+        actionsLeftChildren={
+          <Tooltip title="Copy link to this task">
+            <IconButton onClick={handleCopyLink}>
+              <ContentCopyIcon />
+            </IconButton>
+          </Tooltip>
+        }
       >
         <Grid container spacing={4}>
           <Grid item xs={12} md={6}>
@@ -98,9 +124,18 @@ const TaskModal: React.FC<TaskModalProps> = ({ task, modalShow, onHide, onSubmit
           {(activeBlockers.length > 0 || task.blockedByWorkPackages.length > 0) && (
             <Grid item xs={12} md={6}>
               <Typography fontWeight={'bold'}>Blocked By:</Typography>
-              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.5 }}>
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 1, mt: 0.5 }}>
                 {activeBlockers.map((blocker) => (
-                  <Chip key={blocker.taskId} label={blocker.title} size="small" />
+                  <Link
+                    key={blocker.taskId}
+                    component="button"
+                    type="button"
+                    underline="hover"
+                    onClick={() => onOpenTask(blocker.taskId)}
+                    sx={{ fontSize: '0.875rem' }}
+                  >
+                    {blocker.title}
+                  </Link>
                 ))}
                 {task.blockedByWorkPackages.map((blockingWp) => (
                   <Chip key={wbsPipe(blockingWp.wbsNum)} label={`${blockingWp.name} (WP)`} size="small" variant="outlined" />

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskCard.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskCard.tsx
@@ -10,7 +10,7 @@ import { datePipe, fullNamePipe, listPipe } from '../../../../../utils/pipes';
 import { EditTaskFormInput } from '../TaskFormModal';
 import TaskModal from '../TaskModal';
 import NERModal from '../../../../../components/NERModal';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink, useHistory, useLocation } from 'react-router-dom';
 import { routes } from '../../../../../utils/routes';
 import { wbsPipe } from '../../../../../utils/pipes';
 
@@ -34,7 +34,7 @@ export const TaskCard = ({
 }: {
   task: Task;
   index: number;
-  wbsNum: WbsNumber;
+  wbsNum?: WbsNumber;
   onDeleteTask: (taskId: string) => void;
   onEditTask: (task: Task) => void;
 }) => {
@@ -45,8 +45,26 @@ export const TaskCard = ({
   const user = useCurrentUser();
 
   const toast = useToast();
-  const [showModal, setShowModal] = useState(false);
+  const history = useHistory();
+  const location = useLocation();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  // the open task is encoded in the url (?task=<taskId>) so a task modal can be linked to and shared directly
+  const selectedTaskId = new URLSearchParams(location.search).get('task');
+  const showModal = selectedTaskId === task.taskId;
+
+  const openTask = (taskId: string) => {
+    const params = new URLSearchParams(location.search);
+    params.set('task', taskId);
+    history.push(`${location.pathname}?${params.toString()}`);
+  };
+
+  const closeTask = () => {
+    const params = new URLSearchParams(location.search);
+    params.delete('task');
+    const search = params.toString();
+    history.push(search ? `${location.pathname}?${search}` : location.pathname);
+  };
 
   const handleDelete = async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -100,7 +118,7 @@ export const TaskCard = ({
 
       onEditTask(newTask);
       toast.success('Task edited successfully!');
-      setShowModal(false);
+      closeTask();
     } catch (error: unknown) {
       if (error instanceof Error) {
         toast.error(error.message);
@@ -111,7 +129,8 @@ export const TaskCard = ({
   const priorityColor = task.priority === 'HIGH' ? '#ef4345' : task.priority === 'LOW' ? '#00ab41' : '#FFA500';
   const isOverdue = task.deadline != null && new Date(task.deadline) < new Date() && task.status !== 'DONE';
   const isWpTask = task.wbsNum.workPackageNumber !== 0;
-  const isProjectContext = wbsNum.workPackageNumber === 0;
+  // on the global board there's no board-level wbs, so treat it like the project view (show the WP chip)
+  const isProjectContext = !wbsNum || wbsNum.workPackageNumber === 0;
   const wpColor = wpColors[(task.wbsNum.workPackageNumber - 1) % wpColors.length];
   const activeBlockers = task.blockedBy.filter((blocker) => blocker.status !== TaskStatus.DONE);
 
@@ -120,10 +139,11 @@ export const TaskCard = ({
       <TaskModal
         modalShow={showModal}
         task={task}
-        onHide={() => setShowModal(false)}
+        onHide={closeTask}
         onSubmit={handleEditTask}
         hasEditPermissions={notGuest(user.role)}
-        wbsNum={wbsNum}
+        wbsNum={wbsNum ?? task.wbsNum}
+        onOpenTask={openTask}
       />
       <NERModal
         open={showDeleteConfirm}
@@ -139,7 +159,7 @@ export const TaskCard = ({
       <Draggable draggableId={String(task.taskId)} index={index}>
         {(provided, snapshot) => (
           <Box sx={{ marginBottom: 1 }} {...provided.draggableProps} {...provided.dragHandleProps} ref={provided.innerRef}>
-            <div onClick={() => setShowModal(true)}>
+            <div onClick={() => openTask(task.taskId)}>
               <Card
                 sx={{
                   opacity: snapshot.isDragging ? 0.9 : 1,

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskCard.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskCard.tsx
@@ -30,6 +30,7 @@ export const TaskCard = ({
   task,
   index,
   wbsNum,
+  context,
   showProjectName = false,
   onDeleteTask,
   onEditTask
@@ -37,6 +38,8 @@ export const TaskCard = ({
   task: Task;
   index: number;
   wbsNum?: WbsNumber;
+  // the board this card lives on, forwarded to the modal so the edit form knows whether it's WP-scoped
+  context?: 'global' | 'project' | 'workPackage';
   // shows the owning project's name on the card (used only on the global board, where tasks span projects)
   showProjectName?: boolean;
   onDeleteTask: (taskId: string) => void;
@@ -156,6 +159,7 @@ export const TaskCard = ({
         onSubmit={handleEditTask}
         hasEditPermissions={notGuest(user.role)}
         wbsNum={wbsNum ?? task.wbsNum}
+        context={context}
         onOpenTask={openTask}
       />
       <NERModal

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskCard.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskCard.tsx
@@ -13,7 +13,7 @@ import NERModal from '../../../../../components/NERModal';
 import { Link as RouterLink, useHistory, useLocation } from 'react-router-dom';
 import { routes } from '../../../../../utils/routes';
 import { wbsPipe } from '../../../../../utils/pipes';
-import { useSlimProjects } from '../../../../../hooks/dropdowns.hooks';
+import { useProjectsDropdown } from '../../../../../hooks/dropdowns.hooks';
 
 const wpColors = [
   { bg: 'rgba(55,138,221,0.15)', color: '#7dbef4' }, // blue
@@ -46,10 +46,10 @@ export const TaskCard = ({
   const { mutateAsync: editTask } = useEditTask();
   const { mutateAsync: editTaskAssignees } = useEditTaskAssignees();
 
-  // only fetch slim projects when we actually need to label cards (global board)
-  const { data: slimProjects } = useSlimProjects(showProjectName);
+  // only fetch the projects dropdown list when we actually need to label cards (global board)
+  const { data: dropdownProjects } = useProjectsDropdown(showProjectName);
   const projectName = showProjectName
-    ? slimProjects?.find(
+    ? dropdownProjects?.find(
         (project) =>
           project.wbsNum.carNumber === task.wbsNum.carNumber && project.wbsNum.projectNumber === task.wbsNum.projectNumber
       )?.name

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskCard.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskCard.tsx
@@ -13,6 +13,7 @@ import NERModal from '../../../../../components/NERModal';
 import { Link as RouterLink, useHistory, useLocation } from 'react-router-dom';
 import { routes } from '../../../../../utils/routes';
 import { wbsPipe } from '../../../../../utils/pipes';
+import { useSlimProjects } from '../../../../../hooks/dropdowns.hooks';
 
 const wpColors = [
   { bg: 'rgba(55,138,221,0.15)', color: '#7dbef4' }, // blue
@@ -29,18 +30,30 @@ export const TaskCard = ({
   task,
   index,
   wbsNum,
+  showProjectName = false,
   onDeleteTask,
   onEditTask
 }: {
   task: Task;
   index: number;
   wbsNum?: WbsNumber;
+  // shows the owning project's name on the card (used only on the global board, where tasks span projects)
+  showProjectName?: boolean;
   onDeleteTask: (taskId: string) => void;
   onEditTask: (task: Task) => void;
 }) => {
   const { mutateAsync: deleteTask } = useDeleteTask();
   const { mutateAsync: editTask } = useEditTask();
   const { mutateAsync: editTaskAssignees } = useEditTaskAssignees();
+
+  // only fetch slim projects when we actually need to label cards (global board)
+  const { data: slimProjects } = useSlimProjects(showProjectName);
+  const projectName = showProjectName
+    ? slimProjects?.find(
+        (project) =>
+          project.wbsNum.carNumber === task.wbsNum.carNumber && project.wbsNum.projectNumber === task.wbsNum.projectNumber
+      )?.name
+    : undefined;
 
   const user = useCurrentUser();
 
@@ -170,6 +183,15 @@ export const TaskCard = ({
                 elevation={snapshot.isDragging ? 3 : 1}
               >
                 <CardContent>
+                  {projectName && (
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ display: 'block', fontWeight: 600, mb: 0.5, textTransform: 'uppercase', letterSpacing: 0.4 }}
+                    >
+                      {projectName}
+                    </Typography>
+                  )}
                   <Grid container>
                     <Grid item xs={11}>
                       <Typography variant="h5" component="div">

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskColumn.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskColumn.tsx
@@ -106,6 +106,10 @@ export const TaskColumn = ({
       <Box
         sx={{
           flex: 1,
+          // without an explicit basis + min-width:0, a column whose cards have wider content (common on
+          // the global board, which spans many projects) won't shrink and ends up wider than the others
+          flexBasis: 0,
+          minWidth: 0,
           display: 'flex',
           flexDirection: 'column',
           paddingTop: '8px',
@@ -158,6 +162,7 @@ export const TaskColumn = ({
                   task={task}
                   index={index}
                   wbsNum={wbsNum}
+                  showProjectName={context === 'global'}
                 />
               ))}
               {droppableProvided.placeholder}

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskColumn.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskColumn.tsx
@@ -162,6 +162,7 @@ export const TaskColumn = ({
                   task={task}
                   index={index}
                   wbsNum={wbsNum}
+                  context={context}
                   showProjectName={context === 'global'}
                 />
               ))}

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskColumn.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskColumn.tsx
@@ -13,6 +13,8 @@ export const TaskColumn = ({
   status,
   tasks,
   wbsNum,
+  context,
+  projectCarNumbers,
   equalizedHeight,
   isDragging,
   onEditTask,
@@ -22,7 +24,9 @@ export const TaskColumn = ({
 }: {
   status: TaskStatus;
   tasks: TaskWithIndex[];
-  wbsNum: WbsNumber;
+  wbsNum?: WbsNumber;
+  context?: 'global' | 'project' | 'workPackage';
+  projectCarNumbers?: number[];
   equalizedHeight: number;
   isDragging: boolean;
   onEditTask: (task: Task) => void;
@@ -55,11 +59,18 @@ export const TaskColumn = ({
     blockedBy,
     priority,
     startDate,
-    wpWbsNum
+    wpWbsNum,
+    projectWbsNum
   }: EditTaskFormInput) => {
+    // work package wins, then the chosen project (global create), then the board's own scope
+    const createWbsNum = wpWbsNum ?? projectWbsNum ?? wbsNum;
+    if (!createWbsNum) {
+      toast.error('Please select a project for this task.');
+      return;
+    }
     try {
       const task = await createTask({
-        wbsNum: wpWbsNum ?? wbsNum,
+        wbsNum: createWbsNum,
         title,
         deadline: deadline ? toDateString(deadline) : undefined,
         startDate: startDate ? toDateString(startDate) : undefined,
@@ -88,6 +99,8 @@ export const TaskColumn = ({
         onHide={() => setShowCreateTaskModal(false)}
         modalShow={showCreateTaskModal}
         wbsNum={wbsNum}
+        context={context}
+        projectCarNumbers={projectCarNumbers}
         isLoading={isLoading}
       />
       <Box

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskList.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskList.tsx
@@ -6,5 +6,9 @@ import { GuestsTasksList } from '../GuestTasksList';
 export const TaskList = ({ project, isGuest }: { project: Project; isGuest: boolean }) => {
   const isSmall = useMediaQuery((theme: Theme) => theme.breakpoints.down('sm'));
 
-  return isSmall || isGuest ? <GuestsTasksList project={project} /> : <TaskListContent wbsNum={project.wbsNum} />;
+  return isSmall || isGuest ? (
+    <GuestsTasksList project={project} />
+  ) : (
+    <TaskListContent context="project" wbsNum={project.wbsNum} />
+  );
 };

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskListContent.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskListContent.tsx
@@ -314,6 +314,7 @@ export const TaskListContent = ({
           onHide={() => setFixTaskModal(null)}
           onSubmit={onFixTaskSubmit}
           wbsNum={fixTaskModal.wbsNum}
+          context={context}
         />
       )}
       <NERModal

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskListContent.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskListContent.tsx
@@ -1,34 +1,112 @@
 import { DragDropContext, OnDragEndResponder, OnDragStartResponder } from '@hello-pangea/dnd';
-import { Autocomplete, Box, Button, Chip, TextField, Typography } from '@mui/material';
+import { Badge, Box, Button, TextField, Typography } from '@mui/material';
 import FilterListIcon from '@mui/icons-material/FilterList';
-import { useCallback, useState, useEffect } from 'react';
-import { Task, TaskLabel, TaskStatus, TaskWithIndex, WbsNumber } from 'shared';
+import { useCallback, useMemo, useState, useEffect } from 'react';
+import { FilterTaskArgs, Task, TaskStatus, TaskWithIndex, WbsNumber } from 'shared';
+import { useQueryClient } from 'react-query';
 import { getTasksByStatus, statuses, TasksByStatus } from '.';
-import { useAllTaskLabels, useFilterTasks, useSetTaskStatus } from '../../../../../hooks/tasks.hooks';
+import { useEditTask, useEditTaskAssignees, useFilterTasks, useSetTaskStatus } from '../../../../../hooks/tasks.hooks';
 import { useToast } from '../../../../../hooks/toasts.hooks';
 import { TaskColumn } from './TaskColumn';
 import confetti from 'canvas-confetti';
 import LoadingIndicator from '../../../../../components/LoadingIndicator';
 import ErrorPage from '../../../../ErrorPage';
+import NERModal from '../../../../../components/NERModal';
+import TaskFormModal, { EditTaskFormInput } from '../TaskFormModal';
+import TaskFilterBar, { TaskFilterContext } from '../../../../../components/TaskFilterBar';
+import { TaskFilterFields, useTaskFilters } from '../../../../../hooks/task-filters.hooks';
 
 interface TaskListContentProps {
-  wbsNum: WbsNumber;
+  /** which task board this is; drives which filters appear and how tasks are scoped */
+  context: TaskFilterContext;
+  /** project/work package scope (also the base for created tasks). Absent on the global board. */
+  wbsNum?: WbsNumber;
+  /** global only: show the car dropdown (hidden when a global car is already selected) */
+  showCarDropdown?: boolean;
+  /** global only: car numbers forced by the global car selection, overriding the car filter */
+  forcedCarNumbers?: number[];
+  /** global only: constrain the create form's project picker to these car numbers */
+  projectCarNumbers?: number[];
+  /**
+   * Controlled filter state. When provided (e.g. the global page owns the filters so its search box can
+   * live in the page header), the search box is not rendered inline here. When omitted, the board keeps
+   * its own ephemeral filter state and renders the search box beside the filters button.
+   */
+  filters?: TaskFilterFields;
+  patch?: (partial: Partial<TaskFilterFields>) => void;
 }
 
-export const TaskListContent = ({ wbsNum }: TaskListContentProps) => {
-  const [showFilters, setShowFilters] = useState(false);
-  const [selectedLabelIds, setSelectedLabelIds] = useState<string[]>([]);
+const nonEmpty = <T,>(arr: T[]): T[] | undefined => (arr.length > 0 ? arr : undefined);
 
-  const { data: tasks, isLoading, isError, error } = useFilterTasks({ wbsNum, labelIds: selectedLabelIds });
-  const {
-    data: taskLabels,
-    isLoading: taskLabelsLoading,
-    isError: tasklabelsIsError,
-    error: tasksLabelsError
-  } = useAllTaskLabels();
+export const TaskListContent = ({
+  context,
+  wbsNum,
+  showCarDropdown = false,
+  forcedCarNumbers,
+  projectCarNumbers,
+  filters: externalFilters,
+  patch: externalPatch
+}: TaskListContentProps) => {
+  const [showFilters, setShowFilters] = useState(context === 'global');
+
+  const controlled = externalFilters !== undefined && externalPatch !== undefined;
+  // only the uncontrolled board persists its own filters; when controlled the parent owns persistence
+  const internal = useTaskFilters({
+    persistKey: !controlled && context === 'global' ? 'globalTaskFilters' : undefined
+  });
+  const filters = externalFilters ?? internal.filters;
+  const patch = externalPatch ?? internal.patch;
+
+  const carNumbers = forcedCarNumbers ?? nonEmpty(filters.carNumbers);
+  // NB: search is intentionally excluded — it's applied client-side over the loaded tasks (below) so
+  // typing doesn't refetch the whole board on every keystroke
+  const filterArgs: FilterTaskArgs = {
+    ...(wbsNum ? { wbsNum } : {}),
+    ...(carNumbers ? { carNumbers } : {}),
+    ...(nonEmpty(filters.projectWbsNums) ? { projectWbsNums: filters.projectWbsNums } : {}),
+    ...(nonEmpty(filters.workPackageWbsNums) ? { workPackageWbsNums: filters.workPackageWbsNums } : {}),
+    ...(nonEmpty(filters.memberIds) ? { memberIds: filters.memberIds } : {}),
+    ...(nonEmpty(filters.teamIds) ? { teamIds: filters.teamIds } : {}),
+    ...(nonEmpty(filters.labelIds) ? { labelIds: filters.labelIds } : {}),
+    andMemberTeam: true
+  };
+
+  const { data: tasks, isLoading, isError, error } = useFilterTasks(filterArgs);
+
+  // fuzzy search runs over the tasks already loaded on the page (title + notes), so it's instant
+  const searchLower = filters.search.trim().toLowerCase();
+  const filteredTasks = useMemo(
+    () =>
+      (tasks ?? []).filter(
+        (task) =>
+          !searchLower ||
+          task.title.toLowerCase().includes(searchLower) ||
+          (task.notes ?? '').toLowerCase().includes(searchLower)
+      ),
+    [tasks, searchLower]
+  );
+
+  // number of active dropdown filters (each populated category counts once), shown on the filters button
+  const appliedFilterCount = [
+    filters.carNumbers,
+    filters.projectWbsNums,
+    filters.workPackageWbsNums,
+    filters.memberIds,
+    filters.teamIds,
+    filters.labelIds
+  ].filter((selection) => selection.length > 0).length;
 
   const [tasksByStatus, setTasksByStatus] = useState<TasksByStatus | undefined>(undefined); // can't use getTasksByStatus since tasks are async
   const { mutateAsync: setTaskStatus } = useSetTaskStatus();
+  const { mutateAsync: editTask } = useEditTask();
+  const { mutateAsync: editTaskAssignees } = useEditTaskAssignees();
+  const queryClient = useQueryClient();
+
+  // holds a pending move-to-done that still has incomplete blockers, awaiting user confirmation
+  const [blockerConfirm, setBlockerConfirm] = useState<{ move: PendingMove; blockerNames: string[] } | null>(null);
+
+  // holds a task dragged into In Progress without a deadline/assignee, so the user can fill them in
+  const [fixTaskModal, setFixTaskModal] = useState<TaskWithIndex | null>(null);
 
   const toast = useToast();
 
@@ -36,20 +114,19 @@ export const TaskListContent = ({ wbsNum }: TaskListContentProps) => {
   const [columnHeights, setColumnHeights] = useState<Partial<Record<TaskStatus, number>>>({});
   const equalizedHeight = Math.max(...(Object.values(columnHeights) as number[]));
 
-  // initialize tasksByStatus once tasks load, but only once
+  // (re)build the board whenever the loaded tasks or the client-side search change
   useEffect(() => {
     if (tasks) {
-      setTasksByStatus(getTasksByStatus(tasks));
+      setTasksByStatus(getTasksByStatus(filteredTasks));
     }
-  }, [tasks]);
+  }, [tasks, filteredTasks]);
 
   const onHeightChange = useCallback((status: TaskStatus, height: number) => {
     setColumnHeights((prev) => ({ ...prev, [status]: height }));
   }, []);
 
   if (isError) return <ErrorPage error={error} />;
-  if (tasklabelsIsError) return <ErrorPage error={tasksLabelsError} />;
-  if (isLoading || taskLabelsLoading || !tasksByStatus) return <LoadingIndicator />;
+  if (isLoading || !tasksByStatus) return <LoadingIndicator />;
 
   const onDeleteTask = (taskId: string) => {
     setTasksByStatus((prev) => {
@@ -95,6 +172,36 @@ export const TaskListContent = ({ wbsNum }: TaskListContentProps) => {
     setIsDragging(true);
   };
 
+  // persists a move optimistically, firing confetti on completion and reverting on failure
+  const applyMove = async (move: PendingMove) => {
+    const { task, source, destination } = move;
+
+    // compute local state change synchronously
+    setTasksByStatus(updateTaskStatusLocal(task, source, destination, tasksByStatus));
+
+    //trigger the mutation to persist the changes
+    try {
+      await setTaskStatus({ taskId: task.taskId, status: destination.status });
+      const confettiPositions = [0, 0.15, 0.3, 0.45, 0.6, 0.75, 0.9];
+      if (destination.status === 'DONE' && source.status !== 'DONE') {
+        confettiPositions.forEach((xPos) => {
+          confetti({
+            origin: { y: -0.5, x: xPos },
+            angle: 270,
+            gravity: 1.5,
+            startVelocity: 35,
+            spread: 70,
+            particleCount: 25
+          });
+        });
+      }
+    } catch (error) {
+      if (error instanceof Error) toast.error(error.message);
+      //revert optimistic updates
+      setTasksByStatus(updateTaskStatusLocal(task, destination, source, tasksByStatus));
+    }
+  };
+
   const onDragEnd: OnDragEndResponder = async (result) => {
     setIsDragging(false);
     const { destination, source } = result;
@@ -111,126 +218,168 @@ export const TaskListContent = ({ wbsNum }: TaskListContentProps) => {
     const destinationStatus = destination.droppableId as Task['status'];
     const sourcePost = tasksByStatus[sourceStatus][source.index]!;
 
-    // compute local state change synchronously
-    setTasksByStatus(
-      updateTaskStatusLocal(
-        sourcePost,
-        { status: sourceStatus, index: source.index },
-        { status: destinationStatus, index: destination.index },
-        tasksByStatus
-      )
-    );
+    const move: PendingMove = {
+      task: sourcePost,
+      source: { status: sourceStatus, index: source.index },
+      destination: { status: destinationStatus, index: destination.index }
+    };
 
-    //trigger the mutation to persist the changes
-    try {
-      await setTaskStatus({ taskId: sourcePost.taskId, status: destinationStatus });
-      const confettiPositions = [0, 0.15, 0.3, 0.45, 0.6, 0.75, 0.9];
-      if (destinationStatus === 'DONE' && sourceStatus !== 'DONE') {
-        confettiPositions.forEach((xPos) => {
-          confetti({
-            origin: { y: -0.5, x: xPos },
-            angle: 270,
-            gravity: 1.5,
-            startVelocity: 35,
-            spread: 70,
-            particleCount: 25
-          });
-        });
+    // A task moving into In Progress must have a deadline and assignees. If it's missing either, open the
+    // edit modal with those fields highlighted instead of failing the move, and let the user fill them in.
+    if (destinationStatus === 'IN_PROGRESS' && sourceStatus !== 'IN_PROGRESS') {
+      if (!sourcePost.deadline || sourcePost.assignees.length === 0) {
+        setFixTaskModal(sourcePost);
+        return;
       }
+    }
+
+    // If a task is being completed while it still has incomplete blockers, confirm with the user before
+    // moving it rather than silently completing it. The blocker data already lives on the task itself.
+    if (destinationStatus === 'DONE' && sourceStatus !== 'DONE') {
+      const blockerNames = getIncompleteBlockerNames(sourcePost);
+      if (blockerNames.length > 0) {
+        setBlockerConfirm({ move, blockerNames });
+        return;
+      }
+    }
+
+    await applyMove(move);
+  };
+
+  const onConfirmCompleteBlockedTask = async () => {
+    if (!blockerConfirm) return;
+    const { move } = blockerConfirm;
+    setBlockerConfirm(null);
+    await applyMove(move);
+  };
+
+  // saves the deadline/assignees the user just filled in, then moves the task into In Progress
+  const onFixTaskSubmit = async (data: EditTaskFormInput) => {
+    if (!fixTaskModal) return;
+    try {
+      await editTask({
+        taskId: data.taskId,
+        notes: data.notes,
+        title: data.title,
+        deadline: data.deadline,
+        startDate: data.startDate,
+        priority: data.priority,
+        labelIds: data.labels.map((label) => label.taskLabelId),
+        blockedByIds: data.blockedBy.map((blocker) => blocker.taskId),
+        wbsNum: data.wpWbsNum ?? fixTaskModal.wbsNum
+      });
+      await editTaskAssignees({ taskId: data.taskId, assignees: data.assignees });
+      await setTaskStatus({ taskId: data.taskId, status: TaskStatus.IN_PROGRESS });
+      // editTask/editTaskAssignees refetch tasks while the status is still the old one, so refetch once
+      // more now that the status is In Progress to land the board on the correct final state
+      await queryClient.invalidateQueries(['filter-tasks']);
+      setFixTaskModal(null);
     } catch (error) {
       if (error instanceof Error) toast.error(error.message);
-      //revert optimistic updates
-      setTasksByStatus(
-        updateTaskStatusLocal(
-          sourcePost,
-          { status: destinationStatus, index: destination.index },
-          { status: sourceStatus, index: source.index },
-          tasksByStatus
-        )
-      );
     }
   };
 
+  const blockerCount = blockerConfirm?.blockerNames.length ?? 0;
+
   return (
-    <DragDropContext onDragStart={onDragStart} onDragEnd={onDragEnd}>
-      <Box display="flex" alignItems="center" mb={1}>
-        <Button onClick={() => setShowFilters(!showFilters)} sx={{ height: '2.25rem' }}>
-          <FilterListIcon fontSize="medium" />
-          <Typography fontSize="0.75rem" align="center">
-            Filters
-          </Typography>
-        </Button>
-      </Box>
-      {showFilters && (
-        <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
-          <Autocomplete
-            multiple
-            size="small"
-            options={taskLabels ?? []}
-            getOptionLabel={(option: TaskLabel) => option.name}
-            isOptionEqualToValue={(option, val) => option.taskLabelId === val.taskLabelId}
-            value={(taskLabels ?? []).filter((l) => selectedLabelIds.includes(l.taskLabelId))}
-            onChange={(_, selected) => setSelectedLabelIds(selected.map((l) => l.taskLabelId))}
-            renderOption={(props, option) => (
-              <li {...props} key={option.taskLabelId}>
-                <Box
-                  sx={{
-                    display: 'inline-block',
-                    px: 1.5,
-                    py: 0.25,
-                    borderRadius: '999px',
-                    backgroundColor: option.colorHexCode,
-                    color: 'white',
-                    fontWeight: 500,
-                    fontSize: '0.875rem'
-                  }}
-                >
-                  {option.name}
-                </Box>
-              </li>
-            )}
-            renderTags={(selected, getTagProps) =>
-              selected.map((label, index) => (
-                <Chip
-                  {...getTagProps({ index })}
-                  key={label.taskLabelId}
-                  label={label.name}
-                  size="small"
-                  sx={{
-                    backgroundColor: label.colorHexCode,
-                    color: 'white',
-                    fontWeight: 500,
-                    '& .MuiChip-deleteIcon': { color: 'rgba(255,255,255,0.7)' }
-                  }}
-                />
-              ))
-            }
-            renderInput={(params) => (
-              <TextField {...params} variant="outlined" label="Labels" placeholder="Filter by label" />
-            )}
-            sx={{ width: '20%', minWidth: 200 }}
+    <>
+      {fixTaskModal && (
+        <TaskFormModal
+          task={fixTaskModal}
+          status={TaskStatus.IN_PROGRESS}
+          validateOnOpen
+          modalShow={!!fixTaskModal}
+          onHide={() => setFixTaskModal(null)}
+          onSubmit={onFixTaskSubmit}
+          wbsNum={fixTaskModal.wbsNum}
+        />
+      )}
+      <NERModal
+        open={!!blockerConfirm}
+        onHide={() => setBlockerConfirm(null)}
+        onSubmit={onConfirmCompleteBlockedTask}
+        title="Task is blocked"
+        submitText="Yes"
+        cancelText="No"
+        showCloseButton
+      >
+        <Typography>
+          The following {blockerCount === 1 ? 'task is' : 'tasks are'} supposed to block this task but{' '}
+          {blockerCount === 1 ? 'is' : 'are'} not done yet:
+        </Typography>
+        <ul>
+          {blockerConfirm?.blockerNames.map((name, idx) => (
+            <li key={idx}>{name}</li>
+          ))}
+        </ul>
+        <Typography>Are you sure this task is done?</Typography>
+      </NERModal>
+      <DragDropContext onDragStart={onDragStart} onDragEnd={onDragEnd}>
+        <Box display="flex" alignItems="center" mb={1} gap={1}>
+          <Badge color="error" badgeContent={appliedFilterCount} invisible={showFilters || appliedFilterCount === 0}>
+            <Button onClick={() => setShowFilters(!showFilters)} sx={{ height: '2.25rem' }}>
+              <FilterListIcon fontSize="medium" />
+              <Typography fontSize="0.75rem" align="center">
+                Filters
+              </Typography>
+            </Button>
+          </Badge>
+          {/* uncontrolled boards (project/work package) render the search here; the global page puts it in the header */}
+          {!controlled && (
+            <TextField
+              size="small"
+              placeholder="Search tasks"
+              value={filters.search}
+              onChange={(event) => patch({ search: event.target.value })}
+              sx={{ ml: 'auto', minWidth: 240 }}
+            />
+          )}
+        </Box>
+        {/* kept mounted (just hidden) so the dropdowns fetch their options on page load, not on first open */}
+        <Box sx={{ display: showFilters ? 'block' : 'none' }}>
+          <TaskFilterBar
+            context={context}
+            filters={filters}
+            patch={patch}
+            showCarDropdown={showCarDropdown}
+            scopeProjectWbsNum={context === 'project' ? wbsNum : undefined}
           />
         </Box>
-      )}
-      <Box display="flex">
-        {statuses.map((status) => (
-          <TaskColumn
-            onAddTask={onAddTask}
-            onDeleteTask={onDeleteTask}
-            onEditTask={onEditTask}
-            onHeightChange={onHeightChange}
-            status={status}
-            tasks={tasksByStatus[status]}
-            key={status}
-            wbsNum={wbsNum}
-            equalizedHeight={equalizedHeight}
-            isDragging={isDragging}
-          />
-        ))}
-      </Box>
-    </DragDropContext>
+        <Box display="flex">
+          {statuses.map((status) => (
+            <TaskColumn
+              onAddTask={onAddTask}
+              onDeleteTask={onDeleteTask}
+              onEditTask={onEditTask}
+              onHeightChange={onHeightChange}
+              status={status}
+              tasks={tasksByStatus[status]}
+              key={status}
+              wbsNum={wbsNum}
+              context={context}
+              projectCarNumbers={projectCarNumbers}
+              equalizedHeight={equalizedHeight}
+              isDragging={isDragging}
+            />
+          ))}
+        </Box>
+      </DragDropContext>
+    </>
   );
 };
+
+interface PendingMove {
+  task: TaskWithIndex;
+  source: { status: Task['status']; index: number };
+  destination: { status: Task['status']; index: number };
+}
+
+// The names of everything currently blocking a task from being completed: any incomplete blocking task
+// plus any work package that still blocks this task's work package. Mirrors the backend's block check.
+const getIncompleteBlockerNames = (task: Task): string[] => [
+  ...task.blockedBy.filter((blocker) => blocker.status !== TaskStatus.DONE).map((blocker) => blocker.title),
+  ...task.blockedByWorkPackages.map((workPackage) => workPackage.name)
+];
 
 const updateTaskStatusLocal = (
   sourceTask: TaskWithIndex,

--- a/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskListContent.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage/ProjectViewContainer/TaskList/v2/TaskListContent.tsx
@@ -1,7 +1,7 @@
 import { DragDropContext, OnDragEndResponder, OnDragStartResponder } from '@hello-pangea/dnd';
 import { Badge, Box, Button, TextField, Typography } from '@mui/material';
 import FilterListIcon from '@mui/icons-material/FilterList';
-import { useCallback, useMemo, useState, useEffect } from 'react';
+import { useCallback, useMemo, useRef, useState, useEffect } from 'react';
 import { FilterTaskArgs, Task, TaskStatus, TaskWithIndex, WbsNumber } from 'shared';
 import { useQueryClient } from 'react-query';
 import { getTasksByStatus, statuses, TasksByStatus } from '.';
@@ -37,6 +37,10 @@ interface TaskListContentProps {
 }
 
 const nonEmpty = <T,>(arr: T[]): T[] | undefined => (arr.length > 0 ? arr : undefined);
+
+// how many tasks each column renders initially, and how many more it reveals each time the user scrolls
+// to the bottom — keeps a large global board from mounting hundreds of cards at once
+const TASK_PAGE_SIZE = 20;
 
 export const TaskListContent = ({
   context,
@@ -114,10 +118,28 @@ export const TaskListContent = ({
   const [columnHeights, setColumnHeights] = useState<Partial<Record<TaskStatus, number>>>({});
   const equalizedHeight = Math.max(...(Object.values(columnHeights) as number[]));
 
+  // incremental rendering: only the first `visibleCount` tasks of each column are mounted; the sentinel
+  // rendered below the board grows this as it scrolls into view (see setSentinel)
+  const [visibleCount, setVisibleCount] = useState(TASK_PAGE_SIZE);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const setSentinel = useCallback((node: HTMLDivElement | null) => {
+    observerRef.current?.disconnect();
+    if (!node) return;
+    observerRef.current = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) setVisibleCount((count) => count + TASK_PAGE_SIZE);
+      },
+      { rootMargin: '400px' }
+    );
+    observerRef.current.observe(node);
+  }, []);
+
   // (re)build the board whenever the loaded tasks or the client-side search change
   useEffect(() => {
     if (tasks) {
       setTasksByStatus(getTasksByStatus(filteredTasks));
+      // start fresh when the tasks/filters/search change so a new view doesn't render everything at once
+      setVisibleCount(TASK_PAGE_SIZE);
     }
   }, [tasks, filteredTasks]);
 
@@ -324,16 +346,14 @@ export const TaskListContent = ({
               </Typography>
             </Button>
           </Badge>
-          {/* uncontrolled boards (project/work package) render the search here; the global page puts it in the header */}
-          {!controlled && (
-            <TextField
-              size="small"
-              placeholder="Search tasks"
-              value={filters.search}
-              onChange={(event) => patch({ search: event.target.value })}
-              sx={{ ml: 'auto', minWidth: 240 }}
-            />
-          )}
+          {/* search sits directly to the right of the filters button on every board */}
+          <TextField
+            size="small"
+            placeholder="Search tasks"
+            value={filters.search}
+            onChange={(event) => patch({ search: event.target.value })}
+            sx={{ minWidth: 240 }}
+          />
         </Box>
         {/* kept mounted (just hidden) so the dropdowns fetch their options on page load, not on first open */}
         <Box sx={{ display: showFilters ? 'block' : 'none' }}>
@@ -353,7 +373,7 @@ export const TaskListContent = ({
               onEditTask={onEditTask}
               onHeightChange={onHeightChange}
               status={status}
-              tasks={tasksByStatus[status]}
+              tasks={tasksByStatus[status].slice(0, visibleCount)}
               key={status}
               wbsNum={wbsNum}
               context={context}
@@ -363,6 +383,11 @@ export const TaskListContent = ({
             />
           ))}
         </Box>
+        {/* when any column still has tasks beyond what's rendered, this sentinel reveals another page as
+            it scrolls near the viewport */}
+        {visibleCount < Math.max(0, ...statuses.map((status) => tasksByStatus[status].length)) && (
+          <div ref={setSentinel} style={{ height: 1 }} />
+        )}
       </DragDropContext>
     </>
   );

--- a/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.tsx
+++ b/src/frontend/src/pages/WorkPackageDetailPage/WorkPackageViewContainer/WorkPackageViewContainer.tsx
@@ -144,7 +144,7 @@ const WorkPackageViewContainer: React.FC<WorkPackageViewContainerProps> = ({
         <WorkPackageDetails workPackage={workPackage} dependencies={dependencies} />
       ) : tabValue === 1 ? (
         !allowEdit ? null : (
-          <TaskListContent wbsNum={workPackage.wbsNum} />
+          <TaskListContent context="workPackage" wbsNum={workPackage.wbsNum} />
         )
       ) : tabValue === 2 ? (
         <ChangesList changes={workPackage.changes} />

--- a/src/frontend/src/utils/routes.ts
+++ b/src/frontend/src/utils/routes.ts
@@ -9,6 +9,7 @@ const LOGIN = `/login`;
 const INFO = `/info`;
 const GUEST_INFO = `/guestinfo`;
 const GANTT = `/gantt`;
+const TASKS = `/tasks`;
 const CREDITS = `/credits`;
 
 /**************** Home Section ****************/
@@ -100,6 +101,7 @@ export const routes = {
   TEAMS_BY_ID,
 
   GANTT,
+  TASKS,
 
   PROJECTS,
   PROJECT_MANAGEMENT,

--- a/src/frontend/src/utils/urls.ts
+++ b/src/frontend/src/utils/urls.ts
@@ -525,6 +525,13 @@ const attendanceGetOngoing = (teamId: string) => `${attendance()}/ongoing/${team
 const attendanceCloseOngoing = (teamId: string) => `${attendance()}/close/${teamId}`;
 const attendanceGetById = (meetingAttendanceId: string) => `${attendance()}/${meetingAttendanceId}`;
 
+/**************** Dashboard Endpoints ****************/
+const dashboards = () => `${API_URL}/dashboards`;
+const dashboardsGet = () => `${dashboards()}/`;
+const dashboardsCreate = () => `${dashboards()}/create`;
+const dashboardEdit = (dashboardId: string) => `${dashboards()}/${dashboardId}/edit`;
+const dashboardDelete = (dashboardId: string) => `${dashboards()}/${dashboardId}/delete`;
+
 /**************** Other Endpoints ****************/
 const version = () => `https://api.github.com/repos/Northeastern-Electric-Racing/FinishLine/releases/latest`;
 
@@ -915,6 +922,11 @@ export const apiUrls = {
   attendanceGetOngoing,
   attendanceCloseOngoing,
   attendanceGetById,
+
+  dashboardsGet,
+  dashboardsCreate,
+  dashboardEdit,
+  dashboardDelete,
 
   version
 };

--- a/src/frontend/src/utils/urls.ts
+++ b/src/frontend/src/utils/urls.ts
@@ -397,12 +397,11 @@ const cars = () => `${API_URL}/cars`;
 const carsCreate = () => `${cars()}/create`;
 const carEdit = (id: string) => `${cars()}/${id}/edit`;
 
-// slim ("for dropdown") endpoints — minimal payloads for populating select menus
-const carsSlim = () => `${cars()}/slim`;
-const projectsSlim = () => `${projects()}/slim`;
-const workPackagesSlim = () => `${workPackages()}/slim`;
-const usersSlim = () => `${users()}/slim`;
-const teamsSlim = () => `${teams()}/slim`;
+// dropdown endpoints — minimal payloads for populating select menus
+const projectsDropdown = () => `${projects()}/dropdown`;
+const workPackagesDropdown = () => `${workPackages()}/dropdown`;
+const membersDropdown = () => `${users()}/members/dropdown`;
+const teamsDropdown = () => `${teams()}/dropdown`;
 
 /************** Recruitment Endpoints ***************/
 const recruitment = () => `${API_URL}/recruitment`;
@@ -539,11 +538,10 @@ export const apiUrls = {
   users,
   orgUsers,
   orgMembers,
-  carsSlim,
-  projectsSlim,
-  workPackagesSlim,
-  usersSlim,
-  teamsSlim,
+  projectsDropdown,
+  workPackagesDropdown,
+  membersDropdown,
+  teamsDropdown,
   usersById,
   usersLogin,
   usersLoginDev,

--- a/src/frontend/src/utils/urls.ts
+++ b/src/frontend/src/utils/urls.ts
@@ -397,6 +397,13 @@ const cars = () => `${API_URL}/cars`;
 const carsCreate = () => `${cars()}/create`;
 const carEdit = (id: string) => `${cars()}/${id}/edit`;
 
+// slim ("for dropdown") endpoints — minimal payloads for populating select menus
+const carsSlim = () => `${cars()}/slim`;
+const projectsSlim = () => `${projects()}/slim`;
+const workPackagesSlim = () => `${workPackages()}/slim`;
+const usersSlim = () => `${users()}/slim`;
+const teamsSlim = () => `${teams()}/slim`;
+
 /************** Recruitment Endpoints ***************/
 const recruitment = () => `${API_URL}/recruitment`;
 const allMilestones = () => `${recruitment()}/milestones`;
@@ -525,6 +532,11 @@ export const apiUrls = {
   users,
   orgUsers,
   orgMembers,
+  carsSlim,
+  projectsSlim,
+  workPackagesSlim,
+  usersSlim,
+  teamsSlim,
   usersById,
   usersLogin,
   usersLoginDev,

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -19,6 +19,7 @@ export * from './src/types/announcements.types.js';
 export * from './src/types/part-review.types.js';
 export * from './src/types/calendar-types.js';
 export * from './src/types/attendance-types.js';
+export * from './src/types/dropdown-types.js';
 
 export * from './src/validate-wbs.js';
 export * from './src/date-utils.js';

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -20,6 +20,7 @@ export * from './src/types/part-review.types.js';
 export * from './src/types/calendar-types.js';
 export * from './src/types/attendance-types.js';
 export * from './src/types/dropdown-types.js';
+export * from './src/types/dashboard-types.js';
 
 export * from './src/validate-wbs.js';
 export * from './src/date-utils.js';

--- a/src/shared/src/types/dashboard-types.ts
+++ b/src/shared/src/types/dashboard-types.ts
@@ -1,0 +1,6 @@
+export interface Dashboard {
+  dashboardId: string;
+  name: string;
+  link: string;
+  dateCreated: Date;
+}

--- a/src/shared/src/types/dropdown-types.ts
+++ b/src/shared/src/types/dropdown-types.ts
@@ -6,39 +6,33 @@
 import { WbsNumber } from './project-types.js';
 
 /**
- * Slim ("for dropdown") shapes. These are intentionally minimal: id + display name + just enough
- * context to render and disambiguate an item in a dropdown. They are served by dedicated `/slim`
- * endpoints so callers don't pull the full, deeply-nested objects just to populate a select.
+ * "Dropdown" shapes served by the dedicated `/dropdown` endpoints. These are intentionally minimal:
+ * id + display name + just enough context to render and disambiguate an item in a dropdown, so callers
+ * don't pull the full, deeply-nested objects just to populate a select.
  */
 
-export interface SlimCar {
-  id: string;
-  name: string;
-  wbsNum: WbsNumber;
-}
-
-export interface SlimProject {
+export interface ProjectDropdownItem {
   id: string;
   name: string;
   wbsNum: WbsNumber;
   carNumber: number;
 }
 
-export interface SlimWorkPackage {
+export interface WorkPackageDropdownItem {
   id: string;
   name: string;
   wbsNum: WbsNumber;
   projectName: string;
 }
 
-export interface SlimUser {
+export interface MemberDropdownItem {
   userId: string;
   firstName: string;
   lastName: string;
   email: string;
 }
 
-export interface SlimTeam {
+export interface TeamDropdownItem {
   teamId: string;
   name: string;
 }

--- a/src/shared/src/types/dropdown-types.ts
+++ b/src/shared/src/types/dropdown-types.ts
@@ -1,0 +1,44 @@
+/*
+ * This file is part of NER's FinishLine and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { WbsNumber } from './project-types.js';
+
+/**
+ * Slim ("for dropdown") shapes. These are intentionally minimal: id + display name + just enough
+ * context to render and disambiguate an item in a dropdown. They are served by dedicated `/slim`
+ * endpoints so callers don't pull the full, deeply-nested objects just to populate a select.
+ */
+
+export interface SlimCar {
+  id: string;
+  name: string;
+  wbsNum: WbsNumber;
+}
+
+export interface SlimProject {
+  id: string;
+  name: string;
+  wbsNum: WbsNumber;
+  carNumber: number;
+}
+
+export interface SlimWorkPackage {
+  id: string;
+  name: string;
+  wbsNum: WbsNumber;
+  projectName: string;
+}
+
+export interface SlimUser {
+  userId: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+}
+
+export interface SlimTeam {
+  teamId: string;
+  name: string;
+}

--- a/src/shared/src/types/task-types.ts
+++ b/src/shared/src/types/task-types.ts
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { User } from './user-types.js';
+import { UserPreviewWithEmail } from './user-types.js';
 import { WbsNumber } from './project-types.js';
 
 export enum TaskPriority {
@@ -26,9 +26,9 @@ export interface Task {
   notes: string;
   dateDeleted?: Date;
   dateCreated: Date;
-  createdBy: User;
-  deletedBy?: User;
-  assignees: User[];
+  createdBy: UserPreviewWithEmail;
+  deletedBy?: UserPreviewWithEmail;
+  assignees: UserPreviewWithEmail[];
   labels: TaskLabel[];
   startDate?: Date;
   deadline?: Date;
@@ -67,6 +67,17 @@ export interface FilterTaskArgs {
   endPeriod?: Date;
   labelIds?: string[];
   wbsNum?: WbsNumber;
+  // The following are used by the global tasks page. Each filter OR's over its own selections and
+  // AND's against the other filters. All are optional so the project/work package kanban is unaffected.
+  carNumbers?: number[];
+  projectWbsNums?: WbsNumber[];
+  workPackageWbsNums?: WbsNumber[];
+  search?: string;
+  // When true, the assignee (memberIds) and team (teamIds) filters AND with each other and with every
+  // other filter, and the assignee filter matches only assignees (not the task creator). The global
+  // tasks page sets this. When false/undefined the legacy calendar behavior is kept: memberIds/teamIds
+  // are OR'd together and memberIds also matches the task creator.
+  andMemberTeam?: boolean;
 }
 
 // Need lead and manager in order to determine permissions for editing and deleting tasks in the calendar view

--- a/src/shared/src/types/user-types.ts
+++ b/src/shared/src/types/user-types.ts
@@ -15,6 +15,8 @@ export interface User {
 
 export type UserPreview = Pick<User, 'userId' | 'firstName' | 'lastName'>;
 
+export type UserPreviewWithEmail = Pick<User, 'userId' | 'firstName' | 'lastName' | 'email'>;
+
 export type UserWithRole = User & { role: Role };
 
 export type Role = 'APP_ADMIN' | 'ADMIN' | 'HEAD' | 'LEADERSHIP' | 'MEMBER' | 'GUEST';


### PR DESCRIPTION
## Changes

- global task board page with all filters & fuzzy search
- url param saved filter args allow for sharing between users
- Changed unfinished blocking task error to warning
- Added filter components with slim query args to reduce endpoint latency (generic for future use. Ideally would replace existing dropdowns with these but can do that as we see them)
- removed unnecessary query args on tasks to reduce endpoint latency
- Added slimmer user query arg + transformer for use in task (ideally would also be migrated to many other places in codebase but can be done on case by case basis)
- task caching bug fixes
- added saved dashboards on user basis (just saves url)