### PR TITLE
#4371 rules increase image size

### DIFF
--- a/src/frontend/src/hooks/rules.hooks.ts
+++ b/src/frontend/src/hooks/rules.hooks.ts
@@ -648,7 +648,7 @@ const fetchAllChildRules = async (rule: SharedRule, allRules: SharedRule[]): Pro
 
 /**
  * Hook to get all rules for a ruleset by fetching top-level rules
- * and recursively fetching all children
+ * and recursively fetching all children.
  */
 export const useAllRulesForRuleset = (rulesetId: string) => {
   return useQuery<SharedRule[], Error>(

--- a/src/frontend/src/pages/RulesPage/components/RuleContent.tsx
+++ b/src/frontend/src/pages/RulesPage/components/RuleContent.tsx
@@ -68,17 +68,17 @@ const RuleImages: React.FC<RuleImagesProps> = ({ rule, onImageRemove }) => {
 
   return (
     <>
-      <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mt: 1 }}>
+      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, flexWrap: 'wrap', mt: 1 }}>
         {imageUrls.map(
           (image, index) =>
             image.url && (
-              <Box key={image.id} sx={{ position: 'relative', width: 48, height: 48 }}>
+              <Box key={image.id} sx={{ position: 'relative', display: 'inline-flex' }}>
                 <Box
                   component="img"
                   src={image.url}
                   alt="Rule attachment"
                   onClick={() => setPreviewIndex(index)}
-                  sx={{ width: 48, height: 48, objectFit: 'cover', borderRadius: 1, cursor: 'pointer' }}
+                  sx={{ maxWidth: 300, maxHeight: 300, borderRadius: 1, cursor: 'pointer', display: 'block' }}
                 />
                 {onImageRemove && (
                   <IconButton

--- a/src/frontend/src/pages/RulesPage/components/RulesetTeamView.tsx
+++ b/src/frontend/src/pages/RulesPage/components/RulesetTeamView.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Box, Paper, Table, TableBody, TableContainer, useTheme } from '@mui/material';
 import { Rule } from 'shared';
 import RuleRow from '../RuleRow';
+import RuleContent from './RuleContent';
 
 interface RulesetTeamViewProps {
   topLevelItems: Rule[];
@@ -39,6 +40,7 @@ const RulesetTeamView: React.FC<RulesetTeamViewProps> = ({
                 key={item.ruleId}
                 rule={item}
                 allRules={rowsById}
+                middleContent={(r) => <RuleContent rule={r} color={tableTextColor} />}
                 rightContent={() => null}
                 backgroundColor={tableBackgroundColor}
                 textColor={tableTextColor}


### PR DESCRIPTION
## Changes

Increase rule image sizing and fix spacing

## Screenshots
<img width="1437" height="859" alt="Screenshot 2026-08-10 at 10 24 12 PM" src="https://github.com/user-attachments/assets/2a5d29f8-9c43-48bc-a4b3-5a0676551ce1" />

<img width="1440" height="844" alt="Screenshot 2026-08-10 at 10 24 38 PM" src="https://github.com/user-attachments/assets/d48a4baa-a519-44a6-b5ec-d733d863b3d0" />

<img width="1440" height="856" alt="Screenshot 2026-08-11 at 9 16 15 AM" src="https://github.com/user-attachments/assets/e41a203e-3860-4474-aaad-4cb2220f0eb9" />

https://github.com/user-attachments/assets/c59a57ab-5e60-4115-8663-f112211ec858


<img width="1439" height="860" alt="Screenshot 2026-08-11 at 9 23 28 AM" src="https://github.com/user-attachments/assets/8fa3baa3-3c57-4672-8452-c80f86f53006" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #4371
