### PR TITLE
#4387 replaced general announcments with wp on leads home page

### DIFF
--- a/src/frontend/src/pages/HomePage/LeadHomePage.tsx
+++ b/src/frontend/src/pages/HomePage/LeadHomePage.tsx
@@ -10,6 +10,7 @@ import ChangeRequestsToReview from './components/ChangeRequestsToReview';
 import MyTeamsOverdueTasks from './components/MyTeamsOverdueTasks';
 import UpcomingDesignReviews from './components/UpcomingDesignReviews';
 import GeneralAnnouncements from './components/GeneralAnnouncements';
+import WorkPackagesSelectionView from './components/WorkPackagesSelectionView';
 
 interface LeadHomePageProps {
   user: AuthenticatedUser;
@@ -52,7 +53,7 @@ const LeadHomePage = ({ user }: LeadHomePageProps) => {
               overflow: 'hidden'
             }}
           >
-            <GeneralAnnouncements />
+            <WorkPackagesSelectionView />
           </Grid>
           <Grid
             item

--- a/src/frontend/src/pages/HomePage/LeadHomePage.tsx
+++ b/src/frontend/src/pages/HomePage/LeadHomePage.tsx
@@ -9,7 +9,6 @@ import { AuthenticatedUser } from 'shared';
 import ChangeRequestsToReview from './components/ChangeRequestsToReview';
 import MyTeamsOverdueTasks from './components/MyTeamsOverdueTasks';
 import UpcomingDesignReviews from './components/UpcomingDesignReviews';
-import GeneralAnnouncements from './components/GeneralAnnouncements';
 import WorkPackagesSelectionView from './components/WorkPackagesSelectionView';
 
 interface LeadHomePageProps {

--- a/src/frontend/src/pages/HomePage/components/WorkPackageCard.tsx
+++ b/src/frontend/src/pages/HomePage/components/WorkPackageCard.tsx
@@ -41,7 +41,8 @@ const WorkPackageCard = ({ wp }: { wp: WorkPackagePreview }) => {
       variant="outlined"
       sx={{
         width: '100%',
-        mr: 3,
+        height: 'fit-content',
+        minHeight: 'fit-content',
         background: theme.palette.background.default
       }}
     >

--- a/src/frontend/src/pages/HomePage/components/WorkPackagesSelectionView.tsx
+++ b/src/frontend/src/pages/HomePage/components/WorkPackagesSelectionView.tsx
@@ -53,7 +53,9 @@ const WorkPackagesSelectionView: React.FC = () => {
     }
   }
 
-  const [currentDisplayedWPs, setCurrentDisplayedWPs] = useState<number>(defaultFirstDisplay);
+  // undefined until the user picks one, so the default can be based on loaded data
+  const [selectedOption, setSelectedOption] = useState<number>();
+  const currentDisplayedWPs = selectedOption ?? defaultFirstDisplay;
 
   if (isLoading || !relevantWPs) return <LoadingIndicator />;
   if (isError) return <ErrorPage message={error.message} />;
@@ -65,14 +67,14 @@ const WorkPackagesSelectionView: React.FC = () => {
     <Box
       sx={{
         display: 'grid',
-        gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))',
-        overflow: 'auto',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(min(300px, 100%), 1fr))',
+        flexShrink: 0,
         width: '100%',
         gap: 2
       }}
     >
       {workPackages.map((wp) => (
-        <WorkPackageCard wp={wp} />
+        <WorkPackageCard key={wp.id} wp={wp} />
       ))}
     </Box>
   );
@@ -95,7 +97,7 @@ const WorkPackagesSelectionView: React.FC = () => {
       >
         <WorkPackageSelect
           options={workPackageOptions.map((wp) => wp[0])}
-          onSelect={setCurrentDisplayedWPs}
+          onSelect={setSelectedOption}
           selected={currentDisplayedWPs}
         />
         <Box


### PR DESCRIPTION
## Changes

Replaced the general announcements on the leads/heads home page with overdue/in progress/upcoming work package display. Fixed a bug in the WorkPackageSelectionView that was causing the boxes to shrink into unreadable lines.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `yarn.lock` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #4387 
