### PR TITLE
#4343 Expanding a Work Package in Gantt will cause the blocked lines to move as well

### DIFF
--- a/src/frontend/src/pages/GanttPage/GanttChart/GanttChart.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChart/GanttChart.tsx
@@ -41,9 +41,10 @@ const GanttChart = <E, T>({ startDate, endDate, collections, editability }: Gant
 
   const today = new Date(new Date().setHours(0, 0, 0, 0));
   const currentWeekCol = days.findIndex((day) => toDateString(day) === toDateString(getMonday(today))) + 1;
-  const onToggle = editability?.onToggle;
-  if (!onToggle) throw Error;
-  const registerArcherRef = editability?.registerArcherRef;
+  const onToggle = editability?.onToggle ? editability?.onToggle : () => {};
+  const registerArcherRef = editability?.registerArcherRef
+    ? editability?.registerArcherRef
+    : (_collectionId: string) => (_el: ArcherContainerRef | null) => {};
   const daysIntoWeek = differenceInDays(today, getMonday(today));
   const dailyOffset = daysIntoWeek * (parseFloat(GANTT_CHART_CELL_SIZE) / 7);
 

--- a/src/frontend/src/pages/GanttPage/GanttChart/GanttChart.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChart/GanttChart.tsx
@@ -12,7 +12,6 @@ import { eachDayOfInterval, isMonday, differenceInDays } from 'date-fns';
 import { getMonday } from '../../../utils/datetime.utils';
 import { toDateString } from 'shared';
 import { GANTT_CHART_CELL_SIZE, GANTT_CHART_GAP_SIZE } from '../../../utils/gantt.utils';
-import { ArcherContainerRef } from 'react-archer/lib/ArcherContainer/ArcherContainer.types';
 export interface GanttEditability<E, T> {
   highlightTaskComparator: HighlightTaskComparator<T>;
   highlightSubtaskComparator: HighlightTaskComparator<T>;
@@ -24,8 +23,6 @@ export interface GanttEditability<E, T> {
   onCancelChanges: (collection: GanttCollection<E, T>) => void;
   onCreateChange: (change: GanttChange<T>) => void;
   highlightedChange: RequestEventChange<T>;
-  onToggle: () => void;
-  registerArcherRef: (taskId: string) => (el: ArcherContainerRef | null) => void;
 }
 
 interface GanttChartProps<E, T> {
@@ -41,10 +38,6 @@ const GanttChart = <E, T>({ startDate, endDate, collections, editability }: Gant
 
   const today = new Date(new Date().setHours(0, 0, 0, 0));
   const currentWeekCol = days.findIndex((day) => toDateString(day) === toDateString(getMonday(today))) + 1;
-  const onToggle = editability?.onToggle ? editability?.onToggle : () => {};
-  const registerArcherRef = editability?.registerArcherRef
-    ? editability?.registerArcherRef
-    : (_collectionId: string) => (_el: ArcherContainerRef | null) => {};
   const daysIntoWeek = differenceInDays(today, getMonday(today));
   const dailyOffset = daysIntoWeek * (parseFloat(GANTT_CHART_CELL_SIZE) / 7);
 
@@ -71,8 +64,6 @@ const GanttChart = <E, T>({ startDate, endDate, collections, editability }: Gant
               endDate={endDate}
               collection={collection}
               editability={editability}
-              onToggle={onToggle}
-              registerArcherRef={registerArcherRef}
             />
           ) : (
             <></>

--- a/src/frontend/src/pages/GanttPage/GanttChart/GanttChart.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChart/GanttChart.tsx
@@ -12,6 +12,7 @@ import { eachDayOfInterval, isMonday, differenceInDays } from 'date-fns';
 import { getMonday } from '../../../utils/datetime.utils';
 import { toDateString } from 'shared';
 import { GANTT_CHART_CELL_SIZE, GANTT_CHART_GAP_SIZE } from '../../../utils/gantt.utils';
+import { ArcherContainerRef } from 'react-archer/lib/ArcherContainer/ArcherContainer.types';
 export interface GanttEditability<E, T> {
   highlightTaskComparator: HighlightTaskComparator<T>;
   highlightSubtaskComparator: HighlightTaskComparator<T>;
@@ -23,6 +24,8 @@ export interface GanttEditability<E, T> {
   onCancelChanges: (collection: GanttCollection<E, T>) => void;
   onCreateChange: (change: GanttChange<T>) => void;
   highlightedChange: RequestEventChange<T>;
+  onToggle: () => void;
+  registerArcherRef: (taskId: string) => (el: ArcherContainerRef | null) => void;
 }
 
 interface GanttChartProps<E, T> {
@@ -38,7 +41,9 @@ const GanttChart = <E, T>({ startDate, endDate, collections, editability }: Gant
 
   const today = new Date(new Date().setHours(0, 0, 0, 0));
   const currentWeekCol = days.findIndex((day) => toDateString(day) === toDateString(getMonday(today))) + 1;
-
+  const onToggle = editability?.onToggle;
+  if (!onToggle) throw Error;
+  const registerArcherRef = editability?.registerArcherRef;
   const daysIntoWeek = differenceInDays(today, getMonday(today));
   const dailyOffset = daysIntoWeek * (parseFloat(GANTT_CHART_CELL_SIZE) / 7);
 
@@ -65,6 +70,8 @@ const GanttChart = <E, T>({ startDate, endDate, collections, editability }: Gant
               endDate={endDate}
               collection={collection}
               editability={editability}
+              onToggle={onToggle}
+              registerArcherRef={registerArcherRef}
             />
           ) : (
             <></>

--- a/src/frontend/src/pages/GanttPage/GanttChart/GanttChartCollectionSection.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChart/GanttChartCollectionSection.tsx
@@ -4,19 +4,24 @@ import GanttChartSection from './GanttChartSection';
 import { GanttCollection } from '../../../utils/gantt.utils';
 import { useState } from 'react';
 import { GanttEditability } from './GanttChart';
+import { ArcherContainerRef } from 'react-archer/lib/ArcherContainer/ArcherContainer.types';
 
 interface GanttChartCollectionSectionProps<E, T> {
   startDate: Date;
   endDate: Date;
   collection: GanttCollection<E, T>;
   editability?: GanttEditability<E, T>;
+  onToggle: () => void;
+  registerArcherRef: (taskId: string) => (el: ArcherContainerRef | null) => void;
 }
 
 const GanttChartCollectionSection = <E, T>({
   startDate,
   endDate,
   collection,
-  editability
+  editability,
+  onToggle,
+  registerArcherRef
 }: GanttChartCollectionSectionProps<E, T>) => {
   const theme = useTheme();
   const [isEditMode, setIsEditMode] = useState(false);
@@ -40,6 +45,9 @@ const GanttChartCollectionSection = <E, T>({
     width: 'fit-content',
     height: '30px'
   };
+
+  const Toggle = onToggle;
+  const registerArcher = registerArcherRef;
 
   const handleSave = () => {
     editability?.onSavePressed();
@@ -94,6 +102,8 @@ const GanttChartCollectionSection = <E, T>({
           onAddTaskPressed={editability?.onNewSubTaskPressed ?? ignore}
           highlightSubtaskComparator={editability?.highlightSubtaskComparator ?? ignoreBool}
           highlightTaskComparator={editability?.highlightTaskComparator ?? ignoreBool}
+          onToggle={Toggle}
+          registerArcherRef={registerArcher}
         />
       </Box>
     </Box>

--- a/src/frontend/src/pages/GanttPage/GanttChart/GanttChartCollectionSection.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChart/GanttChartCollectionSection.tsx
@@ -4,24 +4,23 @@ import GanttChartSection from './GanttChartSection';
 import { GanttCollection } from '../../../utils/gantt.utils';
 import { useState } from 'react';
 import { GanttEditability } from './GanttChart';
-import { ArcherContainerRef } from 'react-archer/lib/ArcherContainer/ArcherContainer.types';
+
+const ignore = () => {};
+
+const ignoreBool = () => false;
 
 interface GanttChartCollectionSectionProps<E, T> {
   startDate: Date;
   endDate: Date;
   collection: GanttCollection<E, T>;
   editability?: GanttEditability<E, T>;
-  onToggle: () => void;
-  registerArcherRef: (taskId: string) => (el: ArcherContainerRef | null) => void;
 }
 
 const GanttChartCollectionSection = <E, T>({
   startDate,
   endDate,
   collection,
-  editability,
-  onToggle,
-  registerArcherRef
+  editability
 }: GanttChartCollectionSectionProps<E, T>) => {
   const theme = useTheme();
   const [isEditMode, setIsEditMode] = useState(false);
@@ -62,10 +61,6 @@ const GanttChartCollectionSection = <E, T>({
     setIsEditMode(true);
   };
 
-  const ignore = () => {};
-
-  const ignoreBool = () => false;
-
   return collection.tasks.length > 0 ? (
     <Box sx={collectionSectionBackgroundStyle}>
       <Box sx={collectionDescriptionContainerStyle}>
@@ -99,8 +94,6 @@ const GanttChartCollectionSection = <E, T>({
           onAddTaskPressed={editability?.onNewSubTaskPressed ?? ignore}
           highlightSubtaskComparator={editability?.highlightSubtaskComparator ?? ignoreBool}
           highlightTaskComparator={editability?.highlightTaskComparator ?? ignoreBool}
-          onToggle={onToggle}
-          registerArcherRef={registerArcherRef}
         />
       </Box>
     </Box>

--- a/src/frontend/src/pages/GanttPage/GanttChart/GanttChartCollectionSection.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChart/GanttChartCollectionSection.tsx
@@ -46,9 +46,6 @@ const GanttChartCollectionSection = <E, T>({
     height: '30px'
   };
 
-  const Toggle = onToggle;
-  const registerArcher = registerArcherRef;
-
   const handleSave = () => {
     editability?.onSavePressed();
     setIsEditMode(false);
@@ -102,8 +99,8 @@ const GanttChartCollectionSection = <E, T>({
           onAddTaskPressed={editability?.onNewSubTaskPressed ?? ignore}
           highlightSubtaskComparator={editability?.highlightSubtaskComparator ?? ignoreBool}
           highlightTaskComparator={editability?.highlightTaskComparator ?? ignoreBool}
-          onToggle={Toggle}
-          registerArcherRef={registerArcher}
+          onToggle={onToggle}
+          registerArcherRef={registerArcherRef}
         />
       </Box>
     </Box>

--- a/src/frontend/src/pages/GanttPage/GanttChart/GanttChartSection.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChart/GanttChartSection.tsx
@@ -12,7 +12,7 @@ import {
   RequestEventChange
 } from '../../../utils/gantt.utils';
 import { Box } from '@mui/material';
-import { MutableRefObject, useCallback, useRef, useState } from 'react';
+import { MutableRefObject, useCallback, useEffect, useRef, useState } from 'react';
 import GanttTaskBar from './GanttChartComponents/GanttTaskBar/GanttTaskBar';
 import GanttToolTip from './GanttChartComponents/GanttToolTip';
 import { ArcherContainer, ArcherContainerRef } from 'react-archer';
@@ -27,6 +27,8 @@ interface GanttChartSectionProps<T> {
   onAddTaskPressed: (parentTask: GanttTask<T>) => void;
   highlightTaskComparator: HighlightTaskComparator<T>;
   highlightSubtaskComparator: HighlightTaskComparator<T>;
+  onToggle: () => void;
+  registerArcherRef: (collectionId: string) => (el: ArcherContainerRef | null) => void;
 }
 
 interface GanttTooltipLayerProps {
@@ -66,12 +68,30 @@ const GanttChartSection = <T,>({
   highlightedChange,
   onAddTaskPressed,
   highlightSubtaskComparator,
-  highlightTaskComparator
+  highlightTaskComparator,
+  onToggle,
+  registerArcherRef
 }: GanttChartSectionProps<T>) => {
   const days = eachDayOfInterval({ start, end }).filter((day) => isMonday(day));
+  const treeContainerRef = useRef<HTMLDivElement>(null);
 
-  const archerRef = useRef<ArcherContainerRef>(null);
-  const handleToggle = useCallback(() => archerRef.current?.refreshScreen(), []);
+  useEffect(() => {
+    const node = treeContainerRef.current;
+    if (!node) return;
+
+    let frame: number;
+    const observer = new ResizeObserver(() => {
+      // rAF here avoids "ResizeObserver loop" warnings and batches rapid-fire events
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => onToggle());
+    });
+
+    observer.observe(node);
+    return () => {
+      cancelAnimationFrame(frame);
+      observer.disconnect();
+    };
+  }, [onToggle]);
 
   const updateTooltip = useRef<(options: OnMouseOverOptions | undefined, y?: number) => void>(() => {});
 
@@ -95,9 +115,9 @@ const GanttChartSection = <T,>({
   );
 
   return (
-    <ArcherContainer strokeColor="#ef4545">
+    <ArcherContainer strokeColor="#ef4545" ref={registerArcherRef(tasks[0].id)}>
       <Box sx={{ width: 'fit-content' }}>
-        <Box sx={{ mt: '1rem', width: 'fit-content' }}>
+        <Box ref={treeContainerRef} sx={{ mt: '1rem', width: 'fit-content' }}>
           {tasks.map((task) => {
             return (
               <Box key={task.id} display="flex" alignItems="center">
@@ -112,7 +132,7 @@ const GanttChartSection = <T,>({
                   highlightedChange={highlightedChange}
                   highlightSubtaskComparator={highlightSubtaskComparator}
                   highlightTaskComparator={highlightTaskComparator}
-                  onToggle={handleToggle}
+                  onToggle={onToggle}
                 />
               </Box>
             );

--- a/src/frontend/src/pages/GanttPage/GanttChart/GanttChartSection.tsx
+++ b/src/frontend/src/pages/GanttPage/GanttChart/GanttChartSection.tsx
@@ -27,8 +27,6 @@ interface GanttChartSectionProps<T> {
   onAddTaskPressed: (parentTask: GanttTask<T>) => void;
   highlightTaskComparator: HighlightTaskComparator<T>;
   highlightSubtaskComparator: HighlightTaskComparator<T>;
-  onToggle: () => void;
-  registerArcherRef: (collectionId: string) => (el: ArcherContainerRef | null) => void;
 }
 
 interface GanttTooltipLayerProps {
@@ -68,12 +66,15 @@ const GanttChartSection = <T,>({
   highlightedChange,
   onAddTaskPressed,
   highlightSubtaskComparator,
-  highlightTaskComparator,
-  onToggle,
-  registerArcherRef
+  highlightTaskComparator
 }: GanttChartSectionProps<T>) => {
   const days = eachDayOfInterval({ start, end }).filter((day) => isMonday(day));
   const treeContainerRef = useRef<HTMLDivElement>(null);
+  const archerContainerRef = useRef<ArcherContainerRef>(null);
+
+  const onToggle = useCallback(() => {
+    archerContainerRef.current?.refreshScreen();
+  }, []);
 
   useEffect(() => {
     const node = treeContainerRef.current;
@@ -115,7 +116,7 @@ const GanttChartSection = <T,>({
   );
 
   return (
-    <ArcherContainer strokeColor="#ef4545" ref={registerArcherRef(tasks[0].id)}>
+    <ArcherContainer strokeColor="#ef4545" ref={archerContainerRef}>
       <Box sx={{ width: 'fit-content' }}>
         <Box ref={treeContainerRef} sx={{ mt: '1rem', width: 'fit-content' }}>
           {tasks.map((task) => {

--- a/src/frontend/src/pages/GanttPage/ProjectGanttChart/ProjectGanttChartPage.tsx
+++ b/src/frontend/src/pages/GanttPage/ProjectGanttChart/ProjectGanttChartPage.tsx
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import React, { ChangeEvent, FC, useCallback, useEffect, useRef, useState } from 'react';
+import React, { ChangeEvent, FC, useEffect, useState } from 'react';
 import LoadingIndicator from '../../../components/LoadingIndicator';
 import { useAllProjectsGantt } from '../../../hooks/projects.hooks';
 import ErrorPage from '../../ErrorPage';
@@ -57,7 +57,6 @@ import { v4 as uuidv4 } from 'uuid';
 import { projectWbsPipe } from '../../../utils/pipes';
 import { projectGanttTransformer } from '../../../apis/transformers/projects.transformers';
 import { useCurrentUser } from '../../../hooks/users.hooks';
-import { ArcherContainerRef } from 'react-archer/lib/ArcherContainer/ArcherContainer.types';
 
 const getElementId = (element: WbsElementPreview | Task) => {
   return (element as WbsElementPreview).id ?? (element as Task).taskId;
@@ -97,24 +96,8 @@ const ProjectGanttChartPage: FC = () => {
   const [allProjects, setAllProjects] = useState<ProjectGantt[]>([]);
   const [editedProjects, setEditedProjects] = useState<ProjectGantt[]>([]);
   const user = useCurrentUser();
-  const archerRefs = useRef<Map<string, ArcherContainerRef>>(new Map());
   /******************** Filters ***************************/
   const { filters, setFilters } = useGanttFilters('project-gantt');
-
-  const registerArcherRef = useCallback(
-    (taskId: string) => (el: ArcherContainerRef | null) => {
-      if (el) {
-        archerRefs.current.set(taskId, el);
-      } else {
-        archerRefs.current.delete(taskId);
-      }
-    },
-    []
-  );
-
-  const handleToggle = useCallback(() => {
-    archerRefs.current.forEach((ref) => ref.refreshScreen());
-  }, []);
 
   // Local car filter state — resets to global selection whenever global car filter changes
   const [showCars, setShowCars] = useState<number[]>([]);
@@ -166,8 +149,7 @@ const ProjectGanttChartPage: FC = () => {
     filters,
     showCars,
     searchText,
-    history,
-    handleToggle
+    history
   ]);
 
   const handleSetGanttFilters = (newFilters: GanttFilters) => {
@@ -688,9 +670,7 @@ const ProjectGanttChartPage: FC = () => {
             createTaskTitle: 'Create New Project',
             onSavePressed: saveChanges,
             highlightSubtaskComparator: highlightWorkPackageComparator,
-            highlightTaskComparator: highlightProjectComparator,
-            onToggle: handleToggle,
-            registerArcherRef
+            highlightTaskComparator: highlightProjectComparator
           }}
         />
       </PageLayout>

--- a/src/frontend/src/pages/GanttPage/ProjectGanttChart/ProjectGanttChartPage.tsx
+++ b/src/frontend/src/pages/GanttPage/ProjectGanttChart/ProjectGanttChartPage.tsx
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import React, { ChangeEvent, FC, useEffect, useState } from 'react';
+import React, { ChangeEvent, FC, useCallback, useEffect, useRef, useState } from 'react';
 import LoadingIndicator from '../../../components/LoadingIndicator';
 import { useAllProjectsGantt } from '../../../hooks/projects.hooks';
 import ErrorPage from '../../ErrorPage';
@@ -57,6 +57,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { projectWbsPipe } from '../../../utils/pipes';
 import { projectGanttTransformer } from '../../../apis/transformers/projects.transformers';
 import { useCurrentUser } from '../../../hooks/users.hooks';
+import { ArcherContainerRef } from 'react-archer/lib/ArcherContainer/ArcherContainer.types';
 
 const getElementId = (element: WbsElementPreview | Task) => {
   return (element as WbsElementPreview).id ?? (element as Task).taskId;
@@ -96,9 +97,24 @@ const ProjectGanttChartPage: FC = () => {
   const [allProjects, setAllProjects] = useState<ProjectGantt[]>([]);
   const [editedProjects, setEditedProjects] = useState<ProjectGantt[]>([]);
   const user = useCurrentUser();
-
+  const archerRefs = useRef<Map<string, ArcherContainerRef>>(new Map());
   /******************** Filters ***************************/
   const { filters, setFilters } = useGanttFilters('project-gantt');
+
+  const registerArcherRef = useCallback(
+    (taskId: string) => (el: ArcherContainerRef | null) => {
+      if (el) {
+        archerRefs.current.set(taskId, el);
+      } else {
+        archerRefs.current.delete(taskId);
+      }
+    },
+    []
+  );
+
+  const handleToggle = useCallback(() => {
+    archerRefs.current.forEach((ref) => ref.refreshScreen());
+  }, []);
 
   // Local car filter state — resets to global selection whenever global car filter changes
   const [showCars, setShowCars] = useState<number[]>([]);
@@ -150,7 +166,8 @@ const ProjectGanttChartPage: FC = () => {
     filters,
     showCars,
     searchText,
-    history
+    history,
+    handleToggle
   ]);
 
   const handleSetGanttFilters = (newFilters: GanttFilters) => {
@@ -671,7 +688,9 @@ const ProjectGanttChartPage: FC = () => {
             createTaskTitle: 'Create New Project',
             onSavePressed: saveChanges,
             highlightSubtaskComparator: highlightWorkPackageComparator,
-            highlightTaskComparator: highlightProjectComparator
+            highlightTaskComparator: highlightProjectComparator,
+            onToggle: handleToggle,
+            registerArcherRef
           }}
         />
       </PageLayout>


### PR DESCRIPTION
## Changes

Expanding a Work Package in Gantt will cause the blocked lines to move as well

## Notes

## Test Cases

- Expanding and collapsing a work package repeatedly causes the blocked lines to move accordingly

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `yarn.lock` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #4343
